### PR TITLE
perf: collapse notification status board queries

### DIFF
--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -11,8 +11,8 @@ use App\Models\MonitoringResponse;
 use App\Support\MonitoringStatusMeta;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 
 class NotificationBoardService
 {
@@ -62,8 +62,8 @@ class NotificationBoardService
                         'status_notifications.read',
                         'status_notifications.created_at',
                     ])
-                    ->joinSub($latestStatusChangeTimestamps, 'latest_status_change_timestamps', function (JoinClause $join): void {
-                        $join->on(
+                    ->joinSub($latestStatusChangeTimestamps, 'latest_status_change_timestamps', function (JoinClause $joinClause): void {
+                        $joinClause->on(
                             'latest_status_change_timestamps.monitoring_id',
                             '=',
                             'status_notifications.monitoring_id'
@@ -74,9 +74,9 @@ class NotificationBoardService
                         );
                     })
                     ->where('status_notifications.type', NotificationType::STATUS_CHANGE->value)
-                    ->when(! $showRead, fn (Builder $builder): Builder => $builder->where('status_notifications.read', false))
-                    ->leftJoin('monitoring_notifications as newer_status_notifications', function (JoinClause $join) use ($showRead): void {
-                        $join->on(
+                    ->unless($showRead, fn (Builder $builder): Builder => $builder->where('status_notifications.read', false))
+                    ->leftJoin('monitoring_notifications as newer_status_notifications', function (JoinClause $joinClause) use ($showRead): void {
+                        $joinClause->on(
                             'newer_status_notifications.monitoring_id',
                             '=',
                             'status_notifications.monitoring_id'
@@ -94,12 +94,12 @@ class NotificationBoardService
                         );
 
                         if (! $showRead) {
-                            $join->where('newer_status_notifications.read', false);
+                            $joinClause->where('newer_status_notifications.read', false);
                         }
                     })
                     ->whereNull('newer_status_notifications.id'),
                 'latest_status_notifications',
-                fn (JoinClause $join): JoinClause => $join->on(
+                fn (JoinClause $joinClause): JoinClause => $joinClause->on(
                     'latest_status_notifications.monitoring_id',
                     '=',
                     'monitorings.id'
@@ -127,7 +127,7 @@ class NotificationBoardService
             ->selectRaw('latest_status_notifications.message as status_change_message')
             ->selectRaw('latest_status_notifications.read as notification_read')
             ->selectRaw('latest_status_notifications.created_at as latest_status_change_at')
-            ->orderByDesc('latest_status_change_at')
+            ->latest('latest_status_change_at')
             ->orderByDesc('notification_id')
             ->offset($offset)
             ->limit($limit + 1)
@@ -152,8 +152,8 @@ class NotificationBoardService
                 'target' => $monitoring->target,
                 'type' => $monitoring->type->value,
                 'latest_status_code' => $latestStatusCode !== null ? (int) $latestStatusCode : null,
-                'latest_checked_at' => $latestCheckedAt ? Carbon::parse((string) $latestCheckedAt)->toIso8601String() : null,
-                'latest_status_change_at' => $latestStatusChangeAt ? Carbon::parse((string) $latestStatusChangeAt)->toIso8601String() : null,
+                'latest_checked_at' => $latestCheckedAt ? Date::parse((string) $latestCheckedAt)->toIso8601String() : null,
+                'latest_status_change_at' => $latestStatusChangeAt ? Date::parse((string) $latestStatusChangeAt)->toIso8601String() : null,
                 'status_identifier' => MonitoringStatusMeta::statusIdentifier(
                     $latestStatusCode !== null ? (int) $latestStatusCode : null,
                     $maintenanceActive

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -7,8 +7,11 @@ namespace App\Services;
 use App\Enums\NotificationType;
 use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
+use App\Models\MonitoringResponse;
 use App\Support\MonitoringStatusMeta;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class NotificationBoardService
@@ -32,66 +35,136 @@ class NotificationBoardService
      */
     public function getStatusBoardEntries(bool $showRead, int $offset = 0, int $limit = 5): Collection
     {
-        $statusNotificationRelation = $showRead
-            ? 'latestStatusChangeNotification'
-            : 'latestUnreadStatusChangeNotification';
-
-        $latestStatusChangeAlias = $showRead
-            ? 'latest_status_change_at'
-            : 'latest_unread_status_change_at';
+        $latestStatusChangeTimestamps = MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->selectRaw('monitoring_id, max(created_at) as latest_created_at')
+            ->statusChange()
+            ->when(! $showRead, fn (Builder $builder): Builder => $builder->unread())
+            ->groupBy('monitoring_id');
 
         $monitorings = Monitoring::query()
-            ->select(['id', 'name', 'target', 'type', 'maintenance_from', 'maintenance_until'])
-            ->whereHas($statusNotificationRelation)
-            ->with([
-                $statusNotificationRelation,
-                'latestResponseResult',
+            ->select([
+                'monitorings.id',
+                'monitorings.name',
+                'monitorings.target',
+                'monitorings.type',
+                'monitorings.maintenance_from',
+                'monitorings.maintenance_until',
             ])
-            ->withMax([
-                "notifications as {$latestStatusChangeAlias}" => function (Builder $builder) use ($showRead): void {
-                    $builder->statusChange();
+            ->joinSub(
+                MonitoringNotification::query()
+                    ->withoutGlobalScopes()
+                    ->from('monitoring_notifications as status_notifications')
+                    ->select([
+                        'status_notifications.id',
+                        'status_notifications.monitoring_id',
+                        'status_notifications.message',
+                        'status_notifications.read',
+                        'status_notifications.created_at',
+                    ])
+                    ->joinSub($latestStatusChangeTimestamps, 'latest_status_change_timestamps', function (JoinClause $join): void {
+                        $join->on(
+                            'latest_status_change_timestamps.monitoring_id',
+                            '=',
+                            'status_notifications.monitoring_id'
+                        )->on(
+                            'latest_status_change_timestamps.latest_created_at',
+                            '=',
+                            'status_notifications.created_at'
+                        );
+                    })
+                    ->where('status_notifications.type', NotificationType::STATUS_CHANGE->value)
+                    ->when(! $showRead, fn (Builder $builder): Builder => $builder->where('status_notifications.read', false))
+                    ->leftJoin('monitoring_notifications as newer_status_notifications', function (JoinClause $join) use ($showRead): void {
+                        $join->on(
+                            'newer_status_notifications.monitoring_id',
+                            '=',
+                            'status_notifications.monitoring_id'
+                        )->on(
+                            'newer_status_notifications.created_at',
+                            '=',
+                            'status_notifications.created_at'
+                        )->whereColumn(
+                            'newer_status_notifications.id',
+                            '>',
+                            'status_notifications.id'
+                        )->where(
+                            'newer_status_notifications.type',
+                            NotificationType::STATUS_CHANGE->value
+                        );
 
-                    if (! $showRead) {
-                        $builder->unread();
-                    }
-                },
-            ], 'created_at')
-            ->orderByDesc($latestStatusChangeAlias)
+                        if (! $showRead) {
+                            $join->where('newer_status_notifications.read', false);
+                        }
+                    })
+                    ->whereNull('newer_status_notifications.id'),
+                'latest_status_notifications',
+                fn (JoinClause $join): JoinClause => $join->on(
+                    'latest_status_notifications.monitoring_id',
+                    '=',
+                    'monitorings.id'
+                )
+            )
+            ->selectSub(
+                MonitoringResponse::query()
+                    ->select('http_status_code')
+                    ->whereColumn('monitoring_response_results.monitoring_id', 'monitorings.id')
+                    ->latest('created_at')
+                    ->latest('id')
+                    ->limit(1),
+                'latest_status_code'
+            )
+            ->selectSub(
+                MonitoringResponse::query()
+                    ->select('created_at')
+                    ->whereColumn('monitoring_response_results.monitoring_id', 'monitorings.id')
+                    ->latest('created_at')
+                    ->latest('id')
+                    ->limit(1),
+                'latest_checked_at'
+            )
+            ->selectRaw('latest_status_notifications.id as notification_id')
+            ->selectRaw('latest_status_notifications.message as status_change_message')
+            ->selectRaw('latest_status_notifications.read as notification_read')
+            ->selectRaw('latest_status_notifications.created_at as latest_status_change_at')
+            ->orderByDesc('latest_status_change_at')
+            ->orderByDesc('notification_id')
             ->offset($offset)
             ->limit($limit + 1)
             ->get();
 
-        return $monitorings->map(function (Monitoring $monitoring) use ($statusNotificationRelation): array {
-            /** @var MonitoringNotification $statusNotification */
-            $statusNotification = $monitoring->{$statusNotificationRelation};
-            $latestResponse = $monitoring->latestResponseResult;
+        return $monitorings->map(function (Monitoring $monitoring): array {
+            $latestStatusCode = $monitoring->getAttribute('latest_status_code');
             $maintenanceActive = $monitoring->isUnderMaintenance();
 
-            $statusIdentifier = MonitoringStatusMeta::identifier(
-                $latestResponse?->http_status_code,
-                $maintenanceActive
-            );
+            $statusIdentifier = MonitoringStatusMeta::identifier($latestStatusCode !== null ? (int) $latestStatusCode : null, $maintenanceActive);
+            $statusChangeMessage = (string) $monitoring->getAttribute('status_change_message');
+            $latestCheckedAt = $monitoring->getAttribute('latest_checked_at');
+            $latestStatusChangeAt = $monitoring->getAttribute('latest_status_change_at');
+            $statusChangeIdentifier = $maintenanceActive
+                ? 'maintenance'
+                : MonitoringNotification::extractStatusChangeIdentifierFromMessage($statusChangeMessage);
 
             return [
-                'notification_id' => $statusNotification->id,
+                'notification_id' => (string) $monitoring->getAttribute('notification_id'),
                 'monitoring_id' => $monitoring->id,
                 'monitor_name' => $monitoring->name,
                 'target' => $monitoring->target,
                 'type' => $monitoring->type->value,
-                'latest_status_code' => $latestResponse?->http_status_code,
-                'latest_checked_at' => $latestResponse?->created_at?->toIso8601String(),
-                'latest_status_change_at' => $statusNotification->created_at?->toIso8601String(),
+                'latest_status_code' => $latestStatusCode !== null ? (int) $latestStatusCode : null,
+                'latest_checked_at' => $latestCheckedAt ? Carbon::parse((string) $latestCheckedAt)->toIso8601String() : null,
+                'latest_status_change_at' => $latestStatusChangeAt ? Carbon::parse((string) $latestStatusChangeAt)->toIso8601String() : null,
                 'status_identifier' => MonitoringStatusMeta::statusIdentifier(
-                    $latestResponse?->http_status_code,
+                    $latestStatusCode !== null ? (int) $latestStatusCode : null,
                     $maintenanceActive
                 ),
                 'status_key' => MonitoringStatusMeta::statusKey(
-                    $latestResponse?->http_status_code,
+                    $latestStatusCode !== null ? (int) $latestStatusCode : null,
                     $maintenanceActive
                 ),
-                'status_change_key' => $statusNotification->statusChangeKey($maintenanceActive),
+                'status_change_key' => 'notifications.status_change.' . $statusChangeIdentifier,
                 'badge_type' => MonitoringStatusMeta::badgeType($statusIdentifier),
-                'read' => (bool) $statusNotification->read,
+                'read' => (bool) $monitoring->getAttribute('notification_read'),
             ];
         });
     }

--- a/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Enums\MonitoringStatus;
+use App\Enums\NotificationType;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use App\Services\NotificationBoardService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class NotificationStatusBoardPerformanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_status_board_entries_load_in_a_single_select_query(): void
+    {
+        Date::setTestNow('2026-04-19 10:00:00');
+
+        $package = Package::factory()->create();
+        $user = User::factory()->for($package)->create();
+
+        $firstMonitoring = $this->createStatusBoardMonitoring($user, 503, Date::now()->subMinutes(4));
+        $secondMonitoring = $this->createStatusBoardMonitoring($user, 204, Date::now()->subMinutes(2));
+
+        $this->actingAs($user);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $entries = resolve(NotificationBoardService::class)->getStatusBoardEntries(showRead: true, limit: 5);
+
+        $selectQueries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(fn (string $query): bool => str_starts_with(mb_strtolower($query), 'select'))
+            ->values();
+
+        $this->assertCount(1, $selectQueries);
+        $this->assertSame([$secondMonitoring->id, $firstMonitoring->id], $entries->pluck('monitoring_id')->all());
+    }
+
+    public function test_unread_status_board_keeps_latest_unread_status_change_when_newer_read_entry_exists(): void
+    {
+        Date::setTestNow('2026-04-19 10:00:00');
+
+        $package = Package::factory()->create();
+        $user = User::factory()->for($package)->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'http_status_code' => 503,
+            'response_time' => 180.0,
+            'created_at' => Date::now()->subMinutes(6),
+            'updated_at' => Date::now()->subMinutes(6),
+        ]);
+
+        $latestUnread = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => true,
+            'created_at' => Date::now()->subMinutes(5),
+            'updated_at' => Date::now()->subMinutes(5),
+        ]);
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
+            'read' => true,
+            'sent' => true,
+            'created_at' => Date::now()->subMinute(),
+            'updated_at' => Date::now()->subMinute(),
+        ]);
+
+        $this->actingAs($user);
+
+        $entry = resolve(NotificationBoardService::class)->getStatusBoardEntries(showRead: false)->sole();
+
+        $this->assertSame($latestUnread->id, $entry['notification_id']);
+        $this->assertSame('notifications.status_change.down', $entry['status_change_key']);
+        $this->assertFalse($entry['read']);
+    }
+
+    private function createStatusBoardMonitoring(User $user, int $statusCode, \Carbon\CarbonInterface $notificationTime): Monitoring
+    {
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => $statusCode >= 500 ? MonitoringStatus::DOWN : MonitoringStatus::UP,
+            'http_status_code' => $statusCode,
+            'response_time' => 140.0,
+            'created_at' => $notificationTime->copy()->subMinute(),
+            'updated_at' => $notificationTime->copy()->subMinute(),
+        ]);
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => $statusCode >= 500 ? 'DOWN' : 'UP',
+            'read' => false,
+            'sent' => true,
+            'created_at' => $notificationTime,
+            'updated_at' => $notificationTime,
+        ]);
+
+        return $monitoring;
+    }
+}

--- a/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
@@ -12,6 +12,7 @@ use App\Models\MonitoringResponse;
 use App\Models\Package;
 use App\Models\User;
 use App\Services\NotificationBoardService;
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -64,7 +65,7 @@ class NotificationStatusBoardPerformanceTest extends TestCase
             'updated_at' => Date::now()->subMinutes(6),
         ]);
 
