### PR TITLE
test: cover weekly digest overlapping incidents

### DIFF
--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -181,7 +181,7 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
             'up_at' => null,
         ]);
 
-        $digest = app(WeeklyMonitoringDigestService::class)->buildForUser($user, Date::parse('2026-04-19'));
+        $digest = resolve(WeeklyMonitoringDigestService::class)->buildForUser($user, Date::parse('2026-04-19'));
 
         $this->assertSame(3, $digest['overview']['incidents_count']);
         $this->assertSame(119, $digest['overview']['longest_downtime_minutes']);

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -15,6 +15,7 @@ use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringSslResult;
 use App\Models\Package;
 use App\Models\User;
+use App\Services\WeeklyMonitoringDigestService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Date;
@@ -140,5 +141,51 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         ]);
 
         Mail::assertNothingSent();
+    }
+
+    public function test_weekly_digest_clips_incidents_to_the_requested_period(): void
+    {
+        Date::setTestNow('2026-04-20 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Boundary Monitor',
+            'target' => 'https://example.com',
+            'type' => MonitoringType::HTTP,
+        ]);
+
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-04-01 00:00:00',
+            'up_at' => '2026-04-13 00:30:00',
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-04-19 22:00:00',
+            'up_at' => '2026-04-25 00:00:00',
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-04-19 23:00:00',
+            'up_at' => null,
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-04-12 22:00:00',
+            'up_at' => '2026-04-12 23:00:00',
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-04-20 00:00:00',
+            'up_at' => null,
+        ]);
+
+        $digest = app(WeeklyMonitoringDigestService::class)->buildForUser($user, Date::parse('2026-04-19'));
+
+        $this->assertSame(3, $digest['overview']['incidents_count']);
+        $this->assertSame(119, $digest['overview']['longest_downtime_minutes']);
+        $this->assertSame(3, $digest['monitorings'][0]['incidents_count']);
+        $this->assertSame(119, $digest['monitorings'][0]['longest_downtime_minutes']);
     }
 }


### PR DESCRIPTION
## Summary
- Add focused weekly digest coverage for incidents overlapping the requested report period.
- Assert out-of-window incidents are excluded and boundary-spanning incidents are clipped when computing incident totals and longest downtime.

## Validation
- `composer install --no-interaction --prefer-dist --ignore-platform-req=ext-redis`
- `./vendor/bin/pint tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`
- `php artisan test tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`

Note: dependency install required ignoring `ext-redis` because the local PHP Redis extension is not installed in this worktree environment.