### PR TITLE
test: cover open-ended widget maintenance

### DIFF
--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -150,4 +150,36 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('uptime.30_days', null);
         $testResponse->assertJsonPath('uptime.365_days', null);
     }
+
+    public function test_public_widget_endpoint_returns_maintenance_meta_for_open_ended_maintenance_without_results(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Fresh API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subMinutes(30),
+            'maintenance_from' => Date::now()->subMinutes(10),
+            'maintenance_until' => null,
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('name', 'Fresh API');
+        $testResponse->assertJsonPath('status', MonitoringStatus::UNKNOWN->value);
+        $testResponse->assertJsonPath('status_label', 'UNKNOWN');
+        $testResponse->assertJsonPath('status_code', null);
+        $testResponse->assertJsonPath('status_identifier', 'status.maintenance');
+        $testResponse->assertJsonPath('status_key', 'notifications.status.maintenance');
+        $testResponse->assertJsonPath('checked_at', null);
+        $testResponse->assertJsonPath('checked_at_human', null);
+        $testResponse->assertJsonPath('uptime.7_days', null);
+        $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.365_days', null);
+    }
 }


### PR DESCRIPTION
## Summary
- add coverage for the public monitoring widget when a monitor is under open-ended maintenance and has no results yet
- assert the widget still exposes the maintenance status metadata in that fallback state

## Why
The recent widget maintenance fallback test covered only bounded maintenance windows. `Monitoring::isUnderMaintenance()` also treats a past `maintenance_from` with a null `maintenance_until` as active, and that branch was not directly exercised by the widget API tests.

## Validation
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php`
