### PR TITLE
fix(profile): normalize whitespace notification frequencies

### DIFF
--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -94,4 +94,25 @@ class ProfileRequest extends FormRequest
             }
         });
     }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'monitoring_digest_frequency' => $this->normalizeNullableFrequency('monitoring_digest_frequency'),
+            'unread_notifications_reminder_frequency' => $this->normalizeNullableFrequency('unread_notifications_reminder_frequency'),
+        ]);
+    }
+
+    private function normalizeNullableFrequency(string $key): ?string
+    {
+        $value = $this->input($key);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $value = mb_trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
 }

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -236,6 +236,35 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
     }
 
+    public function test_profile_update_defaults_whitespace_notification_frequencies(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => 'monthly',
+            'unread_notifications_reminder_enabled' => true,
+            'unread_notifications_reminder_frequency' => 'weekly',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+            'monitoring_digest_frequency' => '   ',
+            'unread_notifications_reminder_frequency' => "\t",
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+        $testResponse->assertSessionHasNoErrors();
+
+        $user->refresh();
+
+        $this->assertFalse($user->monitoring_digest_enabled);
+        $this->assertSame('weekly', $user->monitoring_digest_frequency);
+        $this->assertFalse($user->unread_notifications_reminder_enabled);
+        $this->assertSame('daily', $user->unread_notifications_reminder_frequency);
+    }
+
     public function test_profile_update_defaults_missing_notification_frequencies(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## Summary

- Normalize whitespace-only profile notification frequency inputs before validation.

- Add feature coverage for whitespace values defaulting to the existing digest/reminder frequencies.
## Validation

- php artisan test tests/Feature/ProfileNotificationSettingsTest.php

- ./vendor/bin/pint --dirty --test
