### PR TITLE
Batch public widget uptime queries

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -442,6 +442,8 @@ class ApiController extends Controller
                 $status = (string) ($statusSince['status'] ?? 'unknown');
                 $checkedAt = $statusNow['checked_at'] ?? null;
 
+                $uptimePercentages = $this->resolveWidgetUptimePercentages($monitoring, [7, 30, 365]);
+
                 return [
                     'name' => $monitoring->name,
                     'status' => $status,
@@ -452,9 +454,9 @@ class ApiController extends Controller
                     'checked_at' => $checkedAt,
                     'checked_at_human' => $checkedAt ? Date::parse((string) $checkedAt)->diffForHumans() : null,
                     'uptime' => [
-                        '7_days' => $this->resolveWidgetUptimePercentage($monitoring, 7),
-                        '30_days' => $this->resolveWidgetUptimePercentage($monitoring, 30),
-                        '365_days' => $this->resolveWidgetUptimePercentage($monitoring, 365),
+                        '7_days' => $uptimePercentages[7] ?? null,
+                        '30_days' => $uptimePercentages[30] ?? null,
+                        '365_days' => $uptimePercentages[365] ?? null,
                     ],
                     'public_url' => route('public-label', $monitoring),
                 ];
@@ -589,21 +591,33 @@ class ApiController extends Controller
         return $callback();
     }
 
-    private function resolveWidgetUptimePercentage(Monitoring $monitoring, int $days): ?float
+    /**
+     * @param  array<int, int>  $days
+     * @return array<int, float|null>
+     */
+    private function resolveWidgetUptimePercentages(Monitoring $monitoring, array $days): array
     {
-        $startDate = Date::now()->subDays($days)->startOfDay();
-        $endDate = Date::now()->endOfDay();
-        $loadAggregatedData = $days > 1 && $monitoring->created_at->diffInDays(Date::now()) >= 1;
+        if ($monitoring->created_at->diffInDays(Date::now()) < 1) {
+            return collect($days)
+                ->mapWithKeys(fn (int $day): array => [
+                    $day => data_get(MonitoringResultService::getUptimeDowntime(
+                        $monitoring,
+                        Date::now()->subDays($day)->startOfDay(),
+                        Date::now()->endOfDay(),
+                        false,
+                        false
+                    ), 'uptime.percentage'),
+                ])
+                ->all();
+        }
 
-        $stats = MonitoringResultService::getUptimeDowntime(
-            $monitoring,
-            $startDate,
-            $endDate,
-            $loadAggregatedData,
-            false
-        );
+        $statsByRange = MonitoringResultService::getUptimeDowntimesForRanges($monitoring, $days);
 
-        return data_get($stats, 'uptime.percentage');
+        return collect($days)
+            ->mapWithKeys(fn (int $day): array => [
+                $day => data_get($statsByRange, $day . '.uptime.percentage'),
+            ])
+            ->all();
     }
 
     private function buildChecksSourceQuery(

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -14,6 +14,7 @@ use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class PublicMonitoringWidgetApiTest extends TestCase
@@ -74,6 +75,67 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $this->assertIsNumeric($testResponse->json('uptime.7_days'));
         $this->assertIsNumeric($testResponse->json('uptime.30_days'));
         $this->assertIsNumeric($testResponse->json('uptime.365_days'));
+    }
+
+    public function test_public_widget_endpoint_batches_uptime_range_queries(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subDays(400),
+        ]);
+
+        foreach ([7, 30, 365] as $days) {
+            MonitoringDailyResult::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'date' => Date::now()->subDays($days)->toDateString(),
+                'uptime_total' => 1,
+                'downtime_total' => 0,
+                'unknown_total' => 0,
+                'uptime_percentage' => 100,
+                'downtime_percentage' => 0,
+                'unknown_percentage' => 0,
+                'uptime_minutes' => 24 * 60,
+                'downtime_minutes' => 0,
+                'unknown_minutes' => 0,
+                'avg_response_time' => 123.4,
+                'min_response_time' => 123.4,
+                'max_response_time' => 123.4,
+                'incidents_count' => 0,
+            ]);
+        }
+
+        $checkedAt = Date::now()->subMinutes(5);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 123.4,
+            'created_at' => $checkedAt,
+            'updated_at' => $checkedAt,
+        ]);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('uptime.7_days', 100);
+        $testResponse->assertJsonPath('uptime.30_days', 100);
+        $testResponse->assertJsonPath('uptime.365_days', 100);
+
+        $selectCount = collect(DB::getQueryLog())
+            ->filter(static fn (array $entry): bool => str_starts_with(mb_strtolower($entry['query']), 'select'))
+            ->count();
+
+        $this->assertLessThanOrEqual(5, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
     }
 
     public function test_public_widget_endpoint_returns_not_found_when_public_label_is_disabled(): void


### PR DESCRIPTION
## Summary
- Batch the public widget 7/30/365-day uptime calculations through the existing multi-range helper.
- Add a query-count regression test for the public widget endpoint.

## Why
The performance audit trace showed the widget endpoint repeated the same daily-result work for each uptime range. The measured controller path dropped from 8 `select` queries to 4 after batching.

## Validation
- `php artisan test`
- `php artisan test tests/Feature/*PerformanceTest.php tests/Feature/Notifications/*PerformanceTest.php`
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php`
- `./vendor/bin/pint --dirty`
- `git diff --check`