### PR TITLE
Streamline Nixpacks deployment build

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,12 @@
 [phases.setup]
-nixPkgs = ["...", "bun", "python311Packages.supervisor"]
+nixPkgs = ["...", "python311Packages.supervisor"]
+
+[phases.install]
+cmds = [
+    "mkdir -p /var/log/nginx /var/cache/nginx",
+    "composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader",
+    "bun install --frozen-lockfile",
+]
 
 [phases.build]
 cmds = [
@@ -7,10 +14,6 @@ cmds = [
     "cp /assets/worker-*.conf /etc/supervisor/conf.d/",
     "cp /assets/supervisord.conf /etc/supervisord.conf",
     "chmod +x /assets/start.sh",
-    "chmod -R 775 /app/storage /app/bootstrap/cache",
-    "chown -R www-data:www-data /app/storage /app/bootstrap/cache",
-    "bun install --frozen-lockfile",
-    "bun run build",
     "...",
 ]
 

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -19,4 +19,39 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
             $nixpacksConfiguration
         );
     }
+
+    public function test_nixpacks_build_does_not_mutate_laravel_runtime_directory_permissions(): void
+    {
+        $nixpacksConfiguration = file_get_contents(base_path('nixpacks.toml'));
+
+        $this->assertIsString($nixpacksConfiguration);
+        $this->assertStringNotContainsString('chmod -R 775 /app/storage /app/bootstrap/cache', $nixpacksConfiguration);
+        $this->assertStringNotContainsString('chown -R www-data:www-data /app/storage /app/bootstrap/cache', $nixpacksConfiguration);
+    }
+
+    public function test_nixpacks_uses_deterministic_dependency_install_commands_for_deployments(): void
+    {
+        $nixpacksConfiguration = file_get_contents(base_path('nixpacks.toml'));
+
+        $this->assertIsString($nixpacksConfiguration);
+        $this->assertStringContainsString('nixPkgs = ["...", "python311Packages.supervisor"]', $nixpacksConfiguration);
+        $this->assertStringContainsString(
+            '"composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader"',
+            $nixpacksConfiguration
+        );
+        $this->assertStringContainsString('"bun install --frozen-lockfile"', $nixpacksConfiguration);
+        $this->assertStringNotContainsString('"bun i --no-save"', $nixpacksConfiguration);
+    }
+
+    public function test_nixpacks_build_leaves_frontend_build_to_the_default_plan(): void
+    {
+        $nixpacksConfiguration = file_get_contents(base_path('nixpacks.toml'));
+
+        $this->assertIsString($nixpacksConfiguration);
+        preg_match('/\[phases\.build\]\s+cmds = \[(.*?)\]/s', $nixpacksConfiguration, $matches);
+
+        $this->assertNotEmpty($matches[1] ?? null);
+        $this->assertStringNotContainsString('bun install', $matches[1]);
+        $this->assertStringNotContainsString('bun run build', $matches[1]);
+    }
 }


### PR DESCRIPTION
## Summary

- remove recursive Laravel runtime permission mutations from the Nixpacks build phase
- avoid duplicate Bun setup/build work by relying on the Nixpacks default build plan for the frontend build
- make deployment dependency installation deterministic with production Composer install and frozen Bun lockfile
- add deployment config tests that guard the intended Nixpacks behavior

## Why

Coolify's generated Nixpacks plan was running redundant Bun work and mutating runtime directory permissions during the image build. That adds avoidable work to deployments that are already running without Docker cache.

## Validation

- `php artisan test --filter=HeartbeatQueueDeploymentConfigTest`
- `bun run build`