### PR TITLE
test(docker): cover smtp username examples

### DIFF
--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -48,6 +48,15 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
         $this->assertStringContainsString('MAIL_FROM_NAME: "${MAIL_FROM_NAME:-WebGuard}"', $composeConfiguration);
     }
 
+    public function test_docker_mail_username_input_uses_smtp_username_in_environment_example(): void
+    {
+        $environmentExample = file_get_contents(base_path('.env.example'));
+
+        $this->assertIsString($environmentExample);
+        $this->assertStringContainsString('SMTP_USERNAME=null', $environmentExample);
+        $this->assertStringNotContainsString('MAIL_USERNAME=${MAIL_FROM_ADDRESS}', $environmentExample);
+    }
+
     public function test_production_compose_uses_defaults_for_interpolated_environment_variables(): void
     {
         $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));


### PR DESCRIPTION
## Summary

Adds a focused regression test for the recent Docker mail username change. The test now locks the deployment environment example to `SMTP_USERNAME` and checks that the old `MAIL_USERNAME=${MAIL_FROM_ADDRESS}` interpolation pattern does not come back.

## Validation

- `php artisan test tests/Feature/HeartbeatQueueDeploymentConfigTest.php`
- `php artisan test`

Note: dependencies were installed locally with `composer install --ignore-platform-req=ext-redis` because the local PHP CLI lacks the Redis extension.