### PR TITLE
Fix blank profile notification frequencies

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -71,9 +71,15 @@ class ProfileController extends Controller
 
         $user->notification_channels = $this->normalizeNotificationChannels($profileRequest);
         $user->monitoring_digest_enabled = $profileRequest->boolean('monitoring_digest_enabled');
-        $user->monitoring_digest_frequency = (string) $profileRequest->input('monitoring_digest_frequency', 'weekly');
+        $user->monitoring_digest_frequency = $this->normalizeFrequency(
+            $profileRequest->input('monitoring_digest_frequency'),
+            'weekly'
+        );
         $user->unread_notifications_reminder_enabled = $profileRequest->boolean('unread_notifications_reminder_enabled');
-        $user->unread_notifications_reminder_frequency = (string) $profileRequest->input('unread_notifications_reminder_frequency', 'daily');
+        $user->unread_notifications_reminder_frequency = $this->normalizeFrequency(
+            $profileRequest->input('unread_notifications_reminder_frequency'),
+            'daily'
+        );
         $user->save();
 
         return to_route('profile.edit')
@@ -203,5 +209,10 @@ class ProfileController extends Controller
         }
 
         return $normalized;
+    }
+
+    private function normalizeFrequency(mixed $value, string $default): string
+    {
+        return blank($value) ? $default : (string) $value;
     }
 }

--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -54,9 +54,9 @@ class ProfileRequest extends FormRequest
             'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048'],
             'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048'],
             'monitoring_digest_enabled' => ['nullable', 'boolean'],
-            'monitoring_digest_frequency' => ['required', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
+            'monitoring_digest_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
             'unread_notifications_reminder_enabled' => ['nullable', 'boolean'],
-            'unread_notifications_reminder_frequency' => ['required', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
+            'unread_notifications_reminder_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
         ];
 
         foreach (NotificationChannel::values() as $channel) {

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -181,6 +181,34 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
     }
 
+    public function test_profile_update_defaults_blank_notification_frequencies(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => 'monthly',
+            'unread_notifications_reminder_enabled' => true,
+            'unread_notifications_reminder_frequency' => 'weekly',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+            'monitoring_digest_frequency' => '',
+            'unread_notifications_reminder_frequency' => '',
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+
+        $user->refresh();
+
+        $this->assertFalse($user->monitoring_digest_enabled);
+        $this->assertSame('weekly', $user->monitoring_digest_frequency);
+        $this->assertFalse($user->unread_notifications_reminder_enabled);
+        $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
+    }
+
     public function test_profile_page_shows_notification_channel_test_buttons(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## What changed
- allow blank profile notification frequency inputs to pass validation
- normalize blank digest and unread reminder frequencies back to their existing defaults when saving the profile
- add a regression test covering blank frequency submissions on the profile form

## Why it changed
A recent test-only commit (`f25001b`) confirmed the notification commands already fall back from blank frequency values at send time. The profile update path still treated those inputs too strictly, which meant a blank or omitted select value could fail validation or persist incorrectly instead of matching command behavior.

## Impact
Users saving notification settings now keep consistent defaults even if frequency inputs arrive blank from the form submission path.

## Root cause
Fallback handling existed in the command layer, but not in the profile request and persistence layer.

## Validation
- `php artisan test tests/Feature/ProfileNotificationSettingsTest.php`
