### PR TITLE
Batch monitoring card data requests

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Monitoring;
+use App\Services\MonitoringResultService;
+use App\Support\MonitoringStatusMeta;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+class MonitoringCardDataController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'ids' => ['required', 'array', 'min:1', 'max:25'],
+            'ids.*' => ['required', 'string'],
+        ]);
+
+        /** @var Collection<int, string> $requestedIds */
+        $requestedIds = collect($validated['ids'])
+            ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->unique()
+            ->values();
+
+        $monitorings = Monitoring::query()
+            ->select([
+                'id',
+                'name',
+                'target',
+                'type',
+                'created_at',
+                'maintenance_from',
+                'maintenance_until',
+            ])
+            ->whereIn('id', $requestedIds)
+            ->with([
+                'latestIncident',
+                'latestResponseResult',
+            ])
+            ->get()
+            ->keyBy('id');
+
+        $heatmaps = MonitoringResultService::getHeatmapsForMonitorings(
+            $monitorings->values(),
+            Date::now()->subHours(23)->startOfHour(),
+            Date::now()->endOfHour()
+        );
+
+        $data = $requestedIds->mapWithKeys(function (string $monitoringId) use ($monitorings, $heatmaps): array {
+            /** @var Monitoring|null $monitoring */
+            $monitoring = $monitorings->get($monitoringId);
+
+            if (! $monitoring) {
+                return [];
+            }
+
+            $statusSince = MonitoringResultService::getStatusSince($monitoring);
+            $statusNow = MonitoringResultService::getStatusNow($monitoring);
+            $latestStatusCode = $monitoring->latestResponseResult?->http_status_code;
+            $maintenanceActive = $monitoring->isUnderMaintenance();
+
+            return [
+                $monitoringId => array_merge($statusSince, $statusNow, [
+                    'status_code' => $latestStatusCode,
+                    'status_changed_at' => $statusSince['since'] ?? null,
+                    'status_identifier' => MonitoringStatusMeta::statusIdentifier($latestStatusCode, $maintenanceActive),
+                    'status_key' => MonitoringStatusMeta::statusKey($latestStatusCode, $maintenanceActive),
+                    'heatmap' => $heatmaps[$monitoringId] ?? [],
+                ]),
+            ];
+        });
+
+        return response()->json([
+            'data' => $data,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -18,7 +18,7 @@ class MonitoringCardDataController extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'ids' => ['required', 'array', 'min:1', 'max:25'],
+            'ids' => ['required', 'array', 'min:1'],
             'ids.*' => ['required', 'string'],
         ]);
 

