### PR TITLE
test: cover app key entrypoint guard

### DIFF
--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Symfony\Component\Process\Process;
 use Tests\TestCase;
 
 class HeartbeatQueueDeploymentConfigTest extends TestCase
@@ -110,6 +111,50 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
                 $composeConfiguration
             );
         }
+    }
+
+    public function test_app_key_entrypoint_rejects_missing_production_key(): void
+    {
+        $process = new Process([
+            'env',
+            '-i',
+            'APP_ENV=production',
+            'sh',
+            base_path('docker/php/entrypoint.d/10-require-app-key.sh'),
+        ]);
+
+        $process->run();
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString(
+            'APP_KEY must be set to a persistent Laravel application key in production.',
+            $process->getErrorOutput()
+        );
+    }
+
+    public function test_app_key_entrypoint_allows_keyed_production_and_non_production_environments(): void
+    {
+        $productionProcess = new Process([
+            'env',
+            '-i',
+            'APP_ENV=production',
+            'APP_KEY=base64:test-key',
+            'sh',
+            base_path('docker/php/entrypoint.d/10-require-app-key.sh'),
+        ]);
+        $localProcess = new Process([
+            'env',
+            '-i',
+            'APP_ENV=local',
+            'sh',
+            base_path('docker/php/entrypoint.d/10-require-app-key.sh'),
+        ]);
+
+        $productionProcess->run();
+        $localProcess->run();
+
+        $this->assertSame(0, $productionProcess->getExitCode(), $productionProcess->getErrorOutput());
+        $this->assertSame(0, $localProcess->getExitCode(), $localProcess->getErrorOutput());
     }
 
     public function test_production_app_url_is_derived_from_coolify_service_url(): void

--- a/tests/Feature/MysqlMigrationCompatibilityTest.php
+++ b/tests/Feature/MysqlMigrationCompatibilityTest.php
@@ -14,7 +14,7 @@ class MysqlMigrationCompatibilityTest extends TestCase
         $foreignKeyName = 'notif_channel_deliveries_monitoring_notification_fk';
 
         $this->assertIsString($migration);
-        $this->assertLessThanOrEqual(64, strlen($foreignKeyName));
+        $this->assertLessThanOrEqual(64, mb_strlen($foreignKeyName));
         $this->assertStringContainsString("->foreign('monitoring_notification_id', '{$foreignKeyName}')", $migration);
     }
 }

--- a/tests/Feature/ViteManifestAssetTest.php
+++ b/tests/Feature/ViteManifestAssetTest.php
@@ -35,10 +35,15 @@ class ViteManifestAssetTest extends TestCase
         $views = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(resource_path('views')));
 
         foreach ($views as $view) {
-            if (! $view instanceof SplFileInfo || ! $view->isFile() || $view->getExtension() !== 'php') {
+            if (! $view instanceof SplFileInfo) {
                 continue;
             }
-
+            if (! $view->isFile()) {
+                continue;
+            }
+            if ($view->getExtension() !== 'php') {
+                continue;
+            }
             $contents = file_get_contents($view->getPathname());
             $this->assertIsString($contents);
 


### PR DESCRIPTION
## Summary

- Add process-level coverage for the production APP_KEY entrypoint guard.
- Assert production without APP_KEY fails with the expected operator-facing error.
- Assert keyed production and non-production startup paths continue without failing.

## Validation

- `php artisan test tests/Feature/HeartbeatQueueDeploymentConfigTest.php`
- `./vendor/bin/pint --dirty --test`

## Notes

Composer dependencies were installed locally with `--ignore-platform-req=ext-redis` because the local PHP CLI does not have the Redis extension enabled; the focused test does not depend on Redis.