### PR TITLE
Fix public monitoring widget endpoint and script

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -394,6 +394,65 @@ class ApiController extends Controller
     }
 
     /**
+     * Retrieves the public embeddable widget payload for a monitoring instance.
+     *
+     * @response {
+     *   "name": "Primary API",
+     *   "status": "up",
+     *   "status_label": "UP",
+     *   "status_code": 200,
+     *   "status_identifier": "status.success",
+     *   "status_key": "notifications.status.success",
+     *   "checked_at": "2026-04-12T10:00:00Z",
+     *   "checked_at_human": "5 minutes ago",
+     *   "uptime": {
+     *     "7_days": 100,
+     *     "30_days": 99.9,
+     *     "365_days": 99.1
+     *   },
+     *   "public_url": "https://example.com/label/01H..."
+     * }
+     */
+    public function widget(Monitoring $monitoring): JsonResponse
+    {
+        abort_unless($monitoring->public_label_enabled, 404);
+
+        $cacheKey = sprintf('monitoring:%s:widget', $monitoring->id);
+
+        $data = $this->cacheAndReturn(
+            $cacheKey,
+            function () use ($monitoring): array {
+                $statusSince = MonitoringResultService::getStatusSince($monitoring);
+                $statusNow = MonitoringResultService::getStatusNow($monitoring);
+                $latestStatusCode = $monitoring->latestResponseResult?->http_status_code;
+                $status = (string) ($statusSince['status'] ?? 'unknown');
+                $checkedAt = $statusNow['checked_at'] ?? null;
+
+                return [
+                    'name' => $monitoring->name,
+                    'status' => $status,
+                    'status_label' => mb_strtoupper($status),
+                    'status_code' => $latestStatusCode,
+                    'status_identifier' => MonitoringStatusMeta::statusIdentifier($latestStatusCode, $monitoring->isUnderMaintenance()),
+                    'status_key' => MonitoringStatusMeta::statusKey($latestStatusCode, $monitoring->isUnderMaintenance()),
+                    'checked_at' => $checkedAt,
+                    'checked_at_human' => $checkedAt ? Date::parse((string) $checkedAt)->diffForHumans() : null,
+                    'uptime' => [
+                        '7_days' => $this->resolveWidgetUptimePercentage($monitoring, 7),
+                        '30_days' => $this->resolveWidgetUptimePercentage($monitoring, 30),
+                        '365_days' => $this->resolveWidgetUptimePercentage($monitoring, 365),
+                    ],
+                    'public_url' => route('public-label', $monitoring),
+                ];
+            },
+            (int) config('monitoring.interval', 5) * 60,
+            'monitoring:' . $monitoring->id
+        );
+
+        return response()->json($data);
+    }
+
+    /**
      * Retrieves the incidents for a given monitoring instance.
      *
      * @queryParam days integer The number of days to retrieve data for. Defaults to 30. Example: 30
@@ -585,6 +644,23 @@ class ApiController extends Controller
         }
 
         return $callback();
+    }
+
+    private function resolveWidgetUptimePercentage(Monitoring $monitoring, int $days): ?float
+    {
+        $startDate = Date::now()->subDays($days)->startOfDay();
+        $endDate = Date::now()->endOfDay();
+        $loadAggregatedData = $days > 1 && $monitoring->created_at->diffInDays(Date::now()) >= 1;
+
+        $stats = MonitoringResultService::getUptimeDowntime(
+            $monitoring,
+            $startDate,
+            $endDate,
+            $loadAggregatedData,
+            false
+        );
+
+        return data_get($stats, 'uptime.percentage');
     }
 
     private function buildChecksSourceQuery(

--- a/app/Models/ApiLog.php
+++ b/app/Models/ApiLog.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -24,6 +26,11 @@ use Override;
  * @property Carbon $updated_at
  * @property-read User $user
  */
+#[Fillable([
+    'user_id',
+    'route',
+])]
+#[Table(name: 'api_logs', key: 'id', keyType: 'string')]
 class ApiLog extends Model
 {
     use HasFactory;
@@ -35,37 +42,6 @@ class ApiLog extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'api_logs';
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'user_id',
-        'route',
-    ];
 
     /**
      * Get the user that owns the API log.

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -23,22 +24,16 @@ use Illuminate\Support\Carbon;
  * @property Carbon $updated_at
  * @property-read Monitoring $monitoring
  */
