### PR TITLE
Formulare in Bearbeitungsseiten gruppieren

### DIFF
--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -179,6 +179,13 @@ return [
         ],
     ],
     'form' => [
+        'sections' => [
+            'basic' => 'Basisdaten',
+            'check' => 'Prüfkonfiguration',
+            'sharing' => 'Öffentliche Anzeige',
+            'notifications' => 'Benachrichtigungen',
+            'operations' => 'Betrieb',
+        ],
         'type' => 'Überwachungstyp',
         'select_type' => 'Überwachungstyp auswählen',
         'name' => 'Name',

--- a/resources/lang/de/profile.php
+++ b/resources/lang/de/profile.php
@@ -19,6 +19,10 @@ return [
         'send_verification_email' => 'Klicken Sie hier, um die Bestätigungs-E-Mail erneut zu senden',
         'verification_email_sent' => 'Eine neue Bestätigungs-E-Mail wurde an Ihre E-Mail-Adresse gesendet.',
     ],
+    'sections' => [
+        'account' => 'Konto',
+        'preferences' => 'Darstellung',
+    ],
     'theme' => [
         'heading' => 'Design',
         'description' => 'Wählen Sie Ihr bevorzugtes Design.',
@@ -26,6 +30,7 @@ return [
     'notification_settings' => [
         'heading' => 'Benachrichtigungseinstellungen',
         'description' => 'Konfigurieren Sie Ihre Benachrichtigungskanäle. Welche Kanäle eine Überwachung nutzt, legen Sie in der jeweiligen Überwachung fest.',
+        'channels_heading' => 'Kanäle',
         'enabled' => 'Aktiviert',
         'hint_banner' => 'Konfigurieren Sie mindestens einen Kanal, um weiterhin Incident- und SSL-Benachrichtigungen zu erhalten.',
         'digest' => [

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -179,6 +179,13 @@ return [
         ],
     ],
     'form' => [
+        'sections' => [
+            'basic' => 'Basics',
+            'check' => 'Check configuration',
+            'sharing' => 'Public display',
+            'notifications' => 'Notifications',
+            'operations' => 'Operations',
+        ],
         'type' => 'Monitoring Type',
         'select_type' => 'Select Monitoring Type',
         'name' => 'Name',

--- a/resources/lang/en/profile.php
+++ b/resources/lang/en/profile.php
@@ -19,6 +19,10 @@ return [
         'send_verification_email' => 'Click here to re-send the verification email',
         'verification_email_sent' => 'A new verification email has been sent to your email address.',
     ],
+    'sections' => [
+        'account' => 'Account',
+        'preferences' => 'Appearance',
+    ],
     'theme' => [
         'heading' => 'Theme',
         'description' => 'Select your preferred theme.',
@@ -26,6 +30,7 @@ return [
     'notification_settings' => [
         'heading' => 'Notification Settings',
         'description' => 'Configure your notification channels. Choose which channels a monitoring uses in that monitoring.',
+        'channels_heading' => 'Channels',
         'enabled' => 'Enabled',
         'hint_banner' => 'Configure at least one channel to continue receiving incident and SSL alerts.',
         'digest' => [

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -47,24 +47,29 @@
         target = '';
     }
 })">
+    <div class="space-y-8">
+        <section class="space-y-4">
+            <div>
+                <x-heading type="h2">{{ __('monitoring.form.sections.basic') }}</x-heading>
+            </div>
 
-    <div>
-        <x-input-label for="type" :value="__('monitoring.form.type')" />
-        @if (isset($monitoring))
-            <x-text-input id="type" class="cursor-not-allowed" name="type" :value="__('monitoring.types.' . $monitoring->type->value)" readonly />
-            <input type="hidden" name="type" :value="type">
-        @else
-            <x-select-input id="type" class="mt-1 block w-full" name="type" x-model="type" required autofocus>
-                <option value="" disabled hidden>{{ __('monitoring.form.select_type') }}</option>
-                @foreach ($types as $enumType)
-                    <option value="{{ $enumType->value }}" @selected(old('type') === $enumType->value)>
-                        {{ __('monitoring.types.' . $enumType->value) }}
-                    </option>
-                @endforeach
-            </x-select-input>
-        @endif
-        <x-input-error :messages="$errors->get('type')" />
-    </div>
+            <div>
+                <x-input-label for="type" :value="__('monitoring.form.type')" />
+                @if (isset($monitoring))
+                    <x-text-input id="type" class="cursor-not-allowed" name="type" :value="__('monitoring.types.' . $monitoring->type->value)" readonly />
+                    <input type="hidden" name="type" :value="type">
+                @else
+                    <x-select-input id="type" class="mt-1 block w-full" name="type" x-model="type" required autofocus>
+                        <option value="" disabled hidden>{{ __('monitoring.form.select_type') }}</option>
+                        @foreach ($types as $enumType)
+                            <option value="{{ $enumType->value }}" @selected(old('type') === $enumType->value)>
+                                {{ __('monitoring.types.' . $enumType->value) }}
+                            </option>
+                        @endforeach
+                    </x-select-input>
+                @endif
+                <x-input-error :messages="$errors->get('type')" />
+            </div>
 
     <div class="mt-4">
         <x-input-label for="name" :value="__('monitoring.form.name')" />
@@ -101,6 +106,13 @@
             <x-input-error :messages="$errors->get('target')" />
         @endif
     </div>
+
+        </section>
+
+        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div>
+                <x-heading type="h2">{{ __('monitoring.form.sections.check') }}</x-heading>
+            </div>
 
     <template x-if="type === '{{ MonitoringType::PORT->value }}'">
         <div class="mt-4">
@@ -207,6 +219,13 @@
         </div>
     </template>
 
+        </section>
+
+        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div>
+                <x-heading type="h2">{{ __('monitoring.form.sections.sharing') }}</x-heading>
+            </div>
+
     <div class="mt-4">
         <x-input-label for="public_label_enabled" :value="__('monitoring.form.public_label')" />
         <label class="relative inline-flex cursor-pointer items-center">
@@ -238,6 +257,13 @@
             </div>
         @endif
     </div>
+
+        </section>
+
+        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div>
+                <x-heading type="h2">{{ __('monitoring.form.sections.notifications') }}</x-heading>
+            </div>
 
     <div class="mt-4">
         <x-input-label for="notification_on_failure" :value="__('monitoring.form.notification_on_failure')" />
@@ -285,6 +311,13 @@
         <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
     </div>
 
+        </section>
+
+        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div>
+                <x-heading type="h2">{{ __('monitoring.form.sections.operations') }}</x-heading>
+            </div>
+
     <div class="mt-4">
         <x-input-label for="preferred_location" :value="__('monitoring.form.preferred_location')" />
         <x-select-input id="preferred_location" class="mt-1 block w-full" name="preferred_location" required>
@@ -324,6 +357,8 @@
         <x-input-error :messages="$errors->get('maintenance_until')" />
     </div>
 
-    <x-primary-button
-        class="mt-4">{{ isset($monitoring) ? __('button.update') : __('button.create') }}</x-primary-button>
+        </section>
+
+        <x-primary-button>{{ isset($monitoring) ? __('button.update') : __('button.create') }}</x-primary-button>
+    </div>
 </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -17,54 +17,66 @@
         @csrf
         @method('patch')
 
-        <div>
-            <x-input-label for="name" :value="__('profile.fields.name')" />
-            <x-text-input id="name" name="name" type="text" :value="old('name', $user->name)" required autofocus
-                autocomplete="name" />
-            <x-input-error :messages="$errors->get('name')" />
-        </div>
+        <section class="space-y-4">
+            <div>
+                <x-heading type="h3">{{ __('profile.sections.account') }}</x-heading>
+            </div>
 
-        <div>
-            <x-input-label for="email" :value="__('profile.fields.email')" />
-            <x-text-input id="email" name="email" type="email" :value="old('email', $user->email)" required
-                autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" />
+            <div>
+                <x-input-label for="name" :value="__('profile.fields.name')" />
+                <x-text-input id="name" name="name" type="text" :value="old('name', $user->name)" required autofocus
+                    autocomplete="name" />
+                <x-input-error :messages="$errors->get('name')" />
+            </div>
 
-            @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && !$user->hasVerifiedEmail())
-                <div>
-                    <x-paragraph>
-                        {{ __('profile.information.email_unverified') }}
+            <div>
+                <x-input-label for="email" :value="__('profile.fields.email')" />
+                <x-text-input id="email" name="email" type="email" :value="old('email', $user->email)" required
+                    autocomplete="username" />
+                <x-input-error :messages="$errors->get('email')" />
 
-                        <button form="send-verification"
-                            class="focus:outline-hidden rounded-md text-gray-600 underline hover:text-gray-900 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2">
-                            {{ __('profile.information.send_verification_email') }}
-                        </button>
-                    </x-paragraph>
-                </div>
-            @else
-                <div>
-                    <x-paragraph class="text-green-600">
-                        {{ __('profile.messages.email_verified') }}
-                    </x-paragraph>
-                </div>
-            @endif
-        </div>
+                @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && !$user->hasVerifiedEmail())
+                    <div>
+                        <x-paragraph>
+                            {{ __('profile.information.email_unverified') }}
 
-        <div class="w-full md:w-1/2" x-data="{ theme: '{{ old('theme', $user->theme) }}' }">
-            <x-input-label for="theme" :value="__('profile.fields.theme')" />
-            <x-select-input id="theme" class="block w-full" name="theme"
-                @change="theme = $event.target.value">
-                <option value="light" :selected="theme === 'light'">{{ __('profile.fields.theme_light') }}
-                </option>
-                <option value="dark" :selected="theme === 'dark'">{{ __('profile.fields.theme_dark') }}
-                </option>
-                <option value="system" :selected="theme === 'system'">{{ __('profile.fields.theme_system') }}
-                </option>
-            </x-select-input>
-            <x-input-error :messages="$errors->get('theme')" />
-        </div>
+                            <button form="send-verification"
+                                class="focus:outline-hidden rounded-md text-gray-600 underline hover:text-gray-900 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2">
+                                {{ __('profile.information.send_verification_email') }}
+                            </button>
+                        </x-paragraph>
+                    </div>
+                @else
+                    <div>
+                        <x-paragraph class="text-green-600">
+                            {{ __('profile.messages.email_verified') }}
+                        </x-paragraph>
+                    </div>
+                @endif
+            </div>
+        </section>
 
-        <div class="space-y-6 border-t border-gray-200 pt-6 dark:border-gray-700">
+        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div>
+                <x-heading type="h3">{{ __('profile.sections.preferences') }}</x-heading>
+            </div>
+
+            <div class="w-full md:w-1/2" x-data="{ theme: '{{ old('theme', $user->theme) }}' }">
+                <x-input-label for="theme" :value="__('profile.fields.theme')" />
+                <x-select-input id="theme" class="block w-full" name="theme"
+                    @change="theme = $event.target.value">
+                    <option value="light" :selected="theme === 'light'">{{ __('profile.fields.theme_light') }}
+                    </option>
+                    <option value="dark" :selected="theme === 'dark'">{{ __('profile.fields.theme_dark') }}
+                    </option>
+                    <option value="system" :selected="theme === 'system'">{{ __('profile.fields.theme_system') }}
+                    </option>
+                </x-select-input>
+                <x-input-error :messages="$errors->get('theme')" />
+            </div>
+        </section>
+
+        <section class="space-y-6 border-t border-gray-200 pt-6 dark:border-gray-700">
             <x-heading type="h2">{{ __('profile.notification_settings.heading') }}</x-heading>
             <x-paragraph>{{ __('profile.notification_settings.description') }}</x-paragraph>
 
@@ -77,6 +89,10 @@
             @endif
 
             <div class="space-y-4">
+                <div>
+                    <x-heading type="h3">{{ __('profile.notification_settings.channels_heading') }}</x-heading>
+                </div>
+
                 <div class="rounded-xl border border-gray-200 bg-gray-50/60 p-5 shadow-xs dark:border-gray-700 dark:bg-gray-900/30">
                     <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
                         <x-heading type="h3">{{ __('profile.notification_settings.channels.slack.title') }}</x-heading>
@@ -197,7 +213,7 @@
                     <x-input-error :messages="$errors->get('monitoring_digest_frequency')" />
                 </div>
             </div>
-        </div>
+        </section>
 
         <x-primary-button>{{ __('button.update') }}</x-primary-button>
     </form>

--- a/tests/Feature/MonitoringNotificationSettingsTest.php
+++ b/tests/Feature/MonitoringNotificationSettingsTest.php
@@ -68,6 +68,11 @@ class MonitoringNotificationSettingsTest extends TestCase
         $testResponse = $this->actingAs($this->user)->get(route('monitorings.edit', $monitoring));
 
         $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.form.sections.basic'));
+        $testResponse->assertSeeText(__('monitoring.form.sections.check'));
+        $testResponse->assertSeeText(__('monitoring.form.sections.sharing'));
+        $testResponse->assertSeeText(__('monitoring.form.sections.notifications'));
+        $testResponse->assertSeeText(__('monitoring.form.sections.operations'));
         $testResponse->assertSeeText(__('monitoring.form.notification_channels'));
         $testResponse->assertSeeText(__('profile.notification_settings.channels.slack.title'));
         $testResponse->assertSeeText(__('profile.notification_settings.channels.telegram.title'));

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -75,7 +75,10 @@ class ProfileNotificationSettingsTest extends TestCase
 
         $testResponse = $this->actingAs($user)->get(route('profile.edit'));
         $testResponse->assertOk();
+        $testResponse->assertSeeText(__('profile.sections.account'));
+        $testResponse->assertSeeText(__('profile.sections.preferences'));
         $testResponse->assertSeeText(__('profile.notification_settings.heading'));
+        $testResponse->assertSeeText(__('profile.notification_settings.channels_heading'));
         $testResponse->assertSeeText(__('profile.notification_settings.digest.heading'));
         $testResponse->assertDontSeeText(__('profile.notification_settings.expiry_warning_days.heading'));
         $testResponse->assertSeeText(__('profile.notification_settings.hint_banner'));


### PR DESCRIPTION
## Summary
- group the monitoring edit form into clear sections for basics, checks, sharing, notifications, and operations
- split the profile edit form into account, appearance, notification channels, and digest areas
- add translation keys and feature assertions for the new grouping

## Validation
- ./vendor/bin/pint --dirty
- php artisan test tests/Feature/MonitoringNotificationSettingsTest.php tests/Feature/ProfileNotificationSettingsTest.php
- php artisan test tests/Feature