### PR TITLE
test: cover omitted profile notification settings

### DIFF
--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -54,9 +54,9 @@ class ProfileRequest extends FormRequest
             'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048'],
             'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048'],
             'monitoring_digest_enabled' => ['nullable', 'boolean'],
-            'monitoring_digest_frequency' => ['required', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
+            'monitoring_digest_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
             'unread_notifications_reminder_enabled' => ['nullable', 'boolean'],
-            'unread_notifications_reminder_frequency' => ['required', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
+            'unread_notifications_reminder_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
         ];
 
         foreach (NotificationChannel::values() as $channel) {

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -153,6 +153,33 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertNull(data_get($user->notification_channels, 'webhook.events'));
     }
 
+    public function test_profile_update_defaults_optional_notification_settings_when_omitted(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => 'monthly',
+            'unread_notifications_reminder_enabled' => true,
+            'unread_notifications_reminder_frequency' => 'weekly',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+        $testResponse->assertSessionHasNoErrors();
+
+        $user->refresh();
+
+        $this->assertFalse($user->monitoring_digest_enabled);
+        $this->assertSame('weekly', $user->monitoring_digest_frequency);
+        $this->assertFalse($user->unread_notifications_reminder_enabled);
+        $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
+    }
+
     public function test_profile_page_shows_notification_channel_test_buttons(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## Summary
- allow omitted digest and unread reminder frequency fields to use controller defaults
- add regression coverage for profile updates with optional notification settings omitted

## Tests
- php artisan test --filter=ProfileNotificationSettingsTest::test_profile_update_defaults_optional_notification_settings_when_omitted
- php artisan test tests/Feature/ProfileNotificationSettingsTest.php

Note: dependency install required composer install --ignore-platform-req=ext-redis because the local PHP CLI is missing ext-redis.