### PR TITLE
Add async admin tables

### DIFF
--- a/app/Http/Controllers/Admin/ActivityLogController.php
+++ b/app/Http/Controllers/Admin/ActivityLogController.php
@@ -43,8 +43,8 @@ class ActivityLogController extends Controller
         $lengthAwarePaginator = Activity::query()
             ->with('causer')
             ->when($validated['search'] ?? null, function (Builder $builder, string $search): void {
-                $builder->where(function (Builder $query) use ($search): void {
-                    $query->where('description', 'like', '%' . $search . '%')
+                $builder->where(function (Builder $builder) use ($search): void {
+                    $builder->where('description', 'like', '%' . $search . '%')
                         ->orWhere('log_name', 'like', '%' . $search . '%')
                         ->orWhere('event', 'like', '%' . $search . '%')
                         ->orWhere('subject_id', 'like', '%' . $search . '%');

--- a/app/Http/Controllers/Admin/ActivityLogController.php
+++ b/app/Http/Controllers/Admin/ActivityLogController.php
@@ -8,15 +8,17 @@ use App\Http\Controllers\Controller;
 use App\Models\Monitoring;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 use Spatie\Activitylog\Models\Activity;
 
 class ActivityLogController extends Controller
 {
-    public function index(Request $request): View
+    public function index(Request $request): View|JsonResponse
     {
         $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:100'],
             'log_name' => ['nullable', 'string', 'max:100'],
             'event' => ['nullable', 'string', 'max:100'],
             'causer_id' => ['nullable', 'string', 'exists:users,id'],
@@ -24,10 +26,30 @@ class ActivityLogController extends Controller
             'subject_id' => ['nullable', 'string', 'max:36'],
             'date_from' => ['nullable', 'date'],
             'date_to' => ['nullable', 'date'],
+            'sort' => ['nullable', 'string', 'in:created_at,log_name,event,description'],
+            'direction' => ['nullable', 'string', 'in:asc,desc'],
+            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
+            'page' => ['nullable', 'integer', 'min:1'],
         ]);
+
+        $sort = $validated['sort'] ?? 'created_at';
+        $direction = $validated['direction'] ?? 'desc';
+        $perPage = (int) ($validated['per_page'] ?? 25);
+        $subjectTypes = [
+            User::class => __('admin.activity_logs.subject_types.user'),
+            Monitoring::class => __('admin.activity_logs.subject_types.monitoring'),
+        ];
 
         $lengthAwarePaginator = Activity::query()
             ->with('causer')
+            ->when($validated['search'] ?? null, function (Builder $builder, string $search): void {
+                $builder->where(function (Builder $query) use ($search): void {
+                    $query->where('description', 'like', '%' . $search . '%')
+                        ->orWhere('log_name', 'like', '%' . $search . '%')
+                        ->orWhere('event', 'like', '%' . $search . '%')
+                        ->orWhere('subject_id', 'like', '%' . $search . '%');
+                });
+            })
             ->when($validated['log_name'] ?? null, fn (Builder $builder, string $logName): Builder => $builder->where('log_name', $logName))
             ->when($validated['event'] ?? null, fn (Builder $builder, string $event): Builder => $builder->where('event', $event))
             ->when($validated['causer_id'] ?? null, fn (Builder $builder, string $causerId): Builder => $builder->where('causer_type', User::class)->where('causer_id', $causerId))
@@ -35,18 +57,89 @@ class ActivityLogController extends Controller
             ->when($validated['subject_id'] ?? null, fn (Builder $builder, string $subjectId): Builder => $builder->where('subject_id', $subjectId))
             ->when($validated['date_from'] ?? null, fn (Builder $builder, string $dateFrom): Builder => $builder->whereDate('created_at', '>=', $dateFrom))
             ->when($validated['date_to'] ?? null, fn (Builder $builder, string $dateTo): Builder => $builder->whereDate('created_at', '<=', $dateTo))
-            ->latest()
-            ->paginate(25);
+            ->orderBy($sort, $direction)
+            ->orderBy('id')
+            ->paginate($perPage);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'html' => view('admin.activity-logs.partials.rows', [
+                    'activities' => $lengthAwarePaginator,
+                    'subjectTypes' => $subjectTypes,
+                ])->render(),
+                'pagination' => [
+                    'current_page' => $lengthAwarePaginator->currentPage(),
+                    'last_page' => $lengthAwarePaginator->lastPage(),
+                    'from' => $lengthAwarePaginator->firstItem(),
+                    'to' => $lengthAwarePaginator->lastItem(),
+                    'total' => $lengthAwarePaginator->total(),
+                    'per_page' => $lengthAwarePaginator->perPage(),
+                ],
+            ]);
+        }
+
+        $users = User::query()->select('id', 'email')->orderBy('email')->get();
+        $logNames = Activity::query()->whereNotNull('log_name')->distinct()->orderBy('log_name')->pluck('log_name');
+        $events = Activity::query()->whereNotNull('event')->distinct()->orderBy('event')->pluck('event');
 
         return view('admin.activity-logs.index', [
             'activities' => $lengthAwarePaginator,
-            'users' => User::query()->select('id', 'email')->orderBy('email')->get(),
-            'logNames' => Activity::query()->whereNotNull('log_name')->distinct()->orderBy('log_name')->pluck('log_name'),
-            'events' => Activity::query()->whereNotNull('event')->distinct()->orderBy('event')->pluck('event'),
-            'subjectTypes' => [
-                User::class => __('admin.activity_logs.subject_types.user'),
-                Monitoring::class => __('admin.activity_logs.subject_types.monitoring'),
+            'subjectTypes' => $subjectTypes,
+            'filters' => [
+                [
+                    'name' => 'log_name',
+                    'label' => __('admin.activity_logs.filters.log_name'),
+                    'placeholder' => __('admin.activity_logs.filters.log_name'),
+                    'options' => $logNames->mapWithKeys(fn (string $logName): array => [$logName => $logName])->all(),
+                ],
+                [
+                    'name' => 'event',
+                    'label' => __('admin.activity_logs.filters.event'),
+                    'placeholder' => __('admin.activity_logs.filters.event'),
+                    'options' => $events->mapWithKeys(fn (string $event): array => [$event => $event])->all(),
+                ],
+                [
+                    'name' => 'causer_id',
+                    'label' => __('admin.activity_logs.filters.actor'),
+                    'placeholder' => __('admin.activity_logs.filters.actor'),
+                    'options' => $users->mapWithKeys(fn (User $user): array => [$user->id => $user->email])->all(),
+                ],
+                [
+                    'name' => 'subject_type',
+                    'label' => __('admin.activity_logs.filters.subject_type'),
+                    'placeholder' => __('admin.activity_logs.filters.subject_type'),
+                    'options' => $subjectTypes,
+                ],
+                [
+                    'name' => 'subject_id',
+                    'label' => __('admin.activity_logs.filters.subject_id'),
+                    'placeholder' => __('admin.activity_logs.filters.subject_id'),
+                    'type' => 'text',
+                ],
+                [
+                    'name' => 'date_from',
+                    'label' => __('admin.activity_logs.filters.date_from'),
+                    'placeholder' => __('admin.activity_logs.filters.date_from'),
+                    'type' => 'date',
+                ],
+                [
+                    'name' => 'date_to',
+                    'label' => __('admin.activity_logs.filters.date_to'),
+                    'placeholder' => __('admin.activity_logs.filters.date_to'),
+                    'type' => 'date',
+                ],
             ],
+            'activeFilters' => [
+                'log_name' => (string) ($validated['log_name'] ?? ''),
+                'event' => (string) ($validated['event'] ?? ''),
+                'causer_id' => (string) ($validated['causer_id'] ?? ''),
+                'subject_type' => (string) ($validated['subject_type'] ?? ''),
+                'subject_id' => (string) ($validated['subject_id'] ?? ''),
+                'date_from' => (string) ($validated['date_from'] ?? ''),
+                'date_to' => (string) ($validated['date_to'] ?? ''),
+            ],
+            'sort' => $sort,
+            'direction' => $direction,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/ApiController.php
+++ b/app/Http/Controllers/Admin/ApiController.php
@@ -60,15 +60,15 @@ class ApiController extends Controller
             ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
                 $query->where(function (Builder $builder) use ($search): void {
                     $builder->where('api_logs.route', 'like', '%' . $search . '%')
-                        ->orWhereHas('user', fn (Builder $userQuery): Builder => $userQuery->where('email', 'like', '%' . $search . '%'));
+                        ->orWhereHas('user', fn (Builder $builder): Builder => $builder->where('email', 'like', '%' . $search . '%'));
                 });
             })
-            ->when($validated['user_id'] ?? null, fn (Builder $query, string $userId): Builder => $query->where('user_id', $userId));
+            ->when($validated['user_id'] ?? null, fn (Builder $builder, string $userId): Builder => $builder->where('user_id', $userId));
 
         if ($sort === 'email') {
             $query->join('users as sort_users', 'sort_users.id', '=', 'api_logs.user_id')
                 ->orderBy('sort_users.email', $direction)
-                ->orderBy('api_logs.created_at', 'desc');
+                ->latest('api_logs.created_at');
         } else {
             $query->orderBy('api_logs.' . $sort, $direction)
                 ->orderBy('api_logs.id');

--- a/app/Http/Controllers/Admin/ApiController.php
+++ b/app/Http/Controllers/Admin/ApiController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\ApiLog;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -34,16 +36,78 @@ class ApiController extends Controller
      * This method retrieves and displays a paginated list of API logs, with optional filtering by user.
      *
      * @param  Request  $request  The HTTP request instance, potentially containing a 'user_id' for filtering.
-     * @return View The view displaying the API logs.
+     * @return View|JsonResponse The view displaying the API logs or async table rows.
      */
-    public function index(Request $request)
+    public function index(Request $request): View|JsonResponse
     {
-        $lengthAwarePaginator = ApiLog::with('user')
-            ->when($request->filled('user_id'), fn ($query) => $query->where('user_id', $request->user_id))->latest()
-            ->paginate(25);
+        $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:100'],
+            'user_id' => ['nullable', 'string', 'exists:users,id'],
+            'sort' => ['nullable', 'string', 'in:created_at,email,route'],
+            'direction' => ['nullable', 'string', 'in:asc,desc'],
+            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $sort = $validated['sort'] ?? 'created_at';
+        $direction = $validated['direction'] ?? 'desc';
+        $perPage = (int) ($validated['per_page'] ?? 25);
+
+        $query = ApiLog::query()
+            ->withoutGlobalScope('api_logs')
+            ->with('user')
+            ->select('api_logs.*')
+            ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
+                $query->where(function (Builder $builder) use ($search): void {
+                    $builder->where('api_logs.route', 'like', '%' . $search . '%')
+                        ->orWhereHas('user', fn (Builder $userQuery): Builder => $userQuery->where('email', 'like', '%' . $search . '%'));
+                });
+            })
+            ->when($validated['user_id'] ?? null, fn (Builder $query, string $userId): Builder => $query->where('user_id', $userId));
+
+        if ($sort === 'email') {
+            $query->join('users as sort_users', 'sort_users.id', '=', 'api_logs.user_id')
+                ->orderBy('sort_users.email', $direction)
+                ->orderBy('api_logs.created_at', 'desc');
+        } else {
+            $query->orderBy('api_logs.' . $sort, $direction)
+                ->orderBy('api_logs.id');
+        }
+
+        $lengthAwarePaginator = $query->paginate($perPage);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'html' => view('admin.api.partials.rows', ['apiLogs' => $lengthAwarePaginator])->render(),
+                'pagination' => [
+                    'current_page' => $lengthAwarePaginator->currentPage(),
+                    'last_page' => $lengthAwarePaginator->lastPage(),
+                    'from' => $lengthAwarePaginator->firstItem(),
+                    'to' => $lengthAwarePaginator->lastItem(),
+                    'total' => $lengthAwarePaginator->total(),
+                    'per_page' => $lengthAwarePaginator->perPage(),
+                ],
+            ]);
+        }
 
         $users = User::query()->select('id', 'email')->orderBy('email')->get();
 
-        return view('admin.api.index', ['apiLogs' => $lengthAwarePaginator, 'users' => $users]);
+        return view('admin.api.index', [
+            'apiLogs' => $lengthAwarePaginator,
+            'users' => $users,
+            'filters' => [
+                [
+                    'name' => 'user_id',
+                    'label' => __('user.title'),
+                    'placeholder' => __('search.filter.text', ['attribute' => __('user.title')]),
+                    'options' => $users->mapWithKeys(fn (User $user): array => [$user->id => $user->email])->all(),
+                ],
+            ],
+            'activeFilters' => [
+                'user_id' => (string) ($validated['user_id'] ?? ''),
+            ],
+            'sort' => $sort,
+            'direction' => $direction,
+        ]);
     }
 }

