### PR TITLE
Fix weekly digest expiry warning window

### DIFF
--- a/app/Services/WeeklyMonitoringDigestService.php
+++ b/app/Services/WeeklyMonitoringDigestService.php
@@ -43,7 +43,10 @@ class WeeklyMonitoringDigestService
         $longestDowntimeMinutes = 0;
         $sslWarnings = [];
         $domainWarnings = [];
-        $warningThreshold = Date::now()->addDays((int) config('monitoring.digest_expiry_warning_days', 30))->endOfDay();
+        $warningThreshold = $periodEnd
+            ->copy()
+            ->addDays((int) config('monitoring.digest_expiry_warning_days', 30))
+            ->endOfDay();
 
         foreach ($monitorings as $monitoring) {
             $uptimeDowntime = MonitoringResultService::getUptimeDowntime(

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -141,4 +141,37 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
 
         Mail::assertNothingSent();
     }
+
+    public function test_period_end_option_scopes_expiry_warnings_to_the_digest_window(): void
+    {
+        Date::setTestNow('2026-05-20 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Storefront',
+            'target' => 'https://example.com',
+            'type' => MonitoringType::HTTP,
+        ]);
+
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'expires_at' => '2026-05-25 00:00:00',
+            'is_valid' => true,
+            'issuer' => 'Example CA',
+            'issued_at' => '2026-02-01 00:00:00',
+        ]);
+
+        Mail::fake();
+
+        Artisan::call('notifications:send-weekly-monitoring-digest', [
+            '--period-end' => '2026-04-19',
+        ]);
+
+        Mail::assertSent(WeeklyMonitoringDigestMail::class, function (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail) use ($user): bool {
+            return $weeklyMonitoringDigestMail->hasTo($user->email)
+                && $weeklyMonitoringDigestMail->digest['period_end']->toDateString() === '2026-04-19'
+                && count($weeklyMonitoringDigestMail->digest['ssl_warnings']) === 0;
+        });
+    }
 }


### PR DESCRIPTION
## What changed
- scope weekly digest SSL/domain expiry warnings to the digest `period_end` instead of wall-clock execution time
- add a regression test covering backfilled `notifications:send-weekly-monitoring-digest --period-end=...` runs

## Why
The weekly digest feature added in `305adaacca0bd9ebeaf4aad87c11ceb25de4c8bc` calculated the expiry warning window from `Date::now()`. That produced incorrect warnings whenever the command was run for an older reporting window, because the content reflected when the job ran rather than the week being summarized.

## Impact
Delayed or backfilled weekly digests now show SSL/domain warnings that match the digest window the user requested.

## Validation
- `php artisan test tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`
