### PR TITLE
Fix mobile weekly digest email layout

### DIFF
--- a/resources/views/layouts/mail.blade.php
+++ b/resources/views/layouts/mail.blade.php
@@ -23,6 +23,42 @@
                 font-size: 28px !important;
                 line-height: 34px !important;
             }
+
+            .digest-monitorings-table,
+            .digest-monitorings-table thead,
+            .digest-monitorings-table tbody,
+            .digest-monitorings-table tr,
+            .digest-monitorings-table th,
+            .digest-monitorings-table td {
+                display: block !important;
+                width: 100% !important;
+            }
+
+            .digest-monitorings-table thead {
+                display: none !important;
+            }
+
+            .digest-monitoring-row {
+                margin-bottom: 14px !important;
+                padding: 14px !important;
+                border: 1px solid #e2e8f0 !important;
+                border-radius: 8px !important;
+                background-color: #f8fafc !important;
+            }
+
+            .digest-monitoring-row td {
+                padding: 7px 0 !important;
+                border-bottom: 1px solid #e2e8f0 !important;
+            }
+
+            .digest-monitoring-row td:last-child {
+                border-bottom: 0 !important;
+            }
+
+            .digest-mobile-label {
+                display: block !important;
+                margin-bottom: 2px !important;
+            }
         }
 
         body {
@@ -136,6 +172,45 @@
 
         .mail-content p:last-child {
             margin-bottom: 0;
+        }
+
+        .digest-table {
+            width: 100%;
+            margin-bottom: 20px;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+
+        .digest-table th,
+        .digest-table td {
+            padding: 8px;
+            color: #475569;
+            font-size: 14px;
+            line-height: 20px;
+            vertical-align: top;
+        }
+
+        .digest-table th {
+            color: #0f172a;
+            font-weight: 700;
+        }
+
+        .digest-monitoring-name {
+            color: #0f172a;
+        }
+
+        .digest-monitoring-target {
+            color: #64748b;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+        }
+
+        .digest-mobile-label {
+            display: none;
+            color: #0f172a;
+            font-size: 12px;
+            font-weight: 700;
+            line-height: 18px;
         }
 
         .mail-button {

--- a/resources/views/mail/weekly-monitoring-digest.blade.php
+++ b/resources/views/mail/weekly-monitoring-digest.blade.php
@@ -20,7 +20,7 @@
     ]) }}</p>
 
     <h2>{{ __('mail.weekly_monitoring_digest.overview_heading') }}</h2>
-    <table width="100%" cellpadding="8" cellspacing="0" style="border-collapse: collapse; margin-bottom: 20px;">
+    <table class="digest-table" width="100%" cellpadding="8" cellspacing="0">
         <tbody>
             <tr>
                 <td><strong>{{ __('mail.weekly_monitoring_digest.uptime_label') }}</strong></td>
@@ -38,25 +38,35 @@
     </table>
 
     <h2>{{ __('mail.weekly_monitoring_digest.monitorings_heading') }}</h2>
-    <table width="100%" cellpadding="8" cellspacing="0" style="border-collapse: collapse; margin-bottom: 20px;">
+    <table class="digest-table digest-monitorings-table" width="100%" cellpadding="8" cellspacing="0">
         <thead>
             <tr>
-                <th align="left">{{ __('mail.weekly_monitoring_digest.monitor_label') }}</th>
-                <th align="left">{{ __('mail.weekly_monitoring_digest.uptime_label') }}</th>
-                <th align="left">{{ __('mail.weekly_monitoring_digest.incidents_label') }}</th>
-                <th align="left">{{ __('mail.weekly_monitoring_digest.longest_downtime_label') }}</th>
+                <th align="left" width="46%">{{ __('mail.weekly_monitoring_digest.monitor_label') }}</th>
+                <th align="left" width="18%">{{ __('mail.weekly_monitoring_digest.uptime_label') }}</th>
+                <th align="left" width="18%">{{ __('mail.weekly_monitoring_digest.incidents_label') }}</th>
+                <th align="left" width="18%">{{ __('mail.weekly_monitoring_digest.longest_downtime_label') }}</th>
             </tr>
         </thead>
         <tbody>
             @foreach ($digest['monitorings'] as $monitoring)
-                <tr>
+                <tr class="digest-monitoring-row">
                     <td>
-                        <strong>{{ $monitoring['name'] }}</strong><br>
-                        <span style="color: #666;">{{ $monitoring['target'] }}</span>
+                        <span class="digest-mobile-label">{{ __('mail.weekly_monitoring_digest.monitor_label') }}</span>
+                        <strong class="digest-monitoring-name">{{ $monitoring['name'] }}</strong><br>
+                        <span class="digest-monitoring-target">{{ $monitoring['target'] }}</span>
                     </td>
