### PR TITLE
Align legal page card styling

### DIFF
--- a/resources/views/gdpr.blade.php
+++ b/resources/views/gdpr.blade.php
@@ -165,7 +165,7 @@
                 </x-paragraph>
             </section>
 
-            <section class="rounded-3xl border border-emerald-200 bg-emerald-50/70 p-8 dark:border-emerald-900/50 dark:bg-emerald-950/20 sm:p-10">
+            <section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900/70 sm:p-10">
                 <x-heading type="h2" class="text-xl font-semibold text-slate-900 dark:text-white">
                     {{ __('gdpr.sections.contact.title') }}
                 </x-heading>

--- a/resources/views/imprint.blade.php
+++ b/resources/views/imprint.blade.php
@@ -77,14 +77,6 @@
                 </dl>
             </section>
 
-            <section class="rounded-3xl border border-amber-200 bg-amber-50/80 p-8 dark:border-amber-900/50 dark:bg-amber-950/20 sm:p-10">
-                <x-heading type="h2" class="text-xl font-semibold text-slate-900 dark:text-white">
-                    {{ __('imprint.sections.disclaimer') }}
-                </x-heading>
-                <x-paragraph class="mt-3 text-sm leading-7 text-slate-700 dark:text-slate-300">
-                    {{ __('imprint.disclaimer') }}
-                </x-paragraph>
-            </section>
         </x-main>
     </main>
 </x-marketing-layout>

--- a/resources/views/monitoring-locations.blade.php
+++ b/resources/views/monitoring-locations.blade.php
@@ -20,7 +20,7 @@
                 </x-paragraph>
             </header>
 
-            <section class="rounded-3xl border border-amber-200 bg-amber-50/80 p-8 dark:border-amber-900/50 dark:bg-amber-950/20 sm:p-10">
+            <section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900/70 sm:p-10">
                 <x-heading type="h2" class="text-xl font-semibold text-slate-900 dark:text-white">
                     {{ __('monitoring_locations.guidance.title') }}
                 </x-heading>
@@ -35,7 +35,7 @@
                 <ul class="mt-3 space-y-3 text-sm leading-7 text-slate-700 dark:text-slate-300">
                     @foreach ([1, 2, 3] as $item)
                         <li class="flex items-start gap-3">
-                            <span class="mt-1 inline-block h-2 w-2 flex-none rounded-full bg-amber-500 dark:bg-amber-300"></span>
+                            <span class="mt-1 inline-block h-2 w-2 flex-none rounded-full bg-slate-400 dark:bg-slate-500"></span>
                             <span>{{ __('monitoring_locations.guidance.items.' . $item) }}</span>
                         </li>
                     @endforeach
@@ -80,7 +80,7 @@
                 </div>
             </section>
 
-            <section class="rounded-3xl border border-sky-200 bg-sky-50/80 p-8 dark:border-sky-900/50 dark:bg-sky-950/30 sm:p-10">
+            <section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900/70 sm:p-10">
                 <x-heading type="h2" class="text-xl font-semibold text-slate-900 dark:text-white">
                     {{ __('monitoring_locations.note.title') }}
                 </x-heading>

--- a/tests/Feature/GdprPageTest.php
+++ b/tests/Feature/GdprPageTest.php
@@ -33,6 +33,18 @@ class GdprPageTest extends TestCase
         $testResponse->assertSeeHtml('<meta name="robots" content="noindex, nofollow">');
     }
 
+    public function test_gdpr_contact_section_uses_the_default_card_style(): void
+    {
+        $testResponse = $this->get(route('gdpr'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('gdpr.sections.contact.title'));
+        $testResponse->assertDontSeeHtml('border-emerald-200');
+        $testResponse->assertDontSeeHtml('bg-emerald-50/70');
+        $testResponse->assertDontSeeHtml('dark:border-emerald-900/50');
+        $testResponse->assertDontSeeHtml('dark:bg-emerald-950/20');
+    }
+
     public function test_gdpr_page_describes_current_feature_data_processing(): void
     {
         foreach (['de-DE' => 'de', 'en-US' => 'en'] as $acceptLanguage => $locale) {

--- a/tests/Feature/ImprintPageTest.php
+++ b/tests/Feature/ImprintPageTest.php
@@ -23,6 +23,8 @@ class ImprintPageTest extends TestCase
         $testResponse->assertDontSeeText('+49 1512 3456789');
         $testResponse->assertSeeHtml('data-email-payload=');
         $testResponse->assertSeeHtml('data-phone-payload=');
+        $testResponse->assertDontSeeText(__('imprint.sections.disclaimer'));
+        $testResponse->assertDontSeeText(__('imprint.disclaimer'));
     }
 
     public function test_impressum_route_redirects_to_imprint(): void

--- a/tests/Feature/MonitoringLocationsPageTest.php
+++ b/tests/Feature/MonitoringLocationsPageTest.php
@@ -28,6 +28,20 @@ class MonitoringLocationsPageTest extends TestCase
         $testResponse->assertSeeText('203.0.113.10');
     }
 
+    public function test_monitoring_locations_guidance_and_note_use_the_default_card_style(): void
+    {
+        $testResponse = $this->get(route('monitoring-locations'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring_locations.guidance.title'));
+        $testResponse->assertSeeText(__('monitoring_locations.note.title'));
+        $testResponse->assertDontSeeHtml('border-amber-200');
+        $testResponse->assertDontSeeHtml('bg-amber-50/80');
+        $testResponse->assertDontSeeHtml('bg-amber-500');
+        $testResponse->assertDontSeeHtml('border-sky-200');
+        $testResponse->assertDontSeeHtml('bg-sky-50/80');
+    }
+
     public function test_monitoring_locations_page_lists_only_active_server_instances(): void
     {
         ServerInstance::query()->create([


### PR DESCRIPTION
## Summary

- Use the default card styling for the GDPR contact section.
- Remove the project notice card from the imprint page.
- Use default card styling for the monitoring locations guidance and note sections, including neutral checklist bullets.
- Add feature assertions covering the removed highlight styles and removed project notice.

## Validation

- `php artisan test tests/Feature/GdprPageTest.php tests/Feature/ImprintPageTest.php tests/Feature/MonitoringLocationsPageTest.php`
- Result: 19 passed, 101 assertions