### PR TITLE
fix(profile): allow default notification frequencies

### DIFF
--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -54,9 +54,9 @@ class ProfileRequest extends FormRequest
             'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048'],
             'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048'],
             'monitoring_digest_enabled' => ['nullable', 'boolean'],
-            'monitoring_digest_frequency' => ['required', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
+            'monitoring_digest_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
             'unread_notifications_reminder_enabled' => ['nullable', 'boolean'],
-            'unread_notifications_reminder_frequency' => ['required', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
+            'unread_notifications_reminder_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
         ];
 
         foreach (NotificationChannel::values() as $channel) {

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -181,6 +181,32 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
     }
 
+    public function test_profile_update_defaults_missing_notification_frequencies(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'monitoring_digest_frequency' => 'monthly',
+            'unread_notifications_reminder_frequency' => 'weekly',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+            'monitoring_digest_enabled' => '1',
+            'unread_notifications_reminder_enabled' => '1',
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+
+        $user->refresh();
+
+        $this->assertTrue($user->monitoring_digest_enabled);
+        $this->assertSame('weekly', $user->monitoring_digest_frequency);
+        $this->assertTrue($user->unread_notifications_reminder_enabled);
+        $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
+    }
+
     public function test_profile_page_shows_notification_channel_test_buttons(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## Summary
- allow omitted notification digest and unread reminder frequencies through profile validation
- cover the profile update path that falls back to weekly and daily defaults

## Validation
- vendor/bin/pint app/Http/Requests/ProfileRequest.php tests/Feature/ProfileNotificationSettingsTest.php
- php artisan test tests/Feature/ProfileNotificationSettingsTest.php

## Notes
- Installed dependencies locally with composer install --ignore-platform-req=ext-redis because this PHP runtime is missing ext-redis.