--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -41,7 +41,7 @@ class PackageController extends Controller
         $direction = $validated['direction'] ?? 'asc';
         $perPage = (int) ($validated['per_page'] ?? 10);
 
-        $packages = Package::query()
+        $lengthAwarePaginator = Package::query()
             ->withoutGlobalScope('selectable')
             ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
                 $query->where(function (Builder $builder) use ($search): void {
@@ -49,27 +49,27 @@ class PackageController extends Controller
                         ->orWhere('price', 'like', '%' . $search . '%');
                 });
             })
-            ->when(isset($validated['is_selectable']), fn (Builder $query): Builder => $query->where('is_selectable', (bool) $validated['is_selectable']))
+            ->when(isset($validated['is_selectable']), fn (Builder $builder): Builder => $builder->where('is_selectable', (bool) $validated['is_selectable']))
             ->orderBy($sort, $direction)
             ->orderBy('id')
             ->paginate($perPage);
 
         if ($request->expectsJson()) {
             return response()->json([
-                'html' => view('admin.packages.partials.rows', ['packages' => $packages])->render(),
+                'html' => view('admin.packages.partials.rows', ['packages' => $lengthAwarePaginator])->render(),
                 'pagination' => [
-                    'current_page' => $packages->currentPage(),
-                    'last_page' => $packages->lastPage(),
-                    'from' => $packages->firstItem(),
-                    'to' => $packages->lastItem(),
-                    'total' => $packages->total(),
-                    'per_page' => $packages->perPage(),
+                    'current_page' => $lengthAwarePaginator->currentPage(),
+                    'last_page' => $lengthAwarePaginator->lastPage(),
+                    'from' => $lengthAwarePaginator->firstItem(),
+                    'to' => $lengthAwarePaginator->lastItem(),
+                    'total' => $lengthAwarePaginator->total(),
+                    'per_page' => $lengthAwarePaginator->perPage(),
                 ],
             ]);
         }
 
         return view('admin.packages.index', [
-            'packages' => $packages,
+            'packages' => $lengthAwarePaginator,
             'filters' => [
                 [
                     'name' => 'is_selectable',

--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StorePackageRequest;
 use App\Http\Requests\UpdatePackageRequest;
 use App\Models\Package;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -22,13 +24,69 @@ class PackageController extends Controller
     /**
      * Display a listing of the packages.
      *
-     * @return View The view displaying the list of packages.
+     * @return View|JsonResponse The view displaying the list of packages or async table rows.
      */
-    public function index(): View
+    public function index(Request $request): View|JsonResponse
     {
-        $packages = Package::query()->withoutGlobalScope('selectable')->orderBy('is_selectable', 'desc')->orderBy('price')->get();
+        $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:100'],
+            'is_selectable' => ['nullable', 'string', 'in:1,0'],
+            'sort' => ['nullable', 'string', 'in:monitoring_limit,price,is_selectable,created_at,updated_at'],
+            'direction' => ['nullable', 'string', 'in:asc,desc'],
+            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ]);
 
-        return view('admin.packages.index', compact('packages'));
+        $sort = $validated['sort'] ?? 'price';
+        $direction = $validated['direction'] ?? 'asc';
+        $perPage = (int) ($validated['per_page'] ?? 10);
+
+        $packages = Package::query()
+            ->withoutGlobalScope('selectable')
+            ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
+                $query->where(function (Builder $builder) use ($search): void {
+                    $builder->where('monitoring_limit', 'like', '%' . $search . '%')
+                        ->orWhere('price', 'like', '%' . $search . '%');
+                });
+            })
+            ->when(isset($validated['is_selectable']), fn (Builder $query): Builder => $query->where('is_selectable', (bool) $validated['is_selectable']))
+            ->orderBy($sort, $direction)
+            ->orderBy('id')
+            ->paginate($perPage);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'html' => view('admin.packages.partials.rows', ['packages' => $packages])->render(),
+                'pagination' => [
+                    'current_page' => $packages->currentPage(),
+                    'last_page' => $packages->lastPage(),
+                    'from' => $packages->firstItem(),
+                    'to' => $packages->lastItem(),
+                    'total' => $packages->total(),
+                    'per_page' => $packages->perPage(),
+                ],
+            ]);
+        }
+
+        return view('admin.packages.index', [
+            'packages' => $packages,
+            'filters' => [
+                [
+                    'name' => 'is_selectable',
+                    'label' => __('admin.packages.fields.is_selectable'),
+                    'placeholder' => __('search.filter.text', ['attribute' => __('admin.packages.fields.is_selectable')]),
+                    'options' => [
+                        '1' => __('admin.packages.fields.yes'),
+                        '0' => __('admin.packages.fields.no'),
+                    ],
+                ],
+            ],
+            'activeFilters' => [
+                'is_selectable' => (string) ($validated['is_selectable'] ?? ''),
+            ],
+            'sort' => $sort,
+            'direction' => $direction,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Admin/ServerInstanceController.php
+++ b/app/Http/Controllers/Admin/ServerInstanceController.php
@@ -9,16 +9,54 @@ use App\Http\Requests\StoreServerInstanceRequest;
 use App\Http\Requests\UpdateServerInstanceRequest;
 use App\Models\Monitoring;
 use App\Models\ServerInstance;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Illuminate\View\View;
 
 class ServerInstanceController extends Controller
 {
-    public function index(): View
+    public function index(Request $request): View|JsonResponse
     {
-        $instances = ServerInstance::query()->orderBy('code')->get();
-        $instanceCodes = $instances->pluck('code');
+        $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:100'],
+            'is_active' => ['nullable', 'string', 'in:1,0'],
+            'health' => ['nullable', 'string', 'in:healthy,stale,never_seen,inactive'],
+            'sort' => ['nullable', 'string', 'in:code,is_active,last_seen_at,created_at,updated_at'],
+            'direction' => ['nullable', 'string', 'in:asc,desc'],
+            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $sort = $validated['sort'] ?? 'code';
+        $direction = $validated['direction'] ?? 'asc';
+        $perPage = (int) ($validated['per_page'] ?? 10);
+        $staleCutoff = Date::now()->subMinutes(max(1, (int) config('monitoring.instance_stale_after_minutes', 10)));
+
+        $instances = ServerInstance::query()
+            ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
+                $query->where(function (Builder $builder) use ($search): void {
+                    $builder->where('code', 'like', '%' . $search . '%')
+                        ->orWhere('ip_address', 'like', '%' . $search . '%');
+                });
+            })
+            ->when(isset($validated['is_active']), fn (Builder $query): Builder => $query->where('is_active', (bool) $validated['is_active']))
+            ->when($validated['health'] ?? null, function (Builder $query, string $health) use ($staleCutoff): Builder {
+                return match ($health) {
+                    'healthy' => $query->where('is_active', true)->whereNotNull('last_seen_at')->where('last_seen_at', '>=', $staleCutoff),
+                    'stale' => $query->where('is_active', true)->whereNotNull('last_seen_at')->where('last_seen_at', '<', $staleCutoff),
+                    'never_seen' => $query->where('is_active', true)->whereNull('last_seen_at'),
+                    'inactive' => $query->where('is_active', false),
+                };
+            })
+            ->orderBy($sort, $direction)
+            ->orderBy('id')
+            ->paginate($perPage);
+
+        $instanceCodes = $instances->getCollection()->pluck('code');
         $monitoringCounts = Monitoring::query()
             ->withoutGlobalScope('user')
             ->selectRaw('preferred_location, count(*) as monitorings_count')
@@ -37,7 +75,34 @@ class ServerInstanceController extends Controller
                     (string) $monitoring->type->value => (int) $monitoring->getAttribute('monitorings_count'),
                 ]
             ));
-        $healthCounts = $instances
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'html' => view('admin.server-instances.partials.rows', [
+                    'instances' => $instances,
+                    'monitoringCounts' => $monitoringCounts,
+                    'monitoringTypeCounts' => $monitoringTypeCounts,
+                ])->render(),
+                'pagination' => [
+                    'current_page' => $instances->currentPage(),
+                    'last_page' => $instances->lastPage(),
+                    'from' => $instances->firstItem(),
+                    'to' => $instances->lastItem(),
+                    'total' => $instances->total(),
+                    'per_page' => $instances->perPage(),
+                ],
+            ]);
+        }
+
+        $summaryInstances = ServerInstance::query()->get();
+        $summaryInstanceCodes = $summaryInstances->pluck('code');
+        $summaryMonitoringCounts = Monitoring::query()
+            ->withoutGlobalScope('user')
+            ->selectRaw('preferred_location, count(*) as monitorings_count')
+            ->whereIn('preferred_location', $summaryInstanceCodes)
+            ->groupBy('preferred_location')
+            ->pluck('monitorings_count', 'preferred_location');
+        $healthCounts = $summaryInstances
             ->map(fn (ServerInstance $serverInstance): string => $serverInstance->healthStatus())
             ->countBy();
 
@@ -45,11 +110,39 @@ class ServerInstanceController extends Controller
             'instances' => $instances,
             'monitoringCounts' => $monitoringCounts,
             'monitoringTypeCounts' => $monitoringTypeCounts,
+            'filters' => [
+                [
+                    'name' => 'is_active',
+                    'label' => __('admin.server_instances.fields.status'),
+                    'placeholder' => __('search.filter.text', ['attribute' => __('admin.server_instances.fields.status')]),
+                    'options' => [
+                        '1' => __('admin.server_instances.fields.active'),
+                        '0' => __('admin.server_instances.fields.inactive'),
+                    ],
+                ],
+                [
+                    'name' => 'health',
+                    'label' => __('admin.server_instances.fields.health'),
+                    'placeholder' => __('search.filter.text', ['attribute' => __('admin.server_instances.fields.health')]),
+                    'options' => [
+                        'healthy' => __('admin.server_instances.health.healthy'),
+                        'stale' => __('admin.server_instances.health.stale'),
+                        'never_seen' => __('admin.server_instances.health.never_seen'),
+                        'inactive' => __('admin.server_instances.health.inactive'),
+                    ],
+                ],
+            ],
+            'activeFilters' => [
+                'is_active' => (string) ($validated['is_active'] ?? ''),
+                'health' => (string) ($validated['health'] ?? ''),
+            ],
+            'sort' => $sort,
+            'direction' => $direction,
             'summary' => [
-                'total_instances' => $instances->count(),
-                'active_instances' => $instances->where('is_active', true)->count(),
+                'total_instances' => $summaryInstances->count(),
+                'active_instances' => $summaryInstances->where('is_active', true)->count(),
                 'stale_instances' => (int) $healthCounts->get('stale', 0),
-                'total_monitorings' => (int) $monitoringCounts->sum(),
+                'total_monitorings' => (int) $summaryMonitoringCounts->sum(),
             ],
         ]);
     }

--- a/app/Http/Controllers/Admin/ServerInstanceController.php
+++ b/app/Http/Controllers/Admin/ServerInstanceController.php
@@ -36,27 +36,27 @@ class ServerInstanceController extends Controller
         $perPage = (int) ($validated['per_page'] ?? 10);
         $staleCutoff = Date::now()->subMinutes(max(1, (int) config('monitoring.instance_stale_after_minutes', 10)));
 
