### PR TITLE
Cover blank notification frequencies

### DIFF
--- a/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
+++ b/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
@@ -184,6 +184,41 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
         }
     }
 
+    public function test_blank_unread_reminder_frequency_defaults_to_daily(): void
+    {
+        Date::setTestNow('2026-04-07 08:00:00');
+
+        try {
+            Package::factory()->create();
+
+            $user = User::factory()->create([
+                'unread_notifications_reminder_enabled' => true,
+                'unread_notifications_reminder_frequency' => '',
+            ]);
+
+            $monitoring = Monitoring::factory()->for($user)->create();
+
+            MonitoringNotification::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'type' => NotificationType::STATUS_CHANGE,
+                'message' => 'DOWN',
+                'read' => false,
+                'sent' => true,
+            ]);
+
+            Mail::fake();
+
+            Artisan::call('notifications:remind-unread-weekly');
+
+            Mail::assertSent(UnreadNotificationsReminderMail::class, function (UnreadNotificationsReminderMail $unreadNotificationsReminderMail) use ($user): bool {
+                return $unreadNotificationsReminderMail->hasTo($user->email)
+                    && $unreadNotificationsReminderMail->unreadNotificationsCount === 1;
+            });
+        } finally {
+            Date::setTestNow();
+        }
+    }
+
     public function test_weekly_and_monthly_reminders_are_sent_when_due(): void
     {
         Date::setTestNow('2026-06-01 08:00:00');

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -198,6 +198,29 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         Mail::assertNotSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail): bool => $weeklyMonitoringDigestMail->hasTo($weeklyUser->email));
     }
 
+    public function test_blank_digest_frequency_defaults_to_weekly(): void
+    {
+        Date::setTestNow('2026-04-20 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => '',
+        ]);
+        Monitoring::factory()->for($user)->create();
+
+        Mail::fake();
+
+        Artisan::call('notifications:send-weekly-monitoring-digest', [
+            '--period-end' => '2026-04-19',
+        ]);
+
+        Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail): bool => $weeklyMonitoringDigestMail->hasTo($user->email)
+            && $weeklyMonitoringDigestMail->digest['frequency'] === 'weekly'
+            && $weeklyMonitoringDigestMail->digest['period_start']->toDateString() === '2026-04-13'
+            && $weeklyMonitoringDigestMail->digest['period_end']->toDateString() === '2026-04-19');
+    }
+
     public function test_period_end_option_scopes_expiry_warnings_to_the_digest_window(): void
     {
         Date::setTestNow('2026-05-20 09:00:00');


### PR DESCRIPTION
## Summary
- add coverage for blank unread reminder frequency falling back to daily
- add coverage for blank monitoring digest frequency falling back to weekly

## Validation
- composer install --no-interaction --prefer-dist --ignore-platform-req=ext-redis
- ./vendor/bin/pint --dirty
- php artisan test tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php

Note: the first plain composer install was blocked by missing local ext-redis, so dependencies were installed with that platform requirement ignored for this focused test run.