### PR TITLE
test: cover private monitoring validation guard

### DIFF
--- a/tests/Feature/Api/MonitoringDataAccessTest.php
+++ b/tests/Feature/Api/MonitoringDataAccessTest.php
@@ -67,4 +67,17 @@ class MonitoringDataAccessTest extends TestCase
 
         $testResponse->assertNotFound();
     }
+
+    public function test_validation_errors_do_not_leak_private_monitoring_existence(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'public_label_enabled' => false,
+        ]);
+
+        $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/uptime-calendar');
+
+        $testResponse->assertNotFound();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a focused API feature test for private monitoring access on a validation-bearing endpoint.
- Verifies `/api/monitorings/{monitoring}/uptime-calendar` returns `404` before request validation can leak private monitoring existence.

## Validation

- `php artisan test tests/Feature/Api/MonitoringDataAccessTest.php`

## Notes

- Local dependency install required `composer install --ignore-platform-req=ext-redis` because the CLI PHP environment does not have the Redis extension enabled.