-        $instances = ServerInstance::query()
+        $lengthAwarePaginator = ServerInstance::query()
             ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
                 $query->where(function (Builder $builder) use ($search): void {
                     $builder->where('code', 'like', '%' . $search . '%')
                         ->orWhere('ip_address', 'like', '%' . $search . '%');
                 });
             })
-            ->when(isset($validated['is_active']), fn (Builder $query): Builder => $query->where('is_active', (bool) $validated['is_active']))
-            ->when($validated['health'] ?? null, function (Builder $query, string $health) use ($staleCutoff): Builder {
+            ->when(isset($validated['is_active']), fn (Builder $builder): Builder => $builder->where('is_active', (bool) $validated['is_active']))
+            ->when($validated['health'] ?? null, function (Builder $builder, string $health) use ($staleCutoff): Builder {
                 return match ($health) {
-                    'healthy' => $query->where('is_active', true)->whereNotNull('last_seen_at')->where('last_seen_at', '>=', $staleCutoff),
-                    'stale' => $query->where('is_active', true)->whereNotNull('last_seen_at')->where('last_seen_at', '<', $staleCutoff),
-                    'never_seen' => $query->where('is_active', true)->whereNull('last_seen_at'),
-                    'inactive' => $query->where('is_active', false),
+                    'healthy' => $builder->where('is_active', true)->whereNotNull('last_seen_at')->where('last_seen_at', '>=', $staleCutoff),
+                    'stale' => $builder->where('is_active', true)->whereNotNull('last_seen_at')->where('last_seen_at', '<', $staleCutoff),
+                    'never_seen' => $builder->where('is_active', true)->whereNull('last_seen_at'),
+                    'inactive' => $builder->where('is_active', false),
                 };
             })
             ->orderBy($sort, $direction)
             ->orderBy('id')
             ->paginate($perPage);
 
-        $instanceCodes = $instances->getCollection()->pluck('code');
+        $instanceCodes = $lengthAwarePaginator->getCollection()->pluck('code');
         $monitoringCounts = Monitoring::query()
             ->withoutGlobalScope('user')
             ->selectRaw('preferred_location, count(*) as monitorings_count')
@@ -79,17 +79,17 @@ class ServerInstanceController extends Controller
         if ($request->expectsJson()) {
             return response()->json([
                 'html' => view('admin.server-instances.partials.rows', [
-                    'instances' => $instances,
+                    'instances' => $lengthAwarePaginator,
                     'monitoringCounts' => $monitoringCounts,
                     'monitoringTypeCounts' => $monitoringTypeCounts,
                 ])->render(),
                 'pagination' => [
-                    'current_page' => $instances->currentPage(),
-                    'last_page' => $instances->lastPage(),
-                    'from' => $instances->firstItem(),
-                    'to' => $instances->lastItem(),
-                    'total' => $instances->total(),
-                    'per_page' => $instances->perPage(),
+                    'current_page' => $lengthAwarePaginator->currentPage(),
+                    'last_page' => $lengthAwarePaginator->lastPage(),
+                    'from' => $lengthAwarePaginator->firstItem(),
+                    'to' => $lengthAwarePaginator->lastItem(),
+                    'total' => $lengthAwarePaginator->total(),
+                    'per_page' => $lengthAwarePaginator->perPage(),
                 ],
             ]);
         }
@@ -107,7 +107,7 @@ class ServerInstanceController extends Controller
             ->countBy();
 
         return view('admin.server-instances.index', [
-            'instances' => $instances,
+            'instances' => $lengthAwarePaginator,
             'monitoringCounts' => $monitoringCounts,
             'monitoringTypeCounts' => $monitoringTypeCounts,
             'filters' => [

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\UserRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreUserRequest;
 use App\Http\Requests\UpdateUserRequest;
@@ -11,7 +12,8 @@ use App\Jobs\DeleteUser;
 use App\Models\Package;
 use App\Models\User;
 use App\Services\UserDeletionPreparationService;
-use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -28,21 +30,112 @@ class UserController extends Controller
      * Display a listing of the users.
      *
      * @param  Request  $request  The HTTP request instance, potentially containing a 'search' parameter.
-     * @return View The view displaying the list of users.
+     * @return View|JsonResponse The view displaying the list of users or async table rows.
      */
-    public function index(Request $request): View
+    public function index(Request $request): View|JsonResponse
     {
-        $lengthAwarePaginator = User::query()
-            ->with('package')
-            ->when($request->filled('search'), function ($query) use ($request): void {
-                $query->where(function (Builder $builder) use ($request): void {
-                    $builder->where('name', 'like', '%' . $request->search . '%')
-                        ->orWhere('email', 'like', '%' . $request->search . '%');
-                });
-            })->latest()
-            ->paginate(10);
+        $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:100'],
+            'role' => ['nullable', 'string', 'in:' . implode(',', UserRole::values())],
+            'email_verification' => ['nullable', 'string', 'in:verified,unverified'],
+            'package_id' => ['nullable', 'string', 'exists:packages,id'],
+            'sort' => ['nullable', 'string', 'in:name,email,email_verified_at,role,monitoring_limit,created_at,updated_at'],
+            'direction' => ['nullable', 'string', 'in:asc,desc'],
+            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ]);
 
-        return view('admin.users.index', ['users' => $lengthAwarePaginator]);
+        $sort = $validated['sort'] ?? 'created_at';
+        $direction = $validated['direction'] ?? 'desc';
+        $perPage = (int) ($validated['per_page'] ?? 10);
+
+        $query = User::query()
+            ->with('package')
+            ->select('users.*')
+            ->when($validated['search'] ?? null, function (Builder $query, string $search): void {
+                $query->where(function (Builder $builder) use ($search): void {
+                    $builder->where('users.name', 'like', '%' . $search . '%')
+                        ->orWhere('users.email', 'like', '%' . $search . '%')
+                        ->orWhere('users.role', 'like', '%' . $search . '%')
+                        ->orWhereHas('package', function (Builder $packageQuery) use ($search): void {
+                            $packageQuery->where('monitoring_limit', 'like', '%' . $search . '%')
+                                ->orWhere('price', 'like', '%' . $search . '%');
+                        });
+                });
+            })
+            ->when($validated['role'] ?? null, fn (Builder $query, string $role): Builder => $query->where('users.role', $role))
+            ->when($validated['email_verification'] ?? null, function (Builder $query, string $verification): Builder {
+                return $verification === 'verified'
+                    ? $query->whereNotNull('users.email_verified_at')
+                    : $query->whereNull('users.email_verified_at');
+            })
+            ->when($validated['package_id'] ?? null, fn (Builder $query, string $packageId): Builder => $query->where('users.package_id', $packageId));
+
+        if ($sort === 'monitoring_limit') {
+            $query->leftJoin('packages as sort_packages', 'sort_packages.id', '=', 'users.package_id')
+                ->orderBy('sort_packages.monitoring_limit', $direction)
+                ->orderBy('users.created_at', 'desc');
+        } else {
+            $query->orderBy('users.' . $sort, $direction)
+                ->orderBy('users.id');
+        }
+
+        $lengthAwarePaginator = $query->paginate($perPage);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'html' => view('admin.users.partials.rows', ['users' => $lengthAwarePaginator])->render(),
+                'pagination' => [
+                    'current_page' => $lengthAwarePaginator->currentPage(),
+                    'last_page' => $lengthAwarePaginator->lastPage(),
+                    'from' => $lengthAwarePaginator->firstItem(),
+                    'to' => $lengthAwarePaginator->lastItem(),
+                    'total' => $lengthAwarePaginator->total(),
+                    'per_page' => $lengthAwarePaginator->perPage(),
+                ],
+            ]);
+        }
+
+        $packages = Package::query()->withoutGlobalScope('selectable')->orderBy('monitoring_limit')->get();
+        $filters = [
+            [
+                'name' => 'role',
+                'label' => __('user.fields.role'),
+                'placeholder' => __('search.filter.text', ['attribute' => __('user.fields.role')]),
+                'options' => collect(UserRole::cases())->mapWithKeys(fn (UserRole $role): array => [$role->value => ucfirst($role->value)])->all(),
+            ],
+            [
+                'name' => 'email_verification',
+                'label' => __('user.fields.email_verification'),
+                'placeholder' => __('search.filter.text', ['attribute' => __('user.fields.email_verification')]),
+                'options' => [
+                    'verified' => __('user.messages.email_verified'),
+                    'unverified' => __('user.messages.email_unverified'),
+                ],
+            ],
+            [
+                'name' => 'package_id',
+                'label' => __('user.fields.package'),
+                'placeholder' => __('search.filter.text', ['attribute' => __('user.fields.package')]),
+                'options' => $packages
+                    ->mapWithKeys(fn (Package $package): array => [
+                        $package->id => __('user.fields.monitoring_limit') . ': ' . $package->monitoring_limit,
+                    ])
+                    ->all(),
+            ],
+        ];
+
+        return view('admin.users.index', [
+            'users' => $lengthAwarePaginator,
+            'filters' => $filters,
+            'activeFilters' => [
+                'role' => (string) ($validated['role'] ?? ''),
+                'email_verification' => (string) ($validated['email_verification'] ?? ''),
+                'package_id' => (string) ($validated['package_id'] ?? ''),
+            ],
+            'sort' => $sort,
+            'direction' => $direction,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -57,24 +57,24 @@ class UserController extends Controller
                     $builder->where('users.name', 'like', '%' . $search . '%')
                         ->orWhere('users.email', 'like', '%' . $search . '%')
                         ->orWhere('users.role', 'like', '%' . $search . '%')
-                        ->orWhereHas('package', function (Builder $packageQuery) use ($search): void {
-                            $packageQuery->where('monitoring_limit', 'like', '%' . $search . '%')
+                        ->orWhereHas('package', function (Builder $builder) use ($search): void {
+                            $builder->where('monitoring_limit', 'like', '%' . $search . '%')
                                 ->orWhere('price', 'like', '%' . $search . '%');
                         });
                 });
             })
-            ->when($validated['role'] ?? null, fn (Builder $query, string $role): Builder => $query->where('users.role', $role))
-            ->when($validated['email_verification'] ?? null, function (Builder $query, string $verification): Builder {
+            ->when($validated['role'] ?? null, fn (Builder $builder, string $role): Builder => $builder->where('users.role', $role))
+            ->when($validated['email_verification'] ?? null, function (Builder $builder, string $verification): Builder {
                 return $verification === 'verified'
-                    ? $query->whereNotNull('users.email_verified_at')
-                    : $query->whereNull('users.email_verified_at');
+                    ? $builder->whereNotNull('users.email_verified_at')
+                    : $builder->whereNull('users.email_verified_at');
             })
-            ->when($validated['package_id'] ?? null, fn (Builder $query, string $packageId): Builder => $query->where('users.package_id', $packageId));
+            ->when($validated['package_id'] ?? null, fn (Builder $builder, string $packageId): Builder => $builder->where('users.package_id', $packageId));
 
         if ($sort === 'monitoring_limit') {
             $query->leftJoin('packages as sort_packages', 'sort_packages.id', '=', 'users.package_id')
                 ->orderBy('sort_packages.monitoring_limit', $direction)
-                ->orderBy('users.created_at', 'desc');
+                ->latest('users.created_at');
         } else {
             $query->orderBy('users.' . $sort, $direction)
                 ->orderBy('users.id');
@@ -102,7 +102,7 @@ class UserController extends Controller
                 'name' => 'role',
                 'label' => __('user.fields.role'),
                 'placeholder' => __('search.filter.text', ['attribute' => __('user.fields.role')]),
-                'options' => collect(UserRole::cases())->mapWithKeys(fn (UserRole $role): array => [$role->value => ucfirst($role->value)])->all(),
+                'options' => collect(UserRole::cases())->mapWithKeys(fn (UserRole $userRole): array => [$userRole->value => ucfirst($userRole->value)])->all(),
             ],
             [
                 'name' => 'email_verification',

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -14,6 +14,7 @@ import monitoringCardLoader from './components/monitoring-cards';
 import monitoringDetail from './components/monitoring-detail';
 import uptimeCalendar from './components/uptime-calendar';
 import guestLogin from './components/guestLogin';
+import asyncTable from './components/async-table';
 
 const decodeImprintPayload = (payload: string): string => {
     try {
@@ -63,6 +64,7 @@ Alpine.data('monitoringDetail', monitoringDetail);
 Alpine.data('monitoringCardLoader', monitoringCardLoader);
 Alpine.data('uptimeCalendar', uptimeCalendar);
 Alpine.data('guestLogin', guestLogin);
+Alpine.data('asyncTable', asyncTable);
 
 window.Alpine = Alpine;
 window.Chart = Chart;

--- a/resources/js/components/async-table.ts
+++ b/resources/js/components/async-table.ts
@@ -1,0 +1,167 @@
+type PaginationState = {
+    current_page: number;
+    last_page: number;
+    from: number | null;
+    to: number | null;
+    total: number;
+    per_page: number;
+};
+
+type AsyncTableConfig = {
+    endpoint: string;
+    search?: string;
+    sort?: string;
+    direction?: 'asc' | 'desc';
+    perPage?: number | string;
+    filters?: Record<string, string>;
+    pagination: PaginationState;
+    labels: {
+        loading: string;
+        error: string;
+    };
+};
+
+type AsyncTableResponse = {
+    html: string;
+    pagination: PaginationState;
+};
+
+export default function asyncTable(config: AsyncTableConfig) {
+    return {
+        endpoint: config.endpoint,
+        search: config.search ?? '',
+        sort: config.sort ?? '',
+        direction: config.direction ?? 'asc',
+        perPage: String(config.perPage ?? config.pagination.per_page),
+        filters: { ...(config.filters ?? {}) },
+        pagination: config.pagination,
+        labels: config.labels,
+        loading: false,
+        error: '',
+        abortController: null as AbortController | null,
+
+        setSearch(value: string): void {
+            this.search = value;
+            this.fetchPage(1);
+        },
+
+        setFilter(name: string, value: string): void {
+            this.filters[name] = value;
+            this.fetchPage(1);
+        },
+
+        setPerPage(value: string): void {
+            this.perPage = value;
+            this.fetchPage(1);
+        },
+
+        sortBy(column: string): void {
+            if (this.sort === column) {
+                this.direction = this.direction === 'asc' ? 'desc' : 'asc';
+            } else {
+                this.sort = column;
+                this.direction = 'asc';
+            }
+
+            this.fetchPage(1);
+        },
+
+        isSorted(column: string): boolean {
+            return this.sort === column;
+        },
+
+        sortIndicator(column: string): string {
+            if (!this.isSorted(column)) {
+                return '-';
+            }
+
+            return this.direction === 'asc' ? '^' : 'v';
+        },
+
+        async fetchPage(page: number): Promise<void> {
+            if (page < 1 || page > Math.max(1, this.pagination.last_page)) {
+                return;
+            }
+
+            this.abortController?.abort();
+            this.abortController = new AbortController();
+            this.loading = true;
+            this.error = '';
+
+            const url = new URL(this.endpoint, window.location.origin);
+            url.searchParams.set('page', String(page));
+            url.searchParams.set('per_page', this.perPage);
+
+            if (this.search.trim() !== '') {
+                url.searchParams.set('search', this.search.trim());
+            }
+
+            if (this.sort !== '') {
+                url.searchParams.set('sort', this.sort);
+                url.searchParams.set('direction', this.direction);
+            }
+
+            Object.entries(this.filters).forEach(([name, value]) => {
+                if (value !== '') {
+                    url.searchParams.set(name, value);
+                }
+            });
+
+            try {
+                const response = await fetch(url.toString(), {
+                    headers: {
+                        Accept: 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    signal: this.abortController.signal,
+                });
+
+                if (!response.ok) {
+                    throw new Error(`Async table request failed with status ${response.status}`);
+                }
+
+                const data = (await response.json()) as AsyncTableResponse;
+                (this as any).$refs.body.innerHTML = data.html;
+                this.pagination = data.pagination;
+            } catch (error) {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+
+                this.error = this.labels.error;
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        pages(): Array<number | string> {
+            const current = this.pagination.current_page;
+            const last = this.pagination.last_page;
+
+            if (last <= 7) {
+                return Array.from({ length: last }, (_, index) => index + 1);
+            }
+
+            const pages = new Set<number>([1, last]);
+            for (let page = current - 1; page <= current + 1; page += 1) {
+                if (page > 1 && page < last) {
+                    pages.add(page);
+                }
+            }
+
+            const sortedPages = Array.from(pages).sort((a, b) => a - b);
+            const result: Array<number | string> = [];
+
+            sortedPages.forEach((page, index) => {
+                const previous = sortedPages[index - 1];
+                if (previous && page - previous > 1) {
+                    result.push('...');
+                }
+
+                result.push(page);
+            });
+
+            return result;
+        },
+    };
+}

--- a/resources/lang/de/search.php
+++ b/resources/lang/de/search.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 return [
     'fields' => [
+        'placeholder_generic' => 'Suchen',
         'placeholder' => 'Suche nach :attribute',
         'placeholder_monitoring' => 'Suche nach Name, Ziel, Port oder Schlüsselwort',
     ],
@@ -15,6 +16,7 @@ return [
         'loading' => 'Wird geladen ...',
     ],
     'filter' => [
+        'heading' => 'Filter',
         'text' => 'Filtern nach :attribute',
         'all' => 'Alle',
         'name' => [
@@ -30,5 +32,13 @@ return [
             'paused' => 'Pausiert',
         ],
         'lifecycle' => 'Lebenszyklusstatus',
+    ],
+    'table' => [
+        'per_page' => 'Einträge pro Seite',
+        'showing' => 'Zeige',
+        'to' => 'bis',
+        'of' => 'von',
+        'entries' => 'Einträgen',
+        'pagination' => 'Seitennavigation',
     ],
 ];

--- a/resources/lang/en/search.php
+++ b/resources/lang/en/search.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 return [
     'fields' => [
+        'placeholder_generic' => 'Search',
         'placeholder' => 'Search by :attribute',
         'placeholder_monitoring' => 'Search by name, target, port or keyword',
     ],
@@ -15,6 +16,7 @@ return [
         'loading' => 'Loading ...',
     ],
     'filter' => [
+        'heading' => 'Filter',
         'text' => 'Filter by :attribute',
         'all' => 'All',
         'name' => [
@@ -30,5 +32,13 @@ return [
             'paused' => 'Paused',
         ],
         'lifecycle' => 'Lifecycle status',
+    ],
+    'table' => [
+        'per_page' => 'Entries per page',
+        'showing' => 'Showing',
+        'to' => 'to',
+        'of' => 'of',
+        'entries' => 'entries',
+        'pagination' => 'Pagination',
     ],
 ];

--- a/resources/views/admin/activity-logs/index.blade.php
+++ b/resources/views/admin/activity-logs/index.blade.php
@@ -1,33 +1,3 @@
-@php
-    use App\Models\Monitoring;
-    use App\Models\User;
-    use Illuminate\Database\Eloquent\Model;
-
-    $subjectLabel = static function (?string $subjectType, mixed $subjectId) use ($subjectTypes): string {
-        if (! $subjectType || ! $subjectId) {
-            return __('admin.activity_logs.messages.unknown_subject');
-        }
-
-        $type = $subjectTypes[$subjectType] ?? class_basename($subjectType);
-
-        return $type . ' #' . $subjectId;
-    };
-
-    $actorLabel = static function (?Model $actor): string {
-        if (! $actor instanceof User) {
-            return __('admin.activity_logs.messages.anonymous');
-        }
-
-        return $actor->email;
-    };
-
-    $json = static function (mixed $value): string {
-        $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-
-        return is_string($encoded) ? $encoded : '{}';
-    };
-@endphp
-
 <x-app-layout>
     <x-slot name="header">
         <x-heading>{{ __('admin.activity_logs.title') }}</x-heading>
@@ -38,133 +8,26 @@
     </x-slot>
 
     <x-main>
-        <form method="GET" action="{{ route('admin.activity-logs.index') }}"
-            class="mb-4 grid gap-3 rounded-md bg-white p-4 shadow-md dark:bg-gray-800 md:grid-cols-2 xl:grid-cols-4">
-            <div>
-                <x-input-label for="log_name" :value="__('admin.activity_logs.filters.log_name')" />
-                <select id="log_name" name="log_name"
-                    class="mt-1 w-full rounded border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                    <option value="">{{ __('search.filter.all') }}</option>
-                    @foreach ($logNames as $logName)
-                        <option value="{{ $logName }}" @selected(request('log_name') === $logName)>{{ $logName }}</option>
-                    @endforeach
-                </select>
-            </div>
-
-            <div>
-                <x-input-label for="event" :value="__('admin.activity_logs.filters.event')" />
-                <select id="event" name="event"
-                    class="mt-1 w-full rounded border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                    <option value="">{{ __('search.filter.all') }}</option>
-                    @foreach ($events as $event)
-                        <option value="{{ $event }}" @selected(request('event') === $event)>{{ $event }}</option>
-                    @endforeach
-                </select>
-            </div>
-
-            <div>
-                <x-input-label for="causer_id" :value="__('admin.activity_logs.filters.actor')" />
-                <select id="causer_id" name="causer_id"
-                    class="mt-1 w-full rounded border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                    <option value="">{{ __('search.filter.all') }}</option>
-                    @foreach ($users as $user)
-                        <option value="{{ $user->id }}" @selected(request('causer_id') === $user->id)>{{ $user->email }}</option>
-                    @endforeach
-                </select>
-            </div>
-
-            <div>
-                <x-input-label for="subject_type" :value="__('admin.activity_logs.filters.subject_type')" />
-                <select id="subject_type" name="subject_type"
-                    class="mt-1 w-full rounded border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                    <option value="">{{ __('search.filter.all') }}</option>
-                    @foreach ($subjectTypes as $subjectType => $label)
-                        <option value="{{ $subjectType }}" @selected(request('subject_type') === $subjectType)>{{ $label }}</option>
-                    @endforeach
-                </select>
-            </div>
-
-            <div>
-                <x-input-label for="subject_id" :value="__('admin.activity_logs.filters.subject_id')" />
-                <x-text-input id="subject_id" name="subject_id" :value="request('subject_id')" class="mt-1 w-full" />
-            </div>
-
-            <div>
-                <x-input-label for="date_from" :value="__('admin.activity_logs.filters.date_from')" />
-                <x-text-input id="date_from" type="date" name="date_from" :value="request('date_from')" class="mt-1 w-full" />
-            </div>
-
-            <div>
-                <x-input-label for="date_to" :value="__('admin.activity_logs.filters.date_to')" />
-                <x-text-input id="date_to" type="date" name="date_to" :value="request('date_to')" class="mt-1 w-full" />
-            </div>
-
-            <div class="flex items-end gap-2">
-                <x-primary-button type="submit">
-                    {{ __('admin.activity_logs.filters.apply') }}
-                </x-primary-button>
-                <x-secondary-button :href="route('admin.activity-logs.index')">
-                    {{ __('admin.activity_logs.filters.reset') }}
-                </x-secondary-button>
-            </div>
-        </form>
-
-        <x-table>
+        <x-async-table id="admin-activity-logs-table" :endpoint="route('admin.activity-logs.index')"
+            :paginator="$activities" :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
+            :initial-direction="$direction"
+            search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('admin.activity_logs.title')]) }}">
             <x-slot name="head">
-                <x-table.heading>{{ __('admin.activity_logs.fields.created_at') }}</x-table.heading>
+                <x-table.heading sort="created_at">{{ __('admin.activity_logs.fields.created_at') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.activity_logs.fields.actor') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.activity_logs.fields.log_name') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.activity_logs.fields.event') }}</x-table.heading>
+                <x-table.heading sort="log_name">{{ __('admin.activity_logs.fields.log_name') }}</x-table.heading>
+                <x-table.heading sort="event">{{ __('admin.activity_logs.fields.event') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.activity_logs.fields.subject') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.activity_logs.fields.description') }}</x-table.heading>
+                <x-table.heading sort="description">{{ __('admin.activity_logs.fields.description') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.activity_logs.fields.changes') }}</x-table.heading>
             </x-slot>
 
             <x-slot name="body">
-                @forelse ($activities as $activity)
-                    <x-table.row>
-                        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
-                            {{ $activity->created_at?->format('Y-m-d H:i:s') }}
-                        </td>
-                        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
-                            {{ $actorLabel($activity->causer) }}
-                        </td>
-                        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
-                            {{ $activity->log_name }}
-                        </td>
-                        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
-                            {{ $activity->event }}
-                        </td>
-                        <td class="max-w-xs whitespace-normal px-6 py-4 text-gray-900 dark:text-gray-100">
-                            {{ $subjectLabel($activity->subject_type, $activity->subject_id) }}
-                        </td>
-                        <td class="max-w-xs whitespace-normal px-6 py-4 text-gray-900 dark:text-gray-100">
-                            {{ $activity->description }}
-                        </td>
-                        <td class="min-w-96 whitespace-normal px-6 py-4 text-gray-900 dark:text-gray-100">
-                            <details>
-                                <summary class="cursor-pointer text-purple-600 hover:underline dark:text-purple-300">
-                                    {{ __('admin.activity_logs.messages.show_changes') }}
-                                </summary>
-                                <pre class="mt-3 max-h-96 overflow-auto rounded bg-gray-100 p-3 text-xs leading-5 text-gray-900 dark:bg-gray-900 dark:text-gray-100">{{ $json($activity->attribute_changes?->toArray() ?? []) }}</pre>
-                                @if (($activity->properties?->count() ?? 0) > 0)
-                                    <pre class="mt-3 max-h-96 overflow-auto rounded bg-gray-100 p-3 text-xs leading-5 text-gray-900 dark:bg-gray-900 dark:text-gray-100">{{ $json(['properties' => $activity->properties?->toArray() ?? []]) }}</pre>
-                                @endif
-                            </details>
-                        </td>
-                    </x-table.row>
-                @empty
-                    <x-table.row>
-                        <x-table.cell colSpan="7" class="text-center text-gray-500">
-                            {{ __('admin.activity_logs.messages.empty') }}
-                        </x-table.cell>
-                    </x-table.row>
-                @endforelse
+                @include('admin.activity-logs.partials.rows', [
+                    'activities' => $activities,
+                    'subjectTypes' => $subjectTypes,
+                ])
             </x-slot>
-        </x-table>
-
-        <div class="mt-4">
-            {{ $activities->withQueryString()->links() }}
-        </div>
+        </x-async-table>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/activity-logs/partials/rows.blade.php
+++ b/resources/views/admin/activity-logs/partials/rows.blade.php
@@ -1,0 +1,68 @@
+@php
+    use App\Models\User;
+    use Illuminate\Database\Eloquent\Model;
+
+    $subjectLabel = static function (?string $subjectType, mixed $subjectId) use ($subjectTypes): string {
+        if (! $subjectType || ! $subjectId) {
+            return __('admin.activity_logs.messages.unknown_subject');
+        }
+
+        $type = $subjectTypes[$subjectType] ?? class_basename($subjectType);
+
+        return $type . ' #' . $subjectId;
+    };
+
+    $actorLabel = static function (?Model $actor): string {
+        if (! $actor instanceof User) {
+            return __('admin.activity_logs.messages.anonymous');
+        }
+
+        return $actor->email;
+    };
+
+    $json = static function (mixed $value): string {
+        $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return is_string($encoded) ? $encoded : '{}';
+    };
+@endphp
+
+@forelse ($activities as $activity)
+    <x-table.row>
+        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
+            {{ $activity->created_at?->format('Y-m-d H:i:s') }}
+        </td>
+        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
+            {{ $actorLabel($activity->causer) }}
+        </td>
+        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
+            {{ $activity->log_name }}
+        </td>
+        <td class="whitespace-nowrap px-6 py-4 text-gray-900 dark:text-gray-100">
+            {{ $activity->event }}
+        </td>
+        <td class="max-w-xs whitespace-normal px-6 py-4 text-gray-900 dark:text-gray-100">
+            {{ $subjectLabel($activity->subject_type, $activity->subject_id) }}
+        </td>
+        <td class="max-w-xs whitespace-normal px-6 py-4 text-gray-900 dark:text-gray-100">
+            {{ $activity->description }}
+        </td>
+        <td class="min-w-96 whitespace-normal px-6 py-4 text-gray-900 dark:text-gray-100">
+            <details>
+                <summary class="cursor-pointer text-purple-600 hover:underline dark:text-purple-300">
+                    {{ __('admin.activity_logs.messages.show_changes') }}
+                </summary>
+                <pre class="mt-3 max-h-96 overflow-auto rounded bg-gray-100 p-3 text-xs leading-5 text-gray-900 dark:bg-gray-900 dark:text-gray-100">{{ $json($activity->attribute_changes?->toArray() ?? []) }}</pre>
+                @if (($activity->properties?->count() ?? 0) > 0)
+                    <pre class="mt-3 max-h-96 overflow-auto rounded bg-gray-100 p-3 text-xs leading-5 text-gray-900 dark:bg-gray-900 dark:text-gray-100">{{ $json(['properties' => $activity->properties?->toArray() ?? []]) }}</pre>
+                @endif
+            </details>
+        </td>
+    </x-table.row>
+@empty
+    <x-table.row>
+        <x-table.cell colSpan="7" class="text-center text-gray-500">
+            {{ __('admin.activity_logs.messages.empty') }}
+        </x-table.cell>
+    </x-table.row>
+@endforelse

--- a/resources/views/admin/api/index.blade.php
+++ b/resources/views/admin/api/index.blade.php
@@ -8,54 +8,19 @@
     </x-slot>
 
     <x-main>
-        <div x-data class="mb-4 flex flex-wrap items-center gap-2">
-            <x-input-label for="user_id">{{ __('user.title') }}:</x-input-label>
-            <select id="user_id"
-                class="rounded border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                @change="
-                        const url = new URL(window.location.href);
-                        if ($event.target.value) {
-                            url.searchParams.set('user_id', $event.target.value);
-                        } else {
-                            url.searchParams.delete('user_id');
-                        }
-                        window.location.href = url.toString();
-                    ">
-                <option value="">{{ __('search.filter.all') }}</option>
-                @foreach ($users as $user)
-                    <option value="{{ $user->id }}" @selected(request('user_id') === $user->id)>
-                        {{ $user->email }}
-                    </option>
-                @endforeach
-            </select>
-        </div>
-
-        <x-table>
+        <x-async-table id="admin-api-logs-table" :endpoint="route('admin.apis.index')" :paginator="$apiLogs"
+            :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
+            :initial-direction="$direction"
+            search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('api.logs.title')]) }}">
             <x-slot name="head">
-                <x-table.heading>{{ __('api.logs.fields.date') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.email') }}</x-table.heading>
-                <x-table.heading>{{ __('api.logs.fields.endpoint') }}</x-table.heading>
+                <x-table.heading sort="created_at">{{ __('api.logs.fields.date') }}</x-table.heading>
+                <x-table.heading sort="email">{{ __('user.fields.email') }}</x-table.heading>
+                <x-table.heading sort="route">{{ __('api.logs.fields.endpoint') }}</x-table.heading>
             </x-slot>
 
             <x-slot name="body">
-                @forelse ($apiLogs as $log)
-                    <x-table.row>
-                        <x-table.cell>{{ $log->created_at }}</x-table.cell>
-                        <x-table.cell>{{ $log->user->email }}</x-table.cell>
-                        <x-table.cell>{{ $log->route }}</x-table.cell>
-                    </x-table.row>
-                @empty
-                    <x-table.row>
-                        <x-table.cell colSpan="3" class="text-center text-gray-500">
-                            {{ __('api.logs.messages.no_logs') }}
-                        </x-table.cell>
-                    </x-table.row>
-                @endforelse
+                @include('admin.api.partials.rows', ['apiLogs' => $apiLogs])
             </x-slot>
-        </x-table>
-
-        <div class="mt-4">
-            {{ $apiLogs->withQueryString()->links() }}
-        </div>
+        </x-async-table>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/api/partials/rows.blade.php
+++ b/resources/views/admin/api/partials/rows.blade.php
@@ -1,0 +1,13 @@
+@forelse ($apiLogs as $log)
+    <x-table.row>
+        <x-table.cell>{{ $log->created_at }}</x-table.cell>
+        <x-table.cell>{{ $log->user->email }}</x-table.cell>
+        <x-table.cell>{{ $log->route }}</x-table.cell>
+    </x-table.row>
+@empty
+    <x-table.row>
+        <x-table.cell colSpan="3" class="text-center text-gray-500">
+            {{ __('api.logs.messages.no_logs') }}
+        </x-table.cell>
+    </x-table.row>
+@endforelse

--- a/resources/views/admin/packages/index.blade.php
+++ b/resources/views/admin/packages/index.blade.php
@@ -3,52 +3,28 @@
         <x-heading type="h1">
             {{ __('admin.packages.title') }}
         </x-heading>
-        <x-primary-button :href="route('admin.packages.create')" class="sm:ml-auto">
-            {{ __('button.create') }}
-        </x-primary-button>
     </x-slot>
 
     <x-main>
-        <x-table>
+        <x-async-table id="admin-packages-table" :endpoint="route('admin.packages.index')" :paginator="$packages"
+            :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
+            :initial-direction="$direction"
+            search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('admin.packages.title')]) }}">
+            <x-slot name="actions">
+                <x-primary-button :href="route('admin.packages.create')" class="sm:ml-auto">
+                    {{ __('button.create') }}
+                </x-primary-button>
+            </x-slot>
+
             <x-slot name="head">
-                <x-table.heading>{{ __('admin.packages.fields.monitoring_limit') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.packages.fields.price') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.packages.fields.is_selectable') }}</x-table.heading>
+                <x-table.heading sort="monitoring_limit">{{ __('admin.packages.fields.monitoring_limit') }}</x-table.heading>
+                <x-table.heading sort="price">{{ __('admin.packages.fields.price') }}</x-table.heading>
+                <x-table.heading sort="is_selectable">{{ __('admin.packages.fields.is_selectable') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.packages.fields.actions') }}</x-table.heading>
             </x-slot>
             <x-slot name="body">
-                @forelse ($packages as $package)
-                    <x-table.row>
-                        <x-table.cell>{{ $package->monitoring_limit }}</x-table.cell>
-                        <x-table.cell>{{ $package->price }}</x-table.cell>
-                        <x-table.cell>
-                            @if ($package->is_selectable)
-                                <span class="text-green-500">{{ __('admin.packages.fields.yes') }}</span>
-                            @else
-                                <span class="text-red-500">{{ __('admin.packages.fields.no') }}</span>
-                            @endif
-                        </x-table.cell>
-                        <x-table.cell>
-                            <a href="{{ route('admin.packages.edit', $package) }}"
-                                class="text-purple-600 hover:underline">{{ __('button.edit') }}</a>
-                            <form action="{{ route('admin.packages.destroy', $package) }}" method="POST"
-                                class="inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit"
-                                    onclick="return confirm('{{ __('admin.packages.messages.confirm_delete') }}')"
-                                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
-                            </form>
-                        </x-table.cell>
-                    </x-table.row>
-                @empty
-                    <x-table.row>
-                        <x-table.cell colSpan="3" class="text-center">
-                            {{ __('admin.packages.messages.no_packages') }}
-                        </x-table.cell>
-                    </x-table.row>
-                @endforelse
+                @include('admin.packages.partials.rows', ['packages' => $packages])
             </x-slot>
-        </x-table>
+        </x-async-table>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/packages/partials/rows.blade.php
+++ b/resources/views/admin/packages/partials/rows.blade.php
@@ -1,0 +1,30 @@
+@forelse ($packages as $package)
+    <x-table.row>
+        <x-table.cell>{{ $package->monitoring_limit }}</x-table.cell>
+        <x-table.cell>{{ $package->price }}</x-table.cell>
+        <x-table.cell>
+            @if ($package->is_selectable)
+                <span class="text-green-500">{{ __('admin.packages.fields.yes') }}</span>
+            @else
+                <span class="text-red-500">{{ __('admin.packages.fields.no') }}</span>
+            @endif
+        </x-table.cell>
+        <x-table.cell>
+            <a href="{{ route('admin.packages.edit', $package) }}" class="text-purple-600 hover:underline">
+                {{ __('button.edit') }}
+            </a>
+            <form action="{{ route('admin.packages.destroy', $package) }}" method="POST" class="inline">
+                @csrf
+                @method('DELETE')
+                <button type="submit" onclick="return confirm('{{ __('admin.packages.messages.confirm_delete') }}')"
+                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
+            </form>
+        </x-table.cell>
+    </x-table.row>
+@empty
+    <x-table.row>
+        <x-table.cell colSpan="4" class="text-center">
+            {{ __('admin.packages.messages.no_packages') }}
+        </x-table.cell>
+    </x-table.row>
+@endforelse

--- a/resources/views/admin/server-instances/index.blade.php
+++ b/resources/views/admin/server-instances/index.blade.php
@@ -1,22 +1,12 @@
-@php
-    use App\Enums\MonitoringType;
-@endphp
-
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">
             {{ __('admin.server_instances.title') }}
         </x-heading>
 
-        <div class="flex items-center space-x-2">
-            <x-primary-button :href="route('admin.server-instances.create')" class="sm:ml-auto">
-                {{ __('button.create') }}
-            </x-primary-button>
-
-            <x-secondary-button :href="route('admin.dashboard')">
-                {{ __('button.back') }}
-            </x-secondary-button>
-        </div>
+        <x-secondary-button :href="route('admin.dashboard')" class="sm:ml-auto">
+            {{ __('button.back') }}
+        </x-secondary-button>
     </x-slot>
 
     <x-main>
@@ -47,98 +37,34 @@
             </x-container>
         </div>
 
-        <x-table>
+        <x-async-table id="admin-server-instances-table" :endpoint="route('admin.server-instances.index')"
+            :paginator="$instances" :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
+            :initial-direction="$direction"
+            search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('admin.server_instances.title')]) }}">
+            <x-slot name="actions">
+                <x-primary-button :href="route('admin.server-instances.create')" class="sm:ml-auto">
+                    {{ __('button.create') }}
+                </x-primary-button>
+            </x-slot>
+
             <x-slot name="head">
