### PR TITLE
perf: add monitoring history pagination indexes

### DIFF
--- a/database/migrations/2026_04_26_080000_add_history_pagination_indexes_to_monitoring_response_tables.php
+++ b/database/migrations/2026_04_26_080000_add_history_pagination_indexes_to_monitoring_response_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('monitoring_response_results', function (Blueprint $table): void {
+            $table->index(
+                ['monitoring_id', 'created_at', 'id'],
+                'idx_monitoring_response_results_monitoring_created_id'
+            );
+        });
+
+        Schema::table('monitoring_response_archived', function (Blueprint $table): void {
+            $table->index(
+                ['monitoring_id', 'created_at', 'id'],
+                'idx_monitoring_response_archived_monitoring_created_id'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('monitoring_response_results', function (Blueprint $table): void {
+            $table->dropIndex('idx_monitoring_response_results_monitoring_created_id');
+        });
+
+        Schema::table('monitoring_response_archived', function (Blueprint $table): void {
+            $table->dropIndex('idx_monitoring_response_archived_monitoring_created_id');
+        });
+    }
+};

--- a/tests/Feature/Api/ApiControllerTest.php
+++ b/tests/Feature/Api/ApiControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -226,6 +227,19 @@ class ApiControllerTest extends TestCase
         $this->assertSame(106.0, (float) $secondPageResponse->json('data.0.response_time'));
     }
 
+    public function test_history_response_tables_have_indexes_for_timeline_pagination(): void
+    {
+        $this->assertTableHasIndexColumns(
+            'monitoring_response_results',
+            ['monitoring_id', 'created_at', 'id']
+        );
+
+        $this->assertTableHasIndexColumns(
+            'monitoring_response_archived',
+            ['monitoring_id', 'created_at', 'id']
+        );
+    }
+
     /**
      * @return list<string>
      */
@@ -238,5 +252,25 @@ class ApiControllerTest extends TestCase
                 || str_contains($query, 'monitoring_response_archived'))
             ->values()
             ->all();
+    }
+
+    /**
+     * @param  list<string>  $columns
+     */
+    private function assertTableHasIndexColumns(string $table, array $columns): void
+    {
+        $indexColumns = collect(Schema::getIndexes($table))
+            ->map(static fn (array $index): array => $index['columns'])
+            ->values();
+
+        $this->assertTrue(
+            $indexColumns->contains($columns),
+            sprintf(
+                'Expected %s to have an index on (%s). Existing index columns: %s',
+                $table,
+                implode(', ', $columns),
+                $indexColumns->map(static fn (array $indexedColumns): string => '(' . implode(', ', $indexedColumns) . ')')->implode(', ')
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add composite pagination indexes for live and archived monitoring response history.
- Cover the `/checks` endpoint query shape on `monitoring_id`, `created_at`, and `id`.
- Add a schema regression test so future migrations keep the timeline pagination indexes in place.

## Why
The monitoring checks history endpoint pages by monitoring and orders by timestamp with an `id` tiebreaker. Existing tests showed the endpoint already avoids archived history reads when live rows fill the page, but the archived response table only had date-oriented indexing. The new composite indexes reduce the risk of scans or filesorts for large history tables.

## Validation
- `./vendor/bin/pint --dirty`
- `php artisan test --filter=ApiControllerTest`
- `php artisan test tests/Feature/Api tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php`
- `php artisan test`

Local dependency note: `composer install` required `--ignore-platform-req=ext-redis` because this machine does not have the Redis PHP extension enabled; tests use the array cache and in-memory SQLite config.