### PR TITLE
Adjust expected HTTP status detail display

### DIFF
--- a/resources/js/components/monitoring-detail.ts
+++ b/resources/js/components/monitoring-detail.ts
@@ -16,6 +16,7 @@ interface MonitoringDetailComponent {
         source: string;
     }>;
     status: string | null;
+    statusCode: number | null;
     since: string | null;
     heatmap: any[];
     loading: boolean;
@@ -85,6 +86,7 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
         source: string;
     }>,
     status: null as string | null,
+    statusCode: null as number | null,
     since: null as string | null,
     heatmap: [] as any[],
     loading: false,
@@ -128,6 +130,7 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
             const response = await fetch(`/api/monitorings/${monitoringId}/status`);
             const responseData = await response.json();
             this.status = responseData.status;
+            this.statusCode = responseData.status_code ?? null;
             if (responseData.since) {
                 this.sinceDate = new Date(responseData.since);
                 this.since = humanizeDistance(this.sinceDate, { withoutSuffix: true });
@@ -143,6 +146,7 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
             }
         } catch (_) {
             this.status = null;
+            this.statusCode = null;
             this.since = null;
             this.lastCheckedAt = null;
             this.lastCheckedAtHuman = null;

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -160,10 +160,6 @@ return [
             'grace' => 'Kulanzzeit: :minutes Minute|Kulanzzeit: :minutes Minuten',
             'last_ping' => 'Letzter empfangener Ping',
         ],
-        'http' => [
-            'heading' => 'HTTP-Erwartungen',
-            'expected_statuses' => 'Akzeptierte Statuscodes',
-        ],
         'domain' => [
             'heading' => 'Domain-Ablauf',
             'valid' => 'Gültig',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -160,10 +160,6 @@ return [
             'grace' => 'Grace period: :minutes minute|Grace period: :minutes minutes',
             'last_ping' => 'Last ping received',
         ],
-        'http' => [
-            'heading' => 'HTTP Expectations',
-            'expected_statuses' => 'Acceptable status codes',
-        ],
         'domain' => [
             'heading' => 'Domain Expiration',
             'valid' => 'Valid',

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -111,6 +111,10 @@
                         <div>
                             <x-span x-text="status === 'up' ? '🟢' : (status === 'down' ? '🔴' : '🟡')"></x-span>
                             <x-span x-text="status ? status.toUpperCase() : ''" class="font-bold"></x-span>
+                            <template x-if="statusCode !== null">
+                                <x-span class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400"
+                                    x-text="'HTTP ' + statusCode"></x-span>
+                            </template>
                         </div>
                         <x-paragraph x-show="since" x-text="'{{ __('monitoring.index.table.since') }} ' + since"
                             class="text-gray-400">
@@ -133,14 +137,6 @@
             </x-container>
 
             @if ($monitoring->type === MonitoringType::HTTP || $monitoring->type === MonitoringType::KEYWORD)
-                <x-container>
-                    <x-heading type="h2">{{ __('monitoring.detail.http.heading') }}</x-heading>
-                    <x-paragraph>
-                        {{ __('monitoring.detail.http.expected_statuses') }}:
-                        <x-span class="font-medium">{{ $monitoring->expected_http_statuses ?? '200-299' }}</x-span>
-                    </x-paragraph>
-                </x-container>
-
                 <x-container>
                     <x-heading type="h2">{{ __('monitoring.detail.ssl.heading') }}</x-heading>
 

--- a/tests/Feature/MonitoringExpectedHttpStatusesTest.php
+++ b/tests/Feature/MonitoringExpectedHttpStatusesTest.php
@@ -159,6 +159,30 @@ class MonitoringExpectedHttpStatusesTest extends TestCase
         ]);
     }
 
+    public function test_expected_http_statuses_are_rendered_in_form_but_not_as_detail_card(): void
+    {
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com/health',
+            'preferred_location' => $this->serverInstance->code,
+            'expected_http_statuses' => '200-399',
+        ]);
+
+        $testResponse = $this->actingAs($this->user)->get(route('monitorings.edit', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.form.expected_http_statuses'));
+        $testResponse->assertSee('200-399');
+
+        $detailResponse = $this->actingAs($this->user)->get(route('monitorings.show', $monitoring));
+
+        $detailResponse->assertOk();
+        $detailResponse->assertDontSeeText('HTTP Expectations');
+        $detailResponse->assertDontSeeText('HTTP-Erwartungen');
+        $detailResponse->assertDontSeeText('Acceptable status codes');
+        $detailResponse->assertDontSeeText('Akzeptierte Statuscodes');
+    }
+
     public function test_expected_http_status_range_matching_supports_codes_and_ranges(): void
     {
         $this->assertTrue(HttpStatusCodeRanges::contains('200-299,301,302', 204));


### PR DESCRIPTION
## Summary
- remove the separate HTTP expectations card from the monitoring detail page
- keep expected HTTP status configuration in the monitoring form/edit flow
- show the latest received HTTP status code next to the current UP/DOWN status in the current-status card

## Testing
- `./vendor/bin/pint`
- `php artisan test tests/Feature/MonitoringExpectedHttpStatusesTest.php tests/Feature/Api/ApiControllerTest.php`
- `php artisan test`
- `./vendor/bin/rector process --dry-run --ansi`
- `bun install --frozen-lockfile`
- `bun run build`

## Rollout Notes
No migration changes in this PR. It adjusts the display on top of the expected HTTP status code feature already merged in #199.