### PR TITLE
test: cover widget maintenance payload

### DIFF
--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -153,4 +153,36 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('status_identifier', 'status.maintenance');
         $testResponse->assertJsonPath('status_key', 'notifications.status.maintenance');
     }
+
+    public function test_public_widget_endpoint_returns_maintenance_meta_when_monitoring_has_no_results_yet(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Fresh API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subMinutes(30),
+            'maintenance_from' => Date::now()->subMinutes(10),
+            'maintenance_until' => Date::now()->addMinutes(20),
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('name', 'Fresh API');
+        $testResponse->assertJsonPath('status', MonitoringStatus::UNKNOWN->value);
+        $testResponse->assertJsonPath('status_label', 'UNKNOWN');
+        $testResponse->assertJsonPath('status_code', null);
+        $testResponse->assertJsonPath('status_identifier', 'status.maintenance');
+        $testResponse->assertJsonPath('status_key', 'notifications.status.maintenance');
+        $testResponse->assertJsonPath('checked_at', null);
+        $testResponse->assertJsonPath('checked_at_human', null);
+        $testResponse->assertJsonPath('uptime.7_days', null);
+        $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.365_days', null);
+    }
 }

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -118,4 +118,39 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('uptime.30_days', null);
         $testResponse->assertJsonPath('uptime.365_days', null);
     }
+
+    public function test_public_widget_endpoint_returns_maintenance_status_metadata_during_an_active_maintenance_window(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Scheduled Maintenance API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'maintenance_from' => Date::now()->subHour(),
+            'maintenance_until' => Date::now()->addHour(),
+            'created_at' => Date::now()->subDays(10),
+        ]);
+
+        $checkedAt = Date::now()->subMinutes(5);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 123.4,
+            'created_at' => $checkedAt,
+            'updated_at' => $checkedAt,
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('status', MonitoringStatus::UP->value);
+        $testResponse->assertJsonPath('status_label', 'UP');
+        $testResponse->assertJsonPath('status_identifier', 'status.maintenance');
+        $testResponse->assertJsonPath('status_key', 'notifications.status.maintenance');
+    }
 }

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -153,6 +153,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('status_identifier', 'status.maintenance');
         $testResponse->assertJsonPath('status_key', 'notifications.status.maintenance');
     }
+
     public function test_public_widget_endpoint_returns_maintenance_meta_when_monitoring_has_no_results_yet(): void
     {
         Date::setTestNow('2026-04-12 12:00:00');


### PR DESCRIPTION
## What changed
Adds focused coverage for the public widget payload when a monitoring is currently under maintenance.

## Why
Recent widget payload work returns maintenance-aware `status_identifier` and `status_key`, but the feature tests only covered success, disabled, and unknown cases.

## Impact
This protects the public widget contract from regressing when a monitoring has a healthy latest check inside an active maintenance window.

## Validation
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php`