### PR TITLE
Update public status label layout

### DIFF
--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -265,6 +265,7 @@ return [
         'ongoing' => 'Laufend',
         'private_target' => 'Privates Heartbeat-Ziel',
         'range_days' => 'Letzter :days Tag|Letzte :days Tage',
+        'recent_incidents' => 'Letzte Vorfälle',
         'resolved' => 'Behoben',
     ],
     'validation' => [

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -265,6 +265,7 @@ return [
         'ongoing' => 'Ongoing',
         'private_target' => 'Private heartbeat target',
         'range_days' => 'Last :days day|Last :days days',
+        'recent_incidents' => 'Recent Incidents',
         'resolved' => 'Resolved',
     ],
     'validation' => [

--- a/resources/views/monitorings/public-label.blade.php
+++ b/resources/views/monitorings/public-label.blade.php
@@ -25,8 +25,8 @@
 
     <x-main>
         <div class="space-y-6">
-            <section class="grid grid-cols-1 gap-4 md:grid-cols-3">
-                <x-container>
+            <section class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <x-container id="public-current-status">
                     <x-heading type="h2">{{ __('monitoring.public_label.current_status') }}</x-heading>
                     <div class="mt-3 flex flex-wrap items-center gap-2">
                         <x-badge :type="$statusBadgeType">
@@ -57,30 +57,9 @@
                     </div>
                 </x-container>
 
-                @foreach ([7, 30, 90] as $days)
-                    @php
-                        $summary = data_get($rangeSummaries, (string) $days);
-                        $uptime = data_get($summary, 'uptime.percentage');
-                        $incidentsCount = (int) data_get($summary, 'downtime.incidents_count', 0);
-                    @endphp
-                    <x-container>
-                        <x-heading type="h2">
-                            {{ trans_choice('monitoring.public_label.range_days', $days, ['days' => $days]) }}
-                        </x-heading>
-                        <p class="mt-3 text-2xl font-bold text-purple-600 dark:text-purple-300">
-                            {{ is_numeric($uptime) ? number_format((float) $uptime, 2) . '%' : __('monitoring.public_label.no_data') }}
-                        </p>
-                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                            {{ trans_choice('monitoring.public_label.incidents_count', $incidentsCount, ['count' => $incidentsCount]) }}
-                        </p>
-                    </x-container>
-                @endforeach
-            </section>
-
-            @if ($monitoring->type === \App\Enums\MonitoringType::HTTP || $monitoring->type === \App\Enums\MonitoringType::KEYWORD)
-                <section class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                    <x-container>
-                        <x-heading type="h2">{{ __('monitoring.detail.ssl.heading') }}</x-heading>
+                <x-container id="public-ssl-status">
+                    <x-heading type="h2">{{ __('monitoring.detail.ssl.heading') }}</x-heading>
+                    @if ($monitoring->type === \App\Enums\MonitoringType::HTTP || $monitoring->type === \App\Enums\MonitoringType::KEYWORD)
                         @if ($monitoring->sslResult)
                             <p
                                 class="mt-3 font-semibold {{ $monitoring->sslResult->is_valid ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">
@@ -97,42 +76,57 @@
                                 {{ __('monitoring.public_label.no_data') }}
                             </p>
                         @endif
-                    </x-container>
-                </section>
-            @endif
+                    @else
+                        <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                            {{ __('monitoring.public_label.no_data') }}
+                        </p>
+                    @endif
+                </x-container>
+            </section>
 
-            @if ($monitoring->type === \App\Enums\MonitoringType::DOMAIN_EXPIRATION)
-                <section class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                    <x-container>
-                        <x-heading type="h2">{{ __('monitoring.detail.domain.heading') }}</x-heading>
-                        @if ($monitoring->domainResult)
-                            <p
-                                class="mt-3 font-semibold {{ $monitoring->domainResult->is_valid ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">
-                                {{ $monitoring->domainResult->is_valid ? __('monitoring.detail.domain.valid') : __('monitoring.detail.domain.invalid') }}
-                            </p>
-                            @if ($monitoring->domainResult->expires_at)
-                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                                    {{ __('monitoring.detail.domain.expires_at') }}:
-                                    {{ $monitoring->domainResult->expires_at->toFormattedDateString() }}
-                                </p>
-                            @endif
-                        @else
-                            <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
-                                {{ __('monitoring.public_label.no_data') }}
-                            </p>
-                        @endif
+            <section class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                @foreach ([7, 30, 90] as $days)
+                    @php
+                        $summary = data_get($rangeSummaries, (string) $days);
+                        $uptime = data_get($summary, 'uptime.percentage');
+                        $incidentsCount = (int) data_get($summary, 'downtime.incidents_count', 0);
+                    @endphp
+                    <x-container id="public-uptime-card-{{ $days }}">
+                        <x-heading type="h2">
+                            {{ trans_choice('monitoring.public_label.range_days', $days, ['days' => $days]) }}
+                        </x-heading>
+                        <p class="mt-3 text-2xl font-bold text-purple-600 dark:text-purple-300">
+                            {{ is_numeric($uptime) ? number_format((float) $uptime, 2) . '%' : __('monitoring.public_label.no_data') }}
+                        </p>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                            {{ trans_choice('monitoring.public_label.incidents_count', $incidentsCount, ['count' => $incidentsCount]) }}
+                        </p>
                     </x-container>
-                </section>
-            @endif
+                @endforeach
+            </section>
 
-            <section>
+            <section id="public-uptime-calendar-{{ $monitoring->id }}">
+                <div class="mb-4">
+                    <x-heading type="h2">{{ __('monitoring.detail.calendar.heading') }}</x-heading>
+                </div>
+                <div x-data="uptimeCalendar('{{ $monitoring->id }}')" x-init="fetchUptimeCalendar">
+                    <template x-if="isLoading">
+                        <x-container>
+                            <p>{{ __('calendar.loading') }}</p>
+                        </x-container>
+                    </template>
+
+                    <template x-if="!isLoading && calendarData">
+                        <div x-data="{ data: calendarData }">
+                            @include('components.monitoring-calendar')
+                        </div>
+                    </template>
+                </div>
+            </section>
+
+            <section id="public-incidents">
                 <x-container>
-                    <div class="flex flex-wrap items-center justify-between gap-3">
-                        <x-heading type="h2">{{ __('monitoring.detail.incidents.heading') }}</x-heading>
-                        <span class="text-sm text-gray-500 dark:text-gray-400">
-                            {{ trans_choice('monitoring.public_label.range_days', 90, ['days' => 90]) }}
-                        </span>
-                    </div>
+                    <x-heading type="h2">{{ __('monitoring.public_label.recent_incidents') }}</x-heading>
 
                     @if ($incidents->isEmpty())
                         <p class="mt-4 text-gray-500 dark:text-gray-400">
@@ -166,25 +160,6 @@
                         </div>
                     @endif
                 </x-container>
-            </section>
-
-            <section>
-                <div class="mb-4">
-                    <x-heading type="h2">{{ __('monitoring.detail.calendar.heading') }}</x-heading>
-                </div>
-                <div x-data="uptimeCalendar('{{ $monitoring->id }}')" x-init="fetchUptimeCalendar">
-                    <template x-if="isLoading">
-                        <x-container>
-                            <p>{{ __('calendar.loading') }}</p>
-                        </x-container>
-                    </template>
-
-                    <template x-if="!isLoading && calendarData">
-                        <div x-data="{ data: calendarData }">
-                            @include('components.monitoring-calendar')
-                        </div>
-                    </template>
-                </div>
             </section>
         </div>
     </x-main>

--- a/tests/Feature/PublicLabelPageTest.php
+++ b/tests/Feature/PublicLabelPageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\MonitoringSslResult;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class PublicLabelPageTest extends TestCase
+{
+    public function test_public_label_page_uses_status_ssl_uptime_calendar_and_recent_incidents_layout(): void
+    {
+        Date::setTestNow('2026-05-03 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'created_at' => Date::now()->subDays(100),
+        ]);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 120,
+            'created_at' => Date::now()->subMinutes(5),
+            'updated_at' => Date::now()->subMinutes(5),
+        ]);
+
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'issuer' => 'Example CA',
+            'issued_at' => Date::now()->subDays(30),
+            'expires_at' => Date::now()->addDays(60),
+        ]);
+
+        $oldestVisibleIncident = null;
+        $hiddenIncident = null;
+        foreach (range(1, 11) as $hoursAgo) {
+            $downAt = Date::now()->subHours($hoursAgo);
+            $incident = Incident::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'down_at' => $downAt,
+                'up_at' => $downAt->copy()->addMinutes(10),
+            ]);
+
+            if ($hoursAgo === 10) {
+                $oldestVisibleIncident = $incident;
+            }
+
+            if ($hoursAgo === 11) {
+                $hiddenIncident = $incident;
+            }
+        }
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText('Primary API');
+        $testResponse->assertSeeInOrder([
+            __('monitoring.public_label.current_status'),
+            __('monitoring.detail.ssl.heading'),
+            trans_choice('monitoring.public_label.range_days', 7, ['days' => 7]),
+            trans_choice('monitoring.public_label.range_days', 30, ['days' => 30]),
+            trans_choice('monitoring.public_label.range_days', 90, ['days' => 90]),
+            __('monitoring.detail.calendar.heading'),
+            __('monitoring.public_label.recent_incidents'),
+        ]);
+        $testResponse->assertSeeHtml('class="grid grid-cols-1 gap-4 md:grid-cols-2"');
+        $testResponse->assertSeeHtml('class="grid grid-cols-1 gap-4 md:grid-cols-3"');
+        $testResponse->assertSeeHtml('id="public-current-status"');
+        $testResponse->assertSeeHtml('id="public-ssl-status"');
+        $testResponse->assertSeeHtml('id="public-uptime-card-7"');
+        $testResponse->assertSeeHtml('id="public-uptime-card-30"');
+        $testResponse->assertSeeHtml('id="public-uptime-card-90"');
+        $testResponse->assertSeeHtml('id="public-incidents"');
+        $testResponse->assertDontSeeHtml('id="incidents-range"');
+        $testResponse->assertSeeText(Date::parse($oldestVisibleIncident->down_at)->toDayDateTimeString());
+        $testResponse->assertDontSeeText(Date::parse($hiddenIncident->down_at)->toDayDateTimeString());
+    }
+}


### PR DESCRIPTION
## Summary
- Rework the public label page so current status and SSL status share the first row.
- Move 7, 30, and 90 day availability summaries into a three-column row before the uptime calendar.
- Move recent incidents below the calendar, keep the list capped at 10 entries, and remove the incident range label from that section.

## Impact
The public status page now presents operational status, certificate status, availability history, calendar data, and recent incidents in the requested order while keeping the richer server-rendered public label data from main.

## Validation
- `./vendor/bin/pint --dirty`
- `php artisan test tests/Feature/MonitoringDetailRecentChecksSectionTest.php tests/Feature/PublicLabelPageTest.php`