### PR TITLE
test: cover fresh public widget uptime

### DIFF
--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -153,14 +153,14 @@ class PublicMonitoringWidgetApiTest extends TestCase
         ]);
 
         $checkedAt = Date::parse('2026-04-12 11:00:00');
-        $response = MonitoringResponse::query()->create([
+        $monitoringResponse = MonitoringResponse::query()->create([
             'monitoring_id' => $monitoring->id,
             'status' => MonitoringStatus::UP,
             'http_status_code' => 200,
             'response_time' => 123.4,
         ]);
 
-        DB::table('monitoring_response_results')->where('id', $response->id)->update([
+        DB::table('monitoring_response_results')->where('id', $monitoringResponse->id)->update([
             'created_at' => $checkedAt,
             'updated_at' => $checkedAt,
         ]);

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -138,6 +138,42 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $this->assertLessThanOrEqual(5, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
     }
 
+    public function test_public_widget_endpoint_uses_live_uptime_for_fresh_monitoring_without_daily_results(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Fresh API',
+            'type' => MonitoringType::HTTP,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::parse('2026-04-12 10:00:00'),
+        ]);
+
+        $checkedAt = Date::parse('2026-04-12 11:00:00');
+        $response = MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 123.4,
+        ]);
+
+        DB::table('monitoring_response_results')->where('id', $response->id)->update([
+            'created_at' => $checkedAt,
+            'updated_at' => $checkedAt,
+        ]);
+
+        $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('status', MonitoringStatus::UP->value);
+        $testResponse->assertJsonPath('uptime.7_days', 100);
+        $testResponse->assertJsonPath('uptime.30_days', 100);
+        $testResponse->assertJsonPath('uptime.365_days', 100);
+    }
+
     public function test_public_widget_endpoint_returns_not_found_when_public_label_is_disabled(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## What changed
- Added focused API coverage for the public monitoring widget when a monitoring is less than a day old and has only live response rows.
- The test asserts the widget keeps 7, 30, and 365 day uptime percentages populated from live data without daily aggregates.

## Why
The recent widget uptime batching work already covered the aggregate path for older monitorings. This adds coverage for the fresh-monitoring fallback path so it cannot regress silently.

## Validation
- `composer install --no-interaction --prefer-dist --ignore-platform-req=ext-redis`
- `php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php`

Note: normal Composer install is blocked locally because the PHP Redis extension is not installed.
