### PR TITLE
Enable password reset flow

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -7,7 +7,9 @@ use App\Http\Controllers\Auth\ConfirmablePasswordController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\EmailVerificationPromptController;
 use App\Http\Controllers\Auth\GuestLoginController;
+use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordController;
+use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\SocialiteConsentController;
 use App\Http\Controllers\Auth\VerifyEmailController;
@@ -30,17 +32,17 @@ Route::middleware('guest')->group(function (): void {
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
-    // Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-    //     ->name('password.request');
-    //
-    // Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-    //     ->name('password.email');
-    //
-    // Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-    //     ->name('password.reset');
-    //
-    // Route::post('reset-password', [NewPasswordController::class, 'store'])
-    //     ->name('password.store');
+    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
+        ->name('password.request');
+
+    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+        ->name('password.email');
+
+    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
+        ->name('password.reset');
+
+    Route::post('reset-password', [NewPasswordController::class, 'store'])
+        ->name('password.store');
 });
 
 Route::middleware('auth')->group(function (): void {

--- a/tests/Feature/Auth/PasswordResetFlowTest.php
+++ b/tests/Feature/Auth/PasswordResetFlowTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Tests\TestCase;
+
+class PasswordResetFlowTest extends TestCase
+{
+    public function test_guest_can_view_forgot_password_screen(): void
+    {
+        $testResponse = $this->get(route('password.request'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('auth.forgot_password.title'));
+    }
+
+    public function test_login_page_exposes_forgot_password_link(): void
+    {
+        $testResponse = $this->get(route('login'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('href="' . route('password.request') . '"');
+    }
+
+    public function test_guest_can_request_a_password_reset_link(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        Notification::fake();
+
+        $testResponse = $this->post(route('password.email'), [
+            'email' => $user->email,
+        ]);
+
+        $testResponse->assertSessionHas('status', __(Password::RESET_LINK_SENT));
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_guest_can_view_password_reset_screen_with_valid_token(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $token = Password::broker()->createToken($user);
+
+        $testResponse = $this->get(route('password.reset', [
+            'token' => $token,
+            'email' => $user->email,
+        ]));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('auth.reset_password.title'));
+        $testResponse->assertSeeHtml('value="' . $user->email . '"');
+    }
+
+    public function test_guest_can_reset_password_with_valid_token(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'password' => Hash::make('old-password'),
+        ]);
+        $token = Password::broker()->createToken($user);
+
+        $testResponse = $this->post(route('password.store'), [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $testResponse->assertRedirect(route('login'));
+        $testResponse->assertSessionHas('status', __(Password::PASSWORD_RESET));
+        $this->assertTrue(Hash::check('new-password-123', $user->fresh()->password));
+    }
+}


### PR DESCRIPTION
## Summary
- re-enable the built-in forgot-password and reset-password guest routes
- cover the recovery flow with feature tests for request, token form, and successful reset
- restore the login screen's forgot-password link by making the route available again

## Why
Password reset controllers and views already existed, but the routes were commented out. That left account recovery unavailable even though the rest of the flow was implemented.

## Impact
Users can request a reset link, open the reset form, and set a new password without manual intervention.

## Testing
- `php artisan test tests/Feature/Auth/PasswordResetFlowTest.php`
- `php artisan test tests/Feature/Auth`
