### PR TITLE
Add expiry reminder controls

### DIFF
--- a/app/Console/Commands/Notifications/SendSslExpiryWarningsCommand.php
+++ b/app/Console/Commands/Notifications/SendSslExpiryWarningsCommand.php
@@ -6,10 +6,12 @@ namespace App\Console\Commands\Notifications;
 
 use App\Enums\NotificationEventType;
 use App\Enums\NotificationType;
+use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringNotification;
 use App\Models\MonitoringSslResult;
 use App\Services\Notifications\NotificationPayload;
 use App\Services\Notifications\NotificationRouter;
+use Carbon\CarbonInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
 
@@ -27,7 +29,7 @@ class SendSslExpiryWarningsCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Checks SSL certificates and dispatches channel notifications.';
+    protected $description = 'Checks SSL certificates and domains and dispatches expiry notifications.';
 
     public function __construct(private readonly NotificationRouter $notificationRouter)
     {
@@ -39,78 +41,179 @@ class SendSslExpiryWarningsCommand extends Command
      */
     public function handle(): int
     {
+        $maxWarningDays = max(config('monitoring.expiry_warning_days.allowed', [30, 14, 7, 3, 1]));
+
+        $this->sendSslExpiryWarnings($maxWarningDays);
+        $this->sendDomainExpiryWarnings($maxWarningDays);
+
+        return Command::SUCCESS;
+    }
+
+    private function sendSslExpiryWarnings(int $maxWarningDays): void
+    {
         $sslResults = MonitoringSslResult::query()
-            ->where(function ($builder): void {
-                $builder->where('expires_at', '<=', now()->addDays(7))
+            ->where(function ($builder) use ($maxWarningDays): void {
+                $builder->where(function ($builder) use ($maxWarningDays): void {
+                    $builder->whereNotNull('expires_at')
+                        ->where('expires_at', '<=', now()->addDays($maxWarningDays));
+                })
                     ->orWhere('is_valid', false);
             })
             ->with(['monitoring.user'])
             ->get();
 
         foreach ($sslResults as $sslResult) {
-            $monitoring = $sslResult->monitoring;
-            $user = $monitoring->user;
-            if (! $monitoring) {
-                continue;
-            }
-            if (! $user) {
-                continue;
-            }
-
-            if (! $monitoring->notification_on_failure) {
-                continue;
-            }
-
-            $eventType = (! $sslResult->is_valid || $sslResult->expires_at->lte(now()))
-                ? NotificationEventType::SSL_EXPIRED
-                : NotificationEventType::SSL_EXPIRING;
-
-            $cacheKey = sprintf('ssl_notification_%s_%s_%s', $eventType->value, $sslResult->id, now()->format('Y-m-d'));
-
-            if (Cache::has($cacheKey)) {
-                continue;
-            }
-
-            $message = $eventType === NotificationEventType::SSL_EXPIRED
-                ? 'SSL_EXPIRED'
-                : 'SSL_EXPIRING';
-
-            $notification = MonitoringNotification::query()->create([
-                'monitoring_id' => $monitoring->id,
-                'type' => NotificationType::SSL_EXPIRY,
-                'message' => $message,
-                'read' => false,
-                'sent' => false,
-            ]);
-
-            $payload = new NotificationPayload(
-                eventType: $eventType,
-                title: $eventType === NotificationEventType::SSL_EXPIRED
-                    ? 'SSL certificate expired'
-                    : 'SSL certificate expiring soon',
-                message: sprintf(
-                    '%s (%s) certificate expires at %s.',
-                    $monitoring->name,
-                    $monitoring->target,
-                    $sslResult->expires_at->toDateTimeString()
-                ),
-                severity: $eventType === NotificationEventType::SSL_EXPIRED ? 'critical' : 'warning',
-                monitoringId: $monitoring->id,
-                monitoringName: $monitoring->name,
-                monitoringTarget: $monitoring->target,
-                occurredAt: now(),
-                meta: [
-                    'ssl_result_id' => $sslResult->id,
-                    'notification_id' => $notification->id,
-                    'expires_at' => $sslResult->expires_at->toIso8601String(),
-                ],
+            $this->sendExpiryWarning(
+                result: $sslResult,
+                notificationType: NotificationType::SSL_EXPIRY,
+                expiredEventType: NotificationEventType::SSL_EXPIRED,
+                expiringEventType: NotificationEventType::SSL_EXPIRING,
+                expiredMessage: 'SSL_EXPIRED',
+                expiringMessage: 'SSL_EXPIRING',
+                expiredTitle: 'SSL certificate expired',
+                expiringTitle: 'SSL certificate expiring soon',
+                subject: 'certificate',
+                resultMetaKey: 'ssl_result_id'
             );
+        }
+    }
 
-            $this->notificationRouter->dispatch($user, $payload);
-            $notification->update(['sent' => true]);
-            Cache::put($cacheKey, true, now()->addHours(23));
+    private function sendDomainExpiryWarnings(int $maxWarningDays): void
+    {
+        $domainResults = MonitoringDomainResult::query()
+            ->where(function ($builder) use ($maxWarningDays): void {
+                $builder->where(function ($builder) use ($maxWarningDays): void {
+                    $builder->whereNotNull('expires_at')
+                        ->where('expires_at', '<=', now()->addDays($maxWarningDays));
+                })
+                    ->orWhere('is_valid', false);
+            })
+            ->with(['monitoring.user'])
+            ->get();
+
+        foreach ($domainResults as $domainResult) {
+            $this->sendExpiryWarning(
+                result: $domainResult,
+                notificationType: NotificationType::DOMAIN_EXPIRY,
+                expiredEventType: NotificationEventType::DOMAIN_EXPIRED,
+                expiringEventType: NotificationEventType::DOMAIN_EXPIRING,
+                expiredMessage: 'DOMAIN_EXPIRED',
+                expiringMessage: 'DOMAIN_EXPIRING',
+                expiredTitle: 'Domain expired',
+                expiringTitle: 'Domain expiring soon',
+                subject: 'domain registration',
+                resultMetaKey: 'domain_result_id'
+            );
+        }
+    }
+
+    private function sendExpiryWarning(
+        MonitoringSslResult|MonitoringDomainResult $result,
+        NotificationType $notificationType,
+        NotificationEventType $expiredEventType,
+        NotificationEventType $expiringEventType,
+        string $expiredMessage,
+        string $expiringMessage,
+        string $expiredTitle,
+        string $expiringTitle,
+        string $subject,
+        string $resultMetaKey
+    ): void {
+        $monitoring = $result->monitoring;
+        if (! $monitoring) {
+            return;
         }
 
-        return Command::SUCCESS;
+        $user = $monitoring->user;
+        if (! $user) {
+            return;
+        }
+
+        if (! $monitoring->notification_on_failure) {
+            return;
+        }
+
+        $expiresAt = $result->expires_at;
+        $isExpired = ! $result->is_valid || ($expiresAt !== null && $expiresAt->lte(now()));
+        $daysUntilExpiry = $expiresAt !== null ? $this->daysUntilExpiry($expiresAt) : null;
+
+        if (! $isExpired) {
+            if ($daysUntilExpiry === null || ! in_array($daysUntilExpiry, $user->expiryWarningDays(), true)) {
+                return;
+            }
+        }
+
+        $eventType = $isExpired ? $expiredEventType : $expiringEventType;
+        $cacheKey = sprintf(
+            'expiry_notification_%s_%s_%s_%s',
+            $eventType->value,
+            $result->id,
+            $daysUntilExpiry ?? 'expired',
+            now()->format('Y-m-d')
+        );
+
+        if (Cache::has($cacheKey)) {
+            return;
+        }
+
+        $notification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => $notificationType,
+            'message' => $isExpired ? $expiredMessage : $expiringMessage,
+            'read' => false,
+            'sent' => false,
+        ]);
+
+        $payload = new NotificationPayload(
+            eventType: $eventType,
+            title: $isExpired ? $expiredTitle : $expiringTitle,
+            message: $this->expiryMessage($monitoring->name, $monitoring->target, $subject, $expiresAt, $daysUntilExpiry, $isExpired),
+            severity: $isExpired ? 'critical' : 'warning',
+            monitoringId: $monitoring->id,
+            monitoringName: $monitoring->name,
+            monitoringTarget: $monitoring->target,
+            occurredAt: now(),
+            meta: [
+                $resultMetaKey => $result->id,
+                'notification_id' => $notification->id,
+                'expires_at' => $expiresAt?->toIso8601String(),
+                'days_until_expiry' => $daysUntilExpiry,
+            ],
+        );
+
+        $this->notificationRouter->dispatch($user, $payload);
+        $notification->update(['sent' => true]);
+        Cache::put($cacheKey, true, now()->addHours(23));
+    }
+
+    private function daysUntilExpiry(CarbonInterface $expiresAt): int
+    {
+        return (int) now()->startOfDay()->diffInDays($expiresAt->copy()->startOfDay(), false);
+    }
+
+    private function expiryMessage(
+        string $monitoringName,
+        string $monitoringTarget,
+        string $subject,
+        ?CarbonInterface $expiresAt,
+        ?int $daysUntilExpiry,
+        bool $isExpired
+    ): string {
+        if ($expiresAt === null) {
+            return sprintf('%s (%s) %s expiry date is unknown.', $monitoringName, $monitoringTarget, $subject);
+        }
+
+        if ($isExpired) {
+            return sprintf('%s (%s) %s expired at %s.', $monitoringName, $monitoringTarget, $subject, $expiresAt->toDateTimeString());
+        }
+
+        return sprintf(
+            '%s (%s) %s expires in %d days at %s.',
+            $monitoringName,
+            $monitoringTarget,
+            $subject,
+            $daysUntilExpiry,
+            $expiresAt->toDateTimeString()
+        );
     }
 }

--- a/app/Console/Commands/Notifications/SendSslExpiryWarningsCommand.php
+++ b/app/Console/Commands/Notifications/SendSslExpiryWarningsCommand.php
@@ -156,7 +156,7 @@ class SendSslExpiryWarningsCommand extends Command
             return;
         }
 
