### PR TITLE
Fix iPad confirmation dialog for destructive actions

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -49,6 +49,10 @@
     --font-sans: "Sen", ui-sans-serif, system-ui, sans-serif;
 }
 
+[x-cloak] {
+    display: none !important;
+}
+
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';
 @source '../**/*.blade.php';

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -15,6 +15,7 @@ import monitoringDetail from './components/monitoring-detail';
 import uptimeCalendar from './components/uptime-calendar';
 import guestLogin from './components/guestLogin';
 import asyncTable from './components/async-table';
+import confirmDialog, { registerConfirmableForms } from './components/confirm-dialog';
 
 const decodeImprintPayload = (payload: string): string => {
     try {
@@ -65,8 +66,15 @@ Alpine.data('monitoringCardLoader', monitoringCardLoader);
 Alpine.data('uptimeCalendar', uptimeCalendar);
 Alpine.data('guestLogin', guestLogin);
 Alpine.data('asyncTable', asyncTable);
+Alpine.data('confirmDialog', confirmDialog);
 
 window.Alpine = Alpine;
 window.Chart = Chart;
+
+registerConfirmableForms({
+    title: document.documentElement.dataset.confirmTitle ?? 'Confirm action',
+    confirm: document.documentElement.dataset.confirmConfirm ?? 'Confirm',
+    cancel: document.documentElement.dataset.confirmCancel ?? 'Cancel',
+});
 
 Alpine.start();

--- a/resources/js/components/confirm-dialog.ts
+++ b/resources/js/components/confirm-dialog.ts
@@ -1,0 +1,103 @@
+type ConfirmDialogDetail = {
+    title?: string;
+    message: string;
+    confirmText?: string;
+    cancelText?: string;
+    onConfirm: () => void;
+};
+
+type ConfirmableFormLabels = {
+    title: string;
+    confirm: string;
+    cancel: string;
+};
+
+const confirmedForms = new WeakSet<HTMLFormElement>();
+
+const trimText = (value: string | null | undefined): string => value?.trim() ?? '';
+
+export function registerConfirmableForms(labels: ConfirmableFormLabels): void {
+    document.addEventListener('submit', (event: SubmitEvent): void => {
+        const form = event.target;
+
+        if (!(form instanceof HTMLFormElement)) {
+            return;
+        }
+
+        const message = trimText(form.dataset.confirmMessage);
+
+        if (message === '' || confirmedForms.has(form)) {
+            confirmedForms.delete(form);
+            return;
+        }
+
+        event.preventDefault();
+
+        const submitter = event.submitter instanceof HTMLElement ? event.submitter : null;
+        const submitterLabel = trimText(submitter?.textContent);
+
+        window.dispatchEvent(new CustomEvent<ConfirmDialogDetail>('app:confirm', {
+            detail: {
+                title: trimText(form.dataset.confirmTitle) || labels.title,
+                message,
+                confirmText: trimText(form.dataset.confirmConfirmLabel) || submitterLabel || labels.confirm,
+                cancelText: trimText(form.dataset.confirmCancelLabel) || labels.cancel,
+                onConfirm: (): void => {
+                    confirmedForms.add(form);
+
+                    if (submitter instanceof HTMLButtonElement || submitter instanceof HTMLInputElement) {
+                        form.requestSubmit(submitter);
+
+                        return;
+                    }
+
+                    form.requestSubmit();
+                },
+            },
+        }));
+    });
+}
+
+export default function confirmDialog() {
+    return {
+        open: false,
+        title: '',
+        message: '',
+        confirmText: '',
+        cancelText: '',
+        onConfirm: null as (() => void) | null,
+
+        init(): void {
+            window.addEventListener('app:confirm', (event: Event): void => {
+                const detail = (event as CustomEvent<ConfirmDialogDetail>).detail;
+
+                this.title = detail.title ?? '';
+                this.message = detail.message;
+                this.confirmText = detail.confirmText ?? '';
+                this.cancelText = detail.cancelText ?? '';
+                this.onConfirm = detail.onConfirm;
+                this.open = true;
+                document.body.classList.add('overflow-y-hidden');
+                window.setTimeout((): void => {
+                    document.querySelector<HTMLElement>('[data-confirm-cancel-button]')?.focus();
+                }, 0);
+            });
+        },
+
+        close(): void {
+            this.open = false;
+            this.onConfirm = null;
+            document.body.classList.remove('overflow-y-hidden');
+        },
+
+        cancel(): void {
+            this.close();
+        },
+
+        confirm(): void {
+            const action = this.onConfirm;
+            this.close();
+            action?.();
+        },
+    };
+}

--- a/resources/lang/de/app.php
+++ b/resources/lang/de/app.php
@@ -14,5 +14,9 @@ return [
         'copied_to_clipboard' => 'In die Zwischenablage kopiert!',
         'loading' => 'Wird geladen...',
     ],
+    'confirmation' => [
+        'title' => 'Aktion bestätigen',
+        'confirm' => 'Bestätigen',
+    ],
     'public_status_title' => 'WebGuard Öffentlicher Status',
 ];

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -14,5 +14,9 @@ return [
         'copied_to_clipboard' => 'Copied to clipboard!',
         'loading' => 'Loading...',
     ],
+    'confirmation' => [
+        'title' => 'Confirm action',
+        'confirm' => 'Confirm',
+    ],
     'public_status_title' => 'WebGuard Public Status',
 ];

