### PR TITLE
Fix notification counts and guest reminder scheduling

### DIFF
--- a/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
+++ b/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Console\Commands\Notifications;
 
+use App\Enums\UserRole;
 use App\Mail\UnreadNotificationsReminderMail;
-use App\Models\MonitoringNotification;
 use App\Models\User;
+use App\Services\NotificationBoardService;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Throwable;
@@ -23,22 +23,25 @@ class SendUnreadNotificationsReminderCommand extends Command
     /**
      * @var string
      */
-    protected $description = 'Sends weekly email reminders to users with unread board notifications.';
+    protected $description = 'Sends daily email reminders to non-guest users with unread board notifications.';
+
+    public function __construct(private readonly NotificationBoardService $notificationBoardService)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
-        $unreadCounts = MonitoringNotification::query()
-            ->unread()
-            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
-            ->select('monitorings.user_id', DB::raw('count(*) as total'))
-            ->groupBy('monitorings.user_id')
-            ->pluck('total', 'user_id');
+        $unreadCounts = $this->notificationBoardService->getUnreadNotificationCountsByUser();
 
         if ($unreadCounts->isEmpty()) {
             return Command::SUCCESS;
         }
 
-        $users = User::query()->whereIn('id', $unreadCounts->keys())->get();
+        $users = User::query()
+            ->whereIn('id', $unreadCounts->keys())
+            ->where('role', '!=', UserRole::GUEST->value)
+            ->get();
 
         foreach ($users as $user) {
             $unreadNotificationsCount = (int) ($unreadCounts->get($user->id) ?? 0);
@@ -55,7 +58,7 @@ class SendUnreadNotificationsReminderCommand extends Command
                         ->locale($user->locale ?? config('app.locale'))
                 );
             } catch (Throwable $throwable) {
-                Log::error('Failed to send weekly unread notifications reminder.', [
+                Log::error('Failed to send unread notifications reminder.', [
                     'user_id' => $user->id,
                     'exception' => $throwable->getMessage(),
                 ]);

--- a/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
+++ b/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
@@ -32,19 +32,19 @@ class SendUnreadNotificationsReminderCommand extends Command
 
     public function handle(): int
     {
-        $unreadCounts = $this->notificationBoardService->getUnreadNotificationCountsByUser();
+        $unreadNotificationCountsByUser = $this->notificationBoardService->getUnreadNotificationCountsByUser();
 
-        if ($unreadCounts->isEmpty()) {
+        if ($unreadNotificationCountsByUser->isEmpty()) {
             return Command::SUCCESS;
         }
 
         $users = User::query()
-            ->whereIn('id', $unreadCounts->keys())
+            ->whereIn('id', $unreadNotificationCountsByUser->keys())
             ->where('role', '!=', UserRole::GUEST->value)
             ->get();
 
         foreach ($users as $user) {
-            $unreadNotificationsCount = (int) ($unreadCounts->get($user->id) ?? 0);
+            $unreadNotificationsCount = (int) ($unreadNotificationCountsByUser->get($user->id) ?? 0);
             if ($unreadNotificationsCount < 1) {
                 continue;
             }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -8,6 +8,7 @@ use App\Enums\NotificationType;
 use App\Models\MonitoringNotification;
 use App\Models\NotificationChannelDelivery;
 use App\Services\NotificationBoardService;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -52,8 +53,23 @@ class NotificationController extends Controller
     {
         $monitoringNotification = MonitoringNotification::query()->findOrFail($notificationId);
 
-        $monitoringNotification->read = true;
-        $monitoringNotification->save();
+        if ($monitoringNotification->type === NotificationType::STATUS_CHANGE) {
+            MonitoringNotification::query()
+                ->where('monitoring_id', $monitoringNotification->monitoring_id)
+                ->statusChange()
+                ->unread()
+                ->where(function (Builder $builder) use ($monitoringNotification): void {
+                    $builder->where('created_at', '<', $monitoringNotification->created_at)
+                        ->orWhere(function (Builder $builder) use ($monitoringNotification): void {
+                            $builder->where('created_at', $monitoringNotification->created_at)
+                                ->where('id', '<=', $monitoringNotification->id);
+                        });
+                })
+                ->update(['read' => true]);
+        } else {
+            $monitoringNotification->read = true;
+            $monitoringNotification->save();
+        }
 
         return back()->with('success', __('notifications.messages.notification_marked_as_read'));
     }

--- a/app/Http/View/Composers/NotificationComposer.php
+++ b/app/Http/View/Composers/NotificationComposer.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\View\Composers;
 
-use App\Models\MonitoringNotification;
+use App\Services\NotificationBoardService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
 class NotificationComposer
 {
+    public function __construct(private readonly NotificationBoardService $notificationBoardService) {}
+
     /**
      * Bind data to the view.
      *
@@ -23,7 +25,7 @@ class NotificationComposer
             if (request()->attributes->has('unread_notifications_count')) {
                 $unreadNotificationsCount = (int) request()->attributes->get('unread_notifications_count');
             } else {
-                $unreadNotificationsCount = MonitoringNotification::query()->unread()->count();
+                $unreadNotificationsCount = $this->notificationBoardService->getUnreadNotificationCount();
                 request()->attributes->set('unread_notifications_count', $unreadNotificationsCount);
             }
         }

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Enums\NotificationType;
 use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
 use App\Support\MonitoringStatusMeta;
@@ -93,5 +94,53 @@ class NotificationBoardService
                 'read' => (bool) $statusNotification->read,
             ];
         });
+    }
+
+    public function getUnreadNotificationCount(): int
+    {
+        $unreadStatusChangeCount = Monitoring::query()
+            ->whereHas('latestUnreadStatusChangeNotification')
+            ->count();
+
+        $unreadNonStatusChangeCount = MonitoringNotification::query()
+            ->unread()
+            ->where('type', '!=', NotificationType::STATUS_CHANGE->value)
+            ->count();
+
+        return $unreadStatusChangeCount + $unreadNonStatusChangeCount;
+    }
+
+    /**
+     * @return Collection<string, int>
+     */
+    public function getUnreadNotificationCountsByUser(): Collection
+    {
+        $unreadStatusChangeCounts = MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
+            ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
+            ->where('monitoring_notifications.read', false)
+            ->whereNull('monitorings.deleted_at')
+            ->selectRaw('monitorings.user_id as user_id, count(distinct monitoring_notifications.monitoring_id) as total')
+            ->groupBy('monitorings.user_id')
+            ->pluck('total', 'user_id');
+
+        $unreadNonStatusChangeCounts = MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
+            ->where('monitoring_notifications.read', false)
+            ->where('monitoring_notifications.type', '!=', NotificationType::STATUS_CHANGE->value)
+            ->whereNull('monitorings.deleted_at')
+            ->selectRaw('monitorings.user_id as user_id, count(*) as total')
+            ->groupBy('monitorings.user_id')
+            ->pluck('total', 'user_id');
+
+        return $unreadStatusChangeCounts->keys()
+            ->merge($unreadNonStatusChangeCounts->keys())
+            ->unique()
+            ->mapWithKeys(fn (string $userId): array => [
+                $userId => (int) ($unreadStatusChangeCounts->get($userId, 0))
+                    + (int) ($unreadNonStatusChangeCounts->get($userId, 0)),
+            ]);
     }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -20,8 +20,8 @@ Schedule::command('sitemap:generate')->dailyAt('02:00');
 // Dispatch status change notifications immediately.
 Schedule::command('notifications:dispatch-status-changes')->everyMinute()->withoutOverlapping();
 
-// Remind users weekly about unread notifications in their board.
-Schedule::command('notifications:remind-unread-weekly')->weeklyOn(1, '08:00')->withoutOverlapping();
+// Remind users daily about unread notifications in their board.
+Schedule::command('notifications:remind-unread-weekly')->dailyAt('08:00')->withoutOverlapping();
 
 // Prune old read notifications daily.
 Schedule::command('notifications:prune-read')->dailyAt('01:00');

--- a/tests/Feature/Console/NotificationsScheduleTest.php
+++ b/tests/Feature/Console/NotificationsScheduleTest.php
@@ -13,7 +13,7 @@ class NotificationsScheduleTest extends TestCase
     public function test_unread_notifications_reminder_is_scheduled_daily_at_eight_am(): void
     {
         /** @var Event|null $event */
-        $event = collect(app(Schedule::class)->events())
+        $event = collect(resolve(Schedule::class)->events())
             ->first(fn (Event $event): bool => str_contains((string) $event->command, 'notifications:remind-unread-weekly'));
 
         $this->assertNotNull($event);

--- a/tests/Feature/Console/NotificationsScheduleTest.php
+++ b/tests/Feature/Console/NotificationsScheduleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Tests\TestCase;
+
+class NotificationsScheduleTest extends TestCase
+{
+    public function test_unread_notifications_reminder_is_scheduled_daily_at_eight_am(): void
+    {
+        /** @var Event|null $event */
+        $event = collect(app(Schedule::class)->events())
+            ->first(fn (Event $event): bool => str_contains((string) $event->command, 'notifications:remind-unread-weekly'));
+
+        $this->assertNotNull($event);
+        $this->assertSame('0 8 * * *', $event->expression);
+        $this->assertTrue($event->withoutOverlapping);
+    }
+}

--- a/tests/Feature/Notifications/NotificationActionHardeningTest.php
+++ b/tests/Feature/Notifications/NotificationActionHardeningTest.php
@@ -10,6 +10,7 @@ use App\Models\MonitoringNotification;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
 use Tests\TestCase;
 
 class NotificationActionHardeningTest extends TestCase
@@ -52,5 +53,46 @@ class NotificationActionHardeningTest extends TestCase
 
         $testResponse->assertUnprocessable();
         $testResponse->assertJsonValidationErrors(['type']);
+    }
+
+    public function test_marking_a_status_change_as_read_marks_the_visible_status_thread_as_read(): void
+    {
+        Date::setTestNow('2026-03-24 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        $olderNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => false,
+            'created_at' => Date::now()->subMinutes(2),
+            'updated_at' => Date::now()->subMinutes(2),
+        ]);
+
+        $latestNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
+            'read' => false,
+            'sent' => false,
+            'created_at' => Date::now()->subMinute(),
+            'updated_at' => Date::now()->subMinute(),
+        ]);
+
+        $testResponse = $this->actingAs($user)->post(route('notifications.markAsRead', $latestNotification->id));
+
+        $testResponse->assertRedirect();
+        $this->assertDatabaseHas('monitoring_notifications', [
+            'id' => $olderNotification->id,
+            'read' => true,
+        ]);
+        $this->assertDatabaseHas('monitoring_notifications', [
+            'id' => $latestNotification->id,
+            'read' => true,
+        ]);
     }
 }

--- a/tests/Feature/Notifications/NotificationActionHardeningTest.php
+++ b/tests/Feature/Notifications/NotificationActionHardeningTest.php
@@ -63,7 +63,7 @@ class NotificationActionHardeningTest extends TestCase
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create();
 
-        $olderNotification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'DOWN',
@@ -87,7 +87,7 @@ class NotificationActionHardeningTest extends TestCase
 
         $testResponse->assertRedirect();
         $this->assertDatabaseHas('monitoring_notifications', [
-            'id' => $olderNotification->id,
+            'id' => $monitoringNotification->id,
             'read' => true,
         ]);
         $this->assertDatabaseHas('monitoring_notifications', [

--- a/tests/Feature/Notifications/NotificationPaginationStateTest.php
+++ b/tests/Feature/Notifications/NotificationPaginationStateTest.php
@@ -158,6 +158,55 @@ class NotificationPaginationStateTest extends TestCase
         $this->assertSame(['1'], $badgeCounts);
     }
 
+    public function test_navigation_badge_counts_unread_status_changes_per_monitoring(): void
+    {
+        Date::setTestNow('2026-03-24 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => false,
+            'created_at' => Date::now()->subMinutes(2),
+            'updated_at' => Date::now()->subMinutes(2),
+        ]);
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
+            'read' => false,
+            'sent' => false,
+            'created_at' => Date::now()->subMinute(),
+            'updated_at' => Date::now()->subMinute(),
+        ]);
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'Unread SSL notification',
+            'read' => false,
+            'sent' => false,
+            'created_at' => Date::now(),
+            'updated_at' => Date::now(),
+        ]);
+
+        $testResponse = $this->actingAs($user)->get(route('notifications.index'));
+
+        $testResponse->assertOk();
+        $content = $testResponse->getContent() ?? '';
+
+        preg_match_all('/bg-red-500[^>]*>(\d+)<\/span>/', $content, $matches);
+        $badgeCounts = array_values(array_unique($matches[1] ?? []));
+
+        $this->assertSame(['2'], $badgeCounts);
+    }
+
     /**
      * @return array<int, MonitoringNotification>
      */

