### PR TITLE
Add recent monitoring check history

### DIFF
--- a/resources/js/components/monitoring-detail.ts
+++ b/resources/js/components/monitoring-detail.ts
@@ -5,11 +5,22 @@ import dayjs from 'dayjs';
 interface MonitoringDetailComponent {
     sinceDate: any;
     incidents: any[];
+    recentChecks: Array<{
+        id: string;
+        checkedAt: string;
+        checkedAtHuman: string | null;
+        status: string;
+        httpStatusCode: number | null;
+        responseTime: number | null;
+        statusIdentifier: string;
+        source: string;
+    }>;
     status: string | null;
     since: string | null;
     heatmap: any[];
     loading: boolean;
     incidentsLoading: boolean;
+    recentChecksLoading: boolean;
     lastCheckedAt: string | null;
     nextCheckIn: string | null;
     lastCheckedAtDate: Date | null;
@@ -47,6 +58,7 @@ interface MonitoringDetailComponent {
     currentLocale: string;
     loadStatus(this: MonitoringDetailComponent): Promise<void>;
     loadIncidents(this: MonitoringDetailComponent, days?: string | number | null): Promise<void>;
+    loadChecks(this: MonitoringDetailComponent, days?: string | number | null): Promise<void>;
     loadHeatmap(this: MonitoringDetailComponent): Promise<void>;
     loadUptime(this: MonitoringDetailComponent): Promise<void>;
     loadCustomRangeStats(this: MonitoringDetailComponent): Promise<void>;
@@ -54,6 +66,10 @@ interface MonitoringDetailComponent {
     loadPerformanceChart(this: MonitoringDetailComponent, days?: string | number): Promise<void>;
     loadUptimeCalendar(this: MonitoringDetailComponent): Promise<void>;
     initializeDeferredLoads(this: MonitoringDetailComponent): void;
+    resolveCheckStatusLabel(this: MonitoringDetailComponent, statusIdentifier: string): string;
+    resolveCheckStatusClass(this: MonitoringDetailComponent, statusIdentifier: string): string;
+    resolveCheckSourceLabel(this: MonitoringDetailComponent, source: string): string;
+    formatResponseTime(this: MonitoringDetailComponent, responseTime: number | null): string;
 }
 
 interface AlpineThisContext extends MonitoringDetailComponent {
@@ -62,11 +78,22 @@ interface AlpineThisContext extends MonitoringDetailComponent {
 
 export default (monitoringId: string, chartLabels: Record<string, string>): MonitoringDetailComponent => ({
     incidents: [] as any[],
+    recentChecks: [] as Array<{
+        id: string;
+        checkedAt: string;
+        checkedAtHuman: string | null;
+        status: string;
+        httpStatusCode: number | null;
+        responseTime: number | null;
+        statusIdentifier: string;
+        source: string;
+    }>,
     status: null as string | null,
     since: null as string | null,
     heatmap: [] as any[],
     loading: false,
     incidentsLoading: false,
+    recentChecksLoading: false,
     lastCheckedAt: null as string | null,
     nextCheckIn: null as string | null,
     lastCheckedAtDate: null,
@@ -172,6 +199,64 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
             this.incidents = [];
         } finally {
             this.incidentsLoading = false;
+        }
+    },
+
+    async loadChecks(this: MonitoringDetailComponent, days: string | number | null = null): Promise<void> {
+        this.recentChecksLoading = true;
+
+        let finalDays: number;
+
+        if (days === null) {
+            finalDays = parseInt(this.selectedRange, 10);
+        } else if (typeof days === 'string') {
+            finalDays = parseInt(days, 10);
+        } else {
+            finalDays = days;
+        }
+
+        if (isNaN(finalDays) || finalDays < 1) {
+            finalDays = 1;
+        }
+
+        try {
+            const query = new URLSearchParams({
+                days: String(finalDays),
+                limit: '10',
+            });
+
+            const response = await fetch(`/api/monitorings/${monitoringId}/checks?${query.toString()}`);
+
+            if (!response.ok) {
+                throw new Error(`Checks request failed: ${response.status}`);
+            }
+
+            const responseData = await response.json() as {
+                data?: Array<{
+                    id: string;
+                    checked_at: string;
+                    status: string;
+                    http_status_code: number | null;
+                    response_time: number | null;
+                    status_identifier: string;
+                    source: string;
+                }>;
+            };
+
+            this.recentChecks = (responseData.data ?? []).map((check) => ({
+                id: check.id,
+                checkedAt: formatDate(check.checked_at, 'L LTS') ?? check.checked_at,
+                checkedAtHuman: humanizeDistance(check.checked_at),
+                status: check.status,
+                httpStatusCode: check.http_status_code,
+                responseTime: check.response_time,
+                statusIdentifier: check.status_identifier,
+                source: check.source,
+            }));
+        } catch (_) {
+            this.recentChecks = [];
+        } finally {
+            this.recentChecksLoading = false;
         }
     },
 
@@ -484,6 +569,46 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
         }
 
         window.setTimeout(loadCalendar, 600);
+    },
+
+    resolveCheckStatusLabel(this: MonitoringDetailComponent, statusIdentifier: string): string {
+        const labels: Record<string, string> = {
+            'status.success': this.chartLabels.checkStatusSuccess,
+            'status.redirect': this.chartLabels.checkStatusRedirect,
+            'status.client_error': this.chartLabels.checkStatusClientError,
+            'status.server_error': this.chartLabels.checkStatusServerError,
+            'status.maintenance': this.chartLabels.checkStatusMaintenance,
+            'status.unknown': this.chartLabels.checkStatusUnknown,
+        };
+
+        return labels[statusIdentifier] ?? this.chartLabels.checkStatusUnknown;
+    },
+
+    resolveCheckStatusClass(this: MonitoringDetailComponent, statusIdentifier: string): string {
+        const classes: Record<string, string> = {
+            'status.success': 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+            'status.redirect': 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
+            'status.client_error': 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+            'status.server_error': 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200',
+            'status.maintenance': 'bg-slate-200 text-slate-800 dark:bg-slate-700 dark:text-slate-100',
+            'status.unknown': 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
+        };
+
+        return classes[statusIdentifier] ?? classes['status.unknown'];
+    },
+
+    resolveCheckSourceLabel(this: MonitoringDetailComponent, source: string): string {
+        return source === 'archived'
+            ? this.chartLabels.checkSourceArchived
+            : this.chartLabels.checkSourceLive;
+    },
+
+    formatResponseTime(this: MonitoringDetailComponent, responseTime: number | null): string {
+        if (responseTime === null) {
+            return this.chartLabels.checkResponseTimeUnavailable;
+        }
+
+        return `${Math.round(responseTime)} ms`;
     },
 
     chartLabels: chartLabels

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -112,6 +112,32 @@ return [
                 'load_failed' => 'Benutzerdefinierte Statistiken konnten nicht geladen werden.',
             ],
         ],
+        'checks' => [
+            'heading' => 'Letzte Prüfungen',
+            'help' => 'Zeigt die neuesten Einzelprüfungen für den ausgewählten Zeitraum.',
+            'loading' => 'Letzte Prüfungen werden geladen...',
+            'no_checks' => 'In diesem Zeitraum wurden keine Einzelprüfungen erfasst.',
+            'status_code_unavailable' => 'Kein Statuscode',
+            'response_time_unavailable' => 'Nicht verfügbar',
+            'labels' => [
+                'status_code' => 'Statuscode',
+                'response_time' => 'Antwortzeit',
+                'source' => 'Quelle',
+                'raw_status' => 'Rohstatus',
+            ],
+            'sources' => [
+                'live' => 'Live',
+                'archived' => 'Archiviert',
+            ],
+            'statuses' => [
+                'success' => 'Erfolgreich',
+                'redirect' => 'Weiterleitung',
+                'client_error' => 'Client-Fehler',
+                'server_error' => 'Server-Fehler',
+                'unknown' => 'Unbekannt',
+                'maintenance' => 'Wartung',
+            ],
+        ],
         'widget' => [
             'heading' => 'Widget einbetten',
             'description' => 'Betten Sie ein Live-Überwachungs-Widget auf Ihrer Website oder Ihrem Dashboard ein.',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -112,6 +112,32 @@ return [
                 'load_failed' => 'Failed to load custom range statistics.',
             ],
         ],
+        'checks' => [
+            'heading' => 'Recent Checks',
+            'help' => 'Shows the latest individual checks for the selected range.',
+            'loading' => 'Loading recent checks...',
+            'no_checks' => 'No individual checks were recorded in this period.',
+            'status_code_unavailable' => 'No status code',
+            'response_time_unavailable' => 'Not available',
+            'labels' => [
+                'status_code' => 'Status code',
+                'response_time' => 'Response time',
+                'source' => 'Source',
+                'raw_status' => 'Raw status',
+            ],
+            'sources' => [
+                'live' => 'Live',
+                'archived' => 'Archived',
+            ],
+            'statuses' => [
+                'success' => 'Successful',
+                'redirect' => 'Redirect',
+                'client_error' => 'Client Error',
+                'server_error' => 'Server Error',
+                'unknown' => 'Unknown',
+                'maintenance' => 'Maintenance',
+            ],
+        ],
         'widget' => [
             'heading' => 'Embed Widget',
             'description' => 'Embed a live monitoring widget on your website or dashboard.',

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -83,6 +83,7 @@
     loadCustomRangeStats();
     loadPerformanceChart(selectedRange);
     loadIncidents(selectedRange);
+    loadChecks(selectedRange);
     initializeDeferredLoads();" x-data="Object.assign({
         selectedRange: 1
     }, monitoringDetail('{{ $monitoring->id }}', {
@@ -93,6 +94,15 @@
         xAxis: '{{ __('monitoring.detail.response_time.x_axis_label') }}',
         customRangeInvalidDate: '{{ __('monitoring.detail.custom_range.errors.invalid_date_range') }}',
         customRangeLoadError: '{{ __('monitoring.detail.custom_range.errors.load_failed') }}',
+        checkStatusSuccess: '{{ __('monitoring.detail.checks.statuses.success') }}',
+        checkStatusRedirect: '{{ __('monitoring.detail.checks.statuses.redirect') }}',
+        checkStatusClientError: '{{ __('monitoring.detail.checks.statuses.client_error') }}',
+        checkStatusServerError: '{{ __('monitoring.detail.checks.statuses.server_error') }}',
+        checkStatusUnknown: '{{ __('monitoring.detail.checks.statuses.unknown') }}',
+        checkStatusMaintenance: '{{ __('monitoring.detail.checks.statuses.maintenance') }}',
+        checkSourceLive: '{{ __('monitoring.detail.checks.sources.live') }}',
+        checkSourceArchived: '{{ __('monitoring.detail.checks.sources.archived') }}',
+        checkResponseTimeUnavailable: '{{ __('monitoring.detail.checks.response_time_unavailable') }}',
     }))">
 
         <div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -293,7 +303,7 @@
                     <label for="range" class="hidden">{{ __('monitoring.filter.heading') }}</label>
 
                     <select x-model="selectedRange"
-                        @change="loadPerformanceChart(selectedRange); loadIncidents(selectedRange);"
+                        @change="loadPerformanceChart(selectedRange); loadIncidents(selectedRange); loadChecks(selectedRange);"
                         class="rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-500 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
                         <option value="1">{{ __('monitoring.filter.options.today') }}</option>
                         <option value="7">{{ __('monitoring.filter.options.last_week') }}</option>
@@ -383,6 +393,78 @@
                         </div>
                     </x-container>
                 </template>
+            </template>
+        </div>
+
+        <div id="recent-checks" class="mt-8">
+            <div class="mb-2 flex items-center justify-between gap-4">
+                <x-heading type="h2" class="text-lg font-semibold text-gray-800">
+                    {{ __('monitoring.detail.checks.heading') }}
+                </x-heading>
+                <x-paragraph class="text-sm text-gray-500">
+                    {{ __('monitoring.detail.checks.help') }}
+                </x-paragraph>
+            </div>
+
+            <template x-if="recentChecksLoading">
+                <div x-transition.opacity>
+                    <x-loading-indicator>{{ __('monitoring.detail.checks.loading') }}</x-loading-indicator>
+                </div>
+            </template>
+
+            <template x-if="!recentChecksLoading && recentChecks.length === 0">
+                <x-paragraph class="text-gray-500">{{ __('monitoring.detail.checks.no_checks') }}</x-paragraph>
+            </template>
+
+            <template x-if="!recentChecksLoading && recentChecks.length > 0">
+                <div class="space-y-3">
+                    <template x-for="check in recentChecks" :key="check.id">
+                        <x-container space="true">
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <x-paragraph class="text-sm font-semibold text-gray-900 dark:text-gray-100"
+                                        x-text="check.checkedAt"></x-paragraph>
+                                    <x-paragraph class="text-sm text-gray-500"
+                                        x-text="check.checkedAtHuman"></x-paragraph>
+                                </div>
+                                <x-span class="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide"
+                                    x-bind:class="resolveCheckStatusClass(check.statusIdentifier)"
+                                    x-text="resolveCheckStatusLabel(check.statusIdentifier)"></x-span>
+                            </div>
+
+                            <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
+                                <div>
+                                    <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                        {{ __('monitoring.detail.checks.labels.status_code') }}
+                                    </x-span>
+                                    <x-span class="text-sm text-gray-800 dark:text-gray-200"
+                                        x-text="check.httpStatusCode ?? '{{ __('monitoring.detail.checks.status_code_unavailable') }}'"></x-span>
+                                </div>
+                                <div>
+                                    <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                        {{ __('monitoring.detail.checks.labels.response_time') }}
+                                    </x-span>
+                                    <x-span class="text-sm text-gray-800 dark:text-gray-200"
+                                        x-text="formatResponseTime(check.responseTime)"></x-span>
+                                </div>
+                                <div>
+                                    <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                        {{ __('monitoring.detail.checks.labels.source') }}
+                                    </x-span>
+                                    <x-span class="text-sm text-gray-800 dark:text-gray-200"
+                                        x-text="resolveCheckSourceLabel(check.source)"></x-span>
+                                </div>
+                                <div>
+                                    <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                        {{ __('monitoring.detail.checks.labels.raw_status') }}
+                                    </x-span>
+                                    <x-span class="text-sm uppercase text-gray-800 dark:text-gray-200"
+                                        x-text="check.status"></x-span>
+                                </div>
+                            </div>
+                        </x-container>
+                    </template>
+                </div>
             </template>
         </div>
     </x-main>

--- a/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
+++ b/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonitoringDetailRecentChecksSectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_monitoring_detail_page_shows_recent_checks_section(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.show', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.detail.checks.heading'));
+        $testResponse->assertSeeText(__('monitoring.detail.checks.help'));
+        $testResponse->assertSeeText(__('monitoring.detail.checks.no_checks'));
+        $testResponse->assertSeeText(__('monitoring.detail.checks.labels.status_code'));
+        $testResponse->assertSeeText(__('monitoring.detail.checks.labels.response_time'));
+        $testResponse->assertSeeText(__('monitoring.detail.checks.labels.source'));
+        $testResponse->assertSeeHtml('id="recent-checks"');
+    }
+}


### PR DESCRIPTION
## Summary
- add a recent checks section to the monitoring detail page
- load individual check history from the existing monitoring checks API for the selected range
- localize the new UI copy in English and German and cover the section with a feature test

## Motivation
The monitoring detail page already exposed aggregated uptime, incidents, and response-time charts, but it did not surface the existing per-check history endpoint. That made it harder to inspect the exact checks behind a status change without leaving the page.

## Impact
Users can now review the latest individual checks directly in the monitoring detail view, including status category, HTTP status code, response time, raw status, and whether the row comes from live or archived history.

## Testing
- `bun run build`
- `php artisan test tests/Feature/MonitoringDetailCustomRangeCardTest.php tests/Feature/MonitoringDetailRecentChecksSectionTest.php tests/Feature/Api/ApiControllerTest.php`
