### PR TITLE
Cover landing heartbeat metadata

### DIFF
--- a/tests/Feature/WelcomeHeartbeatCopyTest.php
+++ b/tests/Feature/WelcomeHeartbeatCopyTest.php
@@ -11,13 +11,25 @@ use Tests\TestCase;
 class WelcomeHeartbeatCopyTest extends TestCase
 {
     /**
-     * @return array<string, array{0: string, 1: string, 2: string}>
+     * @return array<string, array{0: string, 1: string, 2: string, 3: string, 4: string}>
      */
     public static function heartbeatCopyProvider(): array
     {
         return [
-            'english' => ['en', 'Heartbeat Monitoring', 'Monitor cronjobs, workers, and background processes'],
-            'german' => ['de', 'Heartbeat Monitoring', 'Überwachen Sie Cronjobs, Worker und Hintergrundprozesse'],
+            'english' => [
+                'en',
+                'Heartbeat Monitoring',
+                'Monitor cronjobs, workers, and background processes',
+                'HTTP, Ping, Keyword, Port, and Heartbeat',
+                'HTTP, Ping, Keyword, Port, and Heartbeat checks with notifications',
+            ],
+            'german' => [
+                'de',
+                'Heartbeat Monitoring',
+                'Überwachen Sie Cronjobs, Worker und Hintergrundprozesse',
+                'HTTP, Ping, Keyword, Port und Heartbeat',
+                'HTTP-, Ping-, Keyword-, Port- und Heartbeat-Checks mit Benachrichtigungen',
+            ],
         ];
     }
 
@@ -25,12 +37,16 @@ class WelcomeHeartbeatCopyTest extends TestCase
     public function test_it_renders_heartbeat_monitoring_on_the_welcome_page(
         string $locale,
         string $expectedTitle,
-        string $expectedText
+        string $expectedText,
+        string $expectedCoverage,
+        string $expectedMetaDescription
     ): void {
         $testResponse = $this->withCookie(SupportedLanguage::cookieName(), $locale)->get('/');
 
         $testResponse->assertOk();
         $testResponse->assertSeeText($expectedTitle);
         $testResponse->assertSeeText($expectedText);
+        $testResponse->assertSeeText($expectedCoverage);
+        $testResponse->assertSee($expectedMetaDescription);
     }
 }


### PR DESCRIPTION
## Summary
- Extend the landing heartbeat feature test to cover SEO description copy.
- Assert the visible hero coverage metric still includes Heartbeat in English and German.

## Validation
- php artisan test tests/Feature/WelcomeHeartbeatCopyTest.php
- vendor/bin/pint tests/Feature/WelcomeHeartbeatCopyTest.php

## Notes
- Initial dependency install required ignoring missing local ext-redis; the focused test itself does not use Redis.