### PR TITLE
Fix public indexing cache headers and sitemap

### DIFF
--- a/app/Console/Commands/Sitemap/GenerateSitemapCommand.php
+++ b/app/Console/Commands/Sitemap/GenerateSitemapCommand.php
@@ -32,9 +32,6 @@ class GenerateSitemapCommand extends Command
         Sitemap::create()
             ->add(Url::create(route('welcome')))
             ->add(Url::create(route('monitoring-locations')))
-            ->add(Url::create(route('imprint')))
-            ->add(Url::create(route('terms-of-use')))
-            ->add(Url::create(route('gdpr')))
             ->writeToFile(public_path('sitemap.xml'));
 
         return Command::SUCCESS;

--- a/app/Http/Middleware/SetPublicCacheHeaders.php
+++ b/app/Http/Middleware/SetPublicCacheHeaders.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Middleware\SetCacheHeaders;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetPublicCacheHeaders
+{
+    public function __construct(private readonly SetCacheHeaders $setCacheHeaders) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->user() !== null) {
+            return $next($request);
+        }
+
+        $response = $this->setCacheHeaders->handle($request, $next, 'public;max_age=300;s_maxage=3600;etag');
+
+        $response->headers->set('Vary', 'Accept-Language, Cookie', false);
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Middleware\AuthenticateInstance;
 use App\Http\Middleware\CheckUserRole;
 use App\Http\Middleware\SetLocaleMiddleware;
+use App\Http\Middleware\SetPublicCacheHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -25,6 +26,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'role' => CheckUserRole::class,
             'auth.instance' => AuthenticateInstance::class,
+            'public.cache' => SetPublicCacheHeaders::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,8 +23,8 @@ use Spatie\Sitemap\Tags\Url;
 Route::get('/auth/github/redirect', [SocialiteController::class, 'redirectToProvider'])->name('github.redirect');
 Route::get('/auth/github/callback', [SocialiteController::class, 'handleProviderCallback'])->name('github.callback');
 
-Route::get('/', fn () => view('welcome'))->name('welcome');
-Route::get('/monitoring-locations', MonitoringLocationsController::class)->name('monitoring-locations');
+Route::get('/', fn () => view('welcome'))->middleware('public.cache')->name('welcome');
+Route::get('/monitoring-locations', MonitoringLocationsController::class)->middleware('public.cache')->name('monitoring-locations');
 Route::get('/imprint', [LegalController::class, 'imprint'])->name('imprint');
 Route::get('/terms-of-use', [LegalController::class, 'termsOfUse'])->name('terms-of-use');
 Route::get('/gdpr', [LegalController::class, 'gdpr'])->name('gdpr');
@@ -37,11 +37,8 @@ Route::get('/sitemap.xml', function () {
     return Sitemap::create()
         ->add(Url::create(route('welcome')))
         ->add(Url::create(route('monitoring-locations')))
-        ->add(Url::create(route('imprint')))
-        ->add(Url::create(route('terms-of-use')))
-        ->add(Url::create(route('gdpr')))
         ->toResponse(request());
-})->name('sitemap');
+})->middleware('cache.headers:public;max_age=300;s_maxage=3600;etag')->name('sitemap');
 
 Route::get('/label/{monitoring}', PublicLabelController::class)
     ->name('public-label')

--- a/tests/Feature/GdprPageTest.php
+++ b/tests/Feature/GdprPageTest.php
@@ -88,12 +88,12 @@ class GdprPageTest extends TestCase
         $testResponse->assertRedirect(route('gdpr'));
     }
 
-    public function test_gdpr_page_is_included_in_sitemap(): void
+    public function test_gdpr_page_is_excluded_from_sitemap_because_it_is_noindexed(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml(route('gdpr'));
+        $testResponse->assertDontSeeHtml(route('gdpr'));
     }
 
     public function test_footer_contains_gdpr_link(): void

--- a/tests/Feature/ImprintPageTest.php
+++ b/tests/Feature/ImprintPageTest.php
@@ -35,12 +35,12 @@ class ImprintPageTest extends TestCase
         $testResponse->assertRedirect(route('imprint'));
     }
 