+#[Fillable([
+    'monitoring_id',
+    'down_at',
+    'up_at',
+
+])]
 class Incident extends Model
 {
     use HasFactory;
     use HasUlids;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'down_at',
-        'up_at',
-
-    ];
 
     /**
      * Get the monitoring that the incident belongs to.

--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -7,7 +7,9 @@ namespace App\Models;
 use App\Enums\HttpMethod;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -26,6 +28,28 @@ use Override;
  * associated with a user and having many results.
  *
  **/
+#[Fillable([
+    'user_id',
+    'name',
+    'type',
+    'target',
+    'port',
+    'keyword',
+    'status',
+    'timeout',
+    'http_method',
+    'http_headers',
+    'http_body',
+    'auth_username',
+    'auth_password',
+    'public_label_enabled',
+    'preferred_location',
+    'notification_on_failure',
+    'deleted_at',
+    'maintenance_from',
+    'maintenance_until',
+])]
+#[Table(name: 'monitorings', key: 'id', keyType: 'string')]
 class Monitoring extends Model
 {
     use HasFactory;
@@ -38,54 +62,6 @@ class Monitoring extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitorings';
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the auto-incrementing ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'user_id',
-        'name',
-        'type',
-        'target',
-        'port',
-        'keyword',
-        'status',
-        'timeout',
-        'http_method',
-        'http_headers',
-        'http_body',
-        'auth_username',
-        'auth_password',
-        'public_label_enabled',
-        'preferred_location',
-        'notification_on_failure',
-        'deleted_at',
-        'maintenance_from',
-        'maintenance_until',
-    ];
 
     /**
      * Get the user that owns the monitoring.

--- a/app/Models/MonitoringDailyResult.php
+++ b/app/Models/MonitoringDailyResult.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -36,27 +37,26 @@ use Illuminate\Support\Carbon;
  * Raw monitoring data is processed daily and summarized into this table
  * to optimize performance for historical data retrieval and reporting.
  */
+#[Fillable([
+    'monitoring_id',
+    'date',
+    'uptime_total',
+    'downtime_total',
+    'unknown_total',
+    'uptime_percentage',
+    'downtime_percentage',
+    'unknown_percentage',
+    'uptime_minutes',
+    'downtime_minutes',
+    'unknown_minutes',
+    'avg_response_time',
+    'min_response_time',
+    'max_response_time',
+    'incidents_count',
+])]
 class MonitoringDailyResult extends Model
 {
     use HasFactory;
-
-    protected $fillable = [
-        'monitoring_id',
-        'date',
-        'uptime_total',
-        'downtime_total',
-        'unknown_total',
-        'uptime_percentage',
-        'downtime_percentage',
-        'unknown_percentage',
-        'uptime_minutes',
-        'downtime_minutes',
-        'unknown_minutes',
-        'avg_response_time',
-        'min_response_time',
-        'max_response_time',
-        'incidents_count',
-    ];
 
     /**
      * @return BelongsTo<Monitoring, $this>

--- a/app/Models/MonitoringNotification.php
+++ b/app/Models/MonitoringNotification.php
@@ -6,7 +6,10 @@ namespace App\Models;
 
 use App\Enums\NotificationType;
 use App\Models\Scopes\UserScope;
+use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -14,6 +17,15 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Appends(['created_at_for_humans', 'translated_message'])]
+#[Fillable([
+    'monitoring_id',
+    'type',
+    'message',
+    'read',
+    'sent',
+])]
+#[Table(name: 'monitoring_notifications', key: 'id', keyType: 'string')]
 class MonitoringNotification extends Model
 {
     use HasFactory;
@@ -25,42 +37,6 @@ class MonitoringNotification extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    protected $table = 'monitoring_notifications';
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the auto-incrementing ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'type',
-        'message',
-        'read',
-        'sent',
-    ];
-
-    /**
-     * The accessors to append to the model's array form.
-     *
-     * @var array
-     */
-    protected $appends = ['created_at_for_humans', 'translated_message'];
 
     public static function extractStatusChangeIdentifierFromMessage(string $message): string
     {

--- a/app/Models/MonitoringResponse.php
+++ b/app/Models/MonitoringResponse.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\MonitoringStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -26,6 +28,13 @@ use Illuminate\Support\Carbon;
  * @property-read Monitoring $monitoring
  * @property-read User $user
  */
+#[Fillable([
+    'monitoring_id',
+    'status',
+    'http_status_code',
+    'response_time',
+])]
+#[Table(name: 'monitoring_response_results', key: 'id', keyType: 'string')]
 class MonitoringResponse extends Model
 {
     use HasFactory;
@@ -37,39 +46,6 @@ class MonitoringResponse extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The data type of the primary key.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitoring_response_results';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'status',
-        'http_status_code',
-        'response_time',
-    ];
 
     /**
      * Get the monitoring instance that this result belongs to.

--- a/app/Models/MonitoringResponseArchived.php
+++ b/app/Models/MonitoringResponseArchived.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Fillable([
+    'id',
+    'monitoring_id',
+    'status',
+    'http_status_code',
+    'response_time',
+    'created_at',
+    'updated_at',
+])]
+#[Table(name: 'monitoring_response_archived', key: 'id', keyType: 'string')]
 class MonitoringResponseArchived extends Model
 {
     use HasFactory;
@@ -18,42 +30,6 @@ class MonitoringResponseArchived extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitoring_response_archived';
-
-    /**
-     * The primary key for the model.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the auto-incrementing ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'id',
-        'monitoring_id',
-        'status',
-        'http_status_code',
-        'response_time',
-        'created_at',
-        'updated_at',
-    ];
 
     /**
      * Get the monitoring that owns the archived response.

--- a/app/Models/MonitoringSslResult.php
+++ b/app/Models/MonitoringSslResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -27,6 +29,14 @@ use Illuminate\Support\Carbon;
  * @property-read Monitoring $monitoring
  * @property-read User $user
  */
