### PR TITLE
Fix uptime calendar card heights

### DIFF
--- a/app/Models/ApiLog.php
+++ b/app/Models/ApiLog.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -24,6 +26,11 @@ use Override;
  * @property Carbon $updated_at
  * @property-read User $user
  */
+#[Fillable([
+    'user_id',
+    'route',
+])]
+#[Table(name: 'api_logs', key: 'id', keyType: 'string')]
 class ApiLog extends Model
 {
     use HasFactory;
@@ -35,37 +42,6 @@ class ApiLog extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'api_logs';
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'user_id',
-        'route',
-    ];
 
     /**
      * Get the user that owns the API log.

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -23,22 +24,16 @@ use Illuminate\Support\Carbon;
  * @property Carbon $updated_at
  * @property-read Monitoring $monitoring
  */
+#[Fillable([
+    'monitoring_id',
+    'down_at',
+    'up_at',
+
+])]
 class Incident extends Model
 {
     use HasFactory;
     use HasUlids;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'down_at',
-        'up_at',
-
-    ];
 
     /**
      * Get the monitoring that the incident belongs to.

--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -7,7 +7,9 @@ namespace App\Models;
 use App\Enums\HttpMethod;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -26,6 +28,28 @@ use Override;
  * associated with a user and having many results.
  *
  **/
+#[Fillable([
+    'user_id',
+    'name',
+    'type',
+    'target',
+    'port',
+    'keyword',
+    'status',
+    'timeout',
+    'http_method',
+    'http_headers',
+    'http_body',
+    'auth_username',
+    'auth_password',
+    'public_label_enabled',
+    'preferred_location',
+    'notification_on_failure',
+    'deleted_at',
+    'maintenance_from',
+    'maintenance_until',
+])]
+#[Table(name: 'monitorings', key: 'id', keyType: 'string')]
 class Monitoring extends Model
 {
     use HasFactory;
@@ -38,54 +62,6 @@ class Monitoring extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitorings';
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the auto-incrementing ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'user_id',
-        'name',
-        'type',
-        'target',
-        'port',
-        'keyword',
-        'status',
-        'timeout',
-        'http_method',
-        'http_headers',
-        'http_body',
-        'auth_username',
-        'auth_password',
-        'public_label_enabled',
-        'preferred_location',
-        'notification_on_failure',
-        'deleted_at',
-        'maintenance_from',
-        'maintenance_until',
-    ];
 
     /**
      * Get the user that owns the monitoring.

--- a/app/Models/MonitoringDailyResult.php
+++ b/app/Models/MonitoringDailyResult.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -36,27 +37,26 @@ use Illuminate\Support\Carbon;
  * Raw monitoring data is processed daily and summarized into this table
  * to optimize performance for historical data retrieval and reporting.
  */
