### PR TITLE
Generate Scribe docs on production startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN bun run build
 FROM base AS production
 COPY --from=app_build --chown=www-data:www-data /app /var/www/html
 COPY --from=frontend_build --chown=www-data:www-data /app/public/build /var/www/html/public/build
+COPY docker/php/entrypoint.d/ /etc/entrypoint.d/
+RUN chmod +x /etc/entrypoint.d/*.sh
 USER www-data
 WORKDIR /var/www/html
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       AUTORUN_LARAVEL_MIGRATION_FORCE: "true"
       AUTORUN_LARAVEL_OPTIMIZE: "true"
       AUTORUN_LARAVEL_STORAGE_LINK: "true"
+      AUTORUN_LARAVEL_SCRIBE_GENERATE: "true"
     expose:
       - "8080"
       - "8443"

--- a/docker/php/entrypoint.d/60-laravel-scribe-generate.sh
+++ b/docker/php/entrypoint.d/60-laravel-scribe-generate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${AUTORUN_LARAVEL_SCRIBE_GENERATE:-false}" != "true" ]; then
+  exit 0
+fi
+
+APP_BASE_DIR="${APP_BASE_DIR:-/var/www/html}"
+
+if [ ! -f "$APP_BASE_DIR/artisan" ]; then
+  echo "Artisan file not found in $APP_BASE_DIR"
+  exit 1
+fi
+
+php "$APP_BASE_DIR/artisan" scribe:generate --force

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -116,6 +116,20 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
         $this->assertStringContainsString('- "8443"', $composeConfiguration);
     }
 
+    public function test_production_php_container_generates_scribe_docs_on_startup(): void
+    {
+        $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
+        $dockerfile = file_get_contents(base_path('Dockerfile'));
+        $scribeEntrypoint = file_get_contents(base_path('docker/php/entrypoint.d/60-laravel-scribe-generate.sh'));
+
+        $this->assertIsString($composeConfiguration);
+        $this->assertIsString($dockerfile);
+        $this->assertIsString($scribeEntrypoint);
+        $this->assertStringContainsString('AUTORUN_LARAVEL_SCRIBE_GENERATE: "true"', $composeConfiguration);
+        $this->assertStringContainsString('COPY docker/php/entrypoint.d/ /etc/entrypoint.d/', $dockerfile);
+        $this->assertStringContainsString('php "$APP_BASE_DIR/artisan" scribe:generate --force', $scribeEntrypoint);
+    }
+
     public function test_production_php_container_declares_coolify_traefik_labels(): void
     {
         $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));


### PR DESCRIPTION
## Summary

- enable Scribe documentation generation for the production PHP container
- add a ServerSideUp entrypoint hook that runs `php artisan scribe:generate --force` before the web process starts
- cover the production deployment behavior with a focused feature test

## Validation

- `php artisan test --filter=HeartbeatQueueDeploymentConfigTest`
- `docker compose -f docker-compose.yml config --quiet`