### PR TITLE
fix(legal-pages): restore imprint notice after card styling update

### DIFF
--- a/resources/views/imprint.blade.php
+++ b/resources/views/imprint.blade.php
@@ -77,6 +77,15 @@
                 </dl>
             </section>
 
+            <section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900/70 sm:p-10">
+                <x-heading type="h2" class="text-xl font-semibold text-slate-900 dark:text-white">
+                    {{ __('imprint.sections.disclaimer') }}
+                </x-heading>
+                <x-paragraph class="mt-3 text-sm leading-7 text-slate-700 dark:text-slate-300">
+                    {{ __('imprint.disclaimer') }}
+                </x-paragraph>
+            </section>
+
         </x-main>
     </main>
 </x-marketing-layout>

--- a/tests/Feature/ImprintPageTest.php
+++ b/tests/Feature/ImprintPageTest.php
@@ -23,8 +23,9 @@ class ImprintPageTest extends TestCase
         $testResponse->assertDontSeeText('+49 1512 3456789');
         $testResponse->assertSeeHtml('data-email-payload=');
         $testResponse->assertSeeHtml('data-phone-payload=');
-        $testResponse->assertDontSeeText(__('imprint.sections.disclaimer'));
-        $testResponse->assertDontSeeText(__('imprint.disclaimer'));
+        $testResponse->assertSeeText(__('imprint.sections.disclaimer'));
+        $testResponse->assertSeeText(__('imprint.disclaimer'));
+        $testResponse->assertSeeHtml('rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900/70 sm:p-10');
     }
 
     public function test_impressum_route_redirects_to_imprint(): void


### PR DESCRIPTION
## What changed
- aligned the GDPR, monitoring locations, and imprint legal cards to the shared default card style
- restored the removed imprint project notice section
- updated the imprint feature test to assert the disclaimer content is present

## Why
The styling change in `ee42eb0df00fe1d4daec48b852e439483436a3ac` removed the disclaimer block from `resources/views/imprint.blade.php` instead of restyling it.

## Impact
The legal pages keep the intended card styling changes without dropping the imprint page's project notice.

## Root cause
A style-alignment commit deleted the disclaimer section markup entirely.

## Validation
- `composer install --no-interaction --prefer-dist --ignore-platform-req=ext-redis`
- `php artisan test tests/Feature/ImprintPageTest.php`
