### PR TITLE
fix(api): scope card data to authenticated user

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -37,6 +37,7 @@ class MonitoringCardDataController extends Controller
         $monitorings = Monitoring::query()
             ->select([
                 'id',
+                'user_id',
                 'name',
                 'target',
                 'type',
@@ -44,6 +45,7 @@ class MonitoringCardDataController extends Controller
                 'maintenance_from',
                 'maintenance_until',
             ])
+            ->where('user_id', $request->user()->id)
             ->whereIn('id', $requestedIds)
             ->with([
                 'latestIncident',

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -90,6 +90,16 @@ class MonitoringCardDataApiTest extends TestCase
         $ownedMonitoring = Monitoring::factory()->for($user)->create();
         $foreignMonitoring = Monitoring::factory()->for($otherUser)->create();
 
+        $foreignCheckedAt = Date::now()->subMinutes(5);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $foreignMonitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'http_status_code' => 500,
+            'response_time' => 321.0,
+            'created_at' => $foreignCheckedAt,
+            'updated_at' => $foreignCheckedAt,
+        ]);
+
         $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
             'ids' => [$ownedMonitoring->id, $foreignMonitoring->id],
         ]));


### PR DESCRIPTION
## Summary
- scope `/api/monitorings/card-data` to the authenticated user's monitorings
- keep the fix minimal by filtering the existing query instead of changing payload behavior
- strengthen the feature test so a foreign monitoring with real response data is still omitted

## Root cause
The card-data endpoint accepted arbitrary monitoring IDs and loaded them with `whereIn('id', $requestedIds)` only. An authenticated user could therefore receive another user's monitoring payload if they knew the ID.

## Validation
- `php artisan test tests/Feature/Api/MonitoringCardDataApiTest.php --filter=authenticated_user`
- `php artisan test tests/Feature/Api/MonitoringCardDataApiTest.php`

## Notes
This came from the daily bug scan against recent repo activity. No broader refactor included.