--- a/resources/views/admin/packages/partials/rows.blade.php
+++ b/resources/views/admin/packages/partials/rows.blade.php
@@ -13,11 +13,11 @@
             <a href="{{ route('admin.packages.edit', $package) }}" class="text-purple-600 hover:underline">
                 {{ __('button.edit') }}
             </a>
-            <form action="{{ route('admin.packages.destroy', $package) }}" method="POST" class="inline">
+            <form action="{{ route('admin.packages.destroy', $package) }}" method="POST" class="inline"
+                data-confirm-message="{{ __('admin.packages.messages.confirm_delete') }}">
                 @csrf
                 @method('DELETE')
-                <button type="submit" onclick="return confirm('{{ __('admin.packages.messages.confirm_delete') }}')"
-                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
+                <button type="submit" class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
             </form>
         </x-table.cell>
     </x-table.row>

--- a/resources/views/admin/server-instances/partials/rows.blade.php
+++ b/resources/views/admin/server-instances/partials/rows.blade.php
@@ -64,12 +64,11 @@
             <a href="{{ route('admin.server-instances.edit', $instance) }}" class="text-purple-600 hover:underline">
                 {{ __('button.edit') }}
             </a>
-            <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST" class="inline">
+            <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST" class="inline"
+                data-confirm-message="{{ __('admin.server_instances.messages.confirm_delete') }}">
                 @csrf
                 @method('DELETE')
-                <button type="submit"
-                    onclick="return confirm('{{ __('admin.server_instances.messages.confirm_delete') }}')"
-                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
+                <button type="submit" class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
             </form>
         </x-table.cell>
     </x-table.row>

