### PR TITLE
fix: restrict domain results to domain monitors

### DIFF
--- a/app/Http/Controllers/Api/Internal/MonitoringController.php
+++ b/app/Http/Controllers/Api/Internal/MonitoringController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\Internal;
 
-use App\Enums\MonitoringType;
 use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
 use App\Http\Controllers\Controller;
 use App\Models\Incident;
 use App\Models\Monitoring;

--- a/app/Http/Controllers/Api/Internal/MonitoringController.php
+++ b/app/Http/Controllers/Api/Internal/MonitoringController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\Internal;
 
+use App\Enums\MonitoringType;
 use App\Enums\MonitoringStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Incident;
@@ -95,7 +96,7 @@ class MonitoringController extends Controller
     public function storeDomain(Request $request)
     {
         $validated = $request->validate([
-            'monitoring_id' => ['required', 'exists:monitorings,id'],
+            'monitoring_id' => ['required', Rule::exists('monitorings', 'id')->where('type', MonitoringType::DOMAIN_EXPIRATION->value)],
             'is_valid' => ['required', 'boolean'],
             'expires_at' => ['nullable', 'date'],
             'registrar' => ['nullable', 'string', 'max:255'],

--- a/tests/Feature/DomainExpirationMonitoringTest.php
+++ b/tests/Feature/DomainExpirationMonitoringTest.php
@@ -170,6 +170,31 @@ class DomainExpirationMonitoringTest extends TestCase
         ]);
     }
 
+    public function test_internal_instance_cannot_store_domain_result_for_non_domain_monitoring(): void
+    {
+        $monitoring = Monitoring::factory()
+            ->for($this->user)
+            ->create([
+                'type' => MonitoringType::HTTP,
+                'preferred_location' => $this->serverInstance->code,
+            ]);
+
+        $response = $this->withHeaders($this->instanceHeaders())
+            ->postJson(route('v1.internal.domain-results.store'), [
+                'monitoring_id' => $monitoring->id,
+                'is_valid' => true,
+                'expires_at' => Date::now()->addDays(90)->toIso8601String(),
+                'registrar' => 'Example Registrar',
+                'checked_at' => Date::now()->toIso8601String(),
+            ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['monitoring_id']);
+        $this->assertDatabaseMissing('monitoring_domain_results', [
+            'monitoring_id' => $monitoring->id,
+        ]);
+    }
+
     /**
      * @return array<string, string>
      */

--- a/tests/Feature/DomainExpirationMonitoringTest.php
+++ b/tests/Feature/DomainExpirationMonitoringTest.php
@@ -179,7 +179,7 @@ class DomainExpirationMonitoringTest extends TestCase
                 'preferred_location' => $this->serverInstance->code,
             ]);
 
-        $response = $this->withHeaders($this->instanceHeaders())
+        $testResponse = $this->withHeaders($this->instanceHeaders())
             ->postJson(route('v1.internal.domain-results.store'), [
                 'monitoring_id' => $monitoring->id,
                 'is_valid' => true,
@@ -188,8 +188,8 @@ class DomainExpirationMonitoringTest extends TestCase
                 'checked_at' => Date::now()->toIso8601String(),
             ]);
 
-        $response->assertUnprocessable();
-        $response->assertJsonValidationErrors(['monitoring_id']);
+        $testResponse->assertUnprocessable();
+        $testResponse->assertJsonValidationErrors(['monitoring_id']);
         $this->assertDatabaseMissing('monitoring_domain_results', [
             'monitoring_id' => $monitoring->id,
         ]);


### PR DESCRIPTION
## Summary
- restrict the internal domain-results endpoint to `domain_expiration` monitorings only
- add a regression test covering the rejected non-domain payload path
- keep the fix scoped to validation without changing the persistence flow for valid domain monitorings

## Why
The domain expiration feature introduced in `9133e7d` added `POST /api/v1/internal/domain-results`, but the endpoint only validated that `monitoring_id` existed and belonged to the authenticated instance. That allowed non-domain monitorings to receive `monitoring_domain_results` rows, which is invalid state.

## Impact
Instances can no longer attach domain expiration results to HTTP, ping, port, keyword, or heartbeat monitorings. Valid domain monitorings continue to use the same endpoint and storage path.

## Validation
- `php artisan test tests/Feature/DomainExpirationMonitoringTest.php`