--- a/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
+++ b/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Notifications;
 
 use App\Enums\NotificationType;
+use App\Enums\UserRole;
 use App\Mail\UnreadNotificationsReminderMail;
 use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
@@ -19,7 +20,7 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_sends_weekly_reminder_to_users_with_unread_notifications(): void
+    public function test_sends_daily_reminder_to_non_guest_users_with_unread_notifications(): void
     {
         Package::factory()->create();
 
@@ -33,6 +34,14 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
             'monitoring_id' => $monitoringWithUnread->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'DOWN',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoringWithUnread->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
             'read' => false,
             'sent' => true,
         ]);
@@ -63,6 +72,33 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
         });
         Mail::assertNotSent(UnreadNotificationsReminderMail::class, function (UnreadNotificationsReminderMail $unreadNotificationsReminderMail) use ($userWithoutUnread): bool {
             return $unreadNotificationsReminderMail->hasTo($userWithoutUnread->email);
+        });
+    }
+
+    public function test_does_not_send_reminder_to_guest_users(): void
+    {
+        Package::factory()->create();
+
+        $guestUser = User::factory()->create([
+            'role' => UserRole::GUEST,
+        ]);
+
+        $monitoring = Monitoring::factory()->for($guestUser)->create();
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        Mail::fake();
+
+        Artisan::call('notifications:remind-unread-weekly');
+
+        Mail::assertNotSent(UnreadNotificationsReminderMail::class, function (UnreadNotificationsReminderMail $unreadNotificationsReminderMail) use ($guestUser): bool {
+            return $unreadNotificationsReminderMail->hasTo($guestUser->email);
         });
     }
 


### PR DESCRIPTION
## Summary
- align unread notification counts with the status board aggregation so status-change notifications count once per monitoring
- mark aggregated status-change threads as read when the visible board entry is marked read
- run unread notification reminders daily at 08:00 and skip guest users entirely
- add regression coverage for navigation counts, grouped read behavior, reminder filtering, and scheduler configuration

## Why
The navigation badge and reminder counts were based on raw unread notification rows, while the notification board merges status-change notifications per monitoring. That mismatch caused inflated counts. The reminder job also still targeted guest users, which should not receive these scheduled reminders.

## Validation
- `php artisan test tests/Feature/Notifications/NotificationPaginationStateTest.php tests/Feature/Notifications/NotificationActionHardeningTest.php tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php tests/Feature/Console/NotificationsScheduleTest.php`
- `vendor/bin/pint --dirty`