--- a/resources/views/admin/users/partials/rows.blade.php
+++ b/resources/views/admin/users/partials/rows.blade.php
@@ -16,15 +16,22 @@
         <x-table.cell>{{ $user->created_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>{{ $user->updated_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>
-            <a href="{{ route('admin.users.edit', $user) }}" class="text-purple-600 hover:underline">
-                {{ __('button.edit') }}
-            </a>
-            <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
-                @csrf
-                @method('DELETE')
-                <button type="submit" onclick="return confirm('{{ __('user.delete.confirmation_question') }}')"
-                    class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
-            </form>
+            <div class="flex items-center gap-3">
+                <a href="{{ route('admin.users.edit', $user) }}"
+                    class="inline-flex min-h-10 items-center text-purple-600 hover:underline">
+                    {{ __('button.edit') }}
+                </a>
+                @if ($user->id !== auth()->id())
+                    <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline-flex"
+                        data-confirm-message="{{ __('user.delete.confirmation_question') }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit"
+                            class="inline-flex min-h-10 cursor-pointer items-center text-red-600 hover:underline"
+                            data-testid="delete-user-{{ $user->id }}">{{ __('button.delete') }}</button>
+                    </form>
+                @endif
+            </div>
         </x-table.cell>
     </x-table.row>
 @empty

--- a/resources/views/components/async-table.blade.php
+++ b/resources/views/components/async-table.blade.php
@@ -88,12 +88,9 @@
         </label>
 
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <label class="relative block sm:w-72">
-                <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400">
-                    <span aria-hidden="true">&#128269;</span>
-                </span>
+            <label class="block sm:w-72">
                 <input type="search"
-                    class="w-full rounded-md border-gray-300 pl-9 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                    class="w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
                     placeholder="{{ $searchPlaceholder }}" x-model="search"
                     @input.debounce.400ms="setSearch($event.target.value)" />
             </label>

--- a/resources/views/components/confirm-dialog.blade.php
+++ b/resources/views/components/confirm-dialog.blade.php
@@ -1,0 +1,29 @@
+<div x-data="confirmDialog()" x-show="open" x-cloak x-on:keydown.escape.window="cancel()"
+    class="fixed inset-0 z-50 overflow-y-auto px-4 py-6 sm:px-0" role="dialog" aria-modal="true"
+    aria-labelledby="app-confirm-dialog-title">
+    <div x-show="open" class="fixed inset-0 bg-gray-500 opacity-75" x-on:click="cancel()"
+        x-transition:enter="ease-out duration-200" x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-75" x-transition:leave="ease-in duration-150"
+        x-transition:leave-start="opacity-75" x-transition:leave-end="opacity-0"></div>
+
+    <div x-show="open"
+        class="relative mx-auto mb-6 overflow-hidden rounded-lg bg-white p-6 shadow-xl transition-all dark:bg-gray-800 sm:w-full sm:max-w-md"
+        x-transition:enter="ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100" x-transition:leave="ease-in duration-150"
+        x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+        <h2 id="app-confirm-dialog-title" class="text-lg font-semibold text-gray-900 dark:text-gray-100"
+            x-text="title"></h2>
+        <p class="mt-3 text-sm text-gray-600 dark:text-gray-300" x-text="message"></p>
+
+        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <x-secondary-button type="button" x-on:click="cancel()" class="justify-center"
+                data-confirm-cancel-button>
+                <span x-text="cancelText"></span>
+            </x-secondary-button>
+            <x-danger-button type="button" x-on:click="confirm()" class="justify-center">
+                <span x-text="confirmText"></span>
+            </x-danger-button>
+        </div>
+    </div>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,9 @@
         $theme = 'system';
     }
 @endphp
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="{{ $theme === 'dark' ? 'dark' : '' }}" data-theme="{{ $theme }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="{{ $theme === 'dark' ? 'dark' : '' }}"
+    data-theme="{{ $theme }}" data-confirm-title="{{ __('app.confirmation.title') }}"
+    data-confirm-confirm="{{ __('app.confirmation.confirm') }}" data-confirm-cancel="{{ __('button.cancel') }}">
 
 <head>
     <meta charset="utf-8">
@@ -58,6 +60,7 @@
         {{ $slot }}
 
         @include('components.toast')
+        <x-confirm-dialog />
     </main>
 
     @include('components.footer')

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -49,7 +49,7 @@
                             {{ __('monitoring.actions.edit') }}
                         </a>
                         <form method="POST" action="{{ route('monitorings.destroyResults', $monitoring) }}"
-                            onsubmit="return confirm('{{ __('monitoring.actions.reset.confirmation') }}')">
+                            data-confirm-message="{{ __('monitoring.actions.reset.confirmation') }}">
                             @csrf
                             @method('DELETE')
                             <button type="submit"
@@ -58,7 +58,7 @@
                             </button>
                         </form>
                         <form method="POST" action="{{ route('monitorings.destroy', $monitoring) }}"
-                            onsubmit="return confirm('{{ __('monitoring.actions.delete.confirmation') }}')">
+                            data-confirm-message="{{ __('monitoring.actions.delete.confirmation') }}">
                             @csrf
                             @method('DELETE')
                             <button type="submit"

--- a/tests/Feature/Admin/AsyncAdminTablesTest.php
+++ b/tests/Feature/Admin/AsyncAdminTablesTest.php
@@ -30,7 +30,40 @@ class AsyncAdminTablesTest extends TestCase
         foreach ($routes as $route) {
             $this->actingAs($admin)
                 ->get($route)->assertOk()->assertSeeHtml('asyncTable')
-                ->assertSee(__('search.filter.heading'));
+                ->assertSee(__('search.filter.heading'))
+                ->assertSeeHtml('type="search"')
+                ->assertDontSeeHtml('&#128269;')
+                ->assertDontSeeHtml('pl-9');
+        }
+    }
+
+    public function test_admin_delete_forms_use_app_confirm_dialog_instead_of_native_browser_confirm(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $user = User::factory()->create();
+        $package = Package::factory()->create();
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'confirm-dialog-instance',
+            'ip_address' => '10.0.0.99',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $routes = [
+            route('admin.users.index') => route('admin.users.destroy', $user),
+            route('admin.packages.index') => route('admin.packages.destroy', $package),
+            route('admin.server-instances.index') => route('admin.server-instances.destroy', $serverInstance),
+        ];
+
+        foreach ($routes as $route => $destroyRoute) {
+            $this->actingAs($admin)
+                ->get($route)
+                ->assertOk()
+                ->assertSeeHtml('x-data="confirmDialog()"')
+                ->assertSeeHtml('data-confirm-message')
+                ->assertSeeHtml('action="' . $destroyRoute . '"')
+                ->assertDontSeeHtml('return confirm(');
         }
     }
 

--- a/tests/Feature/Admin/UserDeletionTest.php
+++ b/tests/Feature/Admin/UserDeletionTest.php
@@ -18,6 +18,23 @@ class UserDeletionTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_admin_user_index_renders_clickable_delete_button_for_other_users(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN->value]);
+        $user = User::factory()->create();
+
+        $testResponse = $this->actingAs($admin)->get(route('admin.users.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('action="' . route('admin.users.destroy', $user) . '"');
+        $testResponse->assertSeeHtml('data-confirm-message');
+        $testResponse->assertSeeHtml('data-testid="delete-user-' . $user->id . '"');
+        $testResponse->assertSeeHtml('type="submit"');
+        $testResponse->assertDontSeeHtml('return confirm(');
+        $testResponse->assertDontSeeHtml('data-testid="delete-user-' . $admin->id . '"');
+    }
+
     public function test_admin_delete_revokes_target_user_access_immediately_and_dispatches_job(): void
     {
         Queue::fake();

--- a/tests/Feature/ConfirmDialogTest.php
+++ b/tests/Feature/ConfirmDialogTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Tests\TestCase;
+
+class ConfirmDialogTest extends TestCase
+{
+    public function test_monitoring_destructive_actions_use_app_confirm_dialog(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->create(['user_id' => $user->id]);
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.show', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('x-data="confirmDialog()"');
+        $testResponse->assertSeeHtml('data-confirm-message="' . __('monitoring.actions.reset.confirmation') . '"');
+        $testResponse->assertSeeHtml('data-confirm-message="' . __('monitoring.actions.delete.confirmation') . '"');
+        $testResponse->assertDontSeeHtml('return confirm(');
+    }
+}


### PR DESCRIPTION
## Summary
- replace native browser confirm prompts with an app-owned Alpine confirmation dialog
- route destructive admin and monitoring forms through data-confirm-message so async table rows work reliably
- remove the search icon from the shared async table search input

## Why
Native confirmation prompts were not reliably shown on iPad, which made destructive actions such as deleting users impossible to complete. The app dialog avoids that platform behavior and keeps the confirmation flow consistent.

## Validation
- php artisan test
- php artisan test tests/Feature/Admin/UserDeletionTest.php tests/Feature/Admin/AsyncAdminTablesTest.php tests/Feature/ConfirmDialogTest.php
- bun run build
- vendor/bin/pint --dirty
