### PR TITLE
test(api): cover public widget maintenance fallback payload

### DIFF
--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -118,4 +118,36 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('uptime.30_days', null);
         $testResponse->assertJsonPath('uptime.365_days', null);
     }
+
+    public function test_public_widget_endpoint_returns_maintenance_meta_when_monitoring_has_no_results_yet(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Fresh API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subMinutes(30),
+            'maintenance_from' => Date::now()->subMinutes(10),
+            'maintenance_until' => Date::now()->addMinutes(20),
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('name', 'Fresh API');
+        $testResponse->assertJsonPath('status', MonitoringStatus::UNKNOWN->value);
+        $testResponse->assertJsonPath('status_label', 'UNKNOWN');
+        $testResponse->assertJsonPath('status_code', null);
+        $testResponse->assertJsonPath('status_identifier', 'status.maintenance');
+        $testResponse->assertJsonPath('status_key', 'notifications.status.maintenance');
+        $testResponse->assertJsonPath('checked_at', null);
+        $testResponse->assertJsonPath('checked_at_human', null);
+        $testResponse->assertJsonPath('uptime.7_days', null);
+        $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.365_days', null);
+    }
 }


### PR DESCRIPTION
## What changed
- added a focused feature test for the public widget payload when a monitoring has no results yet but is currently under maintenance
- asserted that the widget keeps the fallback `unknown` status while exposing maintenance-specific `status_identifier` and `status_key`

## Why
The recent widget fallback coverage only exercised the plain no-results case. This adds coverage for the adjacent maintenance branch in the same payload path.

## Impact
This is test-only and narrows regression risk around public monitoring widget metadata.

## Validation
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php`