### PR TITLE
fix: sync landing page monitoring interval copy

### DIFF
--- a/resources/lang/de/welcome.php
+++ b/resources/lang/de/welcome.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+$monitoringInterval = (int) config('monitoring.interval', 5);
+
 return [
     'seo' => [
         'title' => 'WebGuard - Kostenfreies Monitoring für Websites, APIs, Server und Ports',
@@ -155,7 +157,7 @@ return [
             ],
             '2' => [
                 'label' => 'Standard-Intervall',
-                'value' => '60 Sekunden',
+                'value' => $monitoringInterval === 1 ? '1 Minute' : "{$monitoringInterval} Minuten",
             ],
             '3' => [
                 'label' => 'Empfohlene Monitor-Typen',

--- a/resources/lang/en/welcome.php
+++ b/resources/lang/en/welcome.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+$monitoringInterval = (int) config('monitoring.interval', 5);
+
 return [
     'seo' => [
         'title' => 'WebGuard - Free Monitoring for Websites, APIs, Servers, and Ports',
@@ -155,7 +157,7 @@ return [
             ],
             '2' => [
                 'label' => 'Default interval',
-                'value' => '60 seconds',
+                'value' => $monitoringInterval === 1 ? '1 minute' : "{$monitoringInterval} minutes",
             ],
             '3' => [
                 'label' => 'Recommended monitor types',


### PR DESCRIPTION
## Summary
- replace the hard-coded landing page default interval text with a value derived from `config('monitoring.interval', 5)`
- update both German and English marketing copy so the displayed default matches the actual monitoring trigger cadence

## Why
The landing page claimed a 60-second default interval, while the application logic triggers monitoring every 5 minutes.

## Impact
Users now see the correct default interval on the landing page, and future config changes will automatically stay in sync with the copy.

## Root cause
The landing page metrics used static translation strings instead of the existing monitoring interval configuration.

## Validation
- inspected the implementation and confirmed the runtime interval is derived from `config('monitoring.interval', 5)`
- attempted local PHP syntax checks, but `php` is not installed in this environment