### PR TITLE
test: cover public widget fallback payload

### DIFF
--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -88,4 +88,34 @@ class PublicMonitoringWidgetApiTest extends TestCase
 
         $testResponse->assertNotFound();
     }
+
+    public function test_public_widget_endpoint_returns_unknown_state_when_monitoring_has_no_results_yet(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Fresh API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subMinutes(30),
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('name', 'Fresh API');
+        $testResponse->assertJsonPath('status', MonitoringStatus::UNKNOWN->value);
+        $testResponse->assertJsonPath('status_label', 'UNKNOWN');
+        $testResponse->assertJsonPath('status_code', null);
+        $testResponse->assertJsonPath('status_identifier', 'status.unknown');
+        $testResponse->assertJsonPath('status_key', 'notifications.status.unknown');
+        $testResponse->assertJsonPath('checked_at', null);
+        $testResponse->assertJsonPath('checked_at_human', null);
+        $testResponse->assertJsonPath('uptime.7_days', null);
+        $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.365_days', null);
+    }
 }


### PR DESCRIPTION
## What changed
- adds a focused regression test for the public widget endpoint when a monitoring is public but has no response history yet
- asserts the endpoint returns the expected unknown-state metadata and null uptime/check timestamps

## Why
The recent public widget API work added a fallback path for monitors with no checks yet, but the existing test coverage only exercised the enabled/disabled public-label cases.

## Impact
This keeps the recent widget API change covered without broadening scope beyond the new endpoint behavior.

## Validation
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php`