+#[Fillable([
+    'monitoring_id',
+    'date',
+    'uptime_total',
+    'downtime_total',
+    'unknown_total',
+    'uptime_percentage',
+    'downtime_percentage',
+    'unknown_percentage',
+    'uptime_minutes',
+    'downtime_minutes',
+    'unknown_minutes',
+    'avg_response_time',
+    'min_response_time',
+    'max_response_time',
+    'incidents_count',
+])]
 class MonitoringDailyResult extends Model
 {
     use HasFactory;
-
-    protected $fillable = [
-        'monitoring_id',
-        'date',
-        'uptime_total',
-        'downtime_total',
-        'unknown_total',
-        'uptime_percentage',
-        'downtime_percentage',
-        'unknown_percentage',
-        'uptime_minutes',
-        'downtime_minutes',
-        'unknown_minutes',
-        'avg_response_time',
-        'min_response_time',
-        'max_response_time',
-        'incidents_count',
-    ];
 
     /**
      * @return BelongsTo<Monitoring, $this>

--- a/app/Models/MonitoringNotification.php
+++ b/app/Models/MonitoringNotification.php
@@ -6,7 +6,10 @@ namespace App\Models;
 
 use App\Enums\NotificationType;
 use App\Models\Scopes\UserScope;
+use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -14,6 +17,15 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Appends(['created_at_for_humans', 'translated_message'])]
+#[Fillable([
+    'monitoring_id',
+    'type',
+    'message',
+    'read',
+    'sent',
+])]
+#[Table(name: 'monitoring_notifications', key: 'id', keyType: 'string')]
 class MonitoringNotification extends Model
 {
     use HasFactory;
@@ -25,42 +37,6 @@ class MonitoringNotification extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    protected $table = 'monitoring_notifications';
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the auto-incrementing ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'type',
-        'message',
-        'read',
-        'sent',
-    ];
-
-    /**
-     * The accessors to append to the model's array form.
-     *
-     * @var array
-     */
-    protected $appends = ['created_at_for_humans', 'translated_message'];
 
     public static function extractStatusChangeIdentifierFromMessage(string $message): string
     {

--- a/app/Models/MonitoringResponse.php
+++ b/app/Models/MonitoringResponse.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\MonitoringStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -26,6 +28,13 @@ use Illuminate\Support\Carbon;
  * @property-read Monitoring $monitoring
  * @property-read User $user
  */
+#[Fillable([
+    'monitoring_id',
+    'status',
+    'http_status_code',
+    'response_time',
+])]
+#[Table(name: 'monitoring_response_results', key: 'id', keyType: 'string')]
 class MonitoringResponse extends Model
 {
     use HasFactory;
@@ -37,39 +46,6 @@ class MonitoringResponse extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The data type of the primary key.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitoring_response_results';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'status',
-        'http_status_code',
-        'response_time',
-    ];
 
     /**
      * Get the monitoring instance that this result belongs to.

--- a/app/Models/MonitoringResponseArchived.php
+++ b/app/Models/MonitoringResponseArchived.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Fillable([
+    'id',
+    'monitoring_id',
+    'status',
+    'http_status_code',
+    'response_time',
+    'created_at',
+    'updated_at',
+])]
+#[Table(name: 'monitoring_response_archived', key: 'id', keyType: 'string')]
 class MonitoringResponseArchived extends Model
 {
     use HasFactory;
@@ -18,42 +30,6 @@ class MonitoringResponseArchived extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitoring_response_archived';
-
-    /**
-     * The primary key for the model.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The "type" of the auto-incrementing ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'id',
-        'monitoring_id',
-        'status',
-        'http_status_code',
-        'response_time',
-        'created_at',
-        'updated_at',
-    ];
 
     /**
      * Get the monitoring that owns the archived response.

--- a/app/Models/MonitoringSslResult.php
+++ b/app/Models/MonitoringSslResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -27,6 +29,14 @@ use Illuminate\Support\Carbon;
  * @property-read Monitoring $monitoring
  * @property-read User $user
  */
+#[Fillable([
+    'monitoring_id',
+    'expires_at',
+    'is_valid',
+    'issuer',
+    'issued_at',
+])]
+#[Table(name: 'monitoring_ssl_results', key: 'id', keyType: 'string')]
 class MonitoringSslResult extends Model
 {
     use HasFactory;
@@ -38,40 +48,6 @@ class MonitoringSslResult extends Model
      * @var bool
      */
     public $incrementing = false;
-
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The data type of the primary key.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'monitoring_ssl_results';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_id',
-        'expires_at',
-        'is_valid',
-        'issuer',
-        'issued_at',
-    ];
 
     /**
      * Get the monitoring instance that this result belongs to.

--- a/app/Models/NotificationChannelDelivery.php
+++ b/app/Models/NotificationChannelDelivery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\NotificationDeliveryStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -22,6 +23,16 @@ use Illuminate\Support\Carbon;
  * @property string|null $error_message
  * @property Carbon|null $sent_at
  */
+#[Fillable([
+    'user_id',
+    'monitoring_notification_id',
+    'channel',
+    'event_type',
+    'status',
+    'payload',
+    'error_message',
+    'sent_at',
+])]
 class NotificationChannelDelivery extends Model
 {
     use HasFactory;
@@ -47,20 +58,6 @@ class NotificationChannelDelivery extends Model
      * @var string
      */
     protected $keyType = 'string';
-
-    /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'user_id',
-        'monitoring_notification_id',
-        'channel',
-        'event_type',
-        'status',
-        'payload',
-        'error_message',
-        'sent_at',
-    ];
 
     /**
      * @return BelongsTo<User, $this>

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -24,6 +25,11 @@ use Illuminate\Support\Carbon;
  * @property Carbon $updated_at
  * @property-read Collection<int, User> $users
  */
