### PR TITLE
Noindex auth entry pages

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -14,7 +14,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="index, follow">
+    <meta name="robots" content="noindex, follow">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
     {!! $head ?? '' !!}

--- a/tests/Feature/AuthEntryPointsTest.php
+++ b/tests/Feature/AuthEntryPointsTest.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class AuthEntryPointsTest extends TestCase
 {
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function authEntryRouteProvider(): array
+    {
+        return [
+            'login' => ['login'],
+            'register' => ['register'],
+        ];
+    }
+
     public function test_login_page_uses_unified_auth_view_with_login_initial_mode(): void
     {
         $testResponse = $this->get(route('login'));
@@ -25,6 +37,20 @@ class AuthEntryPointsTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('data-initial-mode="register"');
+    }
+
+    #[DataProvider('authEntryRouteProvider')]
+    public function test_auth_entry_pages_are_noindexed_and_not_publicly_cacheable(string $routeName): void
+    {
+        $testResponse = $this->get(route($routeName));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('<meta name="robots" content="noindex, follow">');
+
+        $cacheControl = (string) $testResponse->headers->get('Cache-Control');
+
+        $this->assertStringContainsString('private', $cacheControl);
+        $this->assertStringNotContainsString('public', $cacheControl);
     }
 
     public function test_guest_query_opens_unified_auth_view_in_demo_mode(): void


### PR DESCRIPTION
## Summary

- Mark the guest auth layout as `noindex, follow` so login and register entry points are not treated as indexable marketing pages.
- Keep login and register responses privately cacheable because they contain CSRF-protected forms and the registration captcha flow.
- Add feature coverage for both auth entry routes to verify the robots meta tag and private cache behavior.

## Why

The public marketing pages should be cacheable and indexable, but login/register are session-backed form pages. Making those responses publicly cacheable would risk caching per-session CSRF markup. Explicit `noindex` keeps the indexing intent clear without weakening auth form handling.

## Validation

- `./vendor/bin/pint resources/views/layouts/guest.blade.php tests/Feature/AuthEntryPointsTest.php`
- `php artisan test tests/Feature/AuthEntryPointsTest.php tests/Feature/PublicIndexingTest.php tests/Feature/ImprintPageTest.php tests/Feature/TermsOfUsePageTest.php tests/Feature/GdprPageTest.php tests/Feature/MonitoringLocationsPageTest.php`