-        $notification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => $notificationType,
             'message' => $isExpired ? $expiredMessage : $expiringMessage,
@@ -164,7 +164,7 @@ class SendSslExpiryWarningsCommand extends Command
             'sent' => false,
         ]);
 
-        $payload = new NotificationPayload(
+        $notificationPayload = new NotificationPayload(
             eventType: $eventType,
             title: $isExpired ? $expiredTitle : $expiringTitle,
             message: $this->expiryMessage($monitoring->name, $monitoring->target, $subject, $expiresAt, $daysUntilExpiry, $isExpired),
@@ -175,20 +175,20 @@ class SendSslExpiryWarningsCommand extends Command
             occurredAt: now(),
             meta: [
                 $resultMetaKey => $result->id,
-                'notification_id' => $notification->id,
+                'notification_id' => $monitoringNotification->id,
                 'expires_at' => $expiresAt?->toIso8601String(),
                 'days_until_expiry' => $daysUntilExpiry,
             ],
         );
 
-        $this->notificationRouter->dispatch($user, $payload);
-        $notification->update(['sent' => true]);
+        $this->notificationRouter->dispatch($user, $notificationPayload);
+        $monitoringNotification->update(['sent' => true]);
         Cache::put($cacheKey, true, now()->addHours(23));
     }
 
     private function daysUntilExpiry(CarbonInterface $expiresAt): int
     {
-        return (int) now()->startOfDay()->diffInDays($expiresAt->copy()->startOfDay(), false);
+        return (int) today()->diffInDays($expiresAt->copy()->startOfDay(), false);
     }
 
     private function expiryMessage(

--- a/app/Enums/NotificationEventType.php
+++ b/app/Enums/NotificationEventType.php
@@ -10,6 +10,8 @@ enum NotificationEventType: string
     case RECOVERY = 'recovery';
     case SSL_EXPIRING = 'ssl_expiring';
     case SSL_EXPIRED = 'ssl_expired';
+    case DOMAIN_EXPIRING = 'domain_expiring';
+    case DOMAIN_EXPIRED = 'domain_expired';
 
     /**
      * @return array<int, string>

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -7,6 +7,7 @@ namespace App\Enums;
 enum NotificationType: string
 {
     case SSL_EXPIRY = 'ssl_expiry';
+    case DOMAIN_EXPIRY = 'domain_expiry';
     case STATUS_CHANGE = 'status_change';
 
     /**

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -35,6 +35,7 @@ class NotificationController extends Controller
         );
 
         [$sslExpiryNotifications, $sslExpiryHasMore] = $this->loadSslExpiryNotifications($showRead, 0, $limit);
+        [$domainExpiryNotifications, $domainExpiryHasMore] = $this->loadDomainExpiryNotifications($showRead, 0, $limit);
         [$deliveryHistory, $deliveryHistoryHasMore] = $this->loadDeliveryHistory(0, $limit);
 
         return view('notifications.index', compact(
@@ -42,6 +43,8 @@ class NotificationController extends Controller
             'statusChangeHasMore',
             'sslExpiryNotifications',
             'sslExpiryHasMore',
+            'domainExpiryNotifications',
+            'domainExpiryHasMore',
             'deliveryHistory',
             'deliveryHistoryHasMore',
             'showRead',
@@ -167,6 +170,17 @@ class NotificationController extends Controller
         int $limit = self::DEFAULT_NOTIFICATION_LIMIT
     ): array {
         return $this->loadNotificationsByType(NotificationType::SSL_EXPIRY, $showRead, $offset, $limit);
+    }
+
+    /**
+     * @return array{0: Collection<int, MonitoringNotification>, 1: bool}
+     */
+    private function loadDomainExpiryNotifications(
+        bool $showRead,
+        int $offset = 0,
+        int $limit = self::DEFAULT_NOTIFICATION_LIMIT
+    ): array {
+        return $this->loadNotificationsByType(NotificationType::DOMAIN_EXPIRY, $showRead, $offset, $limit);
     }
 
     /**

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -71,6 +71,7 @@ class ProfileController extends Controller
         }
 
         $user->notification_channels = $this->normalizeNotificationChannels($profileRequest);
+        $user->expiry_warning_days = $this->normalizeExpiryWarningDays($profileRequest);
         $user->save();
 
         return to_route('profile.edit')
@@ -208,5 +209,24 @@ class ProfileController extends Controller
         }
 
         return $normalized;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function normalizeExpiryWarningDays(ProfileRequest $profileRequest): array
+    {
+        $allowedDays = config('monitoring.expiry_warning_days.allowed', [30, 14, 7, 3, 1]);
+        $submittedDays = $profileRequest->input('expiry_warning_days', []);
+
+        if (! is_array($submittedDays)) {
+            return [];
+        }
+
+        $days = array_values(array_unique(array_map('intval', $submittedDays)));
+        $days = array_values(array_intersect($days, $allowedDays));
+        rsort($days);
+
+        return $days;
     }
 }

--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -54,6 +54,8 @@ class ProfileRequest extends FormRequest
             'notification_channels.telegram.chat_id' => ['nullable', 'string', 'max:255'],
             'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048'],
             'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048'],
+            'expiry_warning_days' => ['nullable', 'array'],
+            'expiry_warning_days.*' => ['integer', Rule::in(config('monitoring.expiry_warning_days.allowed', [30, 14, 7, 3, 1]))],
         ];
 
         foreach (NotificationChannel::values() as $channel) {

--- a/app/Models/MonitoringNotification.php
+++ b/app/Models/MonitoringNotification.php
@@ -110,6 +110,15 @@ class MonitoringNotification extends Model
     }
 
     /**
+     * Scope notifications to domain expiry entries.
+     */
+    #[Scope]
+    protected function domainExpiry(Builder $builder): Builder
+    {
+        return $builder->ofType(NotificationType::DOMAIN_EXPIRY);
+    }
+
+    /**
      * Scope notifications to read entries.
      */
     #[Scope]
@@ -157,6 +166,14 @@ class MonitoringNotification extends Model
                 return match ($this->message) {
                     'SSL_EXPIRED' => __('notifications.ssl_messages.expired', ['name' => $this->monitoring->name]),
                     'SSL_EXPIRING' => __('notifications.ssl_messages.expiring', ['name' => $this->monitoring->name]),
+                    default => $this->message,
+                };
+            }
+
+            if ($this->type === NotificationType::DOMAIN_EXPIRY) {
+                return match ($this->message) {
+                    'DOMAIN_EXPIRED' => __('notifications.domain_messages.expired', ['name' => $this->monitoring->name]),
+                    'DOMAIN_EXPIRING' => __('notifications.domain_messages.expiring', ['name' => $this->monitoring->name]),
                     default => $this->message,
                 };
             }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,6 +38,7 @@ use Laravel\Sanctum\PersonalAccessToken;
  * @property string|null $package_id
  * @property array<string, mixed>|null $notification_channels
  * @property Carbon|null $notification_channels_hint_seen_at
