### PR TITLE
Add rich public status pages

### DIFF
--- a/app/Http/Controllers/PublicLabelController.php
+++ b/app/Http/Controllers/PublicLabelController.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
 use App\Models\Monitoring;
+use App\Services\MonitoringResultService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Date;
 use Illuminate\View\View;
 
 /**
@@ -39,8 +43,53 @@ class PublicLabelController extends Controller
     {
         abort_unless($monitoring->public_label_enabled, 404);
 
+        $monitoring->loadMissing([
+            'domainResult',
+            'latestIncident',
+            'latestResponseResult',
+            'sslResult',
+        ]);
+
+        $statusSince = MonitoringResultService::getStatusSince($monitoring);
+        $statusNow = MonitoringResultService::getStatusNow($monitoring);
+        $status = $this->normalizeStatus($statusSince['status'] ?? $statusNow['status'] ?? MonitoringStatus::UNKNOWN->value);
+        $rangeSummaries = MonitoringResultService::getUptimeDowntimesForRanges($monitoring, [7, 30, 90]);
+        $incidents = MonitoringResultService::getIncidents(
+            $monitoring,
+            Date::now()->subDays(90),
+            Date::now()
+        )->take(10);
+
         return view('monitorings.public-label', [
             'monitoring' => $monitoring,
+            'status' => $status,
+            'statusBadgeType' => $this->statusBadgeType($status),
+            'statusSince' => $statusSince['since'] ?? null,
+            'statusNow' => $statusNow,
+            'rangeSummaries' => $rangeSummaries,
+            'incidents' => $incidents,
+            'displayTarget' => $monitoring->type === MonitoringType::HEARTBEAT ? null : $monitoring->target,
+            'isUnderMaintenance' => $monitoring->isUnderMaintenance(),
         ]);
+    }
+
+    private function normalizeStatus(mixed $status): string
+    {
+        if ($status instanceof MonitoringStatus) {
+            return $status->value;
+        }
+
+        $normalized = mb_strtolower((string) $status);
+
+        return MonitoringStatus::tryFrom($normalized)?->value ?? MonitoringStatus::UNKNOWN->value;
+    }
+
+    private function statusBadgeType(string $status): string
+    {
+        return match ($status) {
+            MonitoringStatus::UP->value => 'success',
+            MonitoringStatus::DOWN->value => 'danger',
+            default => 'warning',
+        };
     }
 }

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -259,6 +259,13 @@ return [
     ],
     'public_label' => [
         'title' => ':monitoringName - Öffentlicher Status',
+        'current_status' => 'Aktueller Status',
+        'incidents_count' => ':count Vorfall|:count Vorfälle',
+        'no_data' => 'Noch keine Daten',
+        'ongoing' => 'Laufend',
+        'private_target' => 'Privates Heartbeat-Ziel',
+        'range_days' => 'Letzter :days Tag|Letzte :days Tage',
+        'resolved' => 'Behoben',
     ],
     'validation' => [
         'invalid_type' => 'Der ausgewählte Typ \':type\' ist ungültig.',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -259,6 +259,13 @@ return [
     ],
     'public_label' => [
         'title' => ':monitoringName - Public Status',
+        'current_status' => 'Current Status',
+        'incidents_count' => ':count incident|:count incidents',
+        'no_data' => 'No data yet',
+        'ongoing' => 'Ongoing',
+        'private_target' => 'Private heartbeat target',
+        'range_days' => 'Last :days day|Last :days days',
+        'resolved' => 'Resolved',
     ],
     'validation' => [
         'invalid_type' => 'The selected type \':type\' is invalid.',

--- a/resources/views/monitorings/public-label.blade.php
+++ b/resources/views/monitorings/public-label.blade.php
@@ -5,28 +5,187 @@
     </x-slot>
 
     <x-slot name="header">
-        <x-heading>
-            {{ $monitoring->name }}
-            <small>({{ strtoupper($monitoring->type->value) }})</small>
-
-            <a href="{{ $monitoring->target }}" target="_blank" title="{{ $monitoring->name }}"
-                class="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-white">
-                {{ $monitoring->target }}
-            </a>
-        </x-heading>
+        <div>
+            <x-heading>
+                {{ $monitoring->name }}
+            </x-heading>
+            <div class="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-300">
+                <x-badge type="info">{{ __('monitoring.types.' . $monitoring->type->value) }}</x-badge>
+                @if ($displayTarget)
+                    <a href="{{ $displayTarget }}" target="_blank" title="{{ $monitoring->name }}"
+                        class="break-all hover:text-gray-700 dark:hover:text-white">
+                        {{ $displayTarget }}
+                    </a>
+                @else
+                    <span>{{ __('monitoring.public_label.private_target') }}</span>
+                @endif
+            </div>
+        </div>
     </x-slot>
 
     <x-main>
-        <div x-data="uptimeCalendar('{{ $monitoring->id }}')" x-init="fetchUptimeCalendar">
-            <template x-if="isLoading">
-                <p>{{ __('calendar.loading') }}</p>
-            </template>
+        <div class="space-y-6">
+            <section class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <x-container>
+                    <x-heading type="h2">{{ __('monitoring.public_label.current_status') }}</x-heading>
+                    <div class="mt-3 flex flex-wrap items-center gap-2">
+                        <x-badge :type="$statusBadgeType">
+                            {{ mb_strtoupper($status) }}
+                        </x-badge>
+                        @if ($isUnderMaintenance)
+                            <x-badge type="info">
+                                {{ __('monitoring.index.table.maintenance') }}
+                            </x-badge>
+                        @endif
+                    </div>
+                    <div class="mt-4 space-y-1 text-sm text-gray-500 dark:text-gray-400">
+                        @if ($statusSince)
+                            <p>
+                                {{ __('monitoring.index.table.since') }}
+                                {{ \Illuminate\Support\Facades\Date::parse($statusSince)->diffForHumans() }}
+                            </p>
+                        @endif
+                        @if (data_get($statusNow, 'checked_at'))
+                            <p>
+                                {{ __('monitoring.detail.last_check') }}
+                                {{ \Illuminate\Support\Facades\Date::parse(data_get($statusNow, 'checked_at'))->diffForHumans() }}
+                            </p>
+                        @endif
+                        @if ($monitoring->latestResponseResult?->http_status_code)
+                            <p>HTTP {{ $monitoring->latestResponseResult->http_status_code }}</p>
+                        @endif
+                    </div>
+                </x-container>
 
-            <template x-if="!isLoading && calendarData">
-                <div x-data="{ data: calendarData }">
-                    @include('components.monitoring-calendar')
+                @foreach ([7, 30, 90] as $days)
+                    @php
+                        $summary = data_get($rangeSummaries, (string) $days);
+                        $uptime = data_get($summary, 'uptime.percentage');
+                        $incidentsCount = (int) data_get($summary, 'downtime.incidents_count', 0);
+                    @endphp
+                    <x-container>
+                        <x-heading type="h2">
+                            {{ trans_choice('monitoring.public_label.range_days', $days, ['days' => $days]) }}
+                        </x-heading>
+                        <p class="mt-3 text-2xl font-bold text-purple-600 dark:text-purple-300">
+                            {{ is_numeric($uptime) ? number_format((float) $uptime, 2) . '%' : __('monitoring.public_label.no_data') }}
+                        </p>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                            {{ trans_choice('monitoring.public_label.incidents_count', $incidentsCount, ['count' => $incidentsCount]) }}
+                        </p>
+                    </x-container>
+                @endforeach
+            </section>
+
+            @if ($monitoring->type === \App\Enums\MonitoringType::HTTP || $monitoring->type === \App\Enums\MonitoringType::KEYWORD)
+                <section class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <x-container>
+                        <x-heading type="h2">{{ __('monitoring.detail.ssl.heading') }}</x-heading>
+                        @if ($monitoring->sslResult)
+                            <p
+                                class="mt-3 font-semibold {{ $monitoring->sslResult->is_valid ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">
+                                {{ $monitoring->sslResult->is_valid ? __('monitoring.detail.ssl.valid') : __('monitoring.detail.ssl.expired') }}
+                            </p>
+                            @if ($monitoring->sslResult->expires_at)
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                    {{ __('monitoring.detail.ssl.expires_in') }}:
+                                    {{ $monitoring->sslResult->expires_at->diffForHumans() }}
+                                </p>
+                            @endif
+                        @else
+                            <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                                {{ __('monitoring.public_label.no_data') }}
+                            </p>
+                        @endif
+                    </x-container>
+                </section>
+            @endif
+
+            @if ($monitoring->type === \App\Enums\MonitoringType::DOMAIN_EXPIRATION)
+                <section class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <x-container>
+                        <x-heading type="h2">{{ __('monitoring.detail.domain.heading') }}</x-heading>
+                        @if ($monitoring->domainResult)
+                            <p
+                                class="mt-3 font-semibold {{ $monitoring->domainResult->is_valid ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">
+                                {{ $monitoring->domainResult->is_valid ? __('monitoring.detail.domain.valid') : __('monitoring.detail.domain.invalid') }}
+                            </p>
+                            @if ($monitoring->domainResult->expires_at)
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                    {{ __('monitoring.detail.domain.expires_at') }}:
+                                    {{ $monitoring->domainResult->expires_at->toFormattedDateString() }}
+                                </p>
+                            @endif
+                        @else
+                            <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                                {{ __('monitoring.public_label.no_data') }}
+                            </p>
+                        @endif
+                    </x-container>
+                </section>
+            @endif
+
+            <section>
+                <x-container>
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                        <x-heading type="h2">{{ __('monitoring.detail.incidents.heading') }}</x-heading>
+                        <span class="text-sm text-gray-500 dark:text-gray-400">
+                            {{ trans_choice('monitoring.public_label.range_days', 90, ['days' => 90]) }}
+                        </span>
+                    </div>
+
+                    @if ($incidents->isEmpty())
+                        <p class="mt-4 text-gray-500 dark:text-gray-400">
+                            {{ __('monitoring.detail.incidents.no_incidents') }}
+                        </p>
+                    @else
+                        <div class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($incidents as $incident)
+                                @php
+                                    $downAt = \Illuminate\Support\Facades\Date::parse($incident['down_at']);
+                                    $upAt = $incident['up_at'] ? \Illuminate\Support\Facades\Date::parse($incident['up_at']) : null;
+                                    $duration = $downAt->diffForHumans($upAt ?? now(), true);
+                                @endphp
+                                <div class="py-3">
+                                    <div class="flex flex-wrap items-center justify-between gap-2">
+                                        <span class="font-medium text-gray-900 dark:text-gray-100">
+                                            {{ $downAt->toDayDateTimeString() }}
+                                        </span>
+                                        <x-badge :type="$upAt ? 'success' : 'danger'">
+                                            {{ $upAt ? __('monitoring.public_label.resolved') : __('monitoring.public_label.ongoing') }}
+                                        </x-badge>
+                                    </div>
+                                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                        {{ __('monitoring.detail.incidents.incident.duration') }}: {{ $duration }}
+                                        @if ($upAt)
+                                            - {{ __('monitoring.detail.incidents.incident.up_at') }} {{ $upAt->toDayDateTimeString() }}
+                                        @endif
+                                    </p>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </x-container>
+            </section>
+
+            <section>
+                <div class="mb-4">
+                    <x-heading type="h2">{{ __('monitoring.detail.calendar.heading') }}</x-heading>
                 </div>
-            </template>
+                <div x-data="uptimeCalendar('{{ $monitoring->id }}')" x-init="fetchUptimeCalendar">
+                    <template x-if="isLoading">
+                        <x-container>
+                            <p>{{ __('calendar.loading') }}</p>
+                        </x-container>
+                    </template>
+
+                    <template x-if="!isLoading && calendarData">
+                        <div x-data="{ data: calendarData }">
+                            @include('components.monitoring-calendar')
+                        </div>
+                    </template>
+                </div>
+            </section>
         </div>
     </x-main>
 </x-public-layout>

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class PublicStatusPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_public_status_page_shows_status_uptime_maintenance_and_incidents(): void
+    {
+        Date::setTestNow('2026-05-03 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'maintenance_from' => Date::now()->subHour(),
+            'maintenance_until' => Date::now()->addHour(),
+            'created_at' => Date::now()->subDays(100),
+        ]);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 123.4,
+            'created_at' => Date::now()->subMinutes(5),
+            'updated_at' => Date::now()->subMinutes(5),
+        ]);
+
+        foreach ([2, 20, 60] as $daysAgo) {
+            $this->createDailyResult($monitoring, Date::now()->subDays($daysAgo)->toDateString());
+        }
+
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDays(3)->subMinutes(30),
+            'up_at' => Date::now()->subDays(3),
+        ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText('Primary API');
+        $testResponse->assertSeeText(__('monitoring.public_label.current_status'));
+        $testResponse->assertSeeText('UP');
+        $testResponse->assertSeeText('HTTP 200');
+        $testResponse->assertSeeText(__('monitoring.index.table.maintenance'));
+        $testResponse->assertSeeText('Last 7 days');
+        $testResponse->assertSeeText('Last 30 days');
+        $testResponse->assertSeeText('Last 90 days');
+        $testResponse->assertSeeText('100.00%');
+        $testResponse->assertSeeText(__('monitoring.detail.incidents.heading'));
+        $testResponse->assertSeeText(__('monitoring.public_label.resolved'));
+    }
+
+    public function test_public_status_page_returns_not_found_when_public_label_is_disabled(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'public_label_enabled' => false,
+        ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertNotFound();
+    }
+
+    public function test_public_status_page_does_not_expose_private_monitoring_configuration(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'public_label_enabled' => true,
+            'http_headers' => ['Authorization' => 'Bearer hidden-token'],
+            'http_body' => '{"secret":"hidden-body"}',
+            'auth_username' => 'hidden-user',
+            'auth_password' => 'hidden-password',
+        ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertDontSeeText('hidden-token');
+        $testResponse->assertDontSeeText('hidden-body');
+        $testResponse->assertDontSeeText('hidden-user');
+        $testResponse->assertDontSeeText('hidden-password');
+    }
+
+    public function test_public_status_page_hides_heartbeat_ping_url(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()
+            ->heartbeat()
+            ->for($user)
+            ->create([
+                'target' => 'https://webguard.test/heartbeat/super-secret-token',
+                'heartbeat_token' => 'super-secret-token',
+                'public_label_enabled' => true,
+            ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.public_label.private_target'));
+        $testResponse->assertDontSeeText('super-secret-token');
+        $testResponse->assertDontSeeText($monitoring->target);
+    }
+
+    private function createDailyResult(Monitoring $monitoring, string $date): void
+    {
+        MonitoringDailyResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'date' => $date,
+            'uptime_total' => 1,
+            'downtime_total' => 0,
+            'unknown_total' => 0,
+            'uptime_percentage' => 100,
+            'downtime_percentage' => 0,
+            'unknown_percentage' => 0,
+            'uptime_minutes' => 24 * 60,
+            'downtime_minutes' => 0,
+            'unknown_minutes' => 0,
+            'avg_response_time' => 123.4,
+            'min_response_time' => 123.4,
+            'max_response_time' => 123.4,
+            'incidents_count' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Expand public labels into richer public status pages with current status, uptime ranges, maintenance state, incident history, SSL/domain context, and the existing uptime calendar.
- Hide private heartbeat ping URLs on public status pages.
- Add feature coverage for public rendering, disabled labels, private configuration, and heartbeat URL privacy.

## Motivation
Public labels only showed the uptime calendar, while the application already has useful public-safe status and incident data. This makes public monitoring pages more useful for external status communication.

## Testing
- `php artisan test tests/Feature/PublicStatusPageTest.php`
- `php artisan test tests/Feature/PublicStatusPageTest.php tests/Feature/Api/PublicMonitoringWidgetApiTest.php tests/Feature/WidgetScriptRouteTest.php tests/Feature/MonitoringDetailRecentChecksSectionTest.php`
- `./vendor/bin/pint --dirty`
- `php artisan test`
- `bun run build`

## Rollout Notes
No migrations or configuration changes required.