### PR TITLE
Fix welcome interval copy per request

### DIFF
--- a/resources/lang/de/welcome.php
+++ b/resources/lang/de/welcome.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-$monitoringInterval = (int) config('monitoring.interval', 5);
-
 return [
     'seo' => [
         'title' => 'WebGuard - Kostenfreies Monitoring für Websites, APIs, Server und Ports',
@@ -157,7 +155,7 @@ return [
             ],
             '2' => [
                 'label' => 'Standard-Intervall',
-                'value' => $monitoringInterval === 1 ? '1 Minute' : "{$monitoringInterval} Minuten",
+                'value' => '1 Minute|:count Minuten',
             ],
             '3' => [
                 'label' => 'Empfohlene Monitor-Typen',

--- a/resources/lang/en/welcome.php
+++ b/resources/lang/en/welcome.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-$monitoringInterval = (int) config('monitoring.interval', 5);
-
 return [
     'seo' => [
         'title' => 'WebGuard - Free Monitoring for Websites, APIs, Servers, and Ports',
@@ -157,7 +155,7 @@ return [
             ],
             '2' => [
                 'label' => 'Default interval',
-                'value' => $monitoringInterval === 1 ? '1 minute' : "{$monitoringInterval} minutes",
+                'value' => '1 minute|:count minutes',
             ],
             '3' => [
                 'label' => 'Recommended monitor types',

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -207,7 +207,13 @@
                             @foreach ([1, 2, 3] as $metric)
                                 <div class="flex items-center justify-between gap-4 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-800 dark:bg-slate-900/80">
                                     <dt><x-span class="text-slate-600 dark:text-slate-300">{{ __('welcome.case_study.metrics.' . $metric . '.label') }}</x-span></dt>
-                                    <dd><x-span class="font-semibold text-emerald-700 dark:text-emerald-300">{{ __('welcome.case_study.metrics.' . $metric . '.value') }}</x-span></dd>
+                                    <dd>
+                                        <x-span class="font-semibold text-emerald-700 dark:text-emerald-300">
+                                            {{ $metric === 2
+                                                ? trans_choice('welcome.case_study.metrics.2.value', config('monitoring.interval', 5), ['count' => config('monitoring.interval', 5)])
+                                                : __('welcome.case_study.metrics.' . $metric . '.value') }}
+                                        </x-span>
+                                    </dd>
                                 </div>
                             @endforeach
                         </dl>

--- a/tests/Feature/WelcomeMonitoringIntervalCopyTest.php
+++ b/tests/Feature/WelcomeMonitoringIntervalCopyTest.php
@@ -11,6 +11,11 @@ dataset('welcome-monitoring-interval-copy', [
     'german singular' => ['de', 1, '1 Minute'],
 ]);
 
+dataset('welcome-monitoring-interval-copy-per-request', [
+    'english request update' => ['en', '5 minutes', '1 minute'],
+    'german request update' => ['de', '5 Minuten', '1 Minute'],
+]);
+
 it('renders the configured monitoring interval copy on the welcome page', function (string $locale, int $interval, string $expectedCopy) {
     config(['monitoring.interval' => $interval]);
 
@@ -19,3 +24,19 @@ it('renders the configured monitoring interval copy on the welcome page', functi
     $testResponse->assertOk();
     $testResponse->assertSeeText($expectedCopy);
 })->with('welcome-monitoring-interval-copy');
+
+it('updates the monitoring interval copy for each request', function (string $locale, string $firstExpectedCopy, string $secondExpectedCopy) {
+    config(['monitoring.interval' => 5]);
+
+    $firstResponse = $this->withCookie(SupportedLanguage::cookieName(), $locale)->get('/');
+
+    $firstResponse->assertOk();
+    $firstResponse->assertSeeText($firstExpectedCopy);
+
+    config(['monitoring.interval' => 1]);
+
+    $secondResponse = $this->withCookie(SupportedLanguage::cookieName(), $locale)->get('/');
+
+    $secondResponse->assertOk();
+    $secondResponse->assertSeeText($secondExpectedCopy);
+})->with('welcome-monitoring-interval-copy-per-request');


### PR DESCRIPTION
## What changed
- move the welcome-page interval rendering to `trans_choice(...)` in the Blade view so the copy is evaluated with the current request state instead of when the translation file is first loaded
- keep the translation files declarative by storing pluralizable strings instead of computed config-dependent text
- add a focused feature regression test that makes two welcome-page requests in the same test with different `monitoring.interval` values

## Why
The interval text on the welcome page was previously derived while loading the translation file. Once that translation line was cached, later requests in the same application instance could keep showing stale interval text even after `monitoring.interval` changed.

## Impact
The welcome-page case-study interval now reflects the active config on every request, and the regression test covers the previously untested multi-request path.

## Validation
- added `tests/Feature/WelcomeMonitoringIntervalCopyTest.php` coverage for consecutive requests with different intervals
- local execution is blocked in this environment because `php` is not installed on PATH, so GitHub CI should be used to run the test suite