### PR TITLE
fix: respect configured heartbeat queue name

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ To get started with WebGuard, you'll need to have the following prerequisites in
 
     This will start the Laravel development server, the default queue worker, the dedicated Redis-backed `heartbeat` queue worker, the Pail log viewer, and the Vite development server.
 
-    In production, run a dedicated worker for the `heartbeat` queue on the standard Redis connection as well, for example:
+    In production, run a dedicated worker for the configured heartbeat queue on the standard Redis connection as well. If you do not override `HEARTBEAT_QUEUE`, it defaults to `heartbeat`:
 
     ```bash
-    php artisan queue:work redis --queue=heartbeat --sleep=3 --tries=3 --max-time=3600
+    php artisan queue:work redis --queue="${HEARTBEAT_QUEUE:-heartbeat}" --sleep=3 --tries=3 --max-time=3600
     ```
 
 8.  **Run the test suite:**

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -91,7 +91,7 @@ stderr_logfile=/var/log/worker-laravel.log
 "worker-laravel-heartbeat.conf" = '''
 [program:worker-laravel-heartbeat]
 process_name=%(program_name)s_%(process_num)02d
-command=bash -c 'exec php /app/artisan queue:work redis --queue=heartbeat --sleep=3 --tries=3 --max-time=3600'
+command=bash -lc "exec php /app/artisan queue:work redis --queue=${HEARTBEAT_QUEUE:-heartbeat} --sleep=3 --tries=3 --max-time=3600"
 autostart=true
 autorestart=true
 stopasgroup=true

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -8,14 +8,14 @@ use Tests\TestCase;
 
 class HeartbeatQueueDeploymentConfigTest extends TestCase
 {
-    public function test_nixpacks_supervisor_starts_a_dedicated_heartbeat_queue_worker(): void
+    public function test_nixpacks_supervisor_starts_a_dedicated_heartbeat_queue_worker_for_the_configured_queue_name(): void
     {
         $nixpacksConfiguration = file_get_contents(base_path('nixpacks.toml'));
 
         $this->assertIsString($nixpacksConfiguration);
         $this->assertStringContainsString('"worker-laravel-heartbeat.conf"', $nixpacksConfiguration);
         $this->assertStringContainsString(
-            'php /app/artisan queue:work redis --queue=heartbeat --sleep=3 --tries=3 --max-time=3600',
+            'php /app/artisan queue:work redis --queue=${HEARTBEAT_QUEUE:-heartbeat} --sleep=3 --tries=3 --max-time=3600',
             $nixpacksConfiguration
         );
     }


### PR DESCRIPTION
## What changed
- updated the Nixpacks heartbeat worker command to read `${HEARTBEAT_QUEUE:-heartbeat}` instead of hardcoding `heartbeat`
- updated the deployment test to assert the worker uses the configured queue name
- aligned the production README example with the same environment-aware queue command

## Why this changed
The heartbeat evaluation job dispatches to `config('monitoring.heartbeat_queue')`, but the production worker command still listened on a hardcoded `heartbeat` queue.

## Impact
Deployments that override `HEARTBEAT_QUEUE` will keep processing missed-heartbeat evaluations on the intended queue instead of leaving those jobs unconsumed.

## Root cause
The queue name became configurable in application code, but the Nixpacks supervisor command was not updated to consume that same configuration.

## Validation
- `php artisan test tests/Feature/HeartbeatQueueDeploymentConfigTest.php tests/Feature/Console/EvaluateHeartbeatMonitoringsCommandTest.php tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php tests/Feature/HeartbeatMonitoringTest.php`