--- a/app/Services/MonitoringResultService.php
+++ b/app/Services/MonitoringResultService.php
@@ -50,39 +50,69 @@ class MonitoringResultService
      */
     public static function getHeatmap(Monitoring $monitoring, Carbon $startDate, Carbon $endDate): Collection
     {
-        // Enforce 24-hour window for heatmap
+        $heatmaps = self::getHeatmapsForMonitorings(collect([$monitoring]), $startDate, $endDate);
+
+        return collect($heatmaps[$monitoring->id] ?? []);
+    }
+
+    /**
+     * @param  Collection<int, Monitoring>  $monitorings
+     * @return array<string, list<array{date: Carbon, uptime: int, downtime: int, unknown: int}>>
+     */
+    public static function getHeatmapsForMonitorings(Collection $monitorings, Carbon $startDate, Carbon $endDate): array
+    {
+        if ($monitorings->isEmpty()) {
+            return [];
+        }
+
+        // Enforce 24-hour window for heatmap payloads.
         $startDate = Date::now()->subHours(23)->startOfHour();
         $endDate = Date::now()->endOfHour();
+
+        $monitoringIds = $monitorings
+            ->pluck('id')
+            ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->values();
 
         $interval = (int) config('monitoring.interval', 5);
         $periodExpression = self::getPeriodExpression('created_at', '%Y-%m-%d %H');
 
-        $raw = self::getMonitoringResponseQuery($endDate)
-            ->where('monitoring_id', $monitoring->id)
-            ->selectRaw("{$periodExpression} as period,
+        $rawByMonitoring = self::getMonitoringResponseQuery($endDate)
+            ->whereIn('monitoring_id', $monitoringIds)
+            ->selectRaw("monitoring_id, {$periodExpression} as period,
                 SUM(CASE WHEN status = 'up' THEN 1 ELSE 0 END) * {$interval} as uptime,
                 SUM(CASE WHEN status = 'down' THEN 1 ELSE 0 END) * {$interval} as downtime,
                 SUM(CASE WHEN status NOT IN ('up', 'down') THEN 1 ELSE 0 END) * {$interval} as unknown
             ")
             ->whereBetween('created_at', [$startDate, $endDate])
-            ->groupBy('period')
+            ->groupBy('monitoring_id', 'period')
             ->orderBy('period')
             ->get()
-            ->keyBy('period');
+            ->groupBy('monitoring_id')
+            ->map(static fn (Collection $rows): Collection => $rows->keyBy('period'));
 
-        return collect(
-            CarbonPeriod::create($startDate, '1 hour', $endDate)
-                ->map(function (Carbon $hour) use ($raw) {
-                    $record = $raw->get($hour->format('Y-m-d H'));
+        return $monitoringIds
+            ->mapWithKeys(function (string $monitoringId) use ($rawByMonitoring, $startDate, $endDate): array {
+                /** @var Collection<int, object> $raw */
+                $raw = $rawByMonitoring->get($monitoringId, collect());
 
-                    return [
-                        'date' => $hour,
-                        'uptime' => (int) ($record->uptime ?? 0),
-                        'downtime' => (int) ($record->downtime ?? 0),
-                        'unknown' => (int) ($record->unknown ?? 0),
-                    ];
-                })
-        );
+                $heatmap = collect(CarbonPeriod::create($startDate, '1 hour', $endDate))
+                    ->map(function (Carbon $hour) use ($raw): array {
+                        $record = $raw->get($hour->format('Y-m-d H'));
+
+                        return [
+                            'date' => $hour,
+                            'uptime' => (int) ($record->uptime ?? 0),
+                            'downtime' => (int) ($record->downtime ?? 0),
+                            'unknown' => (int) ($record->unknown ?? 0),
+                        ];
+                    })
+                    ->values()
+                    ->all();
+
+                return [$monitoringId => $heatmap];
+            })
+            ->all();
     }
 
     /**

--- a/resources/js/Components/monitoring-cards.ts
+++ b/resources/js/Components/monitoring-cards.ts
@@ -16,7 +16,6 @@ interface MonitoringCardLoaderComponent {
     lastCheckMap: Record<string, string>;
     currentLocale: string;
     updateSince(this: MonitoringCardLoaderComponent): void;
-    loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void>;
     loadAll(this: MonitoringCardLoaderComponent): Promise<void>;
     init(this: MonitoringCardLoaderComponent): void;
 }
@@ -45,31 +44,40 @@ export default (
 
     currentLocale: getCurrentDayjsLocale(),
 
-    async loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void> {
-        const statusPromise = fetch(`/api/monitorings/${monitoringId}/status`).then(res => res.ok ? res.json() : null).catch(() => null);
-        const heatmapPromise = fetch(`/api/monitorings/${monitoringId}/heatmap`).then(res => res.ok ? res.json() : null).catch(() => null);
-
-        const [statusData, heatmapData] = await Promise.all([statusPromise, heatmapPromise]);
-
-        if (statusData) {
-            this.statusMap = { ...this.statusMap, [monitoringId]: statusData.status };
-            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: statusData.since };
-            this.sinceMap = { ...this.sinceMap, [monitoringId]: statusData.since ? humanizeDistance(statusData.since, { withoutSuffix: true }) : '' };
-        }
-
-        if (heatmapData) {
-            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
-            if (heatmapContainer) {
-                renderHeatmap(heatmapContainer, heatmapData);
-            }
-        }
-    },
-
     async loadAll(this: MonitoringCardLoaderComponent): Promise<void> {
         this.hasMonitorings = this.monitoringIds.length > 0;
         if (!this.hasMonitorings) return;
 
-        await Promise.all(this.monitoringIds.map((id: string) => this.loadCard(id)));
+        const query = new URLSearchParams();
+
+        this.monitoringIds.forEach((id: string) => query.append('ids[]', id));
+
+        const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
+        if (!response?.ok) {
+            return;
+        }
+
+        const payload = await response.json() as { data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }> };
+        const cardData = payload.data ?? {};
+
+        for (const monitoringId of this.monitoringIds) {
+            const monitoringCardData = cardData[monitoringId];
+            if (!monitoringCardData) {
+                continue;
+            }
+
+            this.statusMap = { ...this.statusMap, [monitoringId]: monitoringCardData.status ?? '' };
+            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: monitoringCardData.since ?? null };
+            this.sinceMap = {
+                ...this.sinceMap,
+                [monitoringId]: monitoringCardData.since ? humanizeDistance(monitoringCardData.since, { withoutSuffix: true }) : '',
+            };
+
+            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
+            if (heatmapContainer && monitoringCardData.heatmap) {
+                renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
+            }
+        }
     },
 
     updateSince(this: MonitoringCardLoaderComponent): void {

--- a/resources/js/components/monitoring-cards.ts
+++ b/resources/js/components/monitoring-cards.ts
@@ -16,7 +16,6 @@ interface MonitoringCardLoaderComponent {
     lastCheckMap: Record<string, string>;
     currentLocale: string;
     updateSince(this: MonitoringCardLoaderComponent): void;
-    loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void>;
     loadAll(this: MonitoringCardLoaderComponent): Promise<void>;
     init(this: MonitoringCardLoaderComponent): void;
 }
@@ -45,31 +44,40 @@ export default (
 
     currentLocale: getCurrentDayjsLocale(),
 
-    async loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void> {
-        const statusPromise = fetch(`/api/monitorings/${monitoringId}/status`).then(res => res.ok ? res.json() : null).catch(() => null);
-        const heatmapPromise = fetch(`/api/monitorings/${monitoringId}/heatmap`).then(res => res.ok ? res.json() : null).catch(() => null);
-
-        const [statusData, heatmapData] = await Promise.all([statusPromise, heatmapPromise]);
-
-        if (statusData) {
-            this.statusMap = { ...this.statusMap, [monitoringId]: statusData.status };
-            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: statusData.since };
-            this.sinceMap = { ...this.sinceMap, [monitoringId]: statusData.since ? humanizeDistance(statusData.since, { withoutSuffix: true }) : '' };
-        }
-
-        if (heatmapData) {
-            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
-            if (heatmapContainer) {
-                renderHeatmap(heatmapContainer, heatmapData);
-            }
-        }
-    },
-
     async loadAll(this: MonitoringCardLoaderComponent): Promise<void> {
         this.hasMonitorings = this.monitoringIds.length > 0;
         if (!this.hasMonitorings) return;
 
-        await Promise.all(this.monitoringIds.map((id: string) => this.loadCard(id)));
+        const query = new URLSearchParams();
+
+        this.monitoringIds.forEach((id: string) => query.append('ids[]', id));
+
+        const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
+        if (!response?.ok) {
+            return;
+        }
+
+        const payload = await response.json() as { data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }> };
+        const cardData = payload.data ?? {};
+
+        for (const monitoringId of this.monitoringIds) {
+            const monitoringCardData = cardData[monitoringId];
+            if (!monitoringCardData) {
+                continue;
+            }
+
+            this.statusMap = { ...this.statusMap, [monitoringId]: monitoringCardData.status ?? '' };
+            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: monitoringCardData.since ?? null };
+            this.sinceMap = {
+                ...this.sinceMap,
+                [monitoringId]: monitoringCardData.since ? humanizeDistance(monitoringCardData.since, { withoutSuffix: true }) : '',
+            };
+
+            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
+            if (heatmapContainer && monitoringCardData.heatmap) {
+                renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
+            }
+        }
     },
 
     updateSince(this: MonitoringCardLoaderComponent): void {

--- a/routes/api/internal.php
+++ b/routes/api/internal.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\MonitoringCardDataController;
 use App\Http\Controllers\Api\NotificationBoardController;
 use App\Http\Controllers\ApiController;
 use Illuminate\Support\Facades\Route;
@@ -9,6 +10,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/notifications/status-board', NotificationBoardController::class)->name('notifications.status-board');
 
 Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): void {
+    Route::get('/card-data', MonitoringCardDataController::class)->name('card-data');
     Route::get('/{monitoring}', [ApiController::class, 'all']);
 
     Route::get('/{monitoring}/status', [ApiController::class, 'status']);

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -99,6 +99,24 @@ class MonitoringCardDataApiTest extends TestCase
         $testResponse->assertJsonMissingPath('data.' . $foreignMonitoring->id);
     }
 
+    public function test_card_data_endpoint_accepts_more_than_twenty_five_requested_monitorings(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 50]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+
+        $monitorings = Monitoring::factory()->count(26)->for($user)->create();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => $monitorings->pluck('id')->all(),
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonCount(26, 'data');
+        $testResponse->assertJsonPath('data.' . $monitorings->first()->id . '.heatmap.0.uptime', 0);
+    }
+
     private function selectQueryCount(): int
     {
         return collect(DB::getQueryLog())

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MonitoringCardDataApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_card_data_endpoint_batches_monitoring_status_and_heatmap_queries(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $monitorings = Monitoring::factory()->count(3)->for($user)->create();
+
+        foreach ($monitorings as $index => $monitoring) {
+            foreach (range(0, 2) as $hourOffset) {
+                $checkedAt = Date::now()->subHours($hourOffset)->subMinutes($index + 1);
+
+                MonitoringResponse::query()->create([
+                    'monitoring_id' => $monitoring->id,
+                    'status' => $index === 1 ? MonitoringStatus::DOWN : MonitoringStatus::UP,
+                    'http_status_code' => $index === 1 ? 503 : 200,
+                    'response_time' => 120.0 + $index,
+                    'created_at' => $checkedAt,
+                    'updated_at' => $checkedAt,
+                ]);
+            }
+        }
+
+        Incident::query()->create([
+            'monitoring_id' => $monitorings[1]->id,
+            'down_at' => Date::now()->subHours(2),
+            'up_at' => null,
+            'created_at' => Date::now()->subHours(2),
+            'updated_at' => Date::now()->subHours(2),
+        ]);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        foreach ($monitorings as $monitoring) {
+            $this->actingAs($user)->getJson('/api/monitorings/' . $monitoring->id . '/status')->assertOk();
+            $this->actingAs($user)->getJson('/api/monitorings/' . $monitoring->id . '/heatmap')->assertOk();
+        }
+
+        $legacySelectCount = $this->selectQueryCount();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => $monitorings->pluck('id')->all(),
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('data.' . $monitorings[0]->id . '.status', MonitoringStatus::UP->value);
+        $testResponse->assertJsonPath('data.' . $monitorings[1]->id . '.status', MonitoringStatus::DOWN->value);
+        $testResponse->assertJsonCount(24, 'data.' . $monitorings[2]->id . '.heatmap');
+
+        $selectCount = $this->selectQueryCount();
+
+        $this->assertGreaterThan($selectCount, $legacySelectCount);
+        $this->assertLessThanOrEqual(4, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
+    }
+
+    public function test_card_data_endpoint_returns_only_requested_monitorings_for_the_authenticated_user(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ownedMonitoring = Monitoring::factory()->for($user)->create();
+        $foreignMonitoring = Monitoring::factory()->for($otherUser)->create();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => [$ownedMonitoring->id, $foreignMonitoring->id],
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('data.' . $ownedMonitoring->id . '.heatmap.0.uptime', 0);
+        $testResponse->assertJsonMissingPath('data.' . $foreignMonitoring->id);
+    }
+
+    private function selectQueryCount(): int
+    {
+        return collect(DB::getQueryLog())
+            ->filter(static fn (array $entry): bool => str_starts_with(mb_strtolower($entry['query']), 'select'))
+            ->count();
+    }
+}


### PR DESCRIPTION
## What changed
- batch welcome-page monitoring card loads through the new `/api/monitorings/card-data` endpoint
- remove the 25-ID validation cap so larger accounts can still load every card in a single request
- add a focused API regression test that covers requesting 26 monitorings

## Why
The new batched card-data endpoint improved query fan-out, but the initial request validation rejected more than 25 IDs. Package limits can exceed that threshold, which meant larger accounts would stop receiving card status and heatmap data after this change.

## Impact
Users with more than 25 monitorings keep the batched performance improvement without losing card data on the welcome page.

## Root cause
The endpoint introduced a hard request-size cap that did not match the number of monitorings a user can legitimately own.

## Validation
- `php artisan test tests/Feature/Api/MonitoringCardDataApiTest.php`