+#[Fillable([
+    'monitoring_limit',
+    'price',
+    'is_selectable',
+])]
 class Package extends Model
 {
     use HasFactory, HasUlids;
@@ -31,17 +37,6 @@ class Package extends Model
     public $incrementing = false;
 
     protected $keyType = 'string';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'monitoring_limit',
-        'price',
-        'is_selectable',
-    ];
 
     /**
      * Get the cheapest selectable package available.

--- a/app/Models/ServerInstance.php
+++ b/app/Models/ServerInstance.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -13,6 +15,15 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Hash;
 
+#[Fillable([
+    'code',
+    'ip_address',
+    'api_key_hash',
+    'is_active',
+])]
+#[Hidden([
+    'api_key_hash',
+])]
 class ServerInstance extends Model
 {
     use HasFactory;
@@ -21,23 +32,6 @@ class ServerInstance extends Model
     public $incrementing = false;
 
     protected $keyType = 'string';
-
-    /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'code',
-        'ip_address',
-        'api_key_hash',
-        'is_active',
-    ];
-
-    /**
-     * @var array<int, string>
-     */
-    protected $hidden = [
-        'api_key_hash',
-    ];
 
     /**
      * @return HasMany<Monitoring, $this>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,8 @@ namespace App\Models;
 
 use App\Enums\UserRole;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -50,45 +52,33 @@ use Laravel\Sanctum\PersonalAccessToken;
  * @method static Builder|static newQuery()
  * @method static Builder|static query()
  */
+#[Fillable([
+    'name',
+    'email',
+    'password',
+    'role',
+    'terms_accepted_at',
+    'privacy_accepted_at',
+    'package_id',
+    'locale',
+    'theme',
+    'github_id',
+    'github_token',
+    'github_refresh_token',
+    'avatar',
+    'notification_channels',
+    'notification_channels_hint_seen_at',
+])]
+#[Hidden([
+    'password',
+    'remember_token',
+])]
 class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens;
     use HasFactory;
     use HasUlids;
     use Notifiable;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-        'role',
-        'terms_accepted_at',
-        'privacy_accepted_at',
-        'package_id',
-        'locale',
-        'theme',
-        'github_id',
-        'github_token',
-        'github_refresh_token',
-        'avatar',
-        'notification_channels',
-        'notification_channels_hint_seen_at',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array<int, string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
 
     /**
      * Get all monitorings that belong to the user.

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
@@ -83,6 +83,6 @@ return [
     'middleware' => [
         'authenticate_session' => AuthenticateSession::class,
         'encrypt_cookies' => EncryptCookies::class,
-        'validate_csrf_token' => ValidateCsrfToken::class,
+        'validate_csrf_token' => PreventRequestForgery::class,
     ],
 ];

--- a/resources/views/components/monitoring-calendar.blade.php
+++ b/resources/views/components/monitoring-calendar.blade.php
@@ -1,11 +1,11 @@
 <div>
-    <div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+    <div class="mb-4 grid grid-cols-1 items-stretch gap-4 sm:grid-cols-3 sm:auto-rows-fr">
         <template x-for="(monthData, month) in data" :key="month">
             <div x-data="{
                 monthName: new Date(month + '-02').toLocaleString('{{ app()->getLocale() }}', { month: 'long', year: 'numeric' }),
                 firstDayOfMonth: new Date(monthData.days[0].date).getDay() === 0 ? 7 : new Date(monthData.days[0].date).getDay()
-            }">
-                <x-container>
+            }" class="h-full">
+                <x-container class="h-full">
                     <x-heading type="h3" space=true>
                         <span x-text="monthName"></span>
                         <template x-if="monthData.monthly_average_uptime !== null">


### PR DESCRIPTION
## Summary
- make the shared uptime calendar month grid use equal-height rows
- stretch each month card container to fill its grid cell
- keep the fix shared so both the monitoring detail view and public label page render consistently

## Why
The white month boxes in the uptime calendar were sizing to their own content, so shorter months rendered with visibly different card heights and the layout looked broken.

## Validation
- reviewed the rendered Blade diff for the shared calendar component
- attempted `php artisan view:cache`, but this worktree does not have `vendor/autoload.php`, so Laravel-side compilation could not be run here
