### PR TITLE
test: cover footer responsive markup

### DIFF
--- a/tests/Feature/FooterMarkupTest.php
+++ b/tests/Feature/FooterMarkupTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class FooterMarkupTest extends TestCase
+{
+    public function test_footer_renders_mobile_wrapping_layout_classes_and_public_links(): void
+    {
+        $testResponse = $this->get(route('welcome'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('class="w-full sm:w-auto"');
+        $testResponse->assertSeeHtml('flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-end');
+        $testResponse->assertSeeHtml(route('monitoring-locations'));
+        $testResponse->assertSeeHtml(route('imprint'));
+        $testResponse->assertSeeHtml(route('terms-of-use'));
+        $testResponse->assertSeeHtml(route('gdpr'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a feature-level regression test for the responsive footer markup
- assert the mobile wrapping classes render on the footer navigation without requiring browser assets
- assert the shared public footer link set remains present

## Why
The responsive footer fix is class-only and the existing browser test is skipped or blocked when local/browser assets are unavailable. This small feature test gives reliable coverage for the key markup that prevents mobile overflow.

## Validation
- `./vendor/bin/pint tests/Feature/FooterMarkupTest.php`
- `php artisan test tests/Feature/FooterMarkupTest.php`
- `php artisan test tests/Feature/ImprintPageTest.php tests/Feature/GdprPageTest.php tests/Feature/TermsOfUsePageTest.php tests/Feature/MonitoringLocationsPageTest.php`

## Not Run
- `php artisan test tests/Browser/FooterResponsiveTest.php` - Playwright is not installed in this checkout.