+ * @property list<int>|null $expiry_warning_days
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property-read Collection<int, PersonalAccessToken> $tokens
@@ -68,6 +69,7 @@ use Laravel\Sanctum\PersonalAccessToken;
     'avatar',
     'notification_channels',
     'notification_channels_hint_seen_at',
+    'expiry_warning_days',
 ])]
 #[Hidden([
     'password',
@@ -172,6 +174,23 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
+     * @return list<int>
+     */
+    public function expiryWarningDays(): array
+    {
+        $allowedDays = config('monitoring.expiry_warning_days.allowed', [30, 14, 7, 3, 1]);
+        $configuredDays = is_array($this->expiry_warning_days)
+            ? $this->expiry_warning_days
+            : config('monitoring.expiry_warning_days.default', [7]);
+
+        $days = array_values(array_unique(array_map('intval', $configuredDays)));
+        $days = array_values(array_intersect($days, $allowedDays));
+        rsort($days);
+
+        return $days;
+    }
+
+    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>
@@ -187,6 +206,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'theme' => 'string',
             'notification_channels' => 'array',
             'notification_channels_hint_seen_at' => 'datetime',
+            'expiry_warning_days' => 'array',
         ];
     }
 }

--- a/config/monitoring.php
+++ b/config/monitoring.php
@@ -51,4 +51,18 @@ return [
     |
     */
     'digest_expiry_warning_days' => (int) env('MONITORING_DIGEST_EXPIRY_WARNING_DAYS', 30),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiry Warning Windows
+    |--------------------------------------------------------------------------
+    |
+    | Users can choose which day offsets should trigger SSL and domain expiry
+    | warnings. The default keeps a seven-day warning enabled for existing users.
+    |
+    */
+    'expiry_warning_days' => [
+        'allowed' => [30, 14, 7, 3, 1],
+        'default' => [7],
+    ],
 ];