+#[Fillable([
+    'monitoring_id',
+    'expires_at',
+    'is_valid',
+    'issuer',
+    'issued_at',
+])]
+#[Table(name: 'monitoring_ssl_results', key: 'id', keyType: 'string')]
 class MonitoringSslResult extends Model
 {
     use HasFactory;
@@ -38,40 +48,6 @@ class MonitoringSslResult extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The data type of the primary key.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitoring_ssl_results';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'expires_at',
-        'is_valid',
-        'issuer',
-        'issued_at',
-    ];
 
     /**
      * Get the monitoring instance that this result belongs to.

--- a/app/Models/NotificationChannelDelivery.php
+++ b/app/Models/NotificationChannelDelivery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\NotificationDeliveryStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -22,6 +23,16 @@ use Illuminate\Support\Carbon;
  * @property string|null $error_message
  * @property Carbon|null $sent_at
  */
+#[Fillable([
+    'user_id',
+    'monitoring_notification_id',
+    'channel',
+    'event_type',
+    'status',
+    'payload',
+    'error_message',
+    'sent_at',
+])]
 class NotificationChannelDelivery extends Model
 {
     use HasFactory;
@@ -47,20 +58,6 @@ class NotificationChannelDelivery extends Model
      * @var string
      */
     protected $keyType = 'string';
-
-    /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'user_id',
-        'monitoring_notification_id',
-        'channel',
-        'event_type',
-        'status',
-        'payload',
-        'error_message',
-        'sent_at',
-    ];
 
     /**
      * @return BelongsTo<User, $this>

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -24,6 +25,11 @@ use Illuminate\Support\Carbon;
  * @property Carbon $updated_at
  * @property-read Collection<int, User> $users
  */
+#[Fillable([
+    'monitoring_limit',
+    'price',
+    'is_selectable',
+])]
 class Package extends Model
 {
     use HasFactory, HasUlids;
@@ -31,17 +37,6 @@ class Package extends Model
     public $incrementing = false;
 
     protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_limit',
-        'price',
-        'is_selectable',
-    ];
 
     /**
      * Get the cheapest selectable package available.

--- a/app/Models/ServerInstance.php
+++ b/app/Models/ServerInstance.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -13,6 +15,15 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Hash;
 
+#[Fillable([
+    'code',
+    'ip_address',
+    'api_key_hash',
+    'is_active',
+])]
+#[Hidden([
+    'api_key_hash',
+])]
 class ServerInstance extends Model
 {
     use HasFactory;
@@ -21,23 +32,6 @@ class ServerInstance extends Model
     public $incrementing = false;
 
     protected $keyType = 'string';
-
-    /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'code',
-        'ip_address',
-        'api_key_hash',
-        'is_active',
-    ];
-
-    /**
-     * @var array<int, string>
-     */
-    protected $hidden = [
-        'api_key_hash',
-    ];
 
     /**
      * @return HasMany<Monitoring, $this>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,8 @@ namespace App\Models;
 
 use App\Enums\UserRole;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -50,45 +52,33 @@ use Laravel\Sanctum\PersonalAccessToken;
  * @method static Builder|static newQuery()
  * @method static Builder|static query()
  */