-                <x-table.heading>{{ __('admin.server_instances.fields.code') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.server_instances.fields.status') }}</x-table.heading>
+                <x-table.heading sort="code">{{ __('admin.server_instances.fields.code') }}</x-table.heading>
+                <x-table.heading sort="is_active">{{ __('admin.server_instances.fields.status') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.server_instances.fields.health') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.server_instances.fields.last_seen_at') }}</x-table.heading>
+                <x-table.heading sort="last_seen_at">{{ __('admin.server_instances.fields.last_seen_at') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.server_instances.fields.monitorings') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.server_instances.fields.monitoring_types') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.server_instances.fields.created_at') }}</x-table.heading>
-                <x-table.heading>{{ __('admin.server_instances.fields.updated_at') }}</x-table.heading>
+                <x-table.heading sort="created_at">{{ __('admin.server_instances.fields.created_at') }}</x-table.heading>
+                <x-table.heading sort="updated_at">{{ __('admin.server_instances.fields.updated_at') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.server_instances.fields.actions') }}</x-table.heading>
             </x-slot>
             <x-slot name="body">
-                @forelse ($instances as $instance)
-                    @php
-                        $healthStatus = $instance->healthStatus();
-                        $healthBadgeType = match ($healthStatus) {
-                            'healthy' => 'success',
-                            'stale' => 'warning',
-                            'inactive' => 'danger',
-                            default => 'info',
-                        };
-                        $monitoringsCount = (int) ($monitoringCounts->get($instance->code) ?? 0);
-                        $typeCounts = $monitoringTypeCounts->get($instance->code, collect());
-                    @endphp
-                    <x-table.row>
-                        <x-table.cell>{{ $instance->code }}</x-table.cell>
-                        <x-table.cell>
-                            @if ($instance->is_active)
-                                <span class="text-green-500">{{ __('admin.server_instances.fields.active') }}</span>
-                            @else
-                                <span class="text-red-500">{{ __('admin.server_instances.fields.inactive') }}</span>
-                            @endif
-                        </x-table.cell>
-                        <x-table.cell>
-                            <x-badge :type="$healthBadgeType">
-                                {{ __('admin.server_instances.health.' . $healthStatus) }}
-                            </x-badge>
-                        </x-table.cell>
-                        <x-table.cell>
-                            @if ($instance->last_seen_at)
-                                <span title="{{ $instance->last_seen_at->toDateTimeString() }}">
-                                    {{ $instance->last_seen_at->diffForHumans() }}
-                                </span>
-                            @else
-                                {{ __('admin.server_instances.fields.never') }}
-                            @endif
-                        </x-table.cell>
-                        <x-table.cell>
-                            {{ trans_choice('admin.server_instances.monitorings_count', $monitoringsCount, ['count' => $monitoringsCount]) }}
-                        </x-table.cell>
-                        <x-table.cell>
-                            @if ($typeCounts->isEmpty())
-                                <span class="text-gray-500 dark:text-gray-400">
-                                    {{ __('admin.server_instances.fields.none') }}
-                                </span>
-                            @else
-                                <div class="flex flex-wrap gap-1">
-                                    @foreach (MonitoringType::cases() as $type)
-                                        @if ((int) ($typeCounts->get($type->value) ?? 0) > 0)
-                                            <x-badge type="info">
-                                                {{ __('monitoring.types.' . $type->value) }}:
-                                                {{ $typeCounts->get($type->value) }}
-                                            </x-badge>
-                                        @endif
-                                    @endforeach
-                                </div>
-                            @endif
-                        </x-table.cell>
-                        <x-table.cell>{{ $instance->created_at->format('d.m.Y') }}</x-table.cell>
-                        <x-table.cell>{{ $instance->updated_at->format('d.m.Y') }}</x-table.cell>
-                        <x-table.cell>
-                            <a href="{{ route('admin.server-instances.edit', $instance) }}"
-                                class="text-purple-600 hover:underline">{{ __('button.edit') }}</a>
-                            <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST"
-                                class="inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit"
-                                    onclick="return confirm('{{ __('admin.server_instances.messages.confirm_delete') }}')"
-                                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
-                            </form>
-                        </x-table.cell>
-                    </x-table.row>
-                @empty
-                    <x-table.row>
-                        <x-table.cell colSpan="9" class="text-center">
-                            {{ __('admin.server_instances.messages.no_instances') }}
-                        </x-table.cell>
-                    </x-table.row>
-                @endforelse
+                @include('admin.server-instances.partials.rows', [
+                    'instances' => $instances,
+                    'monitoringCounts' => $monitoringCounts,
+                    'monitoringTypeCounts' => $monitoringTypeCounts,
+                ])
             </x-slot>
-        </x-table>
+        </x-async-table>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/server-instances/partials/rows.blade.php
+++ b/resources/views/admin/server-instances/partials/rows.blade.php
@@ -1,0 +1,82 @@
+@php
+    use App\Enums\MonitoringType;
+@endphp
+
+@forelse ($instances as $instance)
+    @php
+        $healthStatus = $instance->healthStatus();
+        $healthBadgeType = match ($healthStatus) {
+            'healthy' => 'success',
+            'stale' => 'warning',
+            'inactive' => 'danger',
+            default => 'info',
+        };
+        $monitoringsCount = (int) ($monitoringCounts->get($instance->code) ?? 0);
+        $typeCounts = $monitoringTypeCounts->get($instance->code, collect());
+    @endphp
+    <x-table.row>
+        <x-table.cell>{{ $instance->code }}</x-table.cell>
+        <x-table.cell>
+            @if ($instance->is_active)
+                <span class="text-green-500">{{ __('admin.server_instances.fields.active') }}</span>
+            @else
+                <span class="text-red-500">{{ __('admin.server_instances.fields.inactive') }}</span>
+            @endif
+        </x-table.cell>
+        <x-table.cell>
+            <x-badge :type="$healthBadgeType">
+                {{ __('admin.server_instances.health.' . $healthStatus) }}
+            </x-badge>
+        </x-table.cell>
+        <x-table.cell>
+            @if ($instance->last_seen_at)
+                <span title="{{ $instance->last_seen_at->toDateTimeString() }}">
+                    {{ $instance->last_seen_at->diffForHumans() }}
+                </span>
+            @else
+                {{ __('admin.server_instances.fields.never') }}
+            @endif
+        </x-table.cell>
+        <x-table.cell>
+            {{ trans_choice('admin.server_instances.monitorings_count', $monitoringsCount, ['count' => $monitoringsCount]) }}
+        </x-table.cell>
+        <x-table.cell>
+            @if ($typeCounts->isEmpty())
+                <span class="text-gray-500 dark:text-gray-400">
+                    {{ __('admin.server_instances.fields.none') }}
+                </span>
+            @else
+                <div class="flex flex-wrap gap-1">
+                    @foreach (MonitoringType::cases() as $type)
+                        @if ((int) ($typeCounts->get($type->value) ?? 0) > 0)
+                            <x-badge type="info">
+                                {{ __('monitoring.types.' . $type->value) }}:
+                                {{ $typeCounts->get($type->value) }}
+                            </x-badge>
+                        @endif
+                    @endforeach
+                </div>
+            @endif
+        </x-table.cell>
+        <x-table.cell>{{ $instance->created_at->format('d.m.Y') }}</x-table.cell>
+        <x-table.cell>{{ $instance->updated_at->format('d.m.Y') }}</x-table.cell>
+        <x-table.cell>
+            <a href="{{ route('admin.server-instances.edit', $instance) }}" class="text-purple-600 hover:underline">
+                {{ __('button.edit') }}
+            </a>
+            <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST" class="inline">
+                @csrf
+                @method('DELETE')
+                <button type="submit"
+                    onclick="return confirm('{{ __('admin.server_instances.messages.confirm_delete') }}')"
+                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
+            </form>
+        </x-table.cell>
+    </x-table.row>
+@empty
+    <x-table.row>
+        <x-table.cell colSpan="9" class="text-center">
+            {{ __('admin.server_instances.messages.no_instances') }}
+        </x-table.cell>
+    </x-table.row>
+@endforelse

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -4,81 +4,36 @@
             {{ __('user.title') }}
         </x-heading>
 
-        <div class="flex items-center space-x-2">
-            <x-primary-button :href="route('admin.users.create')" class="sm:ml-auto">
-                {{ __('button.create') }}
-            </x-primary-button>
-
-            <x-secondary-button :href="route('admin.dashboard')">
-                {{ __('button.back') }}
-            </x-secondary-button>
-        </div>
+        <x-secondary-button :href="route('admin.dashboard')" class="sm:ml-auto">
+            {{ __('button.back') }}
+        </x-secondary-button>
     </x-slot>
 
     <x-main>
-        <div class="flex items-center justify-between">
-            <form method="GET" action="{{ route('admin.users.index') }}" class="flex items-center space-x-2">
-                <x-text-input type="text" name="search" :value="request('search')"
-                    placeholder="{{ __('search.fields.placeholder', ['attribute' => __('user.title')]) }}"
-                    class="w-full max-w-sm" />
-            </form>
-        </div>
+        <x-async-table id="admin-users-table" :endpoint="route('admin.users.index')" :paginator="$users"
+            :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
+            :initial-direction="$direction"
+            search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('user.title')]) }}">
+            <x-slot name="actions">
+                <x-primary-button :href="route('admin.users.create')" class="sm:ml-auto">
+                    {{ __('button.create') }}
+                </x-primary-button>
+            </x-slot>
 
