### PR TITLE
Fix unread reminder email count card

### DIFF
--- a/resources/lang/de/mail.php
+++ b/resources/lang/de/mail.php
@@ -24,7 +24,6 @@ return [
         'subject' => 'Aktion auf der Plattform erforderlich',
         'greeting' => 'Hallo :userName,',
         'intro' => 'Sie haben :count ungelesene Benachrichtigungen auf der WebGuard-Plattform.',
-        'count_label' => 'Ungelesene Benachrichtigungen',
         'action_text' => 'Bitte besuchen Sie Ihre Benachrichtigungsseite, um diese zu überprüfen.',
         'button_text' => 'Benachrichtigungen anzeigen',
         'salutation' => 'Vielen Dank,',

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -24,7 +24,6 @@ return [
         'subject' => 'Action required on the platform',
         'greeting' => 'Hello :userName,',
         'intro' => 'You have :count unread notifications on the WebGuard platform.',
-        'count_label' => 'Unread notifications',
         'action_text' => 'Please visit your notifications page to review them.',
         'button_text' => 'View Notifications',
         'salutation' => 'Thank you,',

--- a/resources/views/layouts/mail.blade.php
+++ b/resources/views/layouts/mail.blade.php
@@ -138,32 +138,6 @@
             margin-bottom: 0;
         }
 
-        .mail-card {
-            margin: 22px 0;
-            padding: 18px;
-            border: 1px solid #e2e8f0;
-            border-radius: 12px;
-            background-color: #f8fafc;
-        }
-
-        .mail-card-label {
-            margin: 0 0 6px;
-            color: #64748b;
-            font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.08em;
-            line-height: 18px;
-            text-transform: uppercase;
-        }
-
-        .mail-card-value {
-            margin: 0;
-            color: #047857;
-            font-size: 32px;
-            font-weight: 800;
-            line-height: 38px;
-        }
-
         .mail-button {
             display: inline-block;
             margin-top: 4px;

--- a/resources/views/mail/unread-notifications-reminder.blade.php
+++ b/resources/views/mail/unread-notifications-reminder.blade.php
@@ -8,11 +8,6 @@
 
     <p>{{ __('mail.unread_notifications_reminder.intro', ['count' => $unreadNotificationsCount]) }}</p>
 
-    <div class="mail-card">
-        <p class="mail-card-label">{{ __('mail.unread_notifications_reminder.count_label') }}</p>
-        <p class="mail-card-value">{{ $unreadNotificationsCount }}</p>
-    </div>
-
     <p>{{ __('mail.unread_notifications_reminder.action_text') }}</p>
 
     <p>

--- a/resources/views/mail/weekly-monitoring-digest.blade.php
+++ b/resources/views/mail/weekly-monitoring-digest.blade.php
@@ -102,7 +102,7 @@
     @endif
 
     <p>
-        <a href="{{ route('monitorings.index') }}" class="button">{{ __('mail.weekly_monitoring_digest.button_text') }}</a>
+        <a href="{{ route('monitorings.index') }}" class="mail-button">{{ __('mail.weekly_monitoring_digest.button_text') }}</a>
     </p>
 
     <p>{{ __('mail.weekly_monitoring_digest.salutation') }}<br>

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -115,7 +115,9 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
                 && str_contains($rendered, 'Storefront')
                 && str_contains($rendered, '99.31%')
                 && str_contains($rendered, 'SSL certificates')
-                && str_contains($rendered, 'Domains');
+                && str_contains($rendered, 'Domains')
+                && str_contains($rendered, 'class="mail-button"')
+                && ! str_contains($rendered, 'class="button"');
         });
     }
 

--- a/tests/Feature/Notifications/UnreadNotificationsReminderMailTest.php
+++ b/tests/Feature/Notifications/UnreadNotificationsReminderMailTest.php
@@ -27,7 +27,10 @@ class UnreadNotificationsReminderMailTest extends TestCase
         $this->assertStringContainsString(e(__('mail.general.brand_subtitle')), $html);
         $this->assertStringContainsString('class="mail-panel"', $html);
         $this->assertStringContainsString('class="mail-eyebrow"', $html);
-        $this->assertStringContainsString('class="mail-card-value">7</p>', $html);
+        $this->assertStringContainsString('You have 7 unread notifications on the WebGuard platform.', $html);
+        $this->assertStringNotContainsString('class="mail-card"', $html);
+        $this->assertStringNotContainsString('class="mail-card-value">7</p>', $html);
+        $this->assertStringNotContainsString('Unread notifications</p>', $html);
         $this->assertStringContainsString('class="mail-button"', $html);
         $this->assertStringContainsString(route('notifications.index'), $html);
         $this->assertStringContainsString(route('monitoring-locations'), $html);


### PR DESCRIPTION
## Summary
- Remove the duplicate unread-notifications count card from the reminder email while keeping the count in the intro sentence.
- Remove the unused count label translations and card-specific email styles.
- Align the weekly monitoring digest CTA with the corporate email button class.

## Root Cause
The corporate email refresh added a separate unread-count card to the reminder template even though the same count is already shown in the intro copy.

## Validation
- `php artisan test tests/Feature/Notifications/UnreadNotificationsReminderMailTest.php tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php tests/Feature/Auth/AuthMailDesignTest.php`