### PR TITLE
perf(notifications): combine unread count aggregates

### DIFF
--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -171,23 +171,31 @@ class NotificationBoardService
 
     public function getUnreadNotificationCount(): int
     {
-        $builder = MonitoringNotification::query()
+        $total = MonitoringNotification::query()
             ->withoutGlobalScopes()
             ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
             ->where('monitorings.user_id', auth()->id())
             ->whereNull('monitorings.deleted_at')
-            ->where('monitoring_notifications.read', false);
+            ->where('monitoring_notifications.read', false)
+            ->selectRaw(
+                <<<'SQL'
+                count(distinct case
+                    when monitoring_notifications.type = ?
+                    then monitoring_notifications.monitoring_id
+                end) + coalesce(sum(case
+                    when monitoring_notifications.type != ?
+                    then 1
+                    else 0
+                end), 0) as total
+                SQL,
+                [
+                    NotificationType::STATUS_CHANGE->value,
+                    NotificationType::STATUS_CHANGE->value,
+                ]
+            )
+            ->value('total');
 
-        $unreadStatusChangeCount = (clone $builder)
-            ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
-            ->distinct('monitoring_notifications.monitoring_id')
-            ->count('monitoring_notifications.monitoring_id');
-
-        $unreadNonStatusChangeCount = (clone $builder)
-            ->where('monitoring_notifications.type', '!=', NotificationType::STATUS_CHANGE->value)
-            ->count();
-
-        return $unreadStatusChangeCount + $unreadNonStatusChangeCount;
+        return (int) $total;
     }
 
     /**

--- a/tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
+++ b/tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
@@ -92,12 +92,36 @@ class UnreadNotificationCountPerformanceTest extends TestCase
             ->values();
 
         $this->assertSame(3, $count);
-        $this->assertCount(2, $selectQueries);
+        $this->assertCount(1, $selectQueries);
         $this->assertTrue($selectQueries->contains(
             fn (string $query): bool => str_contains(mb_strtolower($query), 'count(distinct')
+        ));
+        $this->assertTrue($selectQueries->contains(
+            fn (string $query): bool => str_contains(mb_strtolower($query), 'sum(case')
         ));
         $this->assertFalse($selectQueries->contains(
             fn (string $query): bool => str_contains($query, 'latestUnreadStatusChangeNotification')
         ));
+    }
+
+    public function test_unread_notification_count_returns_zero_without_notifications(): void
+    {
+        $package = Package::factory()->create();
+        $user = User::factory()->for($package)->create();
+
+        $this->actingAs($user);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $count = resolve(NotificationBoardService::class)->getUnreadNotificationCount();
+
+        $selectQueries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(fn (string $query): bool => str_starts_with(mb_strtolower($query), 'select'))
+            ->values();
+
+        $this->assertSame(0, $count);
+        $this->assertCount(1, $selectQueries);
     }
 }


### PR DESCRIPTION
## Summary
- combine unread notification badge counting into a single conditional aggregate query
- keep status-change notifications counted once per monitoring while counting other unread notifications individually
- add performance coverage for the single-query path and the zero-notifications case

## Evidence
- baseline guard previously expected 2 select queries for unread notification count
- updated guard now asserts 1 select query using conditional aggregate SQL

## Validation
- vendor/bin/pint app/Services/NotificationBoardService.php tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
- php artisan test tests/Feature/Notifications
- php artisan test

## Notes
- local dependency install required composer install --ignore-platform-req=ext-redis because the local PHP CLI lacks ext-redis
