### PR TITLE
Harden monitoring data endpoint access

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -82,6 +82,8 @@ class ApiController extends Controller
      */
     public function all(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $data = [
             'status_since' => $this->statusSince($monitoring)->getData(),
             'status_now' => $this->statusNow($monitoring)->getData(),
@@ -111,6 +113,8 @@ class ApiController extends Controller
      */
     public function uptimeDowntime(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $validated = $request->validate([
             'days' => ['nullable', 'integer'],
         ]);
@@ -158,6 +162,8 @@ class ApiController extends Controller
      */
     public function uptimeDowntimeSummary(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $validated = $request->validate([
             'days' => ['required', 'array', 'min:1', 'max:10'],
             'days.*' => ['required', 'integer', 'min:1', 'max:3650'],
@@ -204,6 +210,8 @@ class ApiController extends Controller
      */
     public function responseTimes(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $validated = $request->validate([
             'days' => ['nullable', 'integer'],
         ]);
@@ -258,6 +266,8 @@ class ApiController extends Controller
      */
     public function checks(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $validated = $request->validate([
             'days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             'limit' => ['nullable', 'integer', 'min:1', 'max:1000'],
@@ -360,6 +370,8 @@ class ApiController extends Controller
      */
     public function uptimeHeatmap(Monitoring $monitoring): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $start_date = now()->subHours(23);
         $end_date = now();
 
@@ -388,6 +400,8 @@ class ApiController extends Controller
      */
     public function status(Monitoring $monitoring): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $statusSince = MonitoringResultService::getStatusSince($monitoring);
         $statusNow = MonitoringResultService::getStatusNow($monitoring);
         $latestStatusCode = $monitoring->latestResponseResult?->http_status_code;
@@ -482,6 +496,8 @@ class ApiController extends Controller
      */
     public function incidents(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $validated = $request->validate([
             'days' => ['nullable', 'integer'],
         ]);
@@ -514,6 +530,8 @@ class ApiController extends Controller
      */
     public function sslStatus(Monitoring $monitoring): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $cacheKey = sprintf('monitoring:%s:ssl-status', $monitoring->id);
 
         $data = $this->cacheAndReturn(
@@ -548,6 +566,8 @@ class ApiController extends Controller
      */
     public function uptimeCalendar(Monitoring $monitoring, Request $request): JsonResponse
     {
+        $this->authorizeMonitoringDataAccess($monitoring);
+
         $validated = $request->validate([
             'start_date' => ['required', 'date'],
             'end_date' => ['required', 'date', 'after_or_equal:start_date'],
@@ -587,6 +607,17 @@ class ApiController extends Controller
         }
 
         return $callback();
+    }
+
+    private function authorizeMonitoringDataAccess(Monitoring $monitoring): void
+    {
+        $user = request()->user();
+
+        if ($user && $monitoring->user_id === $user->id) {
+            return;
+        }
+
+        abort_unless($monitoring->public_label_enabled, 404);
     }
 
     private function resolveWidgetUptimePercentage(Monitoring $monitoring, int $days): ?float

--- a/tests/Feature/Api/MonitoringDataAccessTest.php
+++ b/tests/Feature/Api/MonitoringDataAccessTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Tests\TestCase;
+
+class MonitoringDataAccessTest extends TestCase
+{
+    public function test_shared_monitoring_data_endpoint_blocks_private_monitoring_without_authentication(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'public_label_enabled' => false,
+        ]);
+
+        $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/status');
+
+        $testResponse->assertNotFound();
+    }
+
+    public function test_shared_monitoring_data_endpoint_allows_public_monitoring_without_authentication(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Public API',
+            'public_label_enabled' => true,
+        ]);
+
+        $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/status');
+
+        $testResponse->assertOk()
+            ->assertJsonPath('monitoring.name', 'Public API');
+    }
+
+    public function test_shared_monitoring_data_endpoint_allows_private_monitoring_for_owner(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Private API',
+            'public_label_enabled' => false,
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/' . $monitoring->id . '/status');
+
+        $testResponse->assertOk()
+            ->assertJsonPath('monitoring.name', 'Private API');
+    }
+
+    public function test_shared_monitoring_data_endpoint_blocks_private_monitoring_for_another_user(): void
+    {
+        Package::factory()->create();
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($owner)->create([
+            'public_label_enabled' => false,
+        ]);
+
+        $testResponse = $this->actingAs($otherUser)->getJson('/api/monitorings/' . $monitoring->id . '/status');
+
+        $testResponse->assertNotFound();
+    }
+}

--- a/tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php
+++ b/tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php
@@ -35,6 +35,7 @@ class InternalRoutesAvailableDuringMaintenanceTest extends TestCase
             'user_id' => $user->id,
             'type' => MonitoringType::HTTP,
             'preferred_location' => $serverInstance->code,
+            'public_label_enabled' => true,
         ]);
 
         Artisan::call('down');


### PR DESCRIPTION
## Summary
- Add a shared access guard to monitoring data API endpoints.
- Allow access for the monitoring owner or when the public label is enabled.
- Cover private/public/owner/non-owner access paths with feature tests.
- Keep the maintenance-mode legacy route fixture aligned with public access semantics.

## Motivation
Shared monitoring data endpoints power both authenticated dashboards and public status labels. Private monitors should not expose status, history, SSL, incident, or calendar data by ID when public labels are disabled.

## Testing
- `php artisan test`
- `php artisan test tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php tests/Feature/Api/MonitoringDataAccessTest.php`
- `php artisan test tests/Feature/Api/MonitoringDataAccessTest.php`
- `php artisan test tests/Feature/Api/ApiControllerTest.php tests/Feature/Api/MonitoringCardDataApiTest.php tests/Feature/Api/PublicMonitoringWidgetApiTest.php tests/Feature/Api/UptimeDowntimeApiTest.php`
- `./vendor/bin/pint app/Http/Controllers/ApiController.php tests/Feature/Api/MonitoringDataAccessTest.php`
- `./vendor/bin/pint tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php`
- `./vendor/bin/rector process app/Http/Controllers/ApiController.php tests/Feature/Api/MonitoringDataAccessTest.php --dry-run --ansi`

## Rollout
No migration or configuration changes required.

## Local note
Local dependency install required `--ignore-platform-req=ext-redis` because the PHP CLI on this machine does not have the Redis extension enabled; CI installs the extension.