--- a/database/migrations/2026_04_25_120000_add_expiry_warning_days_to_users_table.php
+++ b/database/migrations/2026_04_25_120000_add_expiry_warning_days_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->json('expiry_warning_days')->nullable()->after('notification_channels_hint_seen_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('expiry_warning_days');
+        });
+    }
+};

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -9,6 +9,7 @@ return [
         'heading' => 'Status-Board',
     ],
     'ssl_expiry_notifications' => 'SSL-Ablauf',
+    'domain_expiry_notifications' => 'Domain-Ablauf',
     'delivery_history' => [
         'heading' => 'Zustellverlauf',
     ],
@@ -57,6 +58,10 @@ return [
         'expiring' => 'Das SSL-Zertifikat für :name läuft bald ab.',
         'expired' => 'Das SSL-Zertifikat für :name ist abgelaufen.',
     ],
+    'domain_messages' => [
+        'expiring' => 'Die Domain :name läuft bald ab.',
+        'expired' => 'Die Domain :name ist abgelaufen.',
+    ],
     'channels' => [
         'slack' => 'Slack',
         'telegram' => 'Telegram',
@@ -68,6 +73,8 @@ return [
         'recovery' => 'Wiederherstellung',
         'ssl_expiring' => 'SSL läuft bald ab',
         'ssl_expired' => 'SSL abgelaufen',
+        'domain_expiring' => 'Domain läuft bald ab',
+        'domain_expired' => 'Domain abgelaufen',
     ],
     'delivery_status' => [
         'sent' => 'Gesendet',

--- a/resources/lang/de/profile.php
+++ b/resources/lang/de/profile.php
@@ -44,6 +44,13 @@ return [
             'recovery' => 'Wiederherstellung',
             'ssl_expiring' => 'SSL läuft bald ab',
             'ssl_expired' => 'SSL abgelaufen',
+            'domain_expiring' => 'Domain läuft bald ab',
+            'domain_expired' => 'Domain abgelaufen',
+        ],
+        'expiry_warning_days' => [
+            'heading' => 'Ablauf-Warnfenster',
+            'help' => 'Wählen Sie, wann SSL-Zertifikate und Domains Ablaufwarnungen auslösen sollen.',
+            'option' => '{1} :days Tag vor Ablauf|[2,*] :days Tage vor Ablauf',
         ],
         'fields' => [
             'telegram_bot_token' => 'Telegram Bot Token',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -9,6 +9,7 @@ return [
         'heading' => 'Notification Board',
     ],
     'ssl_expiry_notifications' => 'SSL Expiry',
+    'domain_expiry_notifications' => 'Domain Expiry',
     'delivery_history' => [
         'heading' => 'Delivery History',
     ],
@@ -57,6 +58,10 @@ return [
         'expiring' => 'SSL certificate for :name is expiring soon.',
         'expired' => 'SSL certificate for :name has expired.',
     ],
+    'domain_messages' => [
+        'expiring' => 'Domain :name is expiring soon.',
+        'expired' => 'Domain :name has expired.',
+    ],
     'channels' => [
         'slack' => 'Slack',
         'telegram' => 'Telegram',
@@ -68,6 +73,8 @@ return [
         'recovery' => 'Recovery',
         'ssl_expiring' => 'SSL expiring',
         'ssl_expired' => 'SSL expired',
+        'domain_expiring' => 'Domain expiring',
+        'domain_expired' => 'Domain expired',
     ],
     'delivery_status' => [
         'sent' => 'Sent',

--- a/resources/lang/en/profile.php
+++ b/resources/lang/en/profile.php
@@ -44,6 +44,13 @@ return [
             'recovery' => 'Recovery',
             'ssl_expiring' => 'SSL expiring',
             'ssl_expired' => 'SSL expired',
+            'domain_expiring' => 'Domain expiring',
+            'domain_expired' => 'Domain expired',
+        ],
+        'expiry_warning_days' => [
+            'heading' => 'Expiry warning windows',
+            'help' => 'Choose when SSL certificates and domains should trigger expiry warnings.',
+            'option' => '{1} :days day before expiry|[2,*] :days days before expiry',
         ],
         'fields' => [
             'telegram_bot_token' => 'Telegram Bot Token',

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -31,12 +31,17 @@
     <x-main x-data="{
         statusChangeOffset: {{ $statusBoardEntries->count() }},
         sslExpiryOffset: {{ $sslExpiryNotifications->count() }},
+        domainExpiryOffset: {{ $domainExpiryNotifications->count() }},
         deliveryHistoryOffset: {{ $deliveryHistory->count() }},
         currentLimit: {{ $limit }},
-        isEmpty: {{ $sslExpiryNotifications->isEmpty() && $statusBoardEntries->isEmpty() && $deliveryHistory->isEmpty() ? 'true' : 'false' }},
+        isEmpty: {{ $sslExpiryNotifications->isEmpty() && $domainExpiryNotifications->isEmpty() && $statusBoardEntries->isEmpty() && $deliveryHistory->isEmpty() ? 'true' : 'false' }},
         getOffsetForType(type) {
             if (type === 'status_change') {
                 return this.statusChangeOffset;
+            }
+
+            if (type === 'domain_expiry') {
+                return this.domainExpiryOffset;
             }
 
             if (type === 'delivery_history') {
@@ -68,6 +73,9 @@
                     if (type === 'status_change') {
                         this.statusChangeOffset += response.data.count;
                         if (!response.data.hasMore) document.getElementById('status-change-load-more-container').style.display = 'none';
+                    } else if (type === 'domain_expiry') {
+                        this.domainExpiryOffset += response.data.count;
+                        if (!response.data.hasMore) document.getElementById('domain-expiry-load-more-container').style.display = 'none';
                     } else if (type === 'delivery_history') {
                         this.deliveryHistoryOffset += response.data.count;
                         if (!response.data.hasMore) document.getElementById('delivery-history-load-more-container').style.display = 'none';
@@ -93,6 +101,8 @@
                     entry.remove();
                     if (type === 'status_change') {
                         this.statusChangeOffset = Math.max(0, this.statusChangeOffset - 1);
+                    } else if (type === 'domain_expiry') {
+                        this.domainExpiryOffset = Math.max(0, this.domainExpiryOffset - 1);
                     } else {
                         this.sslExpiryOffset = Math.max(0, this.sslExpiryOffset - 1);
                     }
@@ -118,6 +128,24 @@
                         <div class="mt-4 text-center" id="ssl-expiry-load-more-container">
                             <x-primary-button
                                 @click="loadMoreNotifications('ssl_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
+                        </div>
+                    @endif
+                </div>
+            @endif
+
+            @if ($domainExpiryNotifications->isNotEmpty())
+                <div class="mb-8">
+                    <x-heading type="h2" space=true>{{ __('notifications.domain_expiry_notifications') }}</x-heading>
+                    <div id="domain-expiry-notifications">
+                        @include('notifications.partials.notification_list', [
+                            'notifications' => $domainExpiryNotifications,
+                            'type' => 'domain_expiry',
+                        ])
+                    </div>
+                    @if ($domainExpiryHasMore)
+                        <div class="mt-4 text-center" id="domain-expiry-load-more-container">
+                            <x-primary-button
+                                @click="loadMoreNotifications('domain_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
                         </div>
                     @endif
                 </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,8 +1,10 @@
 <x-container space="true">
     @php
         $notificationChannels = old('notification_channels', $user->notification_channels ?? []);
-        $eventTypes = ['incident', 'recovery', 'ssl_expiring', 'ssl_expired'];
+        $eventTypes = ['incident', 'recovery', 'ssl_expiring', 'ssl_expired', 'domain_expiring', 'domain_expired'];
         $notificationChannelKeys = ['slack', 'telegram', 'discord', 'webhook'];
+        $allowedExpiryWarningDays = config('monitoring.expiry_warning_days.allowed', [30, 14, 7, 3, 1]);
+        $selectedExpiryWarningDays = old('expiry_warning_days', $user->expiry_warning_days ?? config('monitoring.expiry_warning_days.default', [7]));
     @endphp
 
     <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
@@ -68,6 +70,26 @@
         <div class="space-y-6 border-t border-gray-200 pt-6 dark:border-gray-700">
             <x-heading type="h2">{{ __('profile.notification_settings.heading') }}</x-heading>
             <x-paragraph>{{ __('profile.notification_settings.description') }}</x-paragraph>
+
+            <div class="rounded-xl border border-gray-200 bg-gray-50/60 p-5 shadow-xs dark:border-gray-700 dark:bg-gray-900/30">
+                <x-heading type="h3">{{ __('profile.notification_settings.expiry_warning_days.heading') }}</x-heading>
+                <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                    {{ __('profile.notification_settings.expiry_warning_days.help') }}
+                </x-paragraph>
+
+                <div class="mt-4 flex flex-wrap gap-4">
+                    @foreach ($allowedExpiryWarningDays as $day)
+                        <x-text-checkbox
+                            id="expiry_warning_days_{{ $day }}"
+                            name="expiry_warning_days[]"
+                            value="{{ $day }}"
+                            :checked="in_array($day, array_map('intval', (array) $selectedExpiryWarningDays), true)"
+                            :label="trans_choice('profile.notification_settings.expiry_warning_days.option', $day, ['days' => $day])" />
+                    @endforeach
+                </div>
+                <x-input-error :messages="$errors->get('expiry_warning_days')" />
+                <x-input-error :messages="$errors->get('expiry_warning_days.*')" />
+            </div>
 
             @if (!empty($showNotificationChannelsHint))
                 <div class="rounded-xl border border-amber-300 bg-amber-50/80 p-4 dark:border-amber-700 dark:bg-amber-950/30">

--- a/routes/console.php
+++ b/routes/console.php
@@ -48,7 +48,7 @@ Schedule::command('monitoring:evaluate-heartbeats')->everyMinute()->withoutOverl
 // Archive old monitoring responses weekly.
 Schedule::command('monitoring:archive-responses')->weekly();
 
-// Check for expiring SSL certificates daily.
+// Check for expiring SSL certificates and domains daily.
 Schedule::command('notifications:send-ssl-expiry-warnings')->dailyAt('06:00')->withoutOverlapping();
 
 // Permanently delete soft-deleted monitorings and their data monthly.

--- a/tests/Feature/Notifications/SendSslExpiryWarningsCommandTest.php
+++ b/tests/Feature/Notifications/SendSslExpiryWarningsCommandTest.php
@@ -8,6 +8,7 @@ use App\Enums\NotificationDeliveryStatus;
 use App\Enums\NotificationEventType;
 use App\Enums\NotificationType;
 use App\Models\Monitoring;
+use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringNotification;
 use App\Models\MonitoringSslResult;
 use App\Models\Package;
@@ -25,6 +26,7 @@ class SendSslExpiryWarningsCommandTest extends TestCase
     {
         Package::factory()->create();
         $user = User::factory()->create([
+            'expiry_warning_days' => [3],
             'notification_channels' => [
                 'slack' => [
                     'enabled' => true,
@@ -132,5 +134,100 @@ class SendSslExpiryWarningsCommandTest extends TestCase
                 ->count()
         );
         $this->assertDatabaseCount('notification_channel_deliveries', 0);
+    }
+
+    public function test_dispatches_ssl_expiring_notifications_only_on_configured_warning_days(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'expiry_warning_days' => [14],
+            'notification_channels' => [
+                'webhook' => [
+                    'enabled' => true,
+                    'url' => 'https://example.test/webhook',
+                    'events' => [
+                        'ssl_expiring' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'notification_on_failure' => true,
+        ]);
+
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'expires_at' => now()->addDays(7),
+            'is_valid' => true,
+            'issuer' => 'LetsEncrypt',
+            'issued_at' => now()->subDays(60),
+        ]);
+
+        Http::fake();
+
+        Artisan::call('notifications:send-ssl-expiry-warnings');
+
+        Http::assertNothingSent();
+        $this->assertDatabaseMissing('monitoring_notifications', [
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::SSL_EXPIRY->value,
+        ]);
+    }
+
+    public function test_dispatches_domain_expiring_notifications_to_enabled_channels(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'expiry_warning_days' => [30],
+            'notification_channels' => [
+                'webhook' => [
+                    'enabled' => true,
+                    'url' => 'https://example.test/webhook',
+                    'events' => [
+                        'domain_expiring' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $monitoring = Monitoring::factory()->for($user)->domainExpiration()->create([
+            'notification_on_failure' => true,
+        ]);
+
+        MonitoringDomainResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'expires_at' => now()->addDays(30),
+            'is_valid' => true,
+            'registrar' => 'Example Registrar',
+            'checked_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://example.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        Artisan::call('notifications:send-ssl-expiry-warnings');
+
+        Http::assertSentCount(1);
+        $this->assertDatabaseHas('monitoring_notifications', [
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::DOMAIN_EXPIRY->value,
+            'message' => 'DOMAIN_EXPIRING',
+            'sent' => true,
+        ]);
+
+        $monitoringNotification = MonitoringNotification::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->where('type', NotificationType::DOMAIN_EXPIRY->value)
+            ->firstOrFail();
+
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'monitoring_notification_id' => $monitoringNotification->id,
+            'channel' => 'webhook',
+            'event_type' => NotificationEventType::DOMAIN_EXPIRING->value,
+            'status' => NotificationDeliveryStatus::SENT->value,
+        ]);
     }
 }

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -80,6 +80,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('profile.edit'));
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('profile.notification_settings.heading'));
+        $testResponse->assertSeeText(__('profile.notification_settings.expiry_warning_days.heading'));
         $testResponse->assertSeeText(__('profile.notification_settings.hint_banner'));
 
         $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit'));
@@ -98,6 +99,7 @@ class ProfileNotificationSettingsTest extends TestCase
             'name' => $user->name,
             'email' => $user->email,
             'theme' => 'dark',
+            'expiry_warning_days' => ['30', '7', '3'],
             'notification_channels' => [
                 'slack' => [
                     'enabled' => '1',
@@ -114,6 +116,7 @@ class ProfileNotificationSettingsTest extends TestCase
                     'events' => [
                         'incident' => '1',
                         'ssl_expiring' => '1',
+                        'domain_expiring' => '1',
                     ],
                 ],
                 'discord' => [
@@ -136,6 +139,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $user->refresh();
 
         $this->assertSame('dark', $user->theme);
+        $this->assertSame([30, 7, 3], $user->expiry_warning_days);
         $this->assertIsArray($user->notification_channels);
         $this->assertTrue((bool) data_get($user->notification_channels, 'slack.enabled'));
         $this->assertSame('https://hooks.slack.test/services/T000/B000/XXX', data_get($user->notification_channels, 'slack.webhook_url'));
@@ -146,6 +150,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertSame('-1001234567', data_get($user->notification_channels, 'telegram.chat_id'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'telegram.events.incident'));
         $this->assertFalse((bool) data_get($user->notification_channels, 'telegram.events.recovery'));
+        $this->assertTrue((bool) data_get($user->notification_channels, 'telegram.events.domain_expiring'));
         $this->assertFalse((bool) data_get($user->notification_channels, 'discord.enabled'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'webhook.enabled'));
         $this->assertSame('https://example.test/webhooks/webguard', data_get($user->notification_channels, 'webhook.url'));


### PR DESCRIPTION
## Summary

Adds configurable SSL and domain expiry warning windows so users can choose exact reminder offsets such as 30, 14, 7, 3, and 1 days before expiry.

## Changes

- Add `expiry_warning_days` user storage and profile controls.
- Extend notification events/types for domain expiry states.
- Update the daily expiry warning command to process SSL and domain results using configured exact warning windows.
- Surface domain expiry notifications in the notifications page and delivery history labels.
- Add coverage for persisted settings, exact SSL reminder windows, and domain expiry dispatch.

## Validation

- `./vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Notifications tests/Feature/ProfileNotificationSettingsTest.php`

Note: local Composer install required `--ignore-platform-req=ext-redis` because the PHP Redis extension is not installed in this environment.