-        $latestUnread = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'DOWN',
@@ -88,12 +89,12 @@ class NotificationStatusBoardPerformanceTest extends TestCase
 
         $entry = resolve(NotificationBoardService::class)->getStatusBoardEntries(showRead: false)->sole();
 
-        $this->assertSame($latestUnread->id, $entry['notification_id']);
+        $this->assertSame($monitoringNotification->id, $entry['notification_id']);
         $this->assertSame('notifications.status_change.down', $entry['status_change_key']);
         $this->assertFalse($entry['read']);
     }
 
-    private function createStatusBoardMonitoring(User $user, int $statusCode, \Carbon\CarbonInterface $notificationTime): Monitoring
+    private function createStatusBoardMonitoring(User $user, int $statusCode, CarbonInterface $notificationTime): Monitoring
     {
         $monitoring = Monitoring::factory()->for($user)->create();
 


### PR DESCRIPTION
## Summary
This reduces the notification status board to a single select query instead of the previous multi-query eager-loading path.

## What Changed
- rewrote `NotificationBoardService::getStatusBoardEntries()` to join the latest status-change notification per monitoring directly in SQL
- pulled latest response metadata with subselects instead of loading `latestResponseResult` separately
- kept unread/read semantics intact, including the case where a newer read status change exists after the latest unread one
- added a performance regression test that asserts the status board loads in one select query

## Why
The notifications page was still paying unnecessary query overhead on every status-board load. The prior implementation combined `whereHas`, `ofMany`, `latestOfMany`, and eager loading, which fanned out into multiple selects for a small result set.

## Impact
- lower query count for the notifications status board
- less per-request database overhead on notifications page loads and API fetches
- explicit regression coverage for the query shape

## Root Cause
The previous implementation depended on relation-based eager loading for "latest" records, which is convenient but more expensive than necessary for this read model.

## Validation
- `php artisan test tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php tests/Feature/Notifications/NotificationStatusBoardTest.php tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php tests/Feature/Notifications/NotificationRenderingPerformanceTest.php --compact`

## Notes
Local dependency install required `composer install --ignore-platform-req=ext-redis` because the CLI environment used for this run does not have `ext-redis` available.