-        <x-table class="mt-4">
             <x-slot name="head">
-                <x-table.heading>{{ __('user.fields.name') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.email') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.email_verification') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.role') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.monitoring_limit') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.created_at') }}</x-table.heading>
-                <x-table.heading>{{ __('user.fields.updated_at') }}</x-table.heading>
+                <x-table.heading sort="name">{{ __('user.fields.name') }}</x-table.heading>
+                <x-table.heading sort="email">{{ __('user.fields.email') }}</x-table.heading>
+                <x-table.heading sort="email_verified_at">{{ __('user.fields.email_verification') }}</x-table.heading>
+                <x-table.heading sort="role">{{ __('user.fields.role') }}</x-table.heading>
+                <x-table.heading sort="monitoring_limit">{{ __('user.fields.monitoring_limit') }}</x-table.heading>
+                <x-table.heading sort="created_at">{{ __('user.fields.created_at') }}</x-table.heading>
+                <x-table.heading sort="updated_at">{{ __('user.fields.updated_at') }}</x-table.heading>
                 <x-table.heading>{{ __('user.actions.edit') . ' / ' . __('button.delete') }}</x-table.heading>
             </x-slot>
 
             <x-slot name="body">
-                @forelse ($users as $user)
-                    <x-table.row>
-                        <x-table.cell>{{ $user->name }}</x-table.cell>
-                        <x-table.cell>{{ $user->email }}</x-table.cell>
-                        <x-table.cell>
-                            @if ($user->hasVerifiedEmail())
-                                <x-badge type="success">{{ __('user.messages.email_verified') }}</x-badge>
-                            @else
-                                <x-badge type="danger">{{ __('user.messages.email_unverified') }}</x-badge>
-                            @endif
-                        </x-table.cell>
-                        <x-table.cell>
-                            {{ ucfirst($user->role->value) }}
-                        </x-table.cell>
-                        <x-table.cell>{{ $user->package?->monitoring_limit ?? '-' }}</x-table.cell>
-                        <x-table.cell>{{ $user->created_at->format('d.m.Y') }}</x-table.cell>
-                        <x-table.cell>{{ $user->updated_at->format('d.m.Y') }}</x-table.cell>
-                        <x-table.cell>
-                            <a href="{{ route('admin.users.edit', $user) }}"
-                                class="text-purple-600 hover:underline">{{ __('button.edit') }}</a>
-                            <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit"
-                                    onclick="return confirm('{{ __('user.delete.confirmation_question') }}')"
-                                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
-                            </form>
-                        </x-table.cell>
-                    </x-table.row>
-
-                @empty
-                    <x-table.row>
-                        <x-table.cell colSpan="8" class="text-center text-gray-500">
-                            {{ __('user.messages.empty') }}
-                        </x-table.cell>
-                    </x-table.row>
-                @endforelse
+                @include('admin.users.partials.rows', ['users' => $users])
             </x-slot>
