### PR TITLE
test(api): cover card data foreign-only requests

### DIFF
--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -109,6 +109,36 @@ class MonitoringCardDataApiTest extends TestCase
         $testResponse->assertJsonMissingPath('data.' . $foreignMonitoring->id);
     }
 
+    public function test_card_data_endpoint_returns_an_empty_payload_when_all_requested_monitorings_belong_to_another_user(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $foreignMonitoring = Monitoring::factory()->for($otherUser)->create();
+
+        $foreignCheckedAt = Date::now()->subMinutes(5);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $foreignMonitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'http_status_code' => 500,
+            'response_time' => 321.0,
+            'created_at' => $foreignCheckedAt,
+            'updated_at' => $foreignCheckedAt,
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => [$foreignMonitoring->id],
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertExactJson([
+            'data' => [],
+        ]);
+    }
+
     public function test_card_data_endpoint_accepts_more_than_twenty_five_requested_monitorings(): void
     {
         Date::setTestNow('2026-04-12 12:00:00');


### PR DESCRIPTION
## Summary
- add a focused feature test for requests that only include monitorings owned by another user
- assert the card-data endpoint returns an empty payload instead of leaking foreign monitoring data

## Why
The recent user-scoping fix on the card-data endpoint covered mixed owned/foreign IDs, but it did not directly exercise the fully unauthorized request path.

## Impact
This locks in the empty authorized-result case without changing production behavior.

## Validation
- php artisan test tests/Feature/Api/MonitoringCardDataApiTest.php