### PR TITLE
Improve notification section headings

### DIFF
--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -413,9 +413,6 @@
                 <x-heading type="h2" class="text-lg font-semibold text-gray-800">
                     {{ __('monitoring.detail.checks.heading') }}
                 </x-heading>
-                <x-paragraph class="text-sm text-gray-500">
-                    {{ __('monitoring.detail.checks.help') }}
-                </x-paragraph>
             </div>
 
             <template x-if="recentChecksLoading">

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -153,6 +153,7 @@
 
             @if ($statusBoardEntries->isNotEmpty())
                 <div class="mb-8">
+                    <x-heading type="h2" space=true>{{ __('notifications.status_change_notifications') }}</x-heading>
                     <div id="status-change-notifications">
                         @include('notifications.partials.status_board_list', [
                             'entries' => $statusBoardEntries,

--- a/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
+++ b/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
@@ -28,7 +28,7 @@ class MonitoringDetailRecentChecksSectionTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('monitoring.detail.checks.heading'));
-        $testResponse->assertSeeText(__('monitoring.detail.checks.help'));
+        $testResponse->assertDontSeeText(__('monitoring.detail.checks.help'));
         $testResponse->assertSeeText(__('monitoring.detail.checks.no_checks'));
         $testResponse->assertSeeText(__('monitoring.detail.checks.labels.status_code'));
         $testResponse->assertSeeText(__('monitoring.detail.checks.labels.response_time'));

--- a/tests/Feature/Notifications/NotificationStatusBoardTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardTest.php
@@ -59,6 +59,7 @@ class NotificationStatusBoardTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('notifications.index', ['show_read' => true]));
 
         $testResponse->assertOk();
+        $testResponse->assertSeeText(__('notifications.status_change_notifications'));
         $testResponse->assertSeeHtml('id="' . $latestNotification->id . '"');
         $testResponse->assertDontSeeHtml('id="' . $monitoringNotification->id . '"');
     }


### PR DESCRIPTION
## Summary

- Add a dedicated status change heading on the notifications page so each notification group is clearly labeled.
- Remove the recent checks helper copy from the monitoring detail page to keep the section aligned with the corporate design.
- Update feature tests to assert the new heading and removed helper text.

## Validation

- `php artisan test tests/Feature/Notifications/NotificationStatusBoardTest.php tests/Feature/MonitoringDetailRecentChecksSectionTest.php`

Note: Composer dependencies were installed locally with `--ignore-platform-req=ext-redis` because the local PHP Redis extension is missing.