-        </x-table>
-
-        <div class="mt-4">
-            {{ $users->withQueryString()->links() }}
-        </div>
+        </x-async-table>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/users/partials/rows.blade.php
+++ b/resources/views/admin/users/partials/rows.blade.php
@@ -1,0 +1,36 @@
+@forelse ($users as $user)
+    <x-table.row>
+        <x-table.cell>{{ $user->name }}</x-table.cell>
+        <x-table.cell>{{ $user->email }}</x-table.cell>
+        <x-table.cell>
+            @if ($user->hasVerifiedEmail())
+                <x-badge type="success">{{ __('user.messages.email_verified') }}</x-badge>
+            @else
+                <x-badge type="danger">{{ __('user.messages.email_unverified') }}</x-badge>
+            @endif
+        </x-table.cell>
+        <x-table.cell>
+            {{ ucfirst($user->role->value) }}
+        </x-table.cell>
+        <x-table.cell>{{ $user->package?->monitoring_limit ?? '-' }}</x-table.cell>
+        <x-table.cell>{{ $user->created_at->format('d.m.Y') }}</x-table.cell>
+        <x-table.cell>{{ $user->updated_at->format('d.m.Y') }}</x-table.cell>
+        <x-table.cell>
+            <a href="{{ route('admin.users.edit', $user) }}" class="text-purple-600 hover:underline">
+                {{ __('button.edit') }}
+            </a>
+            <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
+                @csrf
+                @method('DELETE')
+                <button type="submit" onclick="return confirm('{{ __('user.delete.confirmation_question') }}')"
+                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
+            </form>
+        </x-table.cell>
+    </x-table.row>
+@empty
+    <x-table.row>
+        <x-table.cell colSpan="8" class="text-center text-gray-500">
+            {{ __('user.messages.empty') }}
+        </x-table.cell>
+    </x-table.row>
+@endforelse

