### PR TITLE
test: cover disabling profile notification reminders

### DIFF
--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -153,6 +153,34 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertNull(data_get($user->notification_channels, 'webhook.events'));
     }
 
+    public function test_profile_update_can_disable_notification_digest_and_unread_reminders(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => 'monthly',
+            'unread_notifications_reminder_enabled' => true,
+            'unread_notifications_reminder_frequency' => 'weekly',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+            'monitoring_digest_frequency' => 'weekly',
+            'unread_notifications_reminder_frequency' => 'daily',
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+
+        $user->refresh();
+
+        $this->assertFalse($user->monitoring_digest_enabled);
+        $this->assertSame('weekly', $user->monitoring_digest_frequency);
+        $this->assertFalse($user->unread_notifications_reminder_enabled);
+        $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
+    }
+
     public function test_profile_page_shows_notification_channel_test_buttons(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## Summary\n- Add a focused profile update regression test for disabling monitoring digest and unread reminder settings when checkbox fields are omitted.\n\n## Tests\n- php artisan test tests/Feature/ProfileNotificationSettingsTest.php\n- php artisan test tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php\n- vendor/bin/pint --test tests/Feature/ProfileNotificationSettingsTest.php\n\nNote: Composer dependencies were installed locally with --ignore-platform-req=ext-redis because this environment lacks the Redis PHP extension.