### PR TITLE
Fix footer responsiveness on mobile

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,12 +1,12 @@
 <footer class="border-t border-slate-200/80 bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/80">
     <x-main class="w-full py-5">
-        <div class="flex flex-col items-center justify-between gap-2 text-center sm:flex-row sm:text-left">
-            <x-paragraph class="text-sm text-gray-500">
+        <div class="flex flex-col gap-3 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <x-paragraph class="max-w-2xl text-sm leading-6 text-gray-500">
                 &copy; {{ date('Y') }} {{ __('app.name') }}. {{ __('legal.footer.content') }}
             </x-paragraph>
 
-            <nav aria-label="{{ __('imprint.footer_nav_aria') }}">
-                <ul class="flex items-center gap-4">
+            <nav class="w-full sm:w-auto" aria-label="{{ __('imprint.footer_nav_aria') }}">
+                <ul class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-end">
                     <li>
                         <a href="{{ route('monitoring-locations') }}"
                             class="text-sm font-medium text-slate-600 transition hover:text-emerald-700 dark:text-slate-300 dark:hover:text-emerald-300">

--- a/tests/Browser/FooterResponsiveTest.php
+++ b/tests/Browser/FooterResponsiveTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+it('keeps the footer within the viewport on mobile widths', function () {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    visit('/')
+        ->resize(320, 640)
+        ->assertScript(<<<'JS'
+function () {
+    const footer = document.querySelector('footer');
+    const footerNavigation = document.querySelector('footer nav ul');
+
+    if (! footer || ! footerNavigation) {
+        return false;
+    }
+
+    return footer.scrollWidth <= footer.clientWidth
+        && footerNavigation.scrollWidth <= footerNavigation.clientWidth;
+}
+JS, true);
+});


### PR DESCRIPTION
## What changed
- made the footer stack more cleanly on small screens and let the legal links wrap instead of forcing a single row
- kept the desktop alignment unchanged by limiting the responsive changes to smaller breakpoints
- added a browser regression test that checks the footer and footer navigation do not overflow on a 320px viewport

## Why
The footer could overflow horizontally on mobile because the copy and the full link list were competing for width without wrap behavior.

## Impact
Users on narrow screens can read and use the footer links without horizontal overflow.

## Validation
- `php artisan test tests/Browser/FooterResponsiveTest.php`
- `php artisan test tests/Feature/TermsOfUsePageTest.php tests/Feature/ImprintPageTest.php tests/Feature/GdprPageTest.php`
- `vendor/bin/pint --test resources/views/components/footer.blade.php tests/Browser/FooterResponsiveTest.php`