--- a/resources/views/components/async-table.blade.php
+++ b/resources/views/components/async-table.blade.php
@@ -1,0 +1,169 @@
+@props([
+    'id',
+    'endpoint',
+    'paginator',
+    'filters' => [],
+    'searchPlaceholder' => __('search.fields.placeholder_generic'),
+    'perPageOptions' => [5, 10, 25, 50],
+    'initialSort' => '',
+    'initialDirection' => 'asc',
+    'initialSearch' => '',
+    'initialFilters' => [],
+    'class' => '',
+])
+
+@php
+    $pagination = [
+        'current_page' => $paginator->currentPage(),
+        'last_page' => $paginator->lastPage(),
+        'from' => $paginator->firstItem(),
+        'to' => $paginator->lastItem(),
+        'total' => $paginator->total(),
+        'per_page' => $paginator->perPage(),
+    ];
+
+    $normalizedFilters = collect($filters)
+        ->mapWithKeys(fn (array $filter): array => [(string) $filter['name'] => (string) ($initialFilters[$filter['name']] ?? '')])
+        ->all();
+@endphp
+
+<div id="{{ $id }}"
+    x-data="asyncTable({
+        endpoint: @js($endpoint),
+        search: @js($initialSearch),
+        sort: @js($initialSort),
+        direction: @js($initialDirection),
+        perPage: @js($paginator->perPage()),
+        filters: @js($normalizedFilters),
+        pagination: @js($pagination),
+        labels: {
+            loading: @js(__('search.messages.loading')),
+            error: @js(__('search.messages.error')),
+        },
+    })"
+    {{ $attributes->merge(['class' => 'w-full text-left text-gray-500 dark:text-gray-300 ' . $class]) }}>
+    @if (count($filters) > 0)
+        <section class="mb-4 rounded-md bg-white p-4 shadow-md dark:bg-gray-800">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('search.filter.heading') }}</h2>
+
+            <div class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                @foreach ($filters as $filter)
+                    <label class="block">
+                        <span class="sr-only">{{ $filter['label'] }}</span>
+                        @if (($filter['type'] ?? 'select') === 'select')
+                            <select
+                                class="w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                                x-model="filters['{{ $filter['name'] }}']"
+                                @change="setFilter('{{ $filter['name'] }}', $event.target.value)">
+                                <option value="">{{ $filter['placeholder'] ?? __('search.filter.all') }}</option>
+                                @foreach ($filter['options'] as $value => $label)
+                                    <option value="{{ $value }}">{{ $label }}</option>
+                                @endforeach
+                            </select>
+                        @else
+                            <input type="{{ $filter['type'] }}"
+                                class="w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                                placeholder="{{ $filter['placeholder'] ?? $filter['label'] }}"
+                                x-model="filters['{{ $filter['name'] }}']"
+                                @input.debounce.400ms="setFilter('{{ $filter['name'] }}', $event.target.value)"
+                                @change="setFilter('{{ $filter['name'] }}', $event.target.value)" />
+                        @endif
+                    </label>
+                @endforeach
+            </div>
+        </section>
+    @endif
+
+    <div
+        class="mb-4 flex flex-col gap-3 rounded-md bg-white p-4 shadow-md dark:bg-gray-800 lg:flex-row lg:items-center lg:justify-between">
+        <label class="w-24">
+            <span class="sr-only">{{ __('search.table.per_page') }}</span>
+            <select
+                class="w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                x-model="perPage" @change="setPerPage($event.target.value)">
+                @foreach ($perPageOptions as $option)
+                    <option value="{{ $option }}">{{ $option }}</option>
+                @endforeach
+            </select>
+        </label>
+
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label class="relative block sm:w-72">
+                <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400">
+                    <span aria-hidden="true">&#128269;</span>
+                </span>
+                <input type="search"
+                    class="w-full rounded-md border-gray-300 pl-9 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                    placeholder="{{ $searchPlaceholder }}" x-model="search"
+                    @input.debounce.400ms="setSearch($event.target.value)" />
+            </label>
+
+            @isset($actions)
+                <div class="flex flex-wrap items-center gap-2">
+                    {{ $actions }}
+                </div>
+            @endisset
+        </div>
+    </div>
+
+    <div class="relative overflow-hidden rounded-md bg-white shadow-md dark:bg-gray-800">
+        <div x-show="loading" x-cloak
+            class="absolute inset-0 z-10 flex items-center justify-center bg-white/70 text-sm font-semibold text-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
+            {{ __('search.messages.loading') }}
+        </div>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        {{ $head }}
+                    </tr>
+                </thead>
+                <tbody x-ref="body" class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+                    {{ $body }}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <p x-show="error" x-text="error" class="mt-3 text-sm font-semibold text-red-600 dark:text-red-300"></p>
+
+    <div class="mt-4 flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
+        <p>
+            {{ __('search.table.showing') }}
+            <span x-text="pagination.from ?? 0"></span>
+            {{ __('search.table.to') }}
+            <span x-text="pagination.to ?? 0"></span>
+            {{ __('search.table.of') }}
+            <span x-text="pagination.total"></span>
+            {{ __('search.table.entries') }}
+        </p>
+
+        <nav class="flex flex-wrap items-center gap-1" aria-label="{{ __('search.table.pagination') }}">
+            <button type="button"
+                class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 transition hover:bg-purple-50 hover:text-purple-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                :disabled="pagination.current_page <= 1 || loading" @click="fetchPage(pagination.current_page - 1)">
+                &laquo;
+            </button>
+
+            <template x-for="page in pages()" :key="`${page}-${pagination.current_page}`">
+                <span>
+                    <button x-show="page !== '...'" type="button"
+                        class="rounded-md px-3 py-2 font-semibold transition"
+                        :class="page === pagination.current_page
+                            ? 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-100'
+                            : 'bg-gray-100 text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600'"
+                        :disabled="loading" @click="fetchPage(page)" x-text="page"></button>
+                    <span x-show="page === '...'" class="px-2 py-2">...</span>
+                </span>
+            </template>
+
+            <button type="button"
+                class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 transition hover:bg-purple-50 hover:text-purple-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                :disabled="pagination.current_page >= pagination.last_page || loading"
+                @click="fetchPage(pagination.current_page + 1)">
+                &raquo;
+            </button>
+        </nav>
+    </div>
+</div>

--- a/resources/views/components/table/heading.blade.php
+++ b/resources/views/components/table/heading.blade.php
@@ -1,3 +1,14 @@
+@props(['sort' => null])
+
 <th scope="col" class="px-6 py-3 text-left font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300">
-    {{ $slot }}
+    @if ($sort)
+        <button type="button"
+            class="inline-flex items-center gap-2 text-left uppercase tracking-wider transition hover:text-purple-600 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:hover:text-purple-300"
+            @click="sortBy('{{ $sort }}')" :aria-sort="isSorted('{{ $sort }}') ? direction : 'none'">
+            <span>{{ $slot }}</span>
+            <span class="text-xs" x-text="sortIndicator('{{ $sort }}')"></span>
+        </button>
+    @else
+        {{ $slot }}
+    @endif
 </th>

--- a/tests/Feature/Admin/AsyncAdminTablesTest.php
+++ b/tests/Feature/Admin/AsyncAdminTablesTest.php
@@ -29,9 +29,7 @@ class AsyncAdminTablesTest extends TestCase
 
         foreach ($routes as $route) {
             $this->actingAs($admin)
-                ->get($route)
-                ->assertOk()
-                ->assertSee('asyncTable', false)
+                ->get($route)->assertOk()->assertSeeHtml('asyncTable')
                 ->assertSee(__('search.filter.heading'));
         }
     }
@@ -56,15 +54,15 @@ class AsyncAdminTablesTest extends TestCase
             User::factory()->create(['name' => 'Paged User ' . $index]);
         }
 
