### PR TITLE
Test async table JSON response

### DIFF
--- a/tests/Unit/Support/Admin/AsyncTableTest.php
+++ b/tests/Unit/Support/Admin/AsyncTableTest.php
@@ -78,12 +78,12 @@ class AsyncTableTest extends TestCase
             currentPage: 2
         );
 
-        $testResponse = AsyncTable::json($lengthAwarePaginator, 'async-table-test::rows', [
+        $jsonResponse = AsyncTable::json($lengthAwarePaginator, 'async-table-test::rows', [
             'items' => $lengthAwarePaginator,
         ]);
 
-        $this->assertSame(200, $testResponse->getStatusCode());
-        $this->assertSame('<span>alpha</span><span>bravo</span>', $testResponse->getData(true)['html']);
+        $this->assertSame(200, $jsonResponse->getStatusCode());
+        $this->assertSame('<span>alpha</span><span>bravo</span>', $jsonResponse->getData(true)['html']);
         $this->assertSame([
             'current_page' => 2,
             'last_page' => 4,
@@ -91,6 +91,6 @@ class AsyncTableTest extends TestCase
             'to' => 4,
             'total' => 7,
             'per_page' => 2,
-        ], $testResponse->getData(true)['pagination']);
+        ], $jsonResponse->getData(true)['pagination']);
     }
 }

--- a/tests/Unit/Support/Admin/AsyncTableTest.php
+++ b/tests/Unit/Support/Admin/AsyncTableTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Support\Admin;
 
 use App\Support\Admin\AsyncTable;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
 use Tests\TestCase;
 
 class AsyncTableTest extends TestCase
@@ -59,5 +61,36 @@ class AsyncTableTest extends TestCase
             'total' => 12,
             'per_page' => 2,
         ], AsyncTable::pagination($lengthAwarePaginator));
+    }
+
+    public function test_json_renders_rows_view_with_pagination_metadata(): void
+    {
+        $viewPath = storage_path('framework/testing/async-table-views');
+
+        File::ensureDirectoryExists($viewPath);
+        File::put($viewPath . '/rows.blade.php', '@foreach ($items as $item)<span>{{ $item }}</span>@endforeach');
+        View::addNamespace('async-table-test', $viewPath);
+
+        $lengthAwarePaginator = new LengthAwarePaginator(
+            items: collect(['alpha', 'bravo']),
+            total: 7,
+            perPage: 2,
+            currentPage: 2
+        );
+
+        $testResponse = AsyncTable::json($lengthAwarePaginator, 'async-table-test::rows', [
+            'items' => $lengthAwarePaginator,
+        ]);
+
+        $this->assertSame(200, $testResponse->getStatusCode());
+        $this->assertSame('<span>alpha</span><span>bravo</span>', $testResponse->getData(true)['html']);
+        $this->assertSame([
+            'current_page' => 2,
+            'last_page' => 4,
+            'from' => 3,
+            'to' => 4,
+            'total' => 7,
+            'per_page' => 2,
+        ], $testResponse->getData(true)['pagination']);
     }
 }


### PR DESCRIPTION
## What changed
- Added focused unit coverage for `AsyncTable::json()` rendering a supplied rows view.
- Asserted the shared JSON response includes the expected pagination metadata shape.

## Why
The recent admin async table extraction moved JSON response assembly into a shared helper used by multiple admin controllers. The existing tests covered rules, options, pagination metadata, and controller behavior, but not the helper path that renders HTML into the JSON payload.

## Validation
- `composer install --no-interaction --prefer-dist --ignore-platform-req=ext-redis`
- `php artisan test tests/Unit/Support/Admin/AsyncTableTest.php tests/Feature/Admin/AsyncAdminTablesTest.php`
- `./vendor/bin/pint --dirty`