### PR TITLE
Allow unverified profile management

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -51,15 +51,20 @@ Route::get('/widget.js', function () {
     return response(file_get_contents(public_path('js/widget.js')))->header('Content-Type', 'application/javascript');
 })->name('widget.js');
 
+Route::middleware(['auth', 'role:member,admin'])
+    ->prefix('profile')
+    ->as('profile.')
+    ->group(function (): void {
+        Route::get('/', [ProfileController::class, 'edit'])->name('edit');
+        Route::patch('/', [ProfileController::class, 'update'])->name('update');
+        Route::delete('/', [ProfileController::class, 'destroy'])->name('destroy');
+    });
+
 Route::middleware(['auth', 'verified'])->group(function (): void {
 
     Route::get('/dashboard', fn () => to_route('monitorings.index'))->name('dashboard');
 
     Route::group(['prefix' => 'profile', 'as' => 'profile.', 'middleware' => 'role:member,admin'], function (): void {
-        Route::get('/', [ProfileController::class, 'edit'])->name('edit');
-        Route::patch('/', [ProfileController::class, 'update'])->name('update');
-        Route::delete('/', [ProfileController::class, 'destroy'])->name('destroy');
-
         Route::post('/api-generate-token', [ProfileController::class, 'apiGenerateToken'])->name('api-generate-token');
         Route::delete('/api-revoke-token', [ProfileController::class, 'apiRevokeToken'])->name('api-revoke-token');
         Route::post('/notification-channels/{channel}/test', [ProfileController::class, 'sendNotificationChannelTest'])

--- a/tests/Feature/Admin/UserEmailVerificationFromEditPageTest.php
+++ b/tests/Feature/Admin/UserEmailVerificationFromEditPageTest.php
@@ -67,4 +67,31 @@ class UserEmailVerificationFromEditPageTest extends TestCase
         $user->refresh();
         $this->assertNotNull($user->email_verified_at);
     }
+
+    public function test_admin_can_update_unverified_user_profile(): void
+    {
+        $package = Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN->value]);
+        $user = User::factory()->unverified()->create([
+            'name' => 'Original User',
+            'email' => 'original-user@example.test',
+            'package_id' => $package->id,
+        ]);
+
+        $testResponse = $this->actingAs($admin)->patch(route('admin.users.update', $user), [
+            'name' => 'Updated User',
+            'email' => 'updated-user@example.test',
+            'password' => '',
+            'role' => UserRole::REGULAR->value,
+            'package_id' => $package->id,
+        ]);
+
+        $testResponse->assertRedirect(route('admin.users.index'));
+        $testResponse->assertSessionHas('success', __('user.messages.user_updated'));
+
+        $user->refresh();
+        $this->assertSame('Updated User', $user->name);
+        $this->assertSame('updated-user@example.test', $user->email);
+        $this->assertNull($user->email_verified_at);
+    }
 }

--- a/tests/Feature/ProfileAccountDeletionTest.php
+++ b/tests/Feature/ProfileAccountDeletionTest.php
@@ -80,4 +80,23 @@ class ProfileAccountDeletionTest extends TestCase
         $loginAttempt->assertSessionHasErrors('email');
         $this->assertGuest();
     }
+
+    public function test_unverified_user_can_delete_own_profile(): void
+    {
+        Queue::fake();
+        Package::factory()->create();
+
+        $user = User::factory()->unverified()->create();
+
+        $testResponse = $this->actingAs($user)->delete(route('profile.destroy'), [
+            'password' => 'password',
+        ]);
+
+        $testResponse->assertRedirect('/');
+        $this->assertGuest();
+
+        Queue::assertPushed(DeleteUser::class, function (DeleteUser $deleteUser) use ($user): bool {
+            return $deleteUser->user->is($user);
+        });
+    }
 }

--- a/tests/Feature/VerifiedEmailRequiredTest.php
+++ b/tests/Feature/VerifiedEmailRequiredTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use App\Models\Package;
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 class VerifiedEmailRequiredTest extends TestCase
@@ -20,6 +21,54 @@ class VerifiedEmailRequiredTest extends TestCase
 
         $monitoringsResponse = $this->actingAs($user)->get(route('monitorings.index'));
         $monitoringsResponse->assertRedirect(route('verification.notice'));
+    }
+
+    public function test_unverified_user_can_open_profile(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->unverified()->create();
+
+        $testResponse = $this->actingAs($user)->get(route('profile.edit'));
+
+        $testResponse->assertOk();
+    }
+
+    public function test_unverified_user_can_update_own_profile(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->unverified()->create([
+            'name' => 'Original Name',
+            'email' => 'original@example.test',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => 'Updated Name',
+            'email' => 'updated@example.test',
+            'theme' => 'dark',
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+        $testResponse->assertSessionHas('success', __('profile.messages.profile_updated'));
+
+        $user->refresh();
+        $this->assertSame('Updated Name', $user->name);
+        $this->assertSame('updated@example.test', $user->email);
+        $this->assertNull($user->email_verified_at);
+    }
+
+    public function test_unverified_user_can_update_own_password(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->unverified()->create();
+
+        $testResponse = $this->actingAs($user)->put(route('password.update'), [
+            'current_password' => 'password',
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ]);
+
+        $testResponse->assertSessionHas('success', __('profile.form.saved'));
+        $this->assertTrue(Hash::check('new-password', (string) $user->fresh()->password));
     }
 
     public function test_verified_user_can_access_protected_routes(): void


### PR DESCRIPTION
## Summary
- Allow authenticated member/admin users to access, update, and delete their own profile before email verification.
- Keep dashboard, monitoring, admin, API-token, and notification test actions behind email verification.
- Add regression coverage for unverified profile access, name/email update, password update, account deletion, and admin updates of unverified users.

## Validation
- `php artisan test tests/Feature/VerifiedEmailRequiredTest.php tests/Feature/ProfileAccountDeletionTest.php tests/Feature/Admin/UserEmailVerificationFromEditPageTest.php`
- `php artisan test`