+#[Fillable([
+    'name',
+    'email',
+    'password',
+    'role',
+    'terms_accepted_at',
+    'privacy_accepted_at',
+    'package_id',
+    'locale',
+    'theme',
+    'github_id',
+    'github_token',
+    'github_refresh_token',
+    'avatar',
+    'notification_channels',
+    'notification_channels_hint_seen_at',
+])]
+#[Hidden([
+    'password',
+    'remember_token',
+])]
 class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens;
     use HasFactory;
     use HasUlids;
     use Notifiable;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-        'role',
-        'terms_accepted_at',
-        'privacy_accepted_at',
-        'package_id',
-        'locale',
-        'theme',
-        'github_id',
-        'github_token',
-        'github_refresh_token',
-        'avatar',
-        'notification_channels',
-        'notification_channels_hint_seen_at',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array<int, string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
 
     /**
      * Get all monitorings that belong to the user.

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
@@ -83,6 +83,6 @@ return [
     'middleware' => [
         'authenticate_session' => AuthenticateSession::class,
         'encrypt_cookies' => EncryptCookies::class,
-        'validate_csrf_token' => ValidateCsrfToken::class,
+        'validate_csrf_token' => PreventRequestForgery::class,
     ],
 ];

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -3,17 +3,27 @@ if (!window.webguardWidgetInitialized) {
 
     (() => {
         const widgetContainer = document.getElementById('webguard-widget');
-        const monitoringId = widgetContainer.dataset.monitoring;
-
-        if (!monitoringId) {
-            console.error("WebGuard Widget: 'data-monitoring' attribute is missing on the script tag.");
-            return;
-        }
 
         if (!widgetContainer) {
             console.error("WebGuard Widget: Element with ID 'webguard-widget' not found.");
             return;
         }
+
+        const monitoringId = widgetContainer.dataset.monitoring;
+        const scriptSource = document.currentScript?.src;
+
+        if (!monitoringId) {
+            console.error("WebGuard Widget: 'data-monitoring' attribute is missing on the widget container.");
+            return;
+        }
+
+        if (!scriptSource) {
+            console.error('WebGuard Widget: Unable to determine the widget script source.');
+            return;
+        }
+
+        const appBaseUrl = new URL(scriptSource);
+        const apiUrl = new URL(`/api/public/monitorings/${encodeURIComponent(monitoringId)}/widget`, appBaseUrl).toString();
 
         // Inject CSS
         const style = document.createElement('style');
@@ -69,6 +79,10 @@ if (!window.webguardWidgetInitialized) {
                 color: #a71d2a;
                 background-color: #ffe6e6;
             }
+            .wg-status-unknown {
+                color: #7c5e10;
+                background-color: #fff3cd;
+            }
             .wg-info-line {
                 font-size: 0.95rem;
                 color: #555555;
@@ -115,8 +129,6 @@ if (!window.webguardWidgetInitialized) {
         `;
         document.head.appendChild(style);
 
-        const apiUrl = `https://webguard.m-breuer.dev/api/v1/monitorings/${monitoringId}/widget/`;
-
         const fetchAndRenderWidget = () => {
             widgetContainer.innerHTML = '<p class="wg-info-line">Loading WebGuard Widget...</p>';
 
@@ -128,18 +140,23 @@ if (!window.webguardWidgetInitialized) {
                     return response.json();
                 })
                 .then(data => {
+                    const status = typeof data.status === 'string' ? data.status : 'unknown';
+                    const statusLabel = typeof data.status_label === 'string' ? data.status_label : status.toUpperCase();
+                    const lastChecked = data.checked_at_human ?? 'No checks yet';
+                    const formatUptime = (value) => typeof value === 'number' ? `${value.toFixed(2)}%` : 'N/A';
+
                     widgetContainer.innerHTML = `
                         <div class="wg-widget-container">
                             <h3 class="wg-heading">${data.name}</h3>
-                            <p class="wg-status-line"><span class="wg-label">Status:</span> <span class="wg-status-text wg-status-${data.status === 'UP' ? 'up' : 'down'}">${data.status}</span></p>
-                            <p class="wg-info-line"><span class="wg-label">Last Checked:</span> ${data.last_checked_at}</p>
+                            <p class="wg-status-line"><span class="wg-label">Status:</span> <span class="wg-status-text wg-status-${status}">${statusLabel}</span></p>
+                            <p class="wg-info-line"><span class="wg-label">Last Checked:</span> ${lastChecked}</p>
                             <div class="wg-uptime-grid">
-                                <p class="wg-uptime-item"><span class="wg-label">Uptime (7 Days):</span> ${data.uptime['7_days']}%</p>
-                                <p class="wg-uptime-item"><span class="wg-label">Uptime (30 Days):</span> ${data.uptime['30_days']}%</p>
-                                <p class="wg-uptime-item"><span class="wg-label">Uptime (365 Days):</span> ${data.uptime['365_days']}%</p>
+                                <p class="wg-uptime-item"><span class="wg-label">Uptime (7 Days):</span> ${formatUptime(data.uptime?.['7_days'])}</p>
+                                <p class="wg-uptime-item"><span class="wg-label">Uptime (30 Days):</span> ${formatUptime(data.uptime?.['30_days'])}</p>
+                                <p class="wg-uptime-item"><span class="wg-label">Uptime (365 Days):</span> ${formatUptime(data.uptime?.['365_days'])}</p>
                             </div>
                             <div class="wg-footer">
-                                <a href="https://webguard.m-breuer.dev" target="_blank" class="wg-footer-link">Powered by WebGuard</a>
+                                <a href="${appBaseUrl.origin}" target="_blank" class="wg-footer-link">Powered by WebGuard</a>
                             </div>
                         </div>
                     `;

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,8 +2,12 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\ApiController;
 use App\Http\Middleware\TrackApiUsage;
 use Illuminate\Support\Facades\Route;
+
+Route::get('/public/monitorings/{monitoring}/widget', [ApiController::class, 'widget'])
+    ->name('public.monitorings.widget');
 
 Route::group(['prefix' => 'v1', 'as' => 'v1.', 'middleware' => ['auth:sanctum', TrackApiUsage::class]], function (): void {
     require __DIR__ . '/api/external.php';

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class PublicMonitoringWidgetApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_widget_endpoint_returns_public_monitoring_payload_without_authentication(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subDays(10),
+        ]);
+
+        $checkedAt = Date::now()->subMinutes(5);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 123.4,
+            'created_at' => $checkedAt,
+            'updated_at' => $checkedAt,
+        ]);
+
+        MonitoringDailyResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'date' => Date::now()->subDays(2)->toDateString(),
+            'uptime_total' => 1,
+            'downtime_total' => 0,
+            'unknown_total' => 0,
+            'uptime_percentage' => 100,
+            'downtime_percentage' => 0,
+            'unknown_percentage' => 0,
+            'uptime_minutes' => 24 * 60,
+            'downtime_minutes' => 0,
+            'unknown_minutes' => 0,
+            'avg_response_time' => 123.4,
+            'min_response_time' => 123.4,
+            'max_response_time' => 123.4,
+            'incidents_count' => 0,
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('name', 'Primary API');
+        $testResponse->assertJsonPath('status', MonitoringStatus::UP->value);
+        $testResponse->assertJsonPath('status_label', 'UP');
+        $testResponse->assertJsonPath('status_code', 200);
+        $testResponse->assertJsonPath('status_identifier', 'status.success');
+        $testResponse->assertJsonPath('public_url', route('public-label', $monitoring));
+        $this->assertIsNumeric($testResponse->json('uptime.7_days'));
+        $this->assertIsNumeric($testResponse->json('uptime.30_days'));
+        $this->assertIsNumeric($testResponse->json('uptime.365_days'));
+    }
+
+    public function test_public_widget_endpoint_returns_not_found_when_public_label_is_disabled(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'public_label_enabled' => false,
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertNotFound();
+    }
+}

--- a/tests/Feature/WidgetScriptRouteTest.php
+++ b/tests/Feature/WidgetScriptRouteTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class WidgetScriptRouteTest extends TestCase
+{
+    public function test_widget_script_uses_public_widget_endpoint_without_hard_coded_environment_domain(): void
+    {
+        $testResponse = $this->get(route('widget.js'));
+
+        $testResponse->assertOk();
+        $this->assertStringContainsString('/api/public/monitorings/', $testResponse->getContent());
+        $this->assertStringNotContainsString('webguard.m-breuer.dev', $testResponse->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- add a public widget JSON endpoint for monitorings with public labels enabled
- update the shipped widget script to use the script origin instead of a hard-coded production domain
- cover the public widget API and script route with regression tests

## Motivation
The embeddable monitoring widget was advertised in the product UI, but the shipped script pointed at a hard-coded `/api/v1/monitorings/{id}/widget/` endpoint that is not implemented in this repository and could also fail on non-production hosts.

## Testing
- `php artisan test tests/Feature/Api`
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php tests/Feature/WidgetScriptRouteTest.php`
- `node --check public/js/widget.js`

## Rollout Notes
- Widget payloads are only available for monitorings with `public_label_enabled` enabled.
- Existing embed snippets keep working and now resolve against the same origin as the served widget script.