### PR TITLE
Fix production startup without app key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ x-app-environment: &app-environment
   APP_NAME: "WebGuard"
   APP_ENV: "production"
   APP_DEBUG: "false"
-  APP_KEY: "${APP_KEY:-}"
+  APP_KEY: "${APP_KEY:?APP_KEY must be set to a persistent Laravel application key}"
   APP_URL: "${SERVICE_URL_PHP:-https://webguard.example.com}"
   APP_TIMEZONE: "Europe/Berlin"
   APP_LOCALE: "en"

--- a/docker/php/entrypoint.d/10-require-app-key.sh
+++ b/docker/php/entrypoint.d/10-require-app-key.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+case "${APP_ENV:-production}" in
+    production)
+        case "${APP_KEY:-}" in
+            ""|"null")
+                echo "ERROR: APP_KEY must be set to a persistent Laravel application key in production." >&2
+                echo "Generate one with: php artisan key:generate --show" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+esac

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -65,12 +65,29 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
         preg_match_all('/\$\{([^}]+)}/', $composeConfiguration, $matches);
 
         foreach ($matches[1] as $interpolatedVariable) {
-            $this->assertStringContainsString(
-                ':-',
-                $interpolatedVariable,
-                sprintf('Compose variable "%s" must define a default value.', $interpolatedVariable)
+            $this->assertTrue(
+                str_contains($interpolatedVariable, ':-') || str_contains($interpolatedVariable, ':?'),
+                sprintf('Compose variable "%s" must define a default value or be explicitly required.', $interpolatedVariable)
             );
         }
+    }
+
+    public function test_production_requires_app_key_before_serving_http_requests(): void
+    {
+        $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
+        $dockerfile = file_get_contents(base_path('Dockerfile'));
+        $appKeyEntrypoint = file_get_contents(base_path('docker/php/entrypoint.d/10-require-app-key.sh'));
+
+        $this->assertIsString($composeConfiguration);
+        $this->assertIsString($dockerfile);
+        $this->assertIsString($appKeyEntrypoint);
+        $this->assertStringContainsString(
+            'APP_KEY: "${APP_KEY:?APP_KEY must be set to a persistent Laravel application key}"',
+            $composeConfiguration
+        );
+        $this->assertStringContainsString('COPY docker/php/entrypoint.d/ /etc/entrypoint.d/', $dockerfile);
+        $this->assertStringContainsString('APP_KEY must be set to a persistent Laravel application key in production.', $appKeyEntrypoint);
+        $this->assertStringContainsString('php artisan key:generate --show', $appKeyEntrypoint);
     }
 
     public function test_production_app_url_is_derived_from_coolify_service_url(): void


### PR DESCRIPTION
## Summary
- require `APP_KEY` during production Compose interpolation
- add a production entrypoint guard that exits with a clear message when `APP_KEY` is missing or `null`
- cover the deployment guard with a regression test

## Root Cause
Web requests that use Laravel's web middleware fail with `MissingAppKeyException` when `APP_KEY` is empty. In production this surfaced as a generic HTTP 500, while health-style routes such as `/status` could still return 200.

## Validation
- `php artisan test`
- `docker compose config` fails clearly without `APP_KEY`
- `APP_KEY=base64:... docker compose config` succeeds