-                    <td>{{ $formatPercentage($monitoring['uptime_percentage']) }}</td>
-                    <td>{{ $monitoring['incidents_count'] }}</td>
-                    <td>{{ $formatMinutes($monitoring['longest_downtime_minutes']) }}</td>
+                    <td>
+                        <span class="digest-mobile-label">{{ __('mail.weekly_monitoring_digest.uptime_label') }}</span>
+                        {{ $formatPercentage($monitoring['uptime_percentage']) }}
+                    </td>
+                    <td>
+                        <span class="digest-mobile-label">{{ __('mail.weekly_monitoring_digest.incidents_label') }}</span>
+                        {{ $monitoring['incidents_count'] }}
+                    </td>
+                    <td>
+                        <span class="digest-mobile-label">{{ __('mail.weekly_monitoring_digest.longest_downtime_label') }}</span>
+                        {{ $formatMinutes($monitoring['longest_downtime_minutes']) }}
+                    </td>
                 </tr>
             @endforeach
         </tbody>

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -124,6 +124,47 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         });
     }
 
+    public function test_weekly_digest_monitoring_table_uses_mobile_responsive_markup(): void
+    {
+        $user = User::factory()->make([
+            'name' => 'Mobile User',
+        ]);
+
+        $mail = new WeeklyMonitoringDigestMail([
+            'period_start' => Date::parse('2026-04-13'),
+            'period_end' => Date::parse('2026-04-19'),
+            'frequency' => 'weekly',
+            'overview' => [
+                'uptime_percentage' => 99.12,
+                'incidents_count' => 2,
+                'longest_downtime_minutes' => 12,
+                'monitorings_count' => 1,
+            ],
+            'monitorings' => [
+                [
+                    'name' => 'Very long storefront monitor name',
+                    'target' => 'https://very-long-subdomain.example.com/status/with/a/path/that/needs/to-wrap-on-mobile',
+                    'uptime_percentage' => 99.12,
+                    'incidents_count' => 2,
+                    'downtime_minutes' => 12,
+                    'longest_downtime_minutes' => 12,
+                ],
+            ],
+            'ssl_warnings' => [],
+            'domain_warnings' => [],
+        ], $user);
+
+        $rendered = $mail->render();
+
+        $this->assertStringContainsString('class="digest-table digest-monitorings-table"', $rendered);
+        $this->assertStringContainsString('class="digest-monitoring-row"', $rendered);
+        $this->assertStringContainsString('class="digest-mobile-label"', $rendered);
+        $this->assertStringContainsString('class="digest-monitoring-target"', $rendered);
+        $this->assertStringContainsString('.digest-monitorings-table thead', $rendered);
+        $this->assertStringContainsString('display: block !important;', $rendered);
+        $this->assertStringContainsString('overflow-wrap: anywhere;', $rendered);
+    }
+
     public function test_sends_weekly_digest_to_guest_users_when_profile_setting_is_enabled(): void
     {
         Date::setTestNow('2026-04-20 09:00:00');

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -130,7 +130,7 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
             'name' => 'Mobile User',
         ]);
 
-        $mail = new WeeklyMonitoringDigestMail([
+        $weeklyMonitoringDigestMail = new WeeklyMonitoringDigestMail([
             'period_start' => Date::parse('2026-04-13'),
             'period_end' => Date::parse('2026-04-19'),
             'frequency' => 'weekly',
@@ -154,7 +154,7 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
             'domain_warnings' => [],
         ], $user);
 
-        $rendered = $mail->render();
+        $rendered = $weeklyMonitoringDigestMail->render();
 
         $this->assertStringContainsString('class="digest-table digest-monitorings-table"', $rendered);
         $this->assertStringContainsString('class="digest-monitoring-row"', $rendered);


### PR DESCRIPTION
## Summary

Fixes the weekly monitoring digest email layout on mobile by making the monitoring table responsive instead of letting wide columns get clipped inside the mail panel.

## Changes

- Adds digest-specific email CSS for mobile stacking of monitoring rows.
- Adds wrapping behavior for long monitoring targets.
- Adds a rendering test that verifies the responsive markup and CSS are present in the digest email.

## Validation

- `php artisan test tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`
- `./vendor/bin/pint --dirty`

Note: local dependency installation required `composer install --ignore-platform-req=ext-redis` because the local PHP CLI does not have `ext-redis` enabled; the focused mail tests do not depend on Redis.