### PR TITLE
Consolidate unread reminder count query

### DIFF
--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -203,32 +203,30 @@ class NotificationBoardService
      */
     public function getUnreadNotificationCountsByUser(): Collection
     {
-        $unreadStatusChangeCounts = MonitoringNotification::query()
-            ->withoutGlobalScopes()
-            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
-            ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
-            ->where('monitoring_notifications.read', false)
-            ->whereNull('monitorings.deleted_at')
-            ->selectRaw('monitorings.user_id as user_id, count(distinct monitoring_notifications.monitoring_id) as total')
-            ->groupBy('monitorings.user_id')
-            ->pluck('total', 'user_id');
-
-        $unreadNonStatusChangeCounts = MonitoringNotification::query()
+        return MonitoringNotification::query()
             ->withoutGlobalScopes()
             ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
             ->where('monitoring_notifications.read', false)
-            ->where('monitoring_notifications.type', '!=', NotificationType::STATUS_CHANGE->value)
             ->whereNull('monitorings.deleted_at')
-            ->selectRaw('monitorings.user_id as user_id, count(*) as total')
+            ->selectRaw(
+                <<<'SQL'
+                monitorings.user_id as user_id,
+                count(distinct case
+                    when monitoring_notifications.type = ?
+                    then monitoring_notifications.monitoring_id
+                end) + coalesce(sum(case
+                    when monitoring_notifications.type != ?
+                    then 1
+                    else 0
+                end), 0) as total
+                SQL,
+                [
+                    NotificationType::STATUS_CHANGE->value,
+                    NotificationType::STATUS_CHANGE->value,
+                ]
+            )
             ->groupBy('monitorings.user_id')
-            ->pluck('total', 'user_id');
-
-        return $unreadStatusChangeCounts->keys()
-            ->merge($unreadNonStatusChangeCounts->keys())
-            ->unique()
-            ->mapWithKeys(fn (string $userId): array => [
-                $userId => (int) ($unreadStatusChangeCounts->get($userId, 0))
-                    + (int) ($unreadNonStatusChangeCounts->get($userId, 0)),
-            ]);
+            ->pluck('total', 'user_id')
+            ->map(fn (int|string $total): int => (int) $total);
     }
 }

--- a/tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
+++ b/tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
@@ -181,15 +181,15 @@ class UnreadNotificationCountPerformanceTest extends TestCase
         DB::flushQueryLog();
         DB::enableQueryLog();
 
-        $counts = resolve(NotificationBoardService::class)->getUnreadNotificationCountsByUser();
+        $unreadNotificationCountsByUser = resolve(NotificationBoardService::class)->getUnreadNotificationCountsByUser();
 
         $selectQueries = collect(DB::getQueryLog())
             ->pluck('query')
             ->filter(fn (string $query): bool => str_starts_with(mb_strtolower($query), 'select'))
             ->values();
 
-        $this->assertSame(2, $counts->get($firstUser->id));
-        $this->assertSame(1, $counts->get($secondUser->id));
+        $this->assertSame(2, $unreadNotificationCountsByUser->get($firstUser->id));
+        $this->assertSame(1, $unreadNotificationCountsByUser->get($secondUser->id));
         $this->assertCount(1, $selectQueries);
         $this->assertTrue($selectQueries->contains(
             fn (string $query): bool => str_contains(mb_strtolower($query), 'count(distinct')

--- a/tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
+++ b/tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
@@ -124,4 +124,78 @@ class UnreadNotificationCountPerformanceTest extends TestCase
         $this->assertSame(0, $count);
         $this->assertCount(1, $selectQueries);
     }
+
+    public function test_unread_notification_counts_by_user_use_one_grouped_aggregate_query(): void
+    {
+        $package = Package::factory()->create();
+        $firstUser = User::factory()->for($package)->create();
+        $secondUser = User::factory()->for($package)->create();
+
+        $firstMonitoring = Monitoring::factory()->for($firstUser)->create();
+        $secondMonitoring = Monitoring::factory()->for($firstUser)->create();
+        $thirdMonitoring = Monitoring::factory()->for($secondUser)->create();
+        $deletedMonitoring = Monitoring::factory()->for($secondUser)->create();
+
+        MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $firstMonitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $firstMonitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $secondMonitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'SSL_EXPIRING',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $thirdMonitoring->id,
+            'type' => NotificationType::DOMAIN_EXPIRY,
+            'message' => 'DOMAIN_EXPIRING',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $deletedMonitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'SSL_EXPIRING',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        $deletedMonitoring->delete();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $counts = resolve(NotificationBoardService::class)->getUnreadNotificationCountsByUser();
+
+        $selectQueries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(fn (string $query): bool => str_starts_with(mb_strtolower($query), 'select'))
+            ->values();
+
+        $this->assertSame(2, $counts->get($firstUser->id));
+        $this->assertSame(1, $counts->get($secondUser->id));
+        $this->assertCount(1, $selectQueries);
+        $this->assertTrue($selectQueries->contains(
+            fn (string $query): bool => str_contains(mb_strtolower($query), 'count(distinct')
+        ));
+        $this->assertTrue($selectQueries->contains(
+            fn (string $query): bool => str_contains(mb_strtolower($query), 'sum(case')
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- Consolidates unread notification reminder counts into one grouped aggregate query.
- Preserves distinct status-change counting per monitoring while still counting non-status-change notifications individually.
- Adds a query-budget regression test for all-user unread reminder counts.

## Validation

- vendor/bin/pint app/Services/NotificationBoardService.php tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php
- php artisan test tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php tests/Feature/Notifications/NotificationRenderingPerformanceTest.php tests/Feature/Notifications/NotificationStatusBoardTest.php tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
