### PR TITLE
test: cover welcome monitoring interval copy

### DIFF
--- a/tests/Feature/WelcomeMonitoringIntervalCopyTest.php
+++ b/tests/Feature/WelcomeMonitoringIntervalCopyTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SupportedLanguage;
+
+dataset('welcome-monitoring-interval-copy', [
+    'english plural' => ['en', 5, '5 minutes'],
+    'english singular' => ['en', 1, '1 minute'],
+    'german plural' => ['de', 5, '5 Minuten'],
+    'german singular' => ['de', 1, '1 Minute'],
+]);
+
+it('renders the configured monitoring interval copy on the welcome page', function (string $locale, int $interval, string $expectedCopy) {
+    config(['monitoring.interval' => $interval]);
+
+    $testResponse = $this->withCookie(SupportedLanguage::cookieName(), $locale)->get('/');
+
+    $testResponse->assertOk();
+    $testResponse->assertSeeText($expectedCopy);
+})->with('welcome-monitoring-interval-copy');


### PR DESCRIPTION
## What changed
- add a focused feature test for the welcome-page monitoring interval copy
- cover English and German output for both singular and plural configured intervals

## Why
The recent landing-page copy fix changed `resources/lang/en/welcome.php` and `resources/lang/de/welcome.php`, but there was no test asserting that the rendered welcome page actually reflects the configured monitoring interval.

## Impact
This keeps future copy regressions in the landing-page case-study metric from slipping through when the configured interval or locale handling changes.

## Validation
- attempted: `php artisan test tests/Feature/WelcomeMonitoringIntervalCopyTest.php`
- blocked locally because `php` is not available on PATH in this automation environment
