### PR TITLE
Extract admin async table support

### DIFF
--- a/app/Http/Controllers/Admin/ActivityLogController.php
+++ b/app/Http/Controllers/Admin/ActivityLogController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Monitoring;
 use App\Models\User;
+use App\Support\Admin\AsyncTable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,7 +18,7 @@ class ActivityLogController extends Controller
 {
     public function index(Request $request): View|JsonResponse
     {
-        $validated = $request->validate([
+        $validated = $request->validate(AsyncTable::requestRules([
             'search' => ['nullable', 'string', 'max:100'],
             'log_name' => ['nullable', 'string', 'max:100'],
             'event' => ['nullable', 'string', 'max:100'],
@@ -26,15 +27,8 @@ class ActivityLogController extends Controller
             'subject_id' => ['nullable', 'string', 'max:36'],
             'date_from' => ['nullable', 'date'],
             'date_to' => ['nullable', 'date'],
-            'sort' => ['nullable', 'string', 'in:created_at,log_name,event,description'],
-            'direction' => ['nullable', 'string', 'in:asc,desc'],
-            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
-            'page' => ['nullable', 'integer', 'min:1'],
-        ]);
-
-        $sort = $validated['sort'] ?? 'created_at';
-        $direction = $validated['direction'] ?? 'desc';
-        $perPage = (int) ($validated['per_page'] ?? 25);
+        ], ['created_at', 'log_name', 'event', 'description']));
+        $table = AsyncTable::options($validated, 'created_at', 'desc', 25);
         $subjectTypes = [
             User::class => __('admin.activity_logs.subject_types.user'),
             Monitoring::class => __('admin.activity_logs.subject_types.monitoring'),
@@ -57,25 +51,19 @@ class ActivityLogController extends Controller
             ->when($validated['subject_id'] ?? null, fn (Builder $builder, string $subjectId): Builder => $builder->where('subject_id', $subjectId))
             ->when($validated['date_from'] ?? null, fn (Builder $builder, string $dateFrom): Builder => $builder->whereDate('created_at', '>=', $dateFrom))
             ->when($validated['date_to'] ?? null, fn (Builder $builder, string $dateTo): Builder => $builder->whereDate('created_at', '<=', $dateTo))
-            ->orderBy($sort, $direction)
+            ->orderBy($table->sort, $table->direction)
             ->orderBy('id')
-            ->paginate($perPage);
+            ->paginate($table->perPage);
 
         if ($request->expectsJson()) {
-            return response()->json([
-                'html' => view('admin.activity-logs.partials.rows', [
+            return AsyncTable::json(
+                $lengthAwarePaginator,
+                'admin.activity-logs.partials.rows',
+                [
                     'activities' => $lengthAwarePaginator,
                     'subjectTypes' => $subjectTypes,
-                ])->render(),
-                'pagination' => [
-                    'current_page' => $lengthAwarePaginator->currentPage(),
-                    'last_page' => $lengthAwarePaginator->lastPage(),
-                    'from' => $lengthAwarePaginator->firstItem(),
-                    'to' => $lengthAwarePaginator->lastItem(),
-                    'total' => $lengthAwarePaginator->total(),
-                    'per_page' => $lengthAwarePaginator->perPage(),
-                ],
-            ]);
+                ]
+            );
         }
 
         $users = User::query()->select('id', 'email')->orderBy('email')->get();
@@ -138,8 +126,8 @@ class ActivityLogController extends Controller
                 'date_from' => (string) ($validated['date_from'] ?? ''),
                 'date_to' => (string) ($validated['date_to'] ?? ''),
             ],
-            'sort' => $sort,
-            'direction' => $direction,
+            'sort' => $table->sort,
+            'direction' => $table->direction,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/ActivityLogController.php
+++ b/app/Http/Controllers/Admin/ActivityLogController.php
@@ -28,7 +28,7 @@ class ActivityLogController extends Controller
             'date_from' => ['nullable', 'date'],
             'date_to' => ['nullable', 'date'],
         ], ['created_at', 'log_name', 'event', 'description']));
