### PR TITLE
Add notification channel test buttons

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,13 +10,16 @@ use App\Http\Requests\DeleteUserRequest;
 use App\Http\Requests\ProfileRequest;
 use App\Jobs\DeleteUser;
 use App\Models\User;
+use App\Services\Notifications\NotificationChannelTestService;
 use App\Services\UserDeletionPreparationService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
+use Throwable;
 
 /**
  * Class ProfileController
@@ -133,6 +136,39 @@ class ProfileController extends Controller
         $request->user()->tokens()->delete();
 
         return back()->with('success', __('api.configuration.messages.tokens_deleted'));
+    }
+
+    public function sendNotificationChannelTest(
+        Request $request,
+        string $channel,
+        NotificationChannelTestService $notificationChannelTestService
+    ): RedirectResponse {
+        $notificationChannel = NotificationChannel::tryFrom($channel);
+
+        abort_unless($notificationChannel instanceof NotificationChannel, 404);
+
+        /** @var User $user */
+        $user = $request->user();
+        $config = data_get($user->notification_channels, $notificationChannel->value, []);
+        $config = is_array($config) ? $config : [];
+        $channelName = __('profile.notification_settings.channels.' . $notificationChannel->value . '.title');
+        $errorKey = 'notification_channels.' . $notificationChannel->value;
+
+        try {
+            $notificationChannelTestService->send($user, $notificationChannel, $config);
+        } catch (Throwable $throwable) {
+            Log::warning('Notification channel test failed.', [
+                'channel' => $notificationChannel->value,
+                'user_id' => $user->id,
+                'exception' => $throwable->getMessage(),
+            ]);
+
+            return back()->withErrors([
+                $errorKey => __('profile.notification_settings.test.messages.failed', ['channel' => $channelName]),
+            ]);
+        }
+
+        return back()->with('success', __('profile.notification_settings.test.messages.sent', ['channel' => $channelName]));
     }
 
     /**

--- a/app/Services/Notifications/NotificationChannelTestService.php
+++ b/app/Services/Notifications/NotificationChannelTestService.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Notifications;
+
+use App\Enums\NotificationChannel;
+use App\Enums\NotificationEventType;
+use App\Models\User;
+use App\Services\Notifications\Channels\DiscordChannelDriver;
+use App\Services\Notifications\Channels\NotificationChannelDriver;
+use App\Services\Notifications\Channels\SlackChannelDriver;
+use App\Services\Notifications\Channels\TelegramChannelDriver;
+use App\Services\Notifications\Channels\WebhookChannelDriver;
+use InvalidArgumentException;
+
+class NotificationChannelTestService
+{
+    /**
+     * @var array<string, NotificationChannelDriver>
+     */
+    private array $drivers;
+
+    public function __construct(
+        SlackChannelDriver $slackChannelDriver,
+        TelegramChannelDriver $telegramChannelDriver,
+        DiscordChannelDriver $discordChannelDriver,
+        WebhookChannelDriver $webhookChannelDriver
+    ) {
+        $this->drivers = [
+            $slackChannelDriver->channel() => $slackChannelDriver,
+            $telegramChannelDriver->channel() => $telegramChannelDriver,
+            $discordChannelDriver->channel() => $discordChannelDriver,
+            $webhookChannelDriver->channel() => $webhookChannelDriver,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function send(User $user, NotificationChannel $notificationChannel, array $config): void
+    {
+        $driver = $this->drivers[$notificationChannel->value] ?? null;
+
+        throw_unless($driver, InvalidArgumentException::class, 'Unsupported notification channel.');
+        throw_unless($driver->isConfigured($config), InvalidArgumentException::class, 'Notification channel is not configured.');
+
+        $driver->send($this->payload($user, $notificationChannel), $config);
+    }
+
+    private function payload(User $user, NotificationChannel $notificationChannel): NotificationPayload
+    {
+        return new NotificationPayload(
+            eventType: NotificationEventType::INCIDENT,
+            title: __('profile.notification_settings.test.payload.title'),
+            message: __('profile.notification_settings.test.payload.message', [
+                'channel' => __('profile.notification_settings.channels.' . $notificationChannel->value . '.title'),
+            ]),
+            severity: 'info',
+            monitoringId: null,
+            monitoringName: null,
+            monitoringTarget: null,
+            occurredAt: now(),
+            meta: [
+                'test' => true,
+                'channel' => $notificationChannel->value,
+                'user_id' => $user->id,
+            ]
+        );
+    }
+}

--- a/resources/lang/de/profile.php
+++ b/resources/lang/de/profile.php
@@ -28,6 +28,17 @@ return [
         'description' => 'Konfigurieren Sie Ihre globalen Benachrichtigungskanäle. Diese Einstellungen gelten für alle Überwachungen.',
         'enabled' => 'Aktiviert',
         'hint_banner' => 'Konfigurieren Sie mindestens einen Kanal, um weiterhin Incident- und SSL-Benachrichtigungen zu erhalten.',
+        'test' => [
+            'action' => 'Test senden',
+            'messages' => [
+                'sent' => ':channel-Testbenachrichtigung erfolgreich gesendet.',
+                'failed' => ':channel-Testbenachrichtigung konnte nicht gesendet werden. Prüfen Sie die gespeicherte Kanalkonfiguration und versuchen Sie es erneut.',
+            ],
+            'payload' => [
+                'title' => 'WebGuard-Testbenachrichtigung',
+                'message' => 'Ihr :channel-Benachrichtigungskanal ist korrekt konfiguriert.',
+            ],
+        ],
         'events' => [
             'incident' => 'Incident',
             'recovery' => 'Wiederherstellung',

--- a/resources/lang/en/profile.php
+++ b/resources/lang/en/profile.php
@@ -28,6 +28,17 @@ return [
         'description' => 'Configure your global notification channels. These settings apply to all monitorings.',
         'enabled' => 'Enabled',
         'hint_banner' => 'Configure at least one channel to continue receiving incident and SSL alerts.',
+        'test' => [
+            'action' => 'Send test',
+            'messages' => [
+                'sent' => ':channel test notification sent successfully.',
+                'failed' => ':channel test notification could not be sent. Check the saved channel configuration and try again.',
+            ],
+            'payload' => [
+                'title' => 'WebGuard test notification',
+                'message' => 'Your :channel notification channel is configured correctly.',
+            ],
+        ],
         'events' => [
             'incident' => 'Incident',
             'recovery' => 'Recovery',
@@ -83,7 +94,8 @@ return [
         'current_password' => 'Current Password',
         'new_password' => 'New Password',
         'confirm_new_password' => 'Confirm New Password',
-    ],    'actions' => [
+    ],
+    'actions' => [
         'update_password' => 'Update Password',
         'update_profile' => 'Update Profile',
         'delete_account' => 'Delete Account',

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -2,6 +2,7 @@
     @php
         $notificationChannels = old('notification_channels', $user->notification_channels ?? []);
         $eventTypes = ['incident', 'recovery', 'ssl_expiring', 'ssl_expired'];
+        $notificationChannelKeys = ['slack', 'telegram', 'discord', 'webhook'];
     @endphp
 
     <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
@@ -83,7 +84,11 @@
                         <x-text-checkbox id="notification_channels_slack_enabled" name="notification_channels[slack][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'slack.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
+                        <x-secondary-button form="test-slack-notification-channel" class="text-xs">
+                            {{ __('profile.notification_settings.test.action') }}
+                        </x-secondary-button>
                     </div>
+                    <x-input-error :messages="$errors->get('notification_channels.slack')" />
 
                     <x-paragraph class="text-sm text-gray-600 dark:text-gray-300">{{ __('profile.notification_settings.channels.slack.help') }}</x-paragraph>
 
@@ -111,7 +116,11 @@
                         <x-text-checkbox id="notification_channels_telegram_enabled" name="notification_channels[telegram][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'telegram.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
+                        <x-secondary-button form="test-telegram-notification-channel" class="text-xs">
+                            {{ __('profile.notification_settings.test.action') }}
+                        </x-secondary-button>
                     </div>
+                    <x-input-error :messages="$errors->get('notification_channels.telegram')" />
 
                     <x-paragraph class="text-sm text-gray-600 dark:text-gray-300">{{ __('profile.notification_settings.channels.telegram.help') }}</x-paragraph>
 
@@ -147,7 +156,11 @@
                         <x-text-checkbox id="notification_channels_discord_enabled" name="notification_channels[discord][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'discord.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
+                        <x-secondary-button form="test-discord-notification-channel" class="text-xs">
+                            {{ __('profile.notification_settings.test.action') }}
+                        </x-secondary-button>
                     </div>
+                    <x-input-error :messages="$errors->get('notification_channels.discord')" />
 
                     <x-paragraph class="text-sm text-gray-600 dark:text-gray-300">{{ __('profile.notification_settings.channels.discord.help') }}</x-paragraph>
 
@@ -175,7 +188,11 @@
                         <x-text-checkbox id="notification_channels_webhook_enabled" name="notification_channels[webhook][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'webhook.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
+                        <x-secondary-button form="test-webhook-notification-channel" class="text-xs">
+                            {{ __('profile.notification_settings.test.action') }}
+                        </x-secondary-button>
                     </div>
+                    <x-input-error :messages="$errors->get('notification_channels.webhook')" />
 
                     <x-paragraph class="text-sm text-gray-600 dark:text-gray-300">{{ __('profile.notification_settings.channels.webhook.help') }}</x-paragraph>
 
@@ -201,4 +218,11 @@
 
         <x-primary-button>{{ __('button.update') }}</x-primary-button>
     </form>
+
+    @foreach ($notificationChannelKeys as $notificationChannelKey)
+        <form id="test-{{ $notificationChannelKey }}-notification-channel" method="POST"
+            action="{{ route('profile.notification-channels.test', ['channel' => $notificationChannelKey]) }}">
+            @csrf
+        </form>
+    @endforeach
 </x-container>

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,8 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
 
         Route::post('/api-generate-token', [ProfileController::class, 'apiGenerateToken'])->name('api-generate-token');
         Route::delete('/api-revoke-token', [ProfileController::class, 'apiRevokeToken'])->name('api-revoke-token');
+        Route::post('/notification-channels/{channel}/test', [ProfileController::class, 'sendNotificationChannelTest'])
+            ->name('notification-channels.test');
     });
 
     Route::resource('monitorings', MonitoringController::class)->names('monitorings');

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -7,11 +7,67 @@ namespace Tests\Feature;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ProfileNotificationSettingsTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * @return array<string, array{channel: string, notificationChannels: array<string, mixed>, expectedUrl: string}>
+     */
+    public static function notificationChannelConfigurations(): array
+    {
+        return [
+            'slack' => [
+                'channel' => 'slack',
+                'notificationChannels' => [
+                    'slack' => [
+                        'enabled' => false,
+                        'webhook_url' => 'https://hooks.slack.test/services/T000/B000/XXX',
+                        'events' => [],
+                    ],
+                ],
+                'expectedUrl' => 'https://hooks.slack.test/services/T000/B000/XXX',
+            ],
+            'telegram' => [
+                'channel' => 'telegram',
+                'notificationChannels' => [
+                    'telegram' => [
+                        'enabled' => false,
+                        'bot_token' => '12345:ABCDEF',
+                        'chat_id' => '-1001234567',
+                        'events' => [],
+                    ],
+                ],
+                'expectedUrl' => 'https://api.telegram.org/bot12345:ABCDEF/sendMessage',
+            ],
+            'discord' => [
+                'channel' => 'discord',
+                'notificationChannels' => [
+                    'discord' => [
+                        'enabled' => false,
+                        'webhook_url' => 'https://discord.test/api/webhooks/123/token',
+                        'events' => [],
+                    ],
+                ],
+                'expectedUrl' => 'https://discord.test/api/webhooks/123/token',
+            ],
+            'webhook' => [
+                'channel' => 'webhook',
+                'notificationChannels' => [
+                    'webhook' => [
+                        'enabled' => false,
+                        'url' => 'https://example.test/webhooks/webguard',
+                        'events' => [],
+                    ],
+                ],
+                'expectedUrl' => 'https://example.test/webhooks/webguard',
+            ],
+        ];
+    }
 
     public function test_profile_page_shows_notification_settings_and_one_time_hint(): void
     {
@@ -94,5 +150,91 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertTrue((bool) data_get($user->notification_channels, 'webhook.enabled'));
         $this->assertSame('https://example.test/webhooks/webguard', data_get($user->notification_channels, 'webhook.url'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'webhook.events.ssl_expired'));
+    }
+
+    public function test_profile_page_shows_notification_channel_test_buttons(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $testResponse = $this->actingAs($user)->get(route('profile.edit'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('profile.notification_settings.test.action'));
+        $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'slack']));
+        $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'telegram']));
+        $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'discord']));
+        $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'webhook']));
+    }
+
+    /**
+     * @param  array<string, mixed>  $notificationChannels
+     */
+    #[DataProvider('notificationChannelConfigurations')]
+    public function test_user_can_send_test_notification_to_saved_channel(
+        string $channel,
+        array $notificationChannels,
+        string $expectedUrl
+    ): void {
+        Http::fake([
+            '*' => Http::response([], 200),
+        ]);
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => $notificationChannels,
+        ]);
+
+        $testResponse = $this->actingAs($user)->post(route('profile.notification-channels.test', ['channel' => $channel]));
+
+        $testResponse->assertRedirect();
+        $testResponse->assertSessionHas('success', __('profile.notification_settings.test.messages.sent', [
+            'channel' => __('profile.notification_settings.channels.' . $channel . '.title'),
+        ]));
+
+        Http::assertSent(fn ($request): bool => $request->url() === $expectedUrl
+            && str_contains(json_encode($request->data(), JSON_THROW_ON_ERROR), __('profile.notification_settings.test.payload.title')));
+    }
+
+    public function test_channel_test_requires_saved_channel_configuration(): void
+    {
+        Http::fake();
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [],
+        ]);
+
+        $testResponse = $this->actingAs($user)->from(route('profile.edit'))
+            ->post(route('profile.notification-channels.test', ['channel' => 'slack']));
+
+        $testResponse->assertRedirect(route('profile.edit'));
+        $testResponse->assertSessionHasErrors(['notification_channels.slack']);
+        Http::assertNothingSent();
+    }
+
+    public function test_channel_test_reports_delivery_failure(): void
+    {
+        Http::fake([
+            '*' => Http::response([], 500),
+        ]);
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'slack' => [
+                    'enabled' => false,
+                    'webhook_url' => 'https://hooks.slack.test/services/T000/B000/XXX',
+                    'events' => [],
+                ],
+            ],
+        ]);
+
+        $testResponse = $this->actingAs($user)->from(route('profile.edit'))
+            ->post(route('profile.notification-channels.test', ['channel' => 'slack']));
+
+        $testResponse->assertRedirect(route('profile.edit'));
+        $testResponse->assertSessionHasErrors(['notification_channels.slack']);
+        Http::assertSentCount(1);
     }
 }


### PR DESCRIPTION
## Summary
- add per-channel Send test buttons on profile notification settings
- send test payloads through the existing Slack, Telegram, Discord, and webhook drivers using saved channel configuration
- surface success and failure feedback on the profile page
- cover rendered buttons, successful sends for all channels, missing config, and delivery failures

## Motivation
Notification setup is hard to trust without exercising the real saved channel configuration. This gives customers a direct way to verify each destination before relying on incident or SSL alerts.

## Testing
- ./vendor/bin/pint
- php artisan test tests/Feature/ProfileNotificationSettingsTest.php tests/Feature/Notifications/NotificationRouterTest.php tests/Feature/Notifications/DispatchStatusChangeNotificationsCommandTest.php tests/Feature/Notifications/SendSslExpiryWarningsCommandTest.php
- ./vendor/bin/rector process --dry-run --ansi
- php artisan test

## Rollout Notes
No migration required. Test notifications use saved channel settings, so users should save changed credentials before sending a test.
