### PR TITLE
fix(api): require auth for monitoring card batches

### DIFF
--- a/routes/api/internal.php
+++ b/routes/api/internal.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/notifications/status-board', NotificationBoardController::class)->name('notifications.status-board');
 
 Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): void {
-    Route::get('/card-data', MonitoringCardDataController::class)->name('card-data');
+    Route::get('/card-data', MonitoringCardDataController::class)->middleware('auth')->name('card-data');
     Route::get('/{monitoring}', [ApiController::class, 'all']);
 
     Route::get('/{monitoring}/status', [ApiController::class, 'status']);

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -117,6 +117,20 @@ class MonitoringCardDataApiTest extends TestCase
         $testResponse->assertJsonPath('data.' . $monitorings->first()->id . '.heatmap.0.uptime', 0);
     }
 
+    public function test_card_data_endpoint_requires_authentication(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $monitoring = Monitoring::factory()->create();
+
+        $testResponse = $this->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => [$monitoring->id],
+        ]));
+
+        $testResponse->assertStatus(401);
+    }
+
     private function selectQueryCount(): int
     {
         return collect(DB::getQueryLog())

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -128,7 +128,7 @@ class MonitoringCardDataApiTest extends TestCase
             'ids' => [$monitoring->id],
         ]));
 
-        $testResponse->assertStatus(401);
+        $testResponse->assertUnauthorized();
     }
 
     private function selectQueryCount(): int


### PR DESCRIPTION
## Summary
- require authentication for the new `/api/monitorings/card-data` endpoint
- add a regression test that asserts guests receive `401`

## Why
`3b7fc833b31011c3b35ad0b9aa45e7e1eacfd27a` added the bulk monitoring card endpoint under the internal web API route group at `/api/monitorings/card-data`.

That route was reachable without the `auth` middleware, while `App\Models\Monitoring` only applies its ownership scope when `Auth::check()` is true. For guest requests, the scope does not apply, so the new batch endpoint could return monitoring data outside an authenticated user context.

## Impact
This restores the expected access control for bulk monitoring card fetches without changing the existing maintenance-sensitive legacy internal routes.

## Validation
- `php -l routes/api/internal.php`
- `php -l tests/Feature/Api/MonitoringCardDataApiTest.php`

## Notes
The full Laravel feature suite was not runnable in this worktree because `vendor/autoload.php` is missing.