-    public function test_imprint_page_is_included_in_sitemap(): void
+    public function test_imprint_page_is_excluded_from_sitemap_because_it_is_noindexed(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml(route('imprint'));
+        $testResponse->assertDontSeeHtml(route('imprint'));
     }
 
     public function test_footer_contains_imprint_link(): void

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class PublicIndexingTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function indexablePublicRouteProvider(): array
+    {
+        return [
+            'welcome' => ['welcome'],
+            'monitoring locations' => ['monitoring-locations'],
+            'sitemap' => ['sitemap'],
+        ];
+    }
+
+    #[DataProvider('indexablePublicRouteProvider')]
+    public function test_indexable_public_routes_are_publicly_cacheable_for_guests(string $routeName): void
+    {
+        $testResponse = $this->get(route($routeName));
+
+        $testResponse->assertOk();
+
+        $cacheControl = (string) $testResponse->headers->get('Cache-Control');
+
+        $this->assertStringContainsString('public', $cacheControl);
+        $this->assertStringContainsString('max-age=300', $cacheControl);
+        $this->assertStringContainsString('s-maxage=3600', $cacheControl);
+        $this->assertStringNotContainsString('private', $cacheControl);
+        $this->assertStringNotContainsString('no-cache', $cacheControl);
+    }
+
+    public function test_authenticated_public_page_responses_keep_private_cache_headers(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $testResponse = $this->actingAs($user)->get(route('welcome'));
+
+        $testResponse->assertOk();
+
+        $cacheControl = (string) $testResponse->headers->get('Cache-Control');
+
+        $this->assertStringNotContainsString('public', $cacheControl);
+        $this->assertStringContainsString('private', $cacheControl);
+    }
+
+    public function test_sitemap_does_not_list_robots_blocked_legal_pages(): void
+    {
+        $testResponse = $this->get(route('sitemap'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml(route('welcome'));
+        $testResponse->assertSeeHtml(route('monitoring-locations'));
+        $testResponse->assertDontSeeHtml(route('imprint'));
+        $testResponse->assertDontSeeHtml(route('terms-of-use'));
+        $testResponse->assertDontSeeHtml(route('gdpr'));
+    }
+
+    public function test_generated_sitemap_does_not_list_robots_blocked_legal_pages(): void
+    {
+        $sitemapPath = public_path('sitemap.xml');
+
+        if (file_exists($sitemapPath)) {
+            unlink($sitemapPath);
+        }
+
+        $this->artisan('sitemap:generate')->assertSuccessful();
+
+        $sitemapContent = file_get_contents($sitemapPath);
+
+        $this->assertIsString($sitemapContent);
+        $this->assertStringContainsString(route('welcome'), $sitemapContent);
+        $this->assertStringContainsString(route('monitoring-locations'), $sitemapContent);
+        $this->assertStringNotContainsString(route('imprint'), $sitemapContent);
+        $this->assertStringNotContainsString(route('terms-of-use'), $sitemapContent);
+        $this->assertStringNotContainsString(route('gdpr'), $sitemapContent);
+
+        unlink($sitemapPath);
+    }
+}

--- a/tests/Feature/TermsOfUsePageTest.php
+++ b/tests/Feature/TermsOfUsePageTest.php
@@ -59,12 +59,12 @@ class TermsOfUsePageTest extends TestCase
         $testResponse->assertRedirect(route('terms-of-use'));
     }
 
-    public function test_terms_of_use_page_is_included_in_sitemap(): void
+    public function test_terms_of_use_page_is_excluded_from_sitemap_because_it_is_noindexed(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml(route('terms-of-use'));
+        $testResponse->assertDontSeeHtml(route('terms-of-use'));
     }
 
     public function test_footer_contains_terms_of_use_link(): void


### PR DESCRIPTION
## Summary

- Make indexable guest-facing public pages return public cache headers instead of Laravel's private no-cache session default.
- Use Laravel's built-in cache header middleware for the sitemap route and delegate through a small auth-aware wrapper for marketing pages.
- Remove noindexed legal pages from both dynamic and generated sitemaps so robots.txt and sitemap output no longer conflict.
- Add feature coverage for guest cache headers, authenticated private cache behavior, and sitemap exclusions.

## Root Cause

The public marketing responses were passing through the web/session stack and inherited private no-cache headers. The sitemap also listed legal pages that are intentionally blocked/noindexed, creating a Search Console warning.

## Validation

- `./vendor/bin/pint app/Http/Middleware/SetPublicCacheHeaders.php routes/web.php bootstrap/app.php tests/Feature/PublicIndexingTest.php`
- `php artisan test tests/Feature/PublicIndexingTest.php tests/Feature/ImprintPageTest.php tests/Feature/TermsOfUsePageTest.php tests/Feature/GdprPageTest.php tests/Feature/MonitoringLocationsPageTest.php`

Note: the local environment required `composer install --ignore-platform-req=ext-redis` because the PHP Redis extension is not installed locally.