-        $sortedResponse = $this->actingAs($admin)->getJson(route('admin.users.index', [
+        $testResponse = $this->actingAs($admin)->getJson(route('admin.users.index', [
             'search' => 'Sortable',
             'sort' => 'name',
             'direction' => 'desc',
             'per_page' => 5,
         ]));
 
-        $sortedResponse->assertOk()->assertJsonPath('pagination.total', 2);
-        $sortedHtml = $sortedResponse->json('html');
+        $testResponse->assertOk()->assertJsonPath('pagination.total', 2);
+        $sortedHtml = $testResponse->json('html');
         $this->assertStringContainsString('Sortable Zulu', $sortedHtml);
         $this->assertLessThan(mb_strpos($sortedHtml, 'Sortable Alpha'), mb_strpos($sortedHtml, 'Sortable Zulu'));
 
@@ -96,16 +94,16 @@ class AsyncAdminTablesTest extends TestCase
         Package::factory()->create(['monitoring_limit' => 10, 'price' => 29.99, 'is_selectable' => true]);
         Package::factory()->create(['monitoring_limit' => 99, 'price' => 9.99, 'is_selectable' => false]);
 
-        $response = $this->actingAs($admin)->getJson(route('admin.packages.index', [
+        $testResponse = $this->actingAs($admin)->getJson(route('admin.packages.index', [
             'is_selectable' => '0',
             'sort' => 'price',
             'direction' => 'asc',
             'per_page' => 5,
         ]));
 
-        $response->assertOk()->assertJsonPath('pagination.total', 1);
-        $this->assertStringContainsString('99', $response->json('html'));
-        $this->assertStringNotContainsString('29.99', $response->json('html'));
+        $testResponse->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('99', $testResponse->json('html'));
+        $this->assertStringNotContainsString('29.99', $testResponse->json('html'));
     }
 
     public function test_admin_server_instance_table_supports_backend_search_health_filter_and_sorting(): void
@@ -131,7 +129,7 @@ class AsyncAdminTablesTest extends TestCase
             'last_seen_at' => Date::now()->subHour(),
         ]);
 
-        $response = $this->actingAs($admin)->getJson(route('admin.server-instances.index', [
+        $testResponse = $this->actingAs($admin)->getJson(route('admin.server-instances.index', [
             'search' => 'async',
             'health' => 'stale',
             'sort' => 'code',
@@ -139,9 +137,9 @@ class AsyncAdminTablesTest extends TestCase
             'per_page' => 5,
         ]));
 
-        $response->assertOk()->assertJsonPath('pagination.total', 1);
-        $this->assertStringContainsString('async-stale', $response->json('html'));
-        $this->assertStringNotContainsString('async-healthy', $response->json('html'));
+        $testResponse->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('async-stale', $testResponse->json('html'));
+        $this->assertStringNotContainsString('async-healthy', $testResponse->json('html'));
     }
 
     public function test_admin_api_log_table_supports_backend_user_filter_search_and_email_sorting(): void
@@ -154,14 +152,14 @@ class AsyncAdminTablesTest extends TestCase
         ApiLog::query()->create(['user_id' => $zulu->id, 'route' => '/api/monitorings']);
         ApiLog::query()->create(['user_id' => $alpha->id, 'route' => '/api/status']);
 
-        $filteredResponse = $this->actingAs($admin)->getJson(route('admin.apis.index', [
+        $testResponse = $this->actingAs($admin)->getJson(route('admin.apis.index', [
             'user_id' => $zulu->id,
             'search' => 'monitorings',
         ]));
 
-        $filteredResponse->assertOk()->assertJsonPath('pagination.total', 1);
-        $this->assertStringContainsString('zulu-api@example.test', $filteredResponse->json('html'));
-        $this->assertStringNotContainsString('alpha-api@example.test', $filteredResponse->json('html'));
+        $testResponse->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('zulu-api@example.test', $testResponse->json('html'));
+        $this->assertStringNotContainsString('alpha-api@example.test', $testResponse->json('html'));
 
         $sortedResponse = $this->actingAs($admin)->getJson(route('admin.apis.index', [
             'sort' => 'email',
@@ -186,7 +184,7 @@ class AsyncAdminTablesTest extends TestCase
             ->event('created')
             ->log('monitoring_created');
 
-        $response = $this->actingAs($admin)->getJson(route('admin.activity-logs.index', [
+        $testResponse = $this->actingAs($admin)->getJson(route('admin.activity-logs.index', [
             'search' => 'async_profile',
             'log_name' => 'user',
             'event' => 'updated',
@@ -195,8 +193,8 @@ class AsyncAdminTablesTest extends TestCase
             'per_page' => 5,
         ]));
 
-        $response->assertOk()->assertJsonPath('pagination.total', 1);
-        $this->assertStringContainsString('async_profile_changed', $response->json('html'));
-        $this->assertStringNotContainsString('monitoring_created', $response->json('html'));
+        $testResponse->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('async_profile_changed', $testResponse->json('html'));
+        $this->assertStringNotContainsString('monitoring_created', $testResponse->json('html'));
     }
 }

--- a/tests/Feature/Admin/AsyncAdminTablesTest.php
+++ b/tests/Feature/Admin/AsyncAdminTablesTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\ApiLog;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class AsyncAdminTablesTest extends TestCase
+{
+    public function test_admin_async_table_views_render_the_shared_component(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        $routes = [
+            route('admin.users.index'),
+            route('admin.packages.index'),
+            route('admin.server-instances.index'),
+            route('admin.apis.index'),
+            route('admin.activity-logs.index'),
+        ];
+
+        foreach ($routes as $route) {
+            $this->actingAs($admin)
+                ->get($route)
+                ->assertOk()
+                ->assertSee('asyncTable', false)
+                ->assertSee(__('search.filter.heading'));
+        }
+    }
+
+    public function test_admin_user_table_supports_backend_search_filter_sorting_and_pagination(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 5]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        User::factory()->create([
+            'name' => 'Sortable Alpha',
+            'email' => 'alpha@example.test',
+            'role' => UserRole::REGULAR,
+        ]);
+        User::factory()->create([
+            'name' => 'Sortable Zulu',
+            'email' => 'zulu@example.test',
+            'role' => UserRole::GUEST,
+        ]);
+
+        foreach (range(1, 6) as $index) {
+            User::factory()->create(['name' => 'Paged User ' . $index]);
+        }
+
+        $sortedResponse = $this->actingAs($admin)->getJson(route('admin.users.index', [
+            'search' => 'Sortable',
+            'sort' => 'name',
+            'direction' => 'desc',
+            'per_page' => 5,
+        ]));
+
+        $sortedResponse->assertOk()->assertJsonPath('pagination.total', 2);
+        $sortedHtml = $sortedResponse->json('html');
+        $this->assertStringContainsString('Sortable Zulu', $sortedHtml);
+        $this->assertLessThan(mb_strpos($sortedHtml, 'Sortable Alpha'), mb_strpos($sortedHtml, 'Sortable Zulu'));
+
+        $filteredResponse = $this->actingAs($admin)->getJson(route('admin.users.index', [
+            'role' => UserRole::GUEST->value,
+            'per_page' => 5,
+        ]));
+
+        $filteredResponse->assertOk();
+        $this->assertStringContainsString('zulu@example.test', $filteredResponse->json('html'));
+        $this->assertStringNotContainsString('alpha@example.test', $filteredResponse->json('html'));
+
+        $pagedResponse = $this->actingAs($admin)->getJson(route('admin.users.index', [
+            'search' => 'Paged User',
+            'per_page' => 5,
+            'page' => 2,
+        ]));
+
+        $pagedResponse->assertOk()
+            ->assertJsonPath('pagination.total', 6)
+            ->assertJsonPath('pagination.current_page', 2);
+    }
+
+    public function test_admin_package_table_supports_backend_filtering_and_sorting(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        Package::factory()->create(['monitoring_limit' => 10, 'price' => 29.99, 'is_selectable' => true]);
+        Package::factory()->create(['monitoring_limit' => 99, 'price' => 9.99, 'is_selectable' => false]);
+
+        $response = $this->actingAs($admin)->getJson(route('admin.packages.index', [
+            'is_selectable' => '0',
+            'sort' => 'price',
+            'direction' => 'asc',
+            'per_page' => 5,
+        ]));
+
+        $response->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('99', $response->json('html'));
+        $this->assertStringNotContainsString('29.99', $response->json('html'));
+    }
+
+    public function test_admin_server_instance_table_supports_backend_search_health_filter_and_sorting(): void
+    {
+        Date::setTestNow('2026-05-04 12:00:00');
+        $this->beforeApplicationDestroyed(fn (): mixed => Date::setTestNow());
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        ServerInstance::query()->create([
+            'code' => 'async-healthy',
+            'ip_address' => '10.0.0.10',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+            'last_seen_at' => Date::now(),
+        ]);
+        ServerInstance::query()->create([
+            'code' => 'async-stale',
+            'ip_address' => '10.0.0.20',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subHour(),
+        ]);
+
+        $response = $this->actingAs($admin)->getJson(route('admin.server-instances.index', [
+            'search' => 'async',
+            'health' => 'stale',
+            'sort' => 'code',
+            'direction' => 'asc',
+            'per_page' => 5,
+        ]));
+
+        $response->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('async-stale', $response->json('html'));
+        $this->assertStringNotContainsString('async-healthy', $response->json('html'));
+    }
+
+    public function test_admin_api_log_table_supports_backend_user_filter_search_and_email_sorting(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $alpha = User::factory()->create(['email' => 'alpha-api@example.test']);
+        $zulu = User::factory()->create(['email' => 'zulu-api@example.test']);
+
+        ApiLog::query()->create(['user_id' => $zulu->id, 'route' => '/api/monitorings']);
+        ApiLog::query()->create(['user_id' => $alpha->id, 'route' => '/api/status']);
+
+        $filteredResponse = $this->actingAs($admin)->getJson(route('admin.apis.index', [
+            'user_id' => $zulu->id,
+            'search' => 'monitorings',
+        ]));
+
+        $filteredResponse->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('zulu-api@example.test', $filteredResponse->json('html'));
+        $this->assertStringNotContainsString('alpha-api@example.test', $filteredResponse->json('html'));
+
+        $sortedResponse = $this->actingAs($admin)->getJson(route('admin.apis.index', [
+            'sort' => 'email',
+            'direction' => 'asc',
+        ]));
+
+        $sortedHtml = $sortedResponse->json('html');
+        $this->assertLessThan(mb_strpos($sortedHtml, 'zulu-api@example.test'), mb_strpos($sortedHtml, 'alpha-api@example.test'));
+    }
+
+    public function test_admin_activity_log_table_supports_backend_filters_search_and_sorting(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        activity('user')
+            ->causedBy($admin)
+            ->event('updated')
+            ->log('async_profile_changed');
+
+        activity('monitoring')
+            ->event('created')
+            ->log('monitoring_created');
+
+        $response = $this->actingAs($admin)->getJson(route('admin.activity-logs.index', [
+            'search' => 'async_profile',
+            'log_name' => 'user',
+            'event' => 'updated',
+            'sort' => 'description',
+            'direction' => 'asc',
+            'per_page' => 5,
+        ]));
+
+        $response->assertOk()->assertJsonPath('pagination.total', 1);
+        $this->assertStringContainsString('async_profile_changed', $response->json('html'));
+        $this->assertStringNotContainsString('monitoring_created', $response->json('html'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add a reusable async table Blade/Alpine component for server-backed search, filters, sorting, page size, and numbered pagination.
- Move admin table rows into shared partials so initial page loads and Ajax refreshes render the same markup.
- Convert admin users, packages, server instances, API logs, and audit logs to the async table flow without writing state to the browser URL.

## Validation
- `bun run build`
- `php artisan test tests/Feature/Admin/AsyncAdminTablesTest.php tests/Feature/Admin/UserEmailVerificationFromEditPageTest.php tests/Feature/ServerInstanceHealthTest.php`
- `./vendor/bin/pint --dirty`
- `git diff --check`