### PR TITLE
test: cover heartbeat recent checks detail

### DIFF
--- a/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
+++ b/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
@@ -31,4 +31,23 @@ class MonitoringDetailRecentChecksSectionTest extends TestCase
         $testResponse->assertSeeText(__('monitoring.detail.checks.labels.source'));
         $testResponse->assertSeeHtml('id="recent-checks"');
     }
+
+    public function test_heartbeat_monitoring_detail_page_keeps_recent_checks_without_response_time_chart(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()
+            ->heartbeat()
+            ->for($user)
+            ->create();
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.show', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.detail.heartbeat.heading'));
+        $testResponse->assertSeeText(__('monitoring.detail.checks.heading'));
+        $testResponse->assertSeeHtml('id="recent-checks"');
+        $testResponse->assertDontSeeText(__('monitoring.detail.response_time.heading'));
+        $testResponse->assertDontSeeHtml('id="performance-chart"');
+    }
 }


### PR DESCRIPTION
## What changed
- adds a heartbeat-specific feature test for the monitoring detail page
- verifies the new recent-checks section still renders for heartbeat monitors
- verifies the response-time chart remains hidden for heartbeat monitors

## Why
The recent monitoring check history feature updated a detail page with monitor-type-specific branches, but only the generic rendering path was covered. This closes the regression gap for heartbeat monitors.

## Validation
- `php artisan test tests/Feature/MonitoringDetailRecentChecksSectionTest.php`
