### PR TITLE
Cover instance monitoring API during maintenance

### DIFF
--- a/tests/Feature/MaintenanceWindowTest.php
+++ b/tests/Feature/MaintenanceWindowTest.php
@@ -37,6 +37,28 @@ class MaintenanceWindowTest extends TestCase
         $this->monitoring = Monitoring::factory()->create(['user_id' => $this->user->id]);
     }
 
+    protected function tearDown(): void
+    {
+        $this->artisan('up')->assertSuccessful();
+
+        parent::tearDown();
+    }
+
+    public function test_internal_monitoring_api_is_available_during_application_maintenance(): void
+    {
+        $this->artisan('down')->assertSuccessful();
+
+        $this->get('/')->assertServiceUnavailable();
+
+        $this->withHeaders([
+            'X-INSTANCE-CODE' => $this->serverInstance->code,
+            'X-API-KEY' => 'test-token-1234567890',
+        ])
+            ->getJson(route('v1.internal.monitorings.list', ['location' => $this->serverInstance->code]))
+            ->assertOk()
+            ->assertJsonFragment(['id' => $this->monitoring->id]);
+    }
+
     public function test_api_returns_correct_maintenance_active_value()
     {
         // No maintenance window


### PR DESCRIPTION
## Summary
- adds a feature test proving the internal monitoring API stays reachable during Laravel maintenance mode
- asserts a regular web route still returns 503 while `api/v1/internal/monitorings` responds successfully for an authenticated instance
- ensures maintenance mode is cleared after the test

## Validation
- `php artisan test tests/Feature/MaintenanceWindowTest.php`