### PR TITLE
Add heartbeat monitoring to landing page

### DIFF
--- a/resources/lang/de/welcome.php
+++ b/resources/lang/de/welcome.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 return [
     'seo' => [
-        'title' => 'WebGuard - Kostenfreies Monitoring für Websites, APIs, Server und Ports',
-        'description' => 'WebGuard ist eine kostenfrei nutzbare Monitoring-Software für HTTP-, Ping-, Keyword- und Port-Checks mit Benachrichtigungen, SSL-Ablaufkontrolle, Uptime-Auswertungen und öffentlichen Statusseiten.',
-        'keywords' => 'Kostenfreies Monitoring, Uptime Monitoring, Website Monitoring, Ping Monitoring, Keyword Monitoring, Port Monitoring, SSL Ablauf, Statusseite, Incident Benachrichtigung',
+        'title' => 'WebGuard - Kostenfreies Monitoring für Websites, APIs, Server, Ports und Cronjobs',
+        'description' => 'WebGuard ist eine kostenfrei nutzbare Monitoring-Software für HTTP-, Ping-, Keyword-, Port- und Heartbeat-Checks mit Benachrichtigungen, SSL-Ablaufkontrolle, Uptime-Auswertungen und öffentlichen Statusseiten.',
+        'keywords' => 'Kostenfreies Monitoring, Uptime Monitoring, Website Monitoring, Ping Monitoring, Keyword Monitoring, Port Monitoring, Heartbeat Monitoring, Cronjob Monitoring, SSL Ablauf, Statusseite, Incident Benachrichtigung',
         'og_title' => 'WebGuard - Zuverlässigkeit transparent überwachen',
-        'og_description' => 'Überwachen Sie Verfügbarkeit und Performance mit HTTP-, Ping-, Keyword- und Port-Checks, klaren Benachrichtigungen und nachvollziehbaren Uptime-Reports.',
+        'og_description' => 'Überwachen Sie Verfügbarkeit und Performance mit HTTP-, Ping-, Keyword-, Port- und Heartbeat-Checks, klaren Benachrichtigungen und nachvollziehbaren Uptime-Reports.',
     ],
 
     'nav' => [
@@ -34,7 +34,7 @@ return [
             ],
             '2' => [
                 'label' => 'Abdeckung',
-                'value' => 'HTTP, Ping, Keyword und Port',
+                'value' => 'HTTP, Ping, Keyword, Port und Heartbeat',
             ],
             '3' => [
                 'label' => 'Betrieb',
@@ -69,6 +69,11 @@ return [
             'badge' => 'Kernfunktion',
             'title' => 'Port Monitoring',
             'text' => 'Stellen Sie sicher, dass wichtige Service-Ports offen und erreichbar bleiben.',
+        ],
+        'heartbeat' => [
+            'badge' => 'Cronjobs',
+            'title' => 'Heartbeat Monitoring',
+            'text' => 'Überwachen Sie Cronjobs, Worker und Hintergrundprozesse über private Ping-URLs und erwartete Intervalle.',
         ],
         'notifications' => [
             'badge' => 'Alerts',
@@ -122,7 +127,7 @@ return [
         'steps' => [
             '1' => [
                 'title' => 'Monitore erstellen',
-                'text' => 'Legen Sie HTTP-, Ping-, Keyword- oder Port-Checks an und definieren Sie das Intervall.',
+                'text' => 'Legen Sie HTTP-, Ping-, Keyword-, Port- oder Heartbeat-Checks an und definieren Sie das Intervall.',
             ],
             '2' => [
                 'title' => 'Alerts festlegen',
@@ -159,7 +164,7 @@ return [
             ],
             '3' => [
                 'label' => 'Empfohlene Monitor-Typen',
-                'value' => 'HTTP, Ping, Keyword, Port',
+                'value' => 'HTTP, Ping, Keyword, Port, Heartbeat',
             ],
         ],
     ],

--- a/resources/lang/en/welcome.php
+++ b/resources/lang/en/welcome.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 return [
     'seo' => [
-        'title' => 'WebGuard - Free Monitoring for Websites, APIs, Servers, and Ports',
-        'description' => 'WebGuard is free-to-use monitoring software for HTTP, Ping, Keyword, and Port checks with notifications, SSL expiry tracking, uptime insights, and public status pages.',
-        'keywords' => 'free monitoring software, uptime monitoring, website monitoring, ping monitoring, keyword monitoring, port monitoring, SSL expiry monitoring, status page, incident alerts',
+        'title' => 'WebGuard - Free Monitoring for Websites, APIs, Servers, Ports, and Cronjobs',
+        'description' => 'WebGuard is free-to-use monitoring software for HTTP, Ping, Keyword, Port, and Heartbeat checks with notifications, SSL expiry tracking, uptime insights, and public status pages.',
+        'keywords' => 'free monitoring software, uptime monitoring, website monitoring, ping monitoring, keyword monitoring, port monitoring, heartbeat monitoring, cronjob monitoring, SSL expiry monitoring, status page, incident alerts',
         'og_title' => 'WebGuard - Monitor reliability with full transparency',
-        'og_description' => 'Track availability and performance with HTTP, Ping, Keyword, and Port monitoring, clear notifications, and easy-to-read uptime reporting.',
+        'og_description' => 'Track availability and performance with HTTP, Ping, Keyword, Port, and Heartbeat monitoring, clear notifications, and easy-to-read uptime reporting.',
     ],
 
     'nav' => [
@@ -34,7 +34,7 @@ return [
             ],
             '2' => [
                 'label' => 'Coverage',
-                'value' => 'HTTP, Ping, Keyword, and Port',
+                'value' => 'HTTP, Ping, Keyword, Port, and Heartbeat',
             ],
             '3' => [
                 'label' => 'Operation',
@@ -69,6 +69,11 @@ return [
             'badge' => 'Core',
             'title' => 'Port Monitoring',
             'text' => 'Verify key service ports stay open and reachable for your infrastructure.',
+        ],
+        'heartbeat' => [
+            'badge' => 'Cronjobs',
+            'title' => 'Heartbeat Monitoring',
+            'text' => 'Monitor cronjobs, workers, and background processes through private ping URLs and expected intervals.',
         ],
         'notifications' => [
             'badge' => 'Alerts',
@@ -122,7 +127,7 @@ return [
         'steps' => [
             '1' => [
                 'title' => 'Create monitors',
-                'text' => 'Add HTTP, Ping, Keyword, or Port checks and set your target interval.',
+                'text' => 'Add HTTP, Ping, Keyword, Port, or Heartbeat checks and set your target interval.',
             ],
             '2' => [
                 'title' => 'Define alerts',
@@ -159,7 +164,7 @@ return [
             ],
             '3' => [
                 'label' => 'Recommended monitor types',
-                'value' => 'HTTP, Ping, Keyword, Port',
+                'value' => 'HTTP, Ping, Keyword, Port, Heartbeat',
             ],
         ],
     ],

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -89,7 +89,7 @@
                 <x-paragraph class="mt-4 max-w-3xl text-lg text-slate-600 dark:text-slate-300">{{ __('welcome.feature_section.subtitle') }}</x-paragraph>
 
                 <div class="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-                    @foreach (['http', 'ping', 'keyword', 'port', 'notifications', 'ssl', 'stats', 'multi_location'] as $feature)
+                    @foreach (['http', 'ping', 'keyword', 'port', 'heartbeat', 'notifications', 'ssl', 'stats', 'multi_location'] as $feature)
                         <article class="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-lg shadow-slate-300/20 dark:border-slate-800 dark:bg-slate-900/70 dark:shadow-slate-950/20">
                             <div class="flex items-center justify-between gap-4">
                                 <div class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-slate-100 text-emerald-700 dark:bg-slate-800 dark:text-emerald-300">
@@ -108,6 +108,10 @@
 
                                         @case('port')
                                             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10v8H7z" /><path stroke-linecap="round" stroke-linejoin="round" d="M9 8V6m6 2V6m-6 10v2m6-2v2" /></svg>
+                                        @break
+
+                                        @case('heartbeat')
+                                            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 12h3l2-5 4 10 2-5h5" /><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v2m0 12v2m8-8h-2M6 12H4" /></svg>
                                         @break
 
                                         @case('notifications')

--- a/tests/Feature/WelcomeHeartbeatCopyTest.php
+++ b/tests/Feature/WelcomeHeartbeatCopyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\SupportedLanguage;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class WelcomeHeartbeatCopyTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function heartbeatCopyProvider(): array
+    {
+        return [
+            'english' => ['en', 'Heartbeat Monitoring', 'Monitor cronjobs, workers, and background processes'],
+            'german' => ['de', 'Heartbeat Monitoring', 'Überwachen Sie Cronjobs, Worker und Hintergrundprozesse'],
+        ];
+    }
+
+    #[DataProvider('heartbeatCopyProvider')]
+    public function test_it_renders_heartbeat_monitoring_on_the_welcome_page(
+        string $locale,
+        string $expectedTitle,
+        string $expectedText
+    ): void {
+        $testResponse = $this->withCookie(SupportedLanguage::cookieName(), $locale)->get('/');
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText($expectedTitle);
+        $testResponse->assertSeeText($expectedText);
+    }
+}


### PR DESCRIPTION
## Summary
- add Heartbeat Monitoring as a landingpage feature card with a matching icon
- update German and English landingpage SEO, coverage, workflow, and recommendation copy for Heartbeat/Cronjob monitoring
- add a feature test that verifies Heartbeat copy renders in both supported languages

## Validation
- `php artisan test tests/Feature/WelcomeMonitoringIntervalCopyTest.php tests/Feature/WelcomeHeartbeatCopyTest.php`
- `vendor/bin/pint --dirty`