### PR TITLE
fix: restore auth enforcement for monitoring card data

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -17,6 +17,12 @@ class MonitoringCardDataController extends Controller
 {
     public function __invoke(Request $request): JsonResponse
     {
+        if (! $request->user()) {
+            return response()->json([
+                'message' => 'Unauthenticated.',
+            ], 401);
+        }
+
         $validated = $request->validate([
             'ids' => ['required', 'array', 'min:1'],
             'ids.*' => ['required', 'string'],

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -122,7 +122,8 @@ class MonitoringCardDataApiTest extends TestCase
         Date::setTestNow('2026-04-12 12:00:00');
 
         Package::factory()->create();
-        $monitoring = Monitoring::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
 
         $testResponse = $this->getJson('/api/monitorings/card-data?' . http_build_query([
             'ids' => [$monitoring->id],


### PR DESCRIPTION
## What changed
- return a JSON `401` from the monitoring card-data endpoint when no authenticated user is present
- update the authentication coverage test to create a monitoring with a real owner so it matches the non-null `monitorings.user_id` schema

## Why
The pipeline failure exposed two issues in the same path:
- the unauthenticated test was creating a monitoring without `user_id`
- guest requests could still receive card-data payloads instead of being rejected

## Impact
- restores the expected auth contract for `/api/monitorings/card-data`
- keeps the test aligned with the current schema constraints
- prevents guest access to batched monitoring card data

## Validation
- `php artisan test tests/Feature/Api/MonitoringCardDataApiTest.php`
- `php artisan test`