### PR TITLE
Align mail designs with brand

### DIFF
--- a/resources/lang/de/mail.php
+++ b/resources/lang/de/mail.php
@@ -24,6 +24,7 @@ return [
         'subject' => 'Aktion auf der Plattform erforderlich',
         'greeting' => 'Hallo :userName,',
         'intro' => 'Sie haben :count ungelesene Benachrichtigungen auf der WebGuard-Plattform.',
+        'count_label' => 'Ungelesene Benachrichtigungen',
         'action_text' => 'Bitte besuchen Sie Ihre Benachrichtigungsseite, um diese zu überprüfen.',
         'button_text' => 'Benachrichtigungen anzeigen',
         'salutation' => 'Vielen Dank,',
@@ -31,5 +32,7 @@ return [
     'general' => [
         'team_name' => 'Das WebGuard-Team',
         'legal' => 'Rechtliches',
+        'brand_subtitle' => 'Website-, Server- & Port-Monitoring',
+        'notification_eyebrow' => 'Monitoring Update',
     ],
 ];

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -24,6 +24,7 @@ return [
         'subject' => 'Action required on the platform',
         'greeting' => 'Hello :userName,',
         'intro' => 'You have :count unread notifications on the WebGuard platform.',
+        'count_label' => 'Unread notifications',
         'action_text' => 'Please visit your notifications page to review them.',
         'button_text' => 'View Notifications',
         'salutation' => 'Thank you,',
@@ -31,5 +32,7 @@ return [
     'general' => [
         'team_name' => 'The WebGuard Team',
         'legal' => 'Legal',
+        'brand_subtitle' => 'Website, server & port monitoring',
+        'notification_eyebrow' => 'Monitoring update',
     ],
 ];

--- a/resources/views/layouts/mail.blade.php
+++ b/resources/views/layouts/mail.blade.php
@@ -1,65 +1,239 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>@yield('title')</title>
     <style>
+        @media only screen and (max-width: 640px) {
+            .mail-shell {
+                width: 100% !important;
+            }
+
+            .mail-frame {
+                padding: 20px 12px !important;
+            }
+
+            .mail-panel,
+            .mail-footer {
+                padding: 24px !important;
+            }
+
+            .mail-title {
+                font-size: 28px !important;
+                line-height: 34px !important;
+            }
+        }
+
         body {
-            font-family: sans-serif;
-            line-height: 1.5;
-            color: #333;
+            margin: 0;
+            padding: 0;
+            background-color: #f1f5f9;
+            color: #334155;
+            font-family: Sen, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
         }
-        .container {
-            max-width: 600px;
+
+        a {
+            color: #047857;
+        }
+
+        .mail-frame {
+            width: 100%;
+            padding: 32px 16px;
+            background-color: #f1f5f9;
+        }
+
+        .mail-shell {
+            width: 100%;
+            max-width: 640px;
             margin: 0 auto;
-            padding: 20px;
         }
-        .header {
-            text-align: center;
-            margin-bottom: 20px;
+
+        .mail-brand {
+            padding: 0 4px 18px;
         }
-        .content {
-            background-color: #f9f9f9;
-            padding: 20px;
-            border-radius: 5px;
-        }
-        .footer {
-            text-align: center;
-            margin-top: 20px;
-            font-size: 0.8em;
-            color: #777;
-        }
-        .button {
+
+        .mail-logo-mark {
             display: inline-block;
-            background-color: #007bff;
-            color: #fff;
-            padding: 10px 20px;
-            text-decoration: none;
-            border-radius: 5px;
+            width: 44px;
+            height: 44px;
+            border-radius: 12px;
+            background-color: #10b981;
+            color: #ffffff;
+            font-size: 17px;
+            font-weight: 800;
+            line-height: 44px;
+            text-align: center;
+            vertical-align: middle;
         }
-        .legal-links a {
-            color: #555;
-            text-decoration: underline;
-            margin: 0 4px;
+
+        .mail-brand-copy {
+            display: inline-block;
+            margin-left: 12px;
+            vertical-align: middle;
+        }
+
+        .mail-brand-name {
+            margin: 0;
+            color: #0f172a;
+            font-size: 20px;
+            font-weight: 800;
+            line-height: 24px;
+        }
+
+        .mail-brand-subtitle {
+            margin: 2px 0 0;
+            color: #64748b;
+            font-size: 13px;
+            font-weight: 600;
+            line-height: 18px;
+        }
+
+        .mail-panel {
+            overflow: hidden;
+            padding: 32px;
+            border: 1px solid #e2e8f0;
+            border-radius: 16px;
+            background-color: #ffffff;
+            box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+        }
+
+        .mail-eyebrow {
+            display: inline-block;
+            margin: 0 0 14px;
+            padding: 4px 10px;
+            border: 1px solid rgba(16, 185, 129, 0.35);
+            border-radius: 999px;
+            background-color: #d1fae5;
+            color: #047857;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            line-height: 18px;
+            text-transform: uppercase;
+        }
+
+        .mail-title {
+            margin: 0;
+            color: #0f172a;
+            font-size: 34px;
+            font-weight: 800;
+            line-height: 40px;
+        }
+
+        .mail-content {
+            margin-top: 24px;
+        }
+
+        .mail-content p {
+            margin: 0 0 18px;
+            color: #475569;
+            font-size: 16px;
+            line-height: 26px;
+        }
+
+        .mail-content p:last-child {
+            margin-bottom: 0;
+        }
+
+        .mail-card {
+            margin: 22px 0;
+            padding: 18px;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            background-color: #f8fafc;
+        }
+
+        .mail-card-label {
+            margin: 0 0 6px;
+            color: #64748b;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            line-height: 18px;
+            text-transform: uppercase;
+        }
+
+        .mail-card-value {
+            margin: 0;
+            color: #047857;
+            font-size: 32px;
+            font-weight: 800;
+            line-height: 38px;
+        }
+
+        .mail-button {
+            display: inline-block;
+            margin-top: 4px;
+            padding: 12px 18px;
+            border-radius: 8px;
+            background-color: #10b981;
+            color: #ffffff !important;
+            font-size: 14px;
+            font-weight: 700;
+            line-height: 20px;
+            text-decoration: none;
+        }
+
+        .mail-button:hover {
+            background-color: #059669;
+        }
+
+        .mail-footer {
+            padding: 22px 32px 0;
+            text-align: center;
+        }
+
+        .mail-footer p {
+            margin: 0 0 10px;
+            color: #64748b;
+            font-size: 13px;
+            line-height: 20px;
+        }
+
+        .mail-legal-links a {
+            display: inline-block;
+            margin: 0 6px;
+            color: #475569;
+            font-weight: 600;
+            text-decoration: none;
         }
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
-            <h1>{{ config('app.name') }}</h1>
-        </div>
-        <div class="content">
-            @yield('content')
-        </div>
-        <div class="footer">
-            <p>&copy; {{ date('Y') }} {{ config('app.name') }}. All rights reserved.</p>
-            <p class="legal-links">
-                {{ __('mail.general.legal') }}:
-                <a href="{{ route('gdpr') }}">{{ __('gdpr.footer_link') }}</a>
-                <a href="{{ route('imprint') }}">{{ __('imprint.footer_link') }}</a>
-            </p>
+    <div class="mail-frame">
+        <div class="mail-shell">
+            <div class="mail-brand">
+                <span class="mail-logo-mark">WG</span>
+                <span class="mail-brand-copy">
+                    <p class="mail-brand-name">{{ __('app.name') }}</p>
+                    <p class="mail-brand-subtitle">{{ __('mail.general.brand_subtitle') }}</p>
+                </span>
+            </div>
+
+            <div class="mail-panel">
+                @hasSection('eyebrow')
+                    <p class="mail-eyebrow">@yield('eyebrow')</p>
+                @endif
+
+                <h1 class="mail-title">@yield('title')</h1>
+
+                <div class="mail-content">
+                    @yield('content')
+                </div>
+            </div>
+
+            <div class="mail-footer">
+                <p>&copy; {{ date('Y') }} {{ __('app.name') }}. {{ __('legal.footer.content') }}</p>
+                <p class="mail-legal-links">
+                    <a href="{{ route('monitoring-locations') }}">{{ __('monitoring_locations.footer_link') }}</a>
+                    <a href="{{ route('imprint') }}">{{ __('imprint.footer_link') }}</a>
+                    <a href="{{ route('terms-of-use') }}">{{ __('legal.terms_of_use.footer_link') }}</a>
+                    <a href="{{ route('gdpr') }}">{{ __('gdpr.footer_link') }}</a>
+                </p>
+            </div>
         </div>
     </div>
 </body>

--- a/resources/views/mail/unread-notifications-reminder.blade.php
+++ b/resources/views/mail/unread-notifications-reminder.blade.php
@@ -1,15 +1,23 @@
 @extends('layouts.mail')
 
 @section('title', __('mail.unread_notifications_reminder.subject'))
+@section('eyebrow', __('mail.general.notification_eyebrow'))
 
 @section('content')
     <p>{{ __('mail.unread_notifications_reminder.greeting', ['userName' => $user->name]) }}</p>
 
     <p>{{ __('mail.unread_notifications_reminder.intro', ['count' => $unreadNotificationsCount]) }}</p>
 
+    <div class="mail-card">
+        <p class="mail-card-label">{{ __('mail.unread_notifications_reminder.count_label') }}</p>
+        <p class="mail-card-value">{{ $unreadNotificationsCount }}</p>
+    </div>
+
     <p>{{ __('mail.unread_notifications_reminder.action_text') }}</p>
 
-    <a href="{{ route('notifications.index') }}" class="button">{{ __('mail.unread_notifications_reminder.button_text') }}</a>
+    <p>
+        <a href="{{ route('notifications.index') }}" class="mail-button">{{ __('mail.unread_notifications_reminder.button_text') }}</a>
+    </p>
 
     <p>{{ __('mail.unread_notifications_reminder.salutation') }}<br>
     {{ __('mail.general.team_name') }}</p>

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -1,0 +1,13 @@
+@props(['url'])
+
+<tr>
+<td class="header">
+<a href="{{ $url }}" class="mail-brand-link" target="_blank" rel="noopener">
+<span class="mail-logo-mark">WG</span>
+<span class="mail-brand-copy">
+<span class="mail-brand-name">{{ __('app.name') }}</span>
+<span class="mail-brand-subtitle">{{ __('mail.general.brand_subtitle') }}</span>
+</span>
+</a>
+</td>
+</tr>

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,0 +1,30 @@
+<x-mail::layout>
+{{-- Header --}}
+<x-slot:header>
+<x-mail::header :url="config('app.url')" />
+</x-slot:header>
+
+{{-- Body --}}
+{!! $slot !!}
+
+{{-- Subcopy --}}
+@isset($subcopy)
+<x-slot:subcopy>
+<x-mail::subcopy>
+{!! $subcopy !!}
+</x-mail::subcopy>
+</x-slot:subcopy>
+@endisset
+
+{{-- Footer --}}
+<x-slot:footer>
+<x-mail::footer>
+&copy; {{ date('Y') }} {{ __('app.name') }}. {{ __('legal.footer.content') }}
+
+<a href="{{ route('monitoring-locations') }}">{{ __('monitoring_locations.footer_link') }}</a>
+<a href="{{ route('imprint') }}">{{ __('imprint.footer_link') }}</a>
+<a href="{{ route('terms-of-use') }}">{{ __('legal.terms_of_use.footer_link') }}</a>
+<a href="{{ route('gdpr') }}">{{ __('gdpr.footer_link') }}</a>
+</x-mail::footer>
+</x-slot:footer>
+</x-mail::layout>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -1,0 +1,351 @@
+/* Base */
+
+body,
+body *:not(html):not(style):not(br):not(tr):not(code) {
+    box-sizing: border-box;
+    font-family: Sen, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    position: relative;
+}
+
+body {
+    -webkit-text-size-adjust: none;
+    background-color: #f1f5f9;
+    color: #334155;
+    height: 100%;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    width: 100% !important;
+}
+
+p,
+ul,
+ol,
+blockquote {
+    line-height: 1.6;
+    text-align: start;
+}
+
+a {
+    color: #047857;
+}
+
+a img {
+    border: none;
+}
+
+/* Typography */
+
+h1 {
+    color: #0f172a;
+    font-size: 28px;
+    font-weight: 800;
+    line-height: 1.2;
+    margin-top: 0;
+    text-align: start;
+}
+
+h2 {
+    color: #0f172a;
+    font-size: 20px;
+    font-weight: 700;
+    margin-top: 0;
+    text-align: start;
+}
+
+h3 {
+    color: #0f172a;
+    font-size: 16px;
+    font-weight: 700;
+    margin-top: 0;
+    text-align: left;
+}
+
+p {
+    color: #475569;
+    font-size: 16px;
+    line-height: 1.6em;
+    margin-top: 0;
+    text-align: left;
+}
+
+p.sub {
+    font-size: 12px;
+}
+
+img {
+    max-width: 100%;
+}
+
+/* Layout */
+
+.wrapper {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #f1f5f9;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.content {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+/* Header */
+
+.header {
+    padding: 32px 0 18px;
+    text-align: center;
+}
+
+.header a {
+    color: #0f172a;
+    text-decoration: none;
+}
+
+.mail-brand-link {
+    display: inline-block;
+}
+
+.mail-logo-mark {
+    background-color: #10b981;
+    border-radius: 12px;
+    color: #ffffff;
+    display: inline-block;
+    font-size: 17px;
+    font-weight: 800;
+    height: 44px;
+    line-height: 44px;
+    text-align: center;
+    vertical-align: middle;
+    width: 44px;
+}
+
+.mail-brand-copy {
+    display: inline-block;
+    margin-left: 12px;
+    text-align: left;
+    vertical-align: middle;
+}
+
+.mail-brand-name {
+    color: #0f172a;
+    display: block;
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 24px;
+}
+
+.mail-brand-subtitle {
+    color: #64748b;
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 18px;
+}
+
+/* Body */
+
+.body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #f1f5f9;
+    border: hidden !important;
+    margin: 0;
+    padding: 0 16px;
+    width: 100%;
+}
+
+.inner-body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 640px;
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+    margin: 0 auto;
+    padding: 0;
+    width: 640px;
+}
+
+.inner-body a {
+    word-break: break-all;
+}
+
+.content-cell {
+    max-width: 100vw;
+    padding: 32px;
+}
+
+/* Subcopy */
+
+.subcopy {
+    border-top: 1px solid #e2e8f0;
+    margin-top: 25px;
+    padding-top: 25px;
+}
+
+.subcopy p {
+    color: #64748b;
+    font-size: 13px;
+}
+
+/* Footer */
+
+.footer {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 640px;
+    margin: 0 auto;
+    padding: 18px 24px 32px;
+    text-align: center;
+    width: 640px;
+}
+
+.footer p {
+    color: #64748b;
+    font-size: 13px;
+    line-height: 1.6;
+    text-align: center;
+}
+
+.footer a {
+    color: #475569;
+    display: inline-block;
+    font-weight: 600;
+    margin: 0 6px;
+    text-decoration: none;
+}
+
+/* Tables */
+
+.table table {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    width: 100%;
+}
+
+.table th {
+    border-bottom: 1px solid #e2e8f0;
+    margin: 0;
+    padding-bottom: 8px;
+}
+
+.table td {
+    color: #475569;
+    font-size: 15px;
+    line-height: 18px;
+    margin: 0;
+    padding: 10px 0;
+}
+
+/* Buttons */
+
+.action {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    padding: 0;
+    text-align: center;
+    width: 100%;
+}
+
+.button {
+    -webkit-text-size-adjust: none;
+    border-radius: 8px;
+    color: #ffffff;
+    display: inline-block;
+    overflow: hidden;
+    text-decoration: none;
+}
+
+.button-blue,
+.button-primary {
+    background-color: #10b981;
+    border-bottom: 10px solid #10b981;
+    border-left: 18px solid #10b981;
+    border-right: 18px solid #10b981;
+    border-top: 10px solid #10b981;
+}
+
+.button-green,
+.button-success {
+    background-color: #10b981;
+    border-bottom: 10px solid #10b981;
+    border-left: 18px solid #10b981;
+    border-right: 18px solid #10b981;
+    border-top: 10px solid #10b981;
+}
+
+.button-red,
+.button-error {
+    background-color: #dc2626;
+    border-bottom: 10px solid #dc2626;
+    border-left: 18px solid #dc2626;
+    border-right: 18px solid #dc2626;
+    border-top: 10px solid #dc2626;
+}
+
+/* Panels */
+
+.panel {
+    border-left: 4px solid #10b981;
+    margin: 24px 0;
+}
+
+.panel-content {
+    background-color: #f8fafc;
+    color: #475569;
+    padding: 16px;
+}
+
+.panel-content p {
+    color: #475569;
+}
+
+.panel-item {
+    padding: 0;
+}
+
+/* Utilities */
+
+.break-all {
+    word-break: break-all;
+}
+
+@media only screen and (max-width: 640px) {
+    .body {
+        padding: 0 12px !important;
+    }
+
+    .inner-body,
+    .footer {
+        width: 100% !important;
+    }
+
+    .content-cell {
+        padding: 24px !important;
+    }
+
+    h1 {
+        font-size: 24px !important;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .button {
+        width: 100% !important;
+    }
+}

--- a/tests/Feature/Auth/AuthMailDesignTest.php
+++ b/tests/Feature/Auth/AuthMailDesignTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Tests\TestCase;
+
+class AuthMailDesignTest extends TestCase
+{
+    public function test_framework_notification_mails_use_corporate_mail_design(): void
+    {
+        Package::factory()->create();
+
+        $user = User::factory()->create();
+
+        $html = (string) (new ResetPassword('reset-token'))->toMail($user)->render();
+
+        $this->assertStringContainsString('font-family: Sen', $html);
+        $this->assertStringContainsString('background-color: #f1f5f9', $html);
+        $this->assertStringContainsString('class="mail-logo-mark"', $html);
+        $this->assertStringContainsString(e(__('mail.general.brand_subtitle')), $html);
+        $this->assertStringContainsString('border-radius: 16px', $html);
+        $this->assertStringContainsString('background-color: #10b981', $html);
+        $this->assertStringContainsString(route('monitoring-locations'), $html);
+        $this->assertStringContainsString(route('terms-of-use'), $html);
+    }
+}

--- a/tests/Feature/Notifications/UnreadNotificationsReminderMailTest.php
+++ b/tests/Feature/Notifications/UnreadNotificationsReminderMailTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Mail\UnreadNotificationsReminderMail;
+use App\Models\Package;
+use App\Models\User;
+use Tests\TestCase;
+
+class UnreadNotificationsReminderMailTest extends TestCase
+{
+    public function test_unread_notifications_reminder_uses_corporate_mail_design(): void
+    {
+        Package::factory()->create();
+
+        $user = User::factory()->create([
+            'name' => 'Mara Monitor',
+        ]);
+
+        $html = (new UnreadNotificationsReminderMail(7, $user))->render();
+
+        $this->assertStringContainsString('font-family: Sen', $html);
+        $this->assertStringContainsString('background-color: #f1f5f9', $html);
+        $this->assertStringContainsString('class="mail-logo-mark"', $html);
+        $this->assertStringContainsString(e(__('mail.general.brand_subtitle')), $html);
+        $this->assertStringContainsString('class="mail-panel"', $html);
+        $this->assertStringContainsString('class="mail-eyebrow"', $html);
+        $this->assertStringContainsString('class="mail-card-value">7</p>', $html);
+        $this->assertStringContainsString('class="mail-button"', $html);
+        $this->assertStringContainsString(route('notifications.index'), $html);
+        $this->assertStringContainsString(route('monitoring-locations'), $html);
+        $this->assertStringContainsString(route('terms-of-use'), $html);
+        $this->assertStringContainsString('Mara Monitor', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- Redesign the custom unread notifications reminder mail around the existing WebGuard slate/emerald visual language.
- Add branded Laravel Markdown mail overrides for framework notification emails such as password reset and email verification.
- Add rendering tests for both custom and framework mail designs.

## Impact
Mail recipients now see consistent WebGuard branding, typography, colors, CTA styling, and legal footer links across custom and framework-generated emails.

## Validation
- `php artisan test tests/Feature/Auth/AuthMailDesignTest.php tests/Feature/Auth/PasswordResetFlowTest.php tests/Feature/Auth/EmailVerificationSignatureTest.php`
- `php artisan test tests/Feature/Notifications/UnreadNotificationsReminderMailTest.php tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php`
- `vendor/bin/pint --dirty`