-        $table = AsyncTable::options($validated, 'created_at', 'desc', 25);
+        $asyncTableOptions = AsyncTable::options($validated, 'created_at', 'desc', 25);
         $subjectTypes = [
             User::class => __('admin.activity_logs.subject_types.user'),
             Monitoring::class => __('admin.activity_logs.subject_types.monitoring'),
@@ -51,9 +51,9 @@ class ActivityLogController extends Controller
             ->when($validated['subject_id'] ?? null, fn (Builder $builder, string $subjectId): Builder => $builder->where('subject_id', $subjectId))
             ->when($validated['date_from'] ?? null, fn (Builder $builder, string $dateFrom): Builder => $builder->whereDate('created_at', '>=', $dateFrom))
             ->when($validated['date_to'] ?? null, fn (Builder $builder, string $dateTo): Builder => $builder->whereDate('created_at', '<=', $dateTo))
-            ->orderBy($table->sort, $table->direction)
+            ->orderBy($asyncTableOptions->sort, $asyncTableOptions->direction)
             ->orderBy('id')
-            ->paginate($table->perPage);
+            ->paginate($asyncTableOptions->perPage);
 
         if ($request->expectsJson()) {
             return AsyncTable::json(
@@ -126,8 +126,8 @@ class ActivityLogController extends Controller
                 'date_from' => (string) ($validated['date_from'] ?? ''),
                 'date_to' => (string) ($validated['date_to'] ?? ''),
             ],
-            'sort' => $table->sort,
-            'direction' => $table->direction,
+            'sort' => $asyncTableOptions->sort,
+            'direction' => $asyncTableOptions->direction,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/ApiController.php
+++ b/app/Http/Controllers/Admin/ApiController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\ApiLog;
 use App\Models\User;
+use App\Support\Admin\AsyncTable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -40,18 +41,11 @@ class ApiController extends Controller
      */
     public function index(Request $request): View|JsonResponse
     {
-        $validated = $request->validate([
+        $validated = $request->validate(AsyncTable::requestRules([
             'search' => ['nullable', 'string', 'max:100'],
             'user_id' => ['nullable', 'string', 'exists:users,id'],
-            'sort' => ['nullable', 'string', 'in:created_at,email,route'],
-            'direction' => ['nullable', 'string', 'in:asc,desc'],
-            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
-            'page' => ['nullable', 'integer', 'min:1'],
-        ]);
-
-        $sort = $validated['sort'] ?? 'created_at';
-        $direction = $validated['direction'] ?? 'desc';
-        $perPage = (int) ($validated['per_page'] ?? 25);
+        ], ['created_at', 'email', 'route']));
+        $table = AsyncTable::options($validated, 'created_at', 'desc', 25);
 
         $query = ApiLog::query()
             ->withoutGlobalScope('api_logs')
@@ -65,29 +59,19 @@ class ApiController extends Controller
             })
             ->when($validated['user_id'] ?? null, fn (Builder $builder, string $userId): Builder => $builder->where('user_id', $userId));
 
-        if ($sort === 'email') {
+        if ($table->sort === 'email') {
             $query->join('users as sort_users', 'sort_users.id', '=', 'api_logs.user_id')
-                ->orderBy('sort_users.email', $direction)
+                ->orderBy('sort_users.email', $table->direction)
                 ->latest('api_logs.created_at');
         } else {
-            $query->orderBy('api_logs.' . $sort, $direction)
+            $query->orderBy('api_logs.' . $table->sort, $table->direction)
                 ->orderBy('api_logs.id');
         }
 
-        $lengthAwarePaginator = $query->paginate($perPage);
+        $lengthAwarePaginator = $query->paginate($table->perPage);
 
         if ($request->expectsJson()) {
-            return response()->json([
-                'html' => view('admin.api.partials.rows', ['apiLogs' => $lengthAwarePaginator])->render(),
-                'pagination' => [
-                    'current_page' => $lengthAwarePaginator->currentPage(),
-                    'last_page' => $lengthAwarePaginator->lastPage(),
-                    'from' => $lengthAwarePaginator->firstItem(),
-                    'to' => $lengthAwarePaginator->lastItem(),
-                    'total' => $lengthAwarePaginator->total(),
-                    'per_page' => $lengthAwarePaginator->perPage(),
-                ],
-            ]);
+            return AsyncTable::json($lengthAwarePaginator, 'admin.api.partials.rows', ['apiLogs' => $lengthAwarePaginator]);
         }
 
         $users = User::query()->select('id', 'email')->orderBy('email')->get();
@@ -106,8 +90,8 @@ class ApiController extends Controller
             'activeFilters' => [
                 'user_id' => (string) ($validated['user_id'] ?? ''),
             ],
-            'sort' => $sort,
-            'direction' => $direction,
+            'sort' => $table->sort,
+            'direction' => $table->direction,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/ApiController.php
+++ b/app/Http/Controllers/Admin/ApiController.php
@@ -45,7 +45,7 @@ class ApiController extends Controller
             'search' => ['nullable', 'string', 'max:100'],
             'user_id' => ['nullable', 'string', 'exists:users,id'],
         ], ['created_at', 'email', 'route']));
-        $table = AsyncTable::options($validated, 'created_at', 'desc', 25);
+        $asyncTableOptions = AsyncTable::options($validated, 'created_at', 'desc', 25);
 
         $query = ApiLog::query()
             ->withoutGlobalScope('api_logs')
@@ -59,16 +59,16 @@ class ApiController extends Controller
             })
             ->when($validated['user_id'] ?? null, fn (Builder $builder, string $userId): Builder => $builder->where('user_id', $userId));
 
-        if ($table->sort === 'email') {
+        if ($asyncTableOptions->sort === 'email') {
             $query->join('users as sort_users', 'sort_users.id', '=', 'api_logs.user_id')
-                ->orderBy('sort_users.email', $table->direction)
+                ->orderBy('sort_users.email', $asyncTableOptions->direction)
                 ->latest('api_logs.created_at');
         } else {
-            $query->orderBy('api_logs.' . $table->sort, $table->direction)
+            $query->orderBy('api_logs.' . $asyncTableOptions->sort, $asyncTableOptions->direction)
                 ->orderBy('api_logs.id');
         }
 
-        $lengthAwarePaginator = $query->paginate($table->perPage);
+        $lengthAwarePaginator = $query->paginate($asyncTableOptions->perPage);
 
         if ($request->expectsJson()) {
             return AsyncTable::json($lengthAwarePaginator, 'admin.api.partials.rows', ['apiLogs' => $lengthAwarePaginator]);
@@ -90,8 +90,8 @@ class ApiController extends Controller
             'activeFilters' => [
                 'user_id' => (string) ($validated['user_id'] ?? ''),
             ],
-            'sort' => $table->sort,
-            'direction' => $table->direction,
+            'sort' => $asyncTableOptions->sort,
+            'direction' => $asyncTableOptions->direction,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StorePackageRequest;
 use App\Http\Requests\UpdatePackageRequest;
 use App\Models\Package;
+use App\Support\Admin\AsyncTable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -28,18 +29,11 @@ class PackageController extends Controller
      */
     public function index(Request $request): View|JsonResponse
     {
-        $validated = $request->validate([
+        $validated = $request->validate(AsyncTable::requestRules([
             'search' => ['nullable', 'string', 'max:100'],
             'is_selectable' => ['nullable', 'string', 'in:1,0'],
-            'sort' => ['nullable', 'string', 'in:monitoring_limit,price,is_selectable,created_at,updated_at'],
-            'direction' => ['nullable', 'string', 'in:asc,desc'],
-            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
-            'page' => ['nullable', 'integer', 'min:1'],
-        ]);
-
-        $sort = $validated['sort'] ?? 'price';
-        $direction = $validated['direction'] ?? 'asc';
-        $perPage = (int) ($validated['per_page'] ?? 10);
+        ], ['monitoring_limit', 'price', 'is_selectable', 'created_at', 'updated_at']));
+        $table = AsyncTable::options($validated, 'price', 'asc', 10);
 
         $lengthAwarePaginator = Package::query()
             ->withoutGlobalScope('selectable')
@@ -50,22 +44,12 @@ class PackageController extends Controller
                 });
             })
             ->when(isset($validated['is_selectable']), fn (Builder $builder): Builder => $builder->where('is_selectable', (bool) $validated['is_selectable']))
-            ->orderBy($sort, $direction)
+            ->orderBy($table->sort, $table->direction)
             ->orderBy('id')
-            ->paginate($perPage);
+            ->paginate($table->perPage);
 
         if ($request->expectsJson()) {
-            return response()->json([
-                'html' => view('admin.packages.partials.rows', ['packages' => $lengthAwarePaginator])->render(),
-                'pagination' => [
-                    'current_page' => $lengthAwarePaginator->currentPage(),
-                    'last_page' => $lengthAwarePaginator->lastPage(),
-                    'from' => $lengthAwarePaginator->firstItem(),
-                    'to' => $lengthAwarePaginator->lastItem(),
-                    'total' => $lengthAwarePaginator->total(),
-                    'per_page' => $lengthAwarePaginator->perPage(),
-                ],
-            ]);
+            return AsyncTable::json($lengthAwarePaginator, 'admin.packages.partials.rows', ['packages' => $lengthAwarePaginator]);
         }
 
         return view('admin.packages.index', [
@@ -84,8 +68,8 @@ class PackageController extends Controller
             'activeFilters' => [
                 'is_selectable' => (string) ($validated['is_selectable'] ?? ''),
             ],
-            'sort' => $sort,
-            'direction' => $direction,
+            'sort' => $table->sort,
+            'direction' => $table->direction,
         ]);
     }
 

--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -33,7 +33,7 @@ class PackageController extends Controller
             'search' => ['nullable', 'string', 'max:100'],
             'is_selectable' => ['nullable', 'string', 'in:1,0'],
         ], ['monitoring_limit', 'price', 'is_selectable', 'created_at', 'updated_at']));
-        $table = AsyncTable::options($validated, 'price', 'asc', 10);
+        $asyncTableOptions = AsyncTable::options($validated, 'price', 'asc', 10);
 
         $lengthAwarePaginator = Package::query()
             ->withoutGlobalScope('selectable')
@@ -44,9 +44,9 @@ class PackageController extends Controller
                 });
             })
             ->when(isset($validated['is_selectable']), fn (Builder $builder): Builder => $builder->where('is_selectable', (bool) $validated['is_selectable']))
-            ->orderBy($table->sort, $table->direction)
+            ->orderBy($asyncTableOptions->sort, $asyncTableOptions->direction)
             ->orderBy('id')
-            ->paginate($table->perPage);
+            ->paginate($asyncTableOptions->perPage);
 
         if ($request->expectsJson()) {
             return AsyncTable::json($lengthAwarePaginator, 'admin.packages.partials.rows', ['packages' => $lengthAwarePaginator]);
@@ -68,8 +68,8 @@ class PackageController extends Controller
             'activeFilters' => [
                 'is_selectable' => (string) ($validated['is_selectable'] ?? ''),
             ],
-            'sort' => $table->sort,
-            'direction' => $table->direction,
+            'sort' => $asyncTableOptions->sort,
+            'direction' => $asyncTableOptions->direction,
         ]);
     }
 

--- a/app/Http/Controllers/Admin/ServerInstanceController.php
+++ b/app/Http/Controllers/Admin/ServerInstanceController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\StoreServerInstanceRequest;
 use App\Http\Requests\UpdateServerInstanceRequest;
 use App\Models\Monitoring;
 use App\Models\ServerInstance;
+use App\Support\Admin\AsyncTable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -21,19 +22,12 @@ class ServerInstanceController extends Controller
 {
     public function index(Request $request): View|JsonResponse
     {
-        $validated = $request->validate([
+        $validated = $request->validate(AsyncTable::requestRules([
             'search' => ['nullable', 'string', 'max:100'],
             'is_active' => ['nullable', 'string', 'in:1,0'],
             'health' => ['nullable', 'string', 'in:healthy,stale,never_seen,inactive'],
-            'sort' => ['nullable', 'string', 'in:code,is_active,last_seen_at,created_at,updated_at'],
-            'direction' => ['nullable', 'string', 'in:asc,desc'],
-            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
-            'page' => ['nullable', 'integer', 'min:1'],
-        ]);
-
-        $sort = $validated['sort'] ?? 'code';
-        $direction = $validated['direction'] ?? 'asc';
-        $perPage = (int) ($validated['per_page'] ?? 10);
+        ], ['code', 'is_active', 'last_seen_at', 'created_at', 'updated_at']));
+        $table = AsyncTable::options($validated, 'code', 'asc', 10);
         $staleCutoff = Date::now()->subMinutes(max(1, (int) config('monitoring.instance_stale_after_minutes', 10)));
 
         $lengthAwarePaginator = ServerInstance::query()
@@ -52,9 +46,9 @@ class ServerInstanceController extends Controller
                     'inactive' => $builder->where('is_active', false),
                 };
             })
-            ->orderBy($sort, $direction)
+            ->orderBy($table->sort, $table->direction)
             ->orderBy('id')
-            ->paginate($perPage);
+            ->paginate($table->perPage);
 
         $instanceCodes = $lengthAwarePaginator->getCollection()->pluck('code');
         $monitoringCounts = Monitoring::query()
@@ -77,21 +71,15 @@ class ServerInstanceController extends Controller
             ));
 
         if ($request->expectsJson()) {
-            return response()->json([
-                'html' => view('admin.server-instances.partials.rows', [
+            return AsyncTable::json(
+                $lengthAwarePaginator,
+                'admin.server-instances.partials.rows',
+                [
                     'instances' => $lengthAwarePaginator,
                     'monitoringCounts' => $monitoringCounts,
                     'monitoringTypeCounts' => $monitoringTypeCounts,
-                ])->render(),
-                'pagination' => [
-                    'current_page' => $lengthAwarePaginator->currentPage(),
-                    'last_page' => $lengthAwarePaginator->lastPage(),
-                    'from' => $lengthAwarePaginator->firstItem(),
-                    'to' => $lengthAwarePaginator->lastItem(),
-                    'total' => $lengthAwarePaginator->total(),
-                    'per_page' => $lengthAwarePaginator->perPage(),
-                ],
-            ]);
+                ]
+            );
         }
 
         $summaryInstances = ServerInstance::query()->get();
@@ -136,8 +124,8 @@ class ServerInstanceController extends Controller
                 'is_active' => (string) ($validated['is_active'] ?? ''),
                 'health' => (string) ($validated['health'] ?? ''),
             ],
-            'sort' => $sort,
-            'direction' => $direction,
+            'sort' => $table->sort,
+            'direction' => $table->direction,
             'summary' => [
                 'total_instances' => $summaryInstances->count(),
                 'active_instances' => $summaryInstances->where('is_active', true)->count(),

--- a/app/Http/Controllers/Admin/ServerInstanceController.php
+++ b/app/Http/Controllers/Admin/ServerInstanceController.php
@@ -27,7 +27,7 @@ class ServerInstanceController extends Controller
             'is_active' => ['nullable', 'string', 'in:1,0'],
             'health' => ['nullable', 'string', 'in:healthy,stale,never_seen,inactive'],
         ], ['code', 'is_active', 'last_seen_at', 'created_at', 'updated_at']));
-        $table = AsyncTable::options($validated, 'code', 'asc', 10);
+        $asyncTableOptions = AsyncTable::options($validated, 'code', 'asc', 10);
         $staleCutoff = Date::now()->subMinutes(max(1, (int) config('monitoring.instance_stale_after_minutes', 10)));
 
         $lengthAwarePaginator = ServerInstance::query()
@@ -46,9 +46,9 @@ class ServerInstanceController extends Controller
                     'inactive' => $builder->where('is_active', false),
                 };
             })
-            ->orderBy($table->sort, $table->direction)
+            ->orderBy($asyncTableOptions->sort, $asyncTableOptions->direction)
             ->orderBy('id')
-            ->paginate($table->perPage);
+            ->paginate($asyncTableOptions->perPage);
 
         $instanceCodes = $lengthAwarePaginator->getCollection()->pluck('code');
         $monitoringCounts = Monitoring::query()
@@ -124,8 +124,8 @@ class ServerInstanceController extends Controller
                 'is_active' => (string) ($validated['is_active'] ?? ''),
                 'health' => (string) ($validated['health'] ?? ''),
             ],
-            'sort' => $table->sort,
-            'direction' => $table->direction,
+            'sort' => $asyncTableOptions->sort,
+            'direction' => $asyncTableOptions->direction,
             'summary' => [
                 'total_instances' => $summaryInstances->count(),
                 'active_instances' => $summaryInstances->where('is_active', true)->count(),

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -41,7 +41,7 @@ class UserController extends Controller
             'email_verification' => ['nullable', 'string', 'in:verified,unverified'],
             'package_id' => ['nullable', 'string', 'exists:packages,id'],
         ], ['name', 'email', 'email_verified_at', 'role', 'monitoring_limit', 'created_at', 'updated_at']));
-        $table = AsyncTable::options($validated, 'created_at', 'desc', 10);
+        $asyncTableOptions = AsyncTable::options($validated, 'created_at', 'desc', 10);
 
         $query = User::query()
             ->with('package')
@@ -65,16 +65,16 @@ class UserController extends Controller
             })
             ->when($validated['package_id'] ?? null, fn (Builder $builder, string $packageId): Builder => $builder->where('users.package_id', $packageId));
 
-        if ($table->sort === 'monitoring_limit') {
+        if ($asyncTableOptions->sort === 'monitoring_limit') {
             $query->leftJoin('packages as sort_packages', 'sort_packages.id', '=', 'users.package_id')
-                ->orderBy('sort_packages.monitoring_limit', $table->direction)
+                ->orderBy('sort_packages.monitoring_limit', $asyncTableOptions->direction)
                 ->latest('users.created_at');
         } else {
-            $query->orderBy('users.' . $table->sort, $table->direction)
+            $query->orderBy('users.' . $asyncTableOptions->sort, $asyncTableOptions->direction)
                 ->orderBy('users.id');
         }
 
-        $lengthAwarePaginator = $query->paginate($table->perPage);
+        $lengthAwarePaginator = $query->paginate($asyncTableOptions->perPage);
 
         if ($request->expectsJson()) {
             return AsyncTable::json($lengthAwarePaginator, 'admin.users.partials.rows', ['users' => $lengthAwarePaginator]);
@@ -117,8 +117,8 @@ class UserController extends Controller
                 'email_verification' => (string) ($validated['email_verification'] ?? ''),
                 'package_id' => (string) ($validated['package_id'] ?? ''),
             ],
-            'sort' => $table->sort,
-            'direction' => $table->direction,
+            'sort' => $asyncTableOptions->sort,
+            'direction' => $asyncTableOptions->direction,
         ]);
     }
 

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -12,6 +12,7 @@ use App\Jobs\DeleteUser;
 use App\Models\Package;
 use App\Models\User;
 use App\Services\UserDeletionPreparationService;
+use App\Support\Admin\AsyncTable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -34,20 +35,13 @@ class UserController extends Controller
      */
     public function index(Request $request): View|JsonResponse
     {
-        $validated = $request->validate([
+        $validated = $request->validate(AsyncTable::requestRules([
             'search' => ['nullable', 'string', 'max:100'],
             'role' => ['nullable', 'string', 'in:' . implode(',', UserRole::values())],
             'email_verification' => ['nullable', 'string', 'in:verified,unverified'],
             'package_id' => ['nullable', 'string', 'exists:packages,id'],
-            'sort' => ['nullable', 'string', 'in:name,email,email_verified_at,role,monitoring_limit,created_at,updated_at'],
-            'direction' => ['nullable', 'string', 'in:asc,desc'],
-            'per_page' => ['nullable', 'integer', 'in:5,10,25,50'],
-            'page' => ['nullable', 'integer', 'min:1'],
-        ]);
-
-        $sort = $validated['sort'] ?? 'created_at';
-        $direction = $validated['direction'] ?? 'desc';
-        $perPage = (int) ($validated['per_page'] ?? 10);
+        ], ['name', 'email', 'email_verified_at', 'role', 'monitoring_limit', 'created_at', 'updated_at']));
+        $table = AsyncTable::options($validated, 'created_at', 'desc', 10);
 
         $query = User::query()
             ->with('package')
@@ -71,29 +65,19 @@ class UserController extends Controller
             })
             ->when($validated['package_id'] ?? null, fn (Builder $builder, string $packageId): Builder => $builder->where('users.package_id', $packageId));
 
-        if ($sort === 'monitoring_limit') {
+        if ($table->sort === 'monitoring_limit') {
             $query->leftJoin('packages as sort_packages', 'sort_packages.id', '=', 'users.package_id')
-                ->orderBy('sort_packages.monitoring_limit', $direction)
+                ->orderBy('sort_packages.monitoring_limit', $table->direction)
                 ->latest('users.created_at');
         } else {
-            $query->orderBy('users.' . $sort, $direction)
+            $query->orderBy('users.' . $table->sort, $table->direction)
                 ->orderBy('users.id');
         }
 
-        $lengthAwarePaginator = $query->paginate($perPage);
+        $lengthAwarePaginator = $query->paginate($table->perPage);
 
         if ($request->expectsJson()) {
-            return response()->json([
-                'html' => view('admin.users.partials.rows', ['users' => $lengthAwarePaginator])->render(),
-                'pagination' => [
-                    'current_page' => $lengthAwarePaginator->currentPage(),
-                    'last_page' => $lengthAwarePaginator->lastPage(),
-                    'from' => $lengthAwarePaginator->firstItem(),
-                    'to' => $lengthAwarePaginator->lastItem(),
-                    'total' => $lengthAwarePaginator->total(),
-                    'per_page' => $lengthAwarePaginator->perPage(),
-                ],
-            ]);
+            return AsyncTable::json($lengthAwarePaginator, 'admin.users.partials.rows', ['users' => $lengthAwarePaginator]);
         }
 
         $packages = Package::query()->withoutGlobalScope('selectable')->orderBy('monitoring_limit')->get();
@@ -133,8 +117,8 @@ class UserController extends Controller
                 'email_verification' => (string) ($validated['email_verification'] ?? ''),
                 'package_id' => (string) ($validated['package_id'] ?? ''),
             ],
-            'sort' => $sort,
-            'direction' => $direction,
+            'sort' => $table->sort,
+            'direction' => $table->direction,
         ]);
     }
 

--- a/app/Support/Admin/AsyncTable.php
+++ b/app/Support/Admin/AsyncTable.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Admin;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
+
+final class AsyncTable
+{
+    private const DIRECTION_RULE = ['nullable', 'string', 'in:asc,desc'];
+
+    private const PER_PAGE_RULE = ['nullable', 'integer', 'in:5,10,25,50'];
+
+    private const PAGE_RULE = ['nullable', 'integer', 'min:1'];
+
+    /**
+     * @param  array<string, mixed>  $rules
+     * @param  list<string>  $sortableColumns
+     * @return array<string, mixed>
+     */
+    public static function requestRules(array $rules, array $sortableColumns): array
+    {
+        return array_merge($rules, [
+            'sort' => ['nullable', 'string', 'in:' . implode(',', $sortableColumns)],
+            'direction' => self::DIRECTION_RULE,
+            'per_page' => self::PER_PAGE_RULE,
+            'page' => self::PAGE_RULE,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     */
+    public static function options(
+        array $validated,
+        string $defaultSort,
+        string $defaultDirection,
+        int $defaultPerPage
+    ): AsyncTableOptions {
+        return new AsyncTableOptions(
+            sort: (string) ($validated['sort'] ?? $defaultSort),
+            direction: (string) ($validated['direction'] ?? $defaultDirection),
+            perPage: (int) ($validated['per_page'] ?? $defaultPerPage),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function json(LengthAwarePaginator $paginator, string $view, array $data): JsonResponse
+    {
+        return response()->json([
+            'html' => view($view, $data)->render(),
+            'pagination' => self::pagination($paginator),
+        ]);
+    }
+
+    /**
+     * @return array{current_page: int, last_page: int, from: int|null, to: int|null, total: int, per_page: int}
+     */
+    public static function pagination(LengthAwarePaginator $paginator): array
+    {
+        return [
+            'current_page' => $paginator->currentPage(),
+            'last_page' => $paginator->lastPage(),
+            'from' => $paginator->firstItem(),
+            'to' => $paginator->lastItem(),
+            'total' => $paginator->total(),
+            'per_page' => $paginator->perPage(),
+        ];
+    }
+}

--- a/app/Support/Admin/AsyncTable.php
+++ b/app/Support/Admin/AsyncTable.php
@@ -49,26 +49,26 @@ final class AsyncTable
     /**
      * @param  array<string, mixed>  $data
      */
-    public static function json(LengthAwarePaginator $paginator, string $view, array $data): JsonResponse
+    public static function json(LengthAwarePaginator $lengthAwarePaginator, string $view, array $data): JsonResponse
     {
         return response()->json([
             'html' => view($view, $data)->render(),
-            'pagination' => self::pagination($paginator),
+            'pagination' => self::pagination($lengthAwarePaginator),
         ]);
     }
 
     /**
      * @return array{current_page: int, last_page: int, from: int|null, to: int|null, total: int, per_page: int}
      */
-    public static function pagination(LengthAwarePaginator $paginator): array
+    public static function pagination(LengthAwarePaginator $lengthAwarePaginator): array
     {
         return [
-            'current_page' => $paginator->currentPage(),
-            'last_page' => $paginator->lastPage(),
-            'from' => $paginator->firstItem(),
-            'to' => $paginator->lastItem(),
-            'total' => $paginator->total(),
-            'per_page' => $paginator->perPage(),
+            'current_page' => $lengthAwarePaginator->currentPage(),
+            'last_page' => $lengthAwarePaginator->lastPage(),
+            'from' => $lengthAwarePaginator->firstItem(),
+            'to' => $lengthAwarePaginator->lastItem(),
+            'total' => $lengthAwarePaginator->total(),
+            'per_page' => $lengthAwarePaginator->perPage(),
         ];
     }
 }

--- a/app/Support/Admin/AsyncTableOptions.php
+++ b/app/Support/Admin/AsyncTableOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Admin;
+
+final readonly class AsyncTableOptions
+{
+    public function __construct(
+        public string $sort,
+        public string $direction,
+        public int $perPage,
+    ) {}
+}

--- a/tests/Feature/MysqlMigrationCompatibilityTest.php
+++ b/tests/Feature/MysqlMigrationCompatibilityTest.php
@@ -14,7 +14,7 @@ class MysqlMigrationCompatibilityTest extends TestCase
         $foreignKeyName = 'notif_channel_deliveries_monitoring_notification_fk';
 
         $this->assertIsString($migration);
-        $this->assertLessThanOrEqual(64, strlen($foreignKeyName));
+        $this->assertLessThanOrEqual(64, mb_strlen($foreignKeyName));
         $this->assertStringContainsString("->foreign('monitoring_notification_id', '{$foreignKeyName}')", $migration);
     }
 }

--- a/tests/Feature/ViteManifestAssetTest.php
+++ b/tests/Feature/ViteManifestAssetTest.php
@@ -35,10 +35,15 @@ class ViteManifestAssetTest extends TestCase
         $views = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(resource_path('views')));
 
         foreach ($views as $view) {
-            if (! $view instanceof SplFileInfo || ! $view->isFile() || $view->getExtension() !== 'php') {
+            if (! $view instanceof SplFileInfo) {
                 continue;
             }
-
+            if (! $view->isFile()) {
+                continue;
+            }
+            if ($view->getExtension() !== 'php') {
+                continue;
+            }
             $contents = file_get_contents($view->getPathname());
             $this->assertIsString($contents);
 

--- a/tests/Unit/Support/Admin/AsyncTableTest.php
+++ b/tests/Unit/Support/Admin/AsyncTableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Admin;
+
+use App\Support\Admin\AsyncTable;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Tests\TestCase;
+
+class AsyncTableTest extends TestCase
+{
+    public function test_request_rules_add_common_table_controls(): void
+    {
+        $rules = AsyncTable::requestRules([
+            'search' => ['nullable', 'string', 'max:100'],
+        ], ['name', 'created_at']);
+
+        $this->assertSame(['nullable', 'string', 'max:100'], $rules['search']);
+        $this->assertSame(['nullable', 'string', 'in:name,created_at'], $rules['sort']);
+        $this->assertSame(['nullable', 'string', 'in:asc,desc'], $rules['direction']);
+        $this->assertSame(['nullable', 'integer', 'in:5,10,25,50'], $rules['per_page']);
+        $this->assertSame(['nullable', 'integer', 'min:1'], $rules['page']);
+    }
+
+    public function test_options_resolve_defaults_and_validated_values(): void
+    {
+        $defaults = AsyncTable::options([], 'created_at', 'desc', 25);
+
+        $this->assertSame('created_at', $defaults->sort);
+        $this->assertSame('desc', $defaults->direction);
+        $this->assertSame(25, $defaults->perPage);
+
+        $options = AsyncTable::options([
+            'sort' => 'name',
+            'direction' => 'asc',
+            'per_page' => '10',
+        ], 'created_at', 'desc', 25);
+
+        $this->assertSame('name', $options->sort);
+        $this->assertSame('asc', $options->direction);
+        $this->assertSame(10, $options->perPage);
+    }
+
+    public function test_pagination_metadata_matches_async_table_response_shape(): void
+    {
+        $paginator = new LengthAwarePaginator(
+            items: collect(['alpha', 'bravo']),
+            total: 12,
+            perPage: 2,
+            currentPage: 3
+        );
+
+        $this->assertSame([
+            'current_page' => 3,
+            'last_page' => 6,
+            'from' => 5,
+            'to' => 6,
+            'total' => 12,
+            'per_page' => 2,
+        ], AsyncTable::pagination($paginator));
+    }
+}

--- a/tests/Unit/Support/Admin/AsyncTableTest.php
+++ b/tests/Unit/Support/Admin/AsyncTableTest.php
@@ -25,11 +25,11 @@ class AsyncTableTest extends TestCase
 
     public function test_options_resolve_defaults_and_validated_values(): void
     {
-        $defaults = AsyncTable::options([], 'created_at', 'desc', 25);
+        $asyncTableOptions = AsyncTable::options([], 'created_at', 'desc', 25);
 
-        $this->assertSame('created_at', $defaults->sort);
-        $this->assertSame('desc', $defaults->direction);
-        $this->assertSame(25, $defaults->perPage);
+        $this->assertSame('created_at', $asyncTableOptions->sort);
+        $this->assertSame('desc', $asyncTableOptions->direction);
+        $this->assertSame(25, $asyncTableOptions->perPage);
 
         $options = AsyncTable::options([
             'sort' => 'name',
@@ -44,7 +44,7 @@ class AsyncTableTest extends TestCase
 
     public function test_pagination_metadata_matches_async_table_response_shape(): void
     {
-        $paginator = new LengthAwarePaginator(
+        $lengthAwarePaginator = new LengthAwarePaginator(
             items: collect(['alpha', 'bravo']),
             total: 12,
             perPage: 2,
@@ -58,6 +58,6 @@ class AsyncTableTest extends TestCase
             'to' => 6,
             'total' => 12,
             'per_page' => 2,
-        ], AsyncTable::pagination($paginator));
+        ], AsyncTable::pagination($lengthAwarePaginator));
     }
 }


### PR DESCRIPTION
## Summary
- add shared admin async table helpers for request rules, resolved table options, JSON row payloads, and pagination metadata
- update admin users, packages, server instances, API logs, and activity logs controllers to use the shared support while keeping query/filter behavior local
- add focused unit coverage for the helper and keep existing async admin table feature coverage intact
- apply a formatter-required `mb_strlen` cleanup in the MySQL migration compatibility test

## Motivation
Admin table controllers repeated the same sort/direction/per-page validation, default option resolution, and pagination JSON response shape. Extracting that plumbing reduces duplication without changing routes, UI behavior, or table-specific query logic.

## Testing
- `php artisan test tests/Unit/Support/Admin/AsyncTableTest.php tests/Feature/Admin/AsyncAdminTablesTest.php`
- `php artisan test`
- `./vendor/bin/pint --test`

## Rollout
No migration or runtime configuration changes required.