### PR TITLE
Require verified email for feature mails

### DIFF
--- a/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
+++ b/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
@@ -40,6 +40,7 @@ class SendUnreadNotificationsReminderCommand extends Command
 
         $users = User::query()
             ->whereIn('id', $unreadNotificationCountsByUser->keys())
+            ->whereNotNull('email_verified_at')
             ->where('unread_notifications_reminder_enabled', true)
             ->get();
 

--- a/app/Console/Commands/Notifications/SendWeeklyMonitoringDigestCommand.php
+++ b/app/Console/Commands/Notifications/SendWeeklyMonitoringDigestCommand.php
@@ -40,6 +40,7 @@ class SendWeeklyMonitoringDigestCommand extends Command
         User::query()
             ->whereNotNull('email')
             ->where('email', '!=', '')
+            ->whereNotNull('email_verified_at')
             ->where('monitoring_digest_enabled', true)
             ->whereHas('monitorings', fn ($builder) => $builder->active())
             ->chunkById(100, function ($users) use ($periodEnd): void {

--- a/resources/lang/de/user.php
+++ b/resources/lang/de/user.php
@@ -15,6 +15,7 @@ return [
     'fields' => [
         'name' => 'Name',
         'email' => 'E-Mail',
+        'email_verification' => 'E-Mail-Bestätigung',
         'password' => 'Passwort',
         'confirm_password' => 'Passwort bestätigen',
         'role' => 'Rolle',

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -15,6 +15,7 @@ return [
     'fields' => [
         'name' => 'Name',
         'email' => 'Email',
+        'email_verification' => 'Email Verification',
         'password' => 'Password',
         'confirm_password' => 'Confirm Password',
         'role' => 'Role',

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -28,6 +28,7 @@
             <x-slot name="head">
                 <x-table.heading>{{ __('user.fields.name') }}</x-table.heading>
                 <x-table.heading>{{ __('user.fields.email') }}</x-table.heading>
+                <x-table.heading>{{ __('user.fields.email_verification') }}</x-table.heading>
                 <x-table.heading>{{ __('user.fields.role') }}</x-table.heading>
                 <x-table.heading>{{ __('user.fields.monitoring_limit') }}</x-table.heading>
                 <x-table.heading>{{ __('user.fields.created_at') }}</x-table.heading>
@@ -40,6 +41,13 @@
                     <x-table.row>
                         <x-table.cell>{{ $user->name }}</x-table.cell>
                         <x-table.cell>{{ $user->email }}</x-table.cell>
+                        <x-table.cell>
+                            @if ($user->hasVerifiedEmail())
+                                <x-badge type="success">{{ __('user.messages.email_verified') }}</x-badge>
+                            @else
+                                <x-badge type="danger">{{ __('user.messages.email_unverified') }}</x-badge>
+                            @endif
+                        </x-table.cell>
                         <x-table.cell>
                             {{ ucfirst($user->role->value) }}
                         </x-table.cell>
@@ -61,7 +69,7 @@
 
                 @empty
                     <x-table.row>
-                        <x-table.cell colSpan="7" class="text-center text-gray-500">
+                        <x-table.cell colSpan="8" class="text-center text-gray-500">
                             {{ __('user.messages.empty') }}
                         </x-table.cell>
                     </x-table.row>

--- a/tests/Feature/Admin/UserEmailVerificationFromEditPageTest.php
+++ b/tests/Feature/Admin/UserEmailVerificationFromEditPageTest.php
@@ -24,6 +24,23 @@ class UserEmailVerificationFromEditPageTest extends TestCase
         $testResponse->assertSeeHtml('action="' . route('admin.users.verify', $user) . '"');
     }
 
+    public function test_admin_user_overview_shows_email_verification_status(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN->value]);
+        $verifiedUser = User::factory()->create(['email' => 'verified@example.test']);
+        $unverifiedUser = User::factory()->unverified()->create(['email' => 'unverified@example.test']);
+
+        $testResponse = $this->actingAs($admin)->get(route('admin.users.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSee(__('user.fields.email_verification'));
+        $testResponse->assertSee($verifiedUser->email);
+        $testResponse->assertSee($unverifiedUser->email);
+        $testResponse->assertSee(__('user.messages.email_verified'));
+        $testResponse->assertSee(__('user.messages.email_unverified'));
+    }
+
     public function test_admin_edit_page_hides_verify_email_action_for_verified_user(): void
     {
         Package::factory()->create();

--- a/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
+++ b/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
@@ -134,6 +134,32 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
         });
     }
 
+    public function test_does_not_send_reminder_when_user_email_is_unverified(): void
+    {
+        Package::factory()->create();
+
+        $user = User::factory()->unverified()->create([
+            'unread_notifications_reminder_enabled' => true,
+            'unread_notifications_reminder_frequency' => 'daily',
+        ]);
+
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        Mail::fake();
+
+        Artisan::call('notifications:remind-unread-weekly');
+
+        Mail::assertNothingSent();
+    }
+
     public function test_respects_unread_reminder_frequency_settings(): void
     {
         Date::setTestNow('2026-04-07 08:00:00');

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -168,6 +168,26 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         Mail::assertNothingSent();
     }
 
+    public function test_does_not_send_weekly_digest_when_user_email_is_unverified(): void
+    {
+        Date::setTestNow('2026-04-20 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->unverified()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => 'weekly',
+        ]);
+        Monitoring::factory()->for($user)->create();
+
+        Mail::fake();
+
+        Artisan::call('notifications:send-weekly-monitoring-digest', [
+            '--period-end' => '2026-04-19',
+        ]);
+
+        Mail::assertNothingSent();
+    }
+
     public function test_digest_respects_user_frequency_settings(): void
     {
         Date::setTestNow('2026-04-21 09:00:00');


### PR DESCRIPTION
## Summary

Adds email verification visibility to the admin user overview and prevents WebGuard feature emails from being sent to users whose email address is not verified.

## Changes

- Adds an email verification status column to the admin users table with localized labels.
- Filters unread notification reminder recipients to verified email addresses.
- Filters weekly monitoring digest recipients to verified email addresses.
- Adds feature coverage for the admin overview and both email command gates.

## Impact

Unverified users can still exist and use the existing verification flow, but unread notification reminders and monitoring digest emails are only sent after `email_verified_at` is set.

## Validation

- `php artisan test --filter='UserEmailVerificationFromEditPageTest|SendUnreadNotificationsReminderCommandTest|SendWeeklyMonitoringDigestCommandTest'`
- `./vendor/bin/pint --dirty --test`