### PR TITLE
Performance audit: batch monitoring dashboard requests

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Monitoring;
+use App\Services\MonitoringResultService;
+use App\Support\MonitoringStatusMeta;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+class MonitoringCardDataController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'ids' => ['required', 'array', 'min:1', 'max:25'],
+            'ids.*' => ['required', 'string'],
+        ]);
+
+        /** @var Collection<int, string> $requestedIds */
+        $requestedIds = collect($validated['ids'])
+            ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->unique()
+            ->values();
+
+        $monitorings = Monitoring::query()
+            ->select([
+                'id',
+                'name',
+                'target',
+                'type',
+                'created_at',
+                'maintenance_from',
+                'maintenance_until',
+            ])
+            ->whereIn('id', $requestedIds)
+            ->with([
+                'latestIncident',
+                'latestResponseResult',
+            ])
+            ->get()
+            ->keyBy('id');
+
+        $heatmaps = MonitoringResultService::getHeatmapsForMonitorings(
+            $monitorings->values(),
+            Date::now()->subHours(23)->startOfHour(),
+            Date::now()->endOfHour()
+        );
+
+        $data = $requestedIds->mapWithKeys(function (string $monitoringId) use ($monitorings, $heatmaps): array {
+            /** @var Monitoring|null $monitoring */
+            $monitoring = $monitorings->get($monitoringId);
+
+            if (! $monitoring) {
+                return [];
+            }
+
+            $statusSince = MonitoringResultService::getStatusSince($monitoring);
+            $statusNow = MonitoringResultService::getStatusNow($monitoring);
+            $latestStatusCode = $monitoring->latestResponseResult?->http_status_code;
+            $maintenanceActive = $monitoring->isUnderMaintenance();
+
+            return [
+                $monitoringId => array_merge($statusSince, $statusNow, [
+                    'status_code' => $latestStatusCode,
+                    'status_changed_at' => $statusSince['since'] ?? null,
+                    'status_identifier' => MonitoringStatusMeta::statusIdentifier($latestStatusCode, $maintenanceActive),
+                    'status_key' => MonitoringStatusMeta::statusKey($latestStatusCode, $maintenanceActive),
+                    'heatmap' => $heatmaps[$monitoringId] ?? [],
+                ]),
+            ];
+        });
+
+        return response()->json([
+            'data' => $data,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -18,7 +18,7 @@ class MonitoringCardDataController extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'ids' => ['required', 'array', 'min:1', 'max:25'],
+            'ids' => ['required', 'array', 'min:1'],
             'ids.*' => ['required', 'string'],
         ]);
 

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -141,6 +141,56 @@ class ApiController extends Controller
     }
 
     /**
+     * Retrieves uptime and downtime data for multiple day ranges in one request.
+     *
+     * @queryParam days[] integer[] The day ranges to retrieve. Example: [7, 30, 90]
+     *
+     * @response {
+     *   "data": {
+     *     "7": {
+     *       "has_data": true
+     *     },
+     *     "30": {
+     *       "has_data": true
+     *     }
+     *   }
+     * }
+     */
+    public function uptimeDowntimeSummary(Monitoring $monitoring, Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'days' => ['required', 'array', 'min:1', 'max:10'],
+            'days.*' => ['required', 'integer', 'min:1', 'max:3650'],
+        ]);
+
+        /** @var Collection<int, int> $days */
+        $days = collect($validated['days'])
+            ->map(static fn (mixed $day): int => (int) $day)
+            ->unique()
+            ->sort()
+            ->values();
+
+        $endDate = now()->endOfDay();
+        $cacheKey = sprintf(
+            'monitoring:%s:uptime-summary:%s:%s',
+            $monitoring->id,
+            $days->implode('-'),
+            $endDate->format('Ymd')
+        );
+
+        $data = $this->cacheAndReturn(
+            $cacheKey,
+            fn (): array => MonitoringResultService::getUptimeDowntimesForRanges($monitoring, $days->all()),
+            (int) config('monitoring.interval', 5) * 60,
+            'monitoring:' . $monitoring->id
+        );
+
+        return response()->json([
+            'data' => $data,
+        ]);
+    }
+
+    /**
      * Retrieves the response times for a given monitoring instance.
      *
      * @queryParam days integer The number of days to retrieve data for. Defaults to 30. Example: 30

--- a/app/Services/MonitoringResultService.php
+++ b/app/Services/MonitoringResultService.php
@@ -174,6 +174,129 @@ class MonitoringResultService
     }
 
     /**
+     * @param  array<int, int>  $days
+     * @return array<string, Collection{
+     *     data: array{from: Carbon, to: Carbon},
+     *     has_data: bool,
+     *     tracking_started_at: string|null,
+     *     uptime: array{minutes: int, percentage: float|null, total: int},
+     *     downtime: array{minutes: int, percentage: float|null, total: int, incidents_count: int},
+     *     unknown: array{minutes: int, percentage: float|null, total: int}
+     * }>
+     */
+    public static function getUptimeDowntimesForRanges(Monitoring $monitoring, array $days): array
+    {
+        $normalizedDays = collect($days)
+            ->map(static fn (mixed $day): ?int => is_numeric($day) ? (int) $day : null)
+            ->filter(static fn (?int $day): bool => $day !== null && $day > 0)
+            ->unique()
+            ->sort()
+            ->values();
+
+        if ($normalizedDays->isEmpty()) {
+            return [];
+        }
+
+        $now = Date::now();
+        $endDate = $now->copy()->endOfDay();
+        $requiresRawFallback = $normalizedDays->contains(static fn (int $day): bool => $day <= 1)
+            || $monitoring->created_at->diffInDays($now) < 1;
+
+        if ($requiresRawFallback) {
+            return $normalizedDays
+                ->mapWithKeys(function (int $day) use ($monitoring, $now, $endDate): array {
+                    $startDate = $now->copy()->subDays($day)->startOfDay();
+                    $loadAggregatedData = $day > 1;
+                    $includeIntradayRawData = $day <= 1;
+
+                    if ($monitoring->created_at->diffInDays($now) < 1) {
+                        $loadAggregatedData = false;
+                    }
+
+                    return [
+                        (string) $day => self::getUptimeDowntime(
+                            $monitoring,
+                            $startDate,
+                            $endDate,
+                            $loadAggregatedData,
+                            $includeIntradayRawData
+                        ),
+                    ];
+                })
+                ->all();
+        }
+
+        $trackingStartedAt = self::getTrackingStartedAtFromDailyResults($monitoring);
+
+        if (! $trackingStartedAt || $trackingStartedAt->gt($endDate)) {
+            return $normalizedDays
+                ->mapWithKeys(function (int $day) use ($now, $endDate, $trackingStartedAt): array {
+                    $startDate = $now->copy()->subDays($day)->startOfDay();
+
+                    return [
+                        (string) $day => self::buildUptimeDowntimeStats(
+                            $startDate,
+                            $endDate,
+                            $trackingStartedAt,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                        ),
+                    ];
+                })
+                ->all();
+        }
+
+        $maxRangeDays = (int) $normalizedDays->last();
+        $globalStartDate = $now->copy()->subDays($maxRangeDays)->startOfDay();
+
+        $dailyResults = $monitoring->dailyResults()
+            ->whereBetween('date', [$globalStartDate->toDateString(), $endDate->toDateString()])
+            ->get([
+                'date',
+                'uptime_minutes',
+                'downtime_minutes',
+                'unknown_minutes',
+                'uptime_total',
+                'downtime_total',
+                'unknown_total',
+                'incidents_count',
+            ]);
+
+        return $normalizedDays
+            ->mapWithKeys(function (int $day) use ($dailyResults, $endDate, $now, $trackingStartedAt): array {
+                $startDate = $now->copy()->subDays($day)->startOfDay();
+                $startDateString = $startDate->toDateString();
+                $endDateString = $endDate->toDateString();
+
+                $rangeRows = $dailyResults->filter(
+                    static fn (MonitoringDailyResult $dailyResult): bool => $dailyResult->date >= $startDateString
+                        && $dailyResult->date <= $endDateString
+                );
+
+                return [
+                    (string) $day => self::buildUptimeDowntimeStats(
+                        $startDate,
+                        $endDate,
+                        $trackingStartedAt,
+                        (int) $rangeRows->sum('uptime_minutes'),
+                        (int) $rangeRows->sum('downtime_minutes'),
+                        (int) $rangeRows->sum('unknown_minutes'),
+                        (int) $rangeRows->sum('uptime_total'),
+                        (int) $rangeRows->sum('downtime_total'),
+                        (int) $rangeRows->sum('unknown_total'),
+                        (int) $rangeRows->sum('incidents_count')
+                    ),
+                ];
+            })
+            ->all();
+    }
+
+    /**
      * Determine the time since the current monitoring status (up/down) began.
      *
      * @param  Monitoring  $monitoring  The monitoring instance to check the status for.

--- a/app/Services/MonitoringResultService.php
+++ b/app/Services/MonitoringResultService.php
@@ -50,39 +50,69 @@ class MonitoringResultService
      */
     public static function getHeatmap(Monitoring $monitoring, Carbon $startDate, Carbon $endDate): Collection
     {
-        // Enforce 24-hour window for heatmap
+        $heatmaps = self::getHeatmapsForMonitorings(collect([$monitoring]), $startDate, $endDate);
+
+        return collect($heatmaps[$monitoring->id] ?? []);
+    }
+
+    /**
+     * @param  Collection<int, Monitoring>  $monitorings
+     * @return array<string, list<array{date: Carbon, uptime: int, downtime: int, unknown: int}>>
+     */
+    public static function getHeatmapsForMonitorings(Collection $monitorings, Carbon $startDate, Carbon $endDate): array
+    {
+        if ($monitorings->isEmpty()) {
+            return [];
+        }
+
+        // Enforce 24-hour window for heatmap payloads.
         $startDate = Date::now()->subHours(23)->startOfHour();
         $endDate = Date::now()->endOfHour();
+
+        $monitoringIds = $monitorings
+            ->pluck('id')
+            ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->values();
 
         $interval = (int) config('monitoring.interval', 5);
         $periodExpression = self::getPeriodExpression('created_at', '%Y-%m-%d %H');
 
-        $raw = self::getMonitoringResponseQuery($endDate)
-            ->where('monitoring_id', $monitoring->id)
-            ->selectRaw("{$periodExpression} as period,
+        $rawByMonitoring = self::getMonitoringResponseQuery($endDate)
+            ->whereIn('monitoring_id', $monitoringIds)
+            ->selectRaw("monitoring_id, {$periodExpression} as period,
                 SUM(CASE WHEN status = 'up' THEN 1 ELSE 0 END) * {$interval} as uptime,
                 SUM(CASE WHEN status = 'down' THEN 1 ELSE 0 END) * {$interval} as downtime,
                 SUM(CASE WHEN status NOT IN ('up', 'down') THEN 1 ELSE 0 END) * {$interval} as unknown
             ")
             ->whereBetween('created_at', [$startDate, $endDate])
-            ->groupBy('period')
+            ->groupBy('monitoring_id', 'period')
             ->orderBy('period')
             ->get()
-            ->keyBy('period');
+            ->groupBy('monitoring_id')
+            ->map(static fn (Collection $rows): Collection => $rows->keyBy('period'));
 
-        return collect(
-            CarbonPeriod::create($startDate, '1 hour', $endDate)
-                ->map(function (Carbon $hour) use ($raw) {
-                    $record = $raw->get($hour->format('Y-m-d H'));
+        return $monitoringIds
+            ->mapWithKeys(function (string $monitoringId) use ($rawByMonitoring, $startDate, $endDate): array {
+                /** @var Collection<int, object> $raw */
+                $raw = $rawByMonitoring->get($monitoringId, collect());
 
-                    return [
-                        'date' => $hour,
-                        'uptime' => (int) ($record->uptime ?? 0),
-                        'downtime' => (int) ($record->downtime ?? 0),
-                        'unknown' => (int) ($record->unknown ?? 0),
-                    ];
-                })
-        );
+                $heatmap = collect(CarbonPeriod::create($startDate, '1 hour', $endDate))
+                    ->map(function (Carbon $hour) use ($raw): array {
+                        $record = $raw->get($hour->format('Y-m-d H'));
+
+                        return [
+                            'date' => $hour,
+                            'uptime' => (int) ($record->uptime ?? 0),
+                            'downtime' => (int) ($record->downtime ?? 0),
+                            'unknown' => (int) ($record->unknown ?? 0),
+                        ];
+                    })
+                    ->values()
+                    ->all();
+
+                return [$monitoringId => $heatmap];
+            })
+            ->all();
     }
 
     /**

--- a/resources/js/Components/monitoring-cards.ts
+++ b/resources/js/Components/monitoring-cards.ts
@@ -16,7 +16,6 @@ interface MonitoringCardLoaderComponent {
     lastCheckMap: Record<string, string>;
     currentLocale: string;
     updateSince(this: MonitoringCardLoaderComponent): void;
-    loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void>;
     loadAll(this: MonitoringCardLoaderComponent): Promise<void>;
     init(this: MonitoringCardLoaderComponent): void;
 }
@@ -45,31 +44,40 @@ export default (
 
     currentLocale: getCurrentDayjsLocale(),
 
-    async loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void> {
-        const statusPromise = fetch(`/api/monitorings/${monitoringId}/status`).then(res => res.ok ? res.json() : null).catch(() => null);
-        const heatmapPromise = fetch(`/api/monitorings/${monitoringId}/heatmap`).then(res => res.ok ? res.json() : null).catch(() => null);
-
-        const [statusData, heatmapData] = await Promise.all([statusPromise, heatmapPromise]);
-
-        if (statusData) {
-            this.statusMap = { ...this.statusMap, [monitoringId]: statusData.status };
-            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: statusData.since };
-            this.sinceMap = { ...this.sinceMap, [monitoringId]: statusData.since ? humanizeDistance(statusData.since, { withoutSuffix: true }) : '' };
-        }
-
-        if (heatmapData) {
-            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
-            if (heatmapContainer) {
-                renderHeatmap(heatmapContainer, heatmapData);
-            }
-        }
-    },
-
     async loadAll(this: MonitoringCardLoaderComponent): Promise<void> {
         this.hasMonitorings = this.monitoringIds.length > 0;
         if (!this.hasMonitorings) return;
 
-        await Promise.all(this.monitoringIds.map((id: string) => this.loadCard(id)));
+        const query = new URLSearchParams();
+
+        this.monitoringIds.forEach((id: string) => query.append('ids[]', id));
+
+        const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
+        if (!response?.ok) {
+            return;
+        }
+
+        const payload = await response.json() as { data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }> };
+        const cardData = payload.data ?? {};
+
+        for (const monitoringId of this.monitoringIds) {
+            const monitoringCardData = cardData[monitoringId];
+            if (!monitoringCardData) {
+                continue;
+            }
+
+            this.statusMap = { ...this.statusMap, [monitoringId]: monitoringCardData.status ?? '' };
+            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: monitoringCardData.since ?? null };
+            this.sinceMap = {
+                ...this.sinceMap,
+                [monitoringId]: monitoringCardData.since ? humanizeDistance(monitoringCardData.since, { withoutSuffix: true }) : '',
+            };
+
+            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
+            if (heatmapContainer && monitoringCardData.heatmap) {
+                renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
+            }
+        }
     },
 
     updateSince(this: MonitoringCardLoaderComponent): void {

--- a/resources/js/components/monitoring-cards.ts
+++ b/resources/js/components/monitoring-cards.ts
@@ -16,7 +16,6 @@ interface MonitoringCardLoaderComponent {
     lastCheckMap: Record<string, string>;
     currentLocale: string;
     updateSince(this: MonitoringCardLoaderComponent): void;
-    loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void>;
     loadAll(this: MonitoringCardLoaderComponent): Promise<void>;
     init(this: MonitoringCardLoaderComponent): void;
 }
@@ -45,31 +44,40 @@ export default (
 
     currentLocale: getCurrentDayjsLocale(),
 
-    async loadCard(this: MonitoringCardLoaderComponent, monitoringId: string): Promise<void> {
-        const statusPromise = fetch(`/api/monitorings/${monitoringId}/status`).then(res => res.ok ? res.json() : null).catch(() => null);
-        const heatmapPromise = fetch(`/api/monitorings/${monitoringId}/heatmap`).then(res => res.ok ? res.json() : null).catch(() => null);
-
-        const [statusData, heatmapData] = await Promise.all([statusPromise, heatmapPromise]);
-
-        if (statusData) {
-            this.statusMap = { ...this.statusMap, [monitoringId]: statusData.status };
-            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: statusData.since };
-            this.sinceMap = { ...this.sinceMap, [monitoringId]: statusData.since ? humanizeDistance(statusData.since, { withoutSuffix: true }) : '' };
-        }
-
-        if (heatmapData) {
-            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
-            if (heatmapContainer) {
-                renderHeatmap(heatmapContainer, heatmapData);
-            }
-        }
-    },
-
     async loadAll(this: MonitoringCardLoaderComponent): Promise<void> {
         this.hasMonitorings = this.monitoringIds.length > 0;
         if (!this.hasMonitorings) return;
 
-        await Promise.all(this.monitoringIds.map((id: string) => this.loadCard(id)));
+        const query = new URLSearchParams();
+
+        this.monitoringIds.forEach((id: string) => query.append('ids[]', id));
+
+        const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
+        if (!response?.ok) {
+            return;
+        }
+
+        const payload = await response.json() as { data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }> };
+        const cardData = payload.data ?? {};
+
+        for (const monitoringId of this.monitoringIds) {
+            const monitoringCardData = cardData[monitoringId];
+            if (!monitoringCardData) {
+                continue;
+            }
+
+            this.statusMap = { ...this.statusMap, [monitoringId]: monitoringCardData.status ?? '' };
+            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: monitoringCardData.since ?? null };
+            this.sinceMap = {
+                ...this.sinceMap,
+                [monitoringId]: monitoringCardData.since ? humanizeDistance(monitoringCardData.since, { withoutSuffix: true }) : '',
+            };
+
+            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
+            if (heatmapContainer && monitoringCardData.heatmap) {
+                renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
+            }
+        }
     },
 
     updateSince(this: MonitoringCardLoaderComponent): void {

--- a/resources/js/components/monitoring-detail.ts
+++ b/resources/js/components/monitoring-detail.ts
@@ -202,26 +202,30 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
 
     // Loads uptime data for predefined intervals and supplements it with downtime duration
     async loadUptime(this: MonitoringDetailComponent): Promise<void> {
-        const intervals = {
-            '7': 7,
-            '30': 30,
-            '90': 90,
-        };
+        const query = new URLSearchParams();
+        ['7', '30', '90'].forEach((days) => query.append('days[]', days));
 
-        const promises = Object.entries(intervals).map(async ([label, days]) => {
-            const uptimeData = await fetch(`/api/monitorings/${monitoringId}/uptime-downtime?days=${days}`).then(res => res.ok ? res.json() : null);
+        const response = await fetch(`/api/monitorings/${monitoringId}/uptime-downtime-summary?${query.toString()}`).catch(() => null);
 
-            if (uptimeData && uptimeData.downtime) {
-                uptimeData.downtime.human_readable = humanizeDuration(uptimeData.downtime.minutes, 'minutes');
-                uptimeData.downtime.incidents_count = Number(uptimeData.downtime.incidents_count ?? 0);
-            }
+        if (!response?.ok) {
+            this.uptimeStats = {};
 
-            return { [label]: uptimeData };
-        });
+            return;
+        }
 
-        const results = await Promise.all(promises);
+        const payload = await response.json() as { data?: Record<string, any> };
+        const summary = payload.data ?? {};
 
-        this.uptimeStats = Object.assign({}, ...results);
+        this.uptimeStats = Object.fromEntries(
+            Object.entries(summary).map(([label, uptimeData]) => {
+                if (uptimeData && uptimeData.downtime) {
+                    uptimeData.downtime.human_readable = humanizeDuration(uptimeData.downtime.minutes, 'minutes');
+                    uptimeData.downtime.incidents_count = Number(uptimeData.downtime.incidents_count ?? 0);
+                }
+
+                return [label, uptimeData];
+            })
+        );
     },
 
     // Loads uptime percentage and incident count for a custom date range.

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -15,6 +15,7 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
     Route::get('/{monitoring}/status', [ApiController::class, 'status']);
     Route::get('/{monitoring}/uptime-downtime', [ApiController::class, 'uptimeDowntime']);
+    Route::get('/{monitoring}/uptime-downtime-summary', [ApiController::class, 'uptimeDowntimeSummary']);
     Route::get('/{monitoring}/response-times', [ApiController::class, 'responseTimes']);
     Route::get('/{monitoring}/checks', [ApiController::class, 'checks']);
     Route::get('/{monitoring}/incidents', [ApiController::class, 'incidents']);

--- a/routes/api/internal.php
+++ b/routes/api/internal.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\MonitoringCardDataController;
 use App\Http\Controllers\Api\NotificationBoardController;
 use App\Http\Controllers\ApiController;
 use Illuminate\Support\Facades\Route;
@@ -9,6 +10,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/notifications/status-board', NotificationBoardController::class)->name('notifications.status-board');
 
 Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): void {
+    Route::get('/card-data', MonitoringCardDataController::class)->name('card-data');
     Route::get('/{monitoring}', [ApiController::class, 'all']);
 
     Route::get('/{monitoring}/status', [ApiController::class, 'status']);

--- a/routes/api/internal.php
+++ b/routes/api/internal.php
@@ -15,6 +15,7 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
     Route::get('/{monitoring}/status', [ApiController::class, 'status']);
     Route::get('/{monitoring}/uptime-downtime', [ApiController::class, 'uptimeDowntime']);
+    Route::get('/{monitoring}/uptime-downtime-summary', [ApiController::class, 'uptimeDowntimeSummary']);
     Route::get('/{monitoring}/response-times', [ApiController::class, 'responseTimes']);
     Route::get('/{monitoring}/checks', [ApiController::class, 'checks']);
     Route::get('/{monitoring}/incidents', [ApiController::class, 'incidents']);

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -99,6 +99,24 @@ class MonitoringCardDataApiTest extends TestCase
         $testResponse->assertJsonMissingPath('data.' . $foreignMonitoring->id);
     }
 
+    public function test_card_data_endpoint_accepts_more_than_twenty_five_requested_monitorings(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 50]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+
+        $monitorings = Monitoring::factory()->count(26)->for($user)->create();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => $monitorings->pluck('id')->all(),
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonCount(26, 'data');
+        $testResponse->assertJsonPath('data.' . $monitorings->first()->id . '.heatmap.0.uptime', 0);
+    }
+
     private function selectQueryCount(): int
     {
         return collect(DB::getQueryLog())

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MonitoringCardDataApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_card_data_endpoint_batches_monitoring_status_and_heatmap_queries(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $monitorings = Monitoring::factory()->count(3)->for($user)->create();
+
+        foreach ($monitorings as $index => $monitoring) {
+            foreach (range(0, 2) as $hourOffset) {
+                $checkedAt = Date::now()->subHours($hourOffset)->subMinutes($index + 1);
+
+                MonitoringResponse::query()->create([
+                    'monitoring_id' => $monitoring->id,
+                    'status' => $index === 1 ? MonitoringStatus::DOWN : MonitoringStatus::UP,
+                    'http_status_code' => $index === 1 ? 503 : 200,
+                    'response_time' => 120.0 + $index,
+                    'created_at' => $checkedAt,
+                    'updated_at' => $checkedAt,
+                ]);
+            }
+        }
+
+        Incident::query()->create([
+            'monitoring_id' => $monitorings[1]->id,
+            'down_at' => Date::now()->subHours(2),
+            'up_at' => null,
+            'created_at' => Date::now()->subHours(2),
+            'updated_at' => Date::now()->subHours(2),
+        ]);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        foreach ($monitorings as $monitoring) {
+            $this->actingAs($user)->getJson('/api/monitorings/' . $monitoring->id . '/status')->assertOk();
+            $this->actingAs($user)->getJson('/api/monitorings/' . $monitoring->id . '/heatmap')->assertOk();
+        }
+
+        $legacySelectCount = $this->selectQueryCount();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => $monitorings->pluck('id')->all(),
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('data.' . $monitorings[0]->id . '.status', MonitoringStatus::UP->value);
+        $testResponse->assertJsonPath('data.' . $monitorings[1]->id . '.status', MonitoringStatus::DOWN->value);
+        $testResponse->assertJsonCount(24, 'data.' . $monitorings[2]->id . '.heatmap');
+
+        $selectCount = $this->selectQueryCount();
+
+        $this->assertGreaterThan($selectCount, $legacySelectCount);
+        $this->assertLessThanOrEqual(4, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
+    }
+
+    public function test_card_data_endpoint_returns_only_requested_monitorings_for_the_authenticated_user(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ownedMonitoring = Monitoring::factory()->for($user)->create();
+        $foreignMonitoring = Monitoring::factory()->for($otherUser)->create();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => [$ownedMonitoring->id, $foreignMonitoring->id],
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('data.' . $ownedMonitoring->id . '.heatmap.0.uptime', 0);
+        $testResponse->assertJsonMissingPath('data.' . $foreignMonitoring->id);
+    }
+
+    private function selectQueryCount(): int
+    {
+        return collect(DB::getQueryLog())
+            ->filter(static fn (array $entry): bool => str_starts_with(mb_strtolower($entry['query']), 'select'))
+            ->count();
+    }
+}

--- a/tests/Feature/Api/UptimeDowntimeApiTest.php
+++ b/tests/Feature/Api/UptimeDowntimeApiTest.php
@@ -13,6 +13,7 @@ use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class UptimeDowntimeApiTest extends TestCase
@@ -152,5 +153,80 @@ class UptimeDowntimeApiTest extends TestCase
         $this->assertEqualsWithDelta((600 / 1439) * 100, (float) $testResponse->json('uptime.percentage'), 0.0001);
         $this->assertEqualsWithDelta((600 / 1439) * 100, (float) $testResponse->json('downtime.percentage'), 0.0001);
         $this->assertEqualsWithDelta((239 / 1439) * 100, (float) $testResponse->json('unknown.percentage'), 0.0001);
+    }
+
+    public function test_uptime_summary_batches_multi_range_daily_result_queries(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => Date::now()->subDays(120),
+        ]);
+
+        foreach (range(1, 90) as $daysAgo) {
+            $date = Date::now()->subDays($daysAgo)->startOfDay();
+
+            MonitoringDailyResult::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'date' => $date->toDateString(),
+                'uptime_total' => 10,
+                'downtime_total' => 1,
+                'unknown_total' => 0,
+                'uptime_percentage' => 99.0,
+                'downtime_percentage' => 1.0,
+                'unknown_percentage' => 0.0,
+                'uptime_minutes' => 1_400,
+                'downtime_minutes' => 40,
+                'unknown_minutes' => 0,
+                'avg_response_time' => 120.0,
+                'min_response_time' => 100,
+                'max_response_time' => 180,
+                'incidents_count' => 1,
+            ]);
+        }
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        foreach ([7, 30, 90] as $days) {
+            $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/uptime-downtime?days=' . $days)
+                ->assertOk();
+        }
+
+        $legacyDailyResultsQueries = $this->dailyResultsQueryCount();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $testResponse = $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/uptime-downtime-summary?' . http_build_query([
+            'days' => [7, 30, 90],
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('data.7.has_data', true);
+        $testResponse->assertJsonPath('data.30.has_data', true);
+        $testResponse->assertJsonPath('data.90.has_data', true);
+        $testResponse->assertJsonPath('data.7.uptime.minutes', 9_800);
+        $testResponse->assertJsonPath('data.30.downtime.minutes', 1_200);
+        $testResponse->assertJsonPath('data.90.downtime.incidents_count', 90);
+
+        $summaryDailyResultsQueries = $this->dailyResultsQueryCount();
+
+        $this->assertGreaterThan($summaryDailyResultsQueries, $legacyDailyResultsQueries);
+        $this->assertLessThanOrEqual(
+            2,
+            $summaryDailyResultsQueries,
+            (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL)
+        );
+    }
+
+    private function dailyResultsQueryCount(): int
+    {
+        return collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(static fn (string $query): bool => str_contains(mb_strtolower($query), 'monitoring_daily_results'))
+            ->count();
     }
 }


### PR DESCRIPTION
## What changed
- batch monitoring index card status and heatmap requests behind a single `card-data` API endpoint
- batch monitoring detail uptime summary requests for the 7/30/90 day cards behind a single `uptime-downtime-summary` API endpoint
- add regression coverage for both batched paths, including query-count assertions

## Why
The dashboard was fanning out multiple requests for data that could be fetched and aggregated together:
- the monitoring index loaded per-card status and heatmap data separately
- the monitoring detail page loaded 7, 30, and 90 day uptime summaries through separate requests that repeated `monitoring_daily_results` work

That produced avoidable request overhead and repeated database reads on high-traffic views.

## Impact
- fewer HTTP requests during monitoring dashboard and detail page load
- fewer repeated `monitoring_daily_results` queries for multi-range uptime cards
- tighter regression protection around performance-sensitive monitoring surfaces

## Validation
- `./vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Api/UptimeDowntimeApiTest.php tests/Feature/Api/MonitoringCardDataApiTest.php`

## Notes
- `bunx tsc --noEmit` still reports pre-existing frontend path/case issues outside this PR’s scope.