### PR TITLE
Serve indexable public pages without sessions

### DIFF
--- a/app/Http/Middleware/SetLocaleMiddleware.php
+++ b/app/Http/Middleware/SetLocaleMiddleware.php
@@ -20,7 +20,7 @@ class SetLocaleMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (Auth::check()) {
+        if ($request->hasSession() && Auth::check()) {
             $user = Auth::user();
             $locale = SupportedLanguage::isSupported($user->locale)
                 ? $user->locale

--- a/app/Http/Middleware/SetPublicCacheHeaders.php
+++ b/app/Http/Middleware/SetPublicCacheHeaders.php
@@ -20,10 +20,6 @@ class SetPublicCacheHeaders
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user() !== null) {
-            return $next($request);
-        }
-
         $response = $this->setCacheHeaders->handle($request, $next, 'public;max_age=300;s_maxage=3600;etag');
 
         $response->headers->set('Vary', 'Accept-Language, Cookie', false);

--- a/app/Http/Middleware/SetPublicCacheHeaders.php
+++ b/app/Http/Middleware/SetPublicCacheHeaders.php
@@ -22,7 +22,15 @@ class SetPublicCacheHeaders
     {
         $response = $this->setCacheHeaders->handle($request, $next, 'public;max_age=300;s_maxage=3600;etag');
 
-        $response->headers->set('Vary', 'Accept-Language, Cookie', false);
+        if ($response->isSuccessful()) {
+            $response->setCache([
+                'public' => true,
+                'max_age' => 300,
+                's_maxage' => 3600,
+            ]);
+
+            $response->headers->set('Vary', 'Accept-Language, Cookie', false);
+        }
 
         return $response;
     }

--- a/resources/views/components/marketing-layout.blade.php
+++ b/resources/views/components/marketing-layout.blade.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 @php
-    $theme = auth()->check() ? auth()->user()->theme : 'system';
+    $theme = 'system';
     if (! in_array($theme, ['light', 'dark', 'system'], true)) {
         $theme = 'system';
     }
@@ -10,7 +10,6 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="robots" content="{{ isset($robots) ? trim($robots) : 'index, follow' }}">
 
     {!! $head ?? '' !!}
@@ -64,17 +63,10 @@
                     <div class="flex items-center gap-2 sm:gap-3">
                         <x-language-switch id="language-switch-guest" variant="marketing" />
 
-                        @guest
-                            <x-primary-button :href="route('login')"
-                                class="bg-emerald-500 text-white normal-case tracking-normal hover:bg-emerald-600 focus:ring-emerald-500 dark:bg-emerald-400 dark:text-slate-950 dark:hover:bg-emerald-300 dark:focus:ring-emerald-300">
-                                {{ __('welcome.nav.login') }}
-                            </x-primary-button>
-                        @else
-                            <x-primary-button :href="route('dashboard')"
-                                class="bg-emerald-500 text-white normal-case tracking-normal hover:bg-emerald-600 focus:ring-emerald-500 dark:bg-emerald-400 dark:text-slate-950 dark:hover:bg-emerald-300 dark:focus:ring-emerald-300">
-                                {{ __('welcome.nav.dashboard') }}
-                            </x-primary-button>
-                        @endguest
+                        <x-primary-button :href="route('login')"
+                            class="bg-emerald-500 text-white normal-case tracking-normal hover:bg-emerald-600 focus:ring-emerald-500 dark:bg-emerald-400 dark:text-slate-950 dark:hover:bg-emerald-300 dark:focus:ring-emerald-300">
+                            {{ __('welcome.nav.login') }}
+                        </x-primary-button>
                     </div>
                 </x-main>
             </nav>

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,7 @@ Route::get('/sitemap.xml', function () {
         ->toResponse(request());
 })
     ->withoutMiddleware($sessionlessPublicRoutes)
-    ->middleware('cache.headers:public;max_age=300;s_maxage=3600;etag')
+    ->middleware('public.cache')
     ->name('sitemap');
 
 Route::get('/label/{monitoring}', PublicLabelController::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,15 +16,30 @@ use App\Http\Controllers\MonitoringLocationsController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PublicLabelController;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
+
+$sessionlessPublicRoutes = [
+    PreventRequestForgery::class,
+    ShareErrorsFromSession::class,
+    StartSession::class,
+];
 
 Route::get('/auth/github/redirect', [SocialiteController::class, 'redirectToProvider'])->name('github.redirect');
 Route::get('/auth/github/callback', [SocialiteController::class, 'handleProviderCallback'])->name('github.callback');
 
-Route::get('/', fn () => view('welcome'))->middleware('public.cache')->name('welcome');
-Route::get('/monitoring-locations', MonitoringLocationsController::class)->middleware('public.cache')->name('monitoring-locations');
+Route::get('/', fn () => view('welcome'))
+    ->withoutMiddleware($sessionlessPublicRoutes)
+    ->middleware('public.cache')
+    ->name('welcome');
+Route::get('/monitoring-locations', MonitoringLocationsController::class)
+    ->withoutMiddleware($sessionlessPublicRoutes)
+    ->middleware('public.cache')
+    ->name('monitoring-locations');
 Route::get('/imprint', [LegalController::class, 'imprint'])->name('imprint');
 Route::get('/terms-of-use', [LegalController::class, 'termsOfUse'])->name('terms-of-use');
 Route::get('/gdpr', [LegalController::class, 'gdpr'])->name('gdpr');
@@ -38,7 +53,10 @@ Route::get('/sitemap.xml', function () {
         ->add(Url::create(route('welcome')))
         ->add(Url::create(route('monitoring-locations')))
         ->toResponse(request());
-})->middleware('cache.headers:public;max_age=300;s_maxage=3600;etag')->name('sitemap');
+})
+    ->withoutMiddleware($sessionlessPublicRoutes)
+    ->middleware('cache.headers:public;max_age=300;s_maxage=3600;etag')
+    ->name('sitemap');
 
 Route::get('/label/{monitoring}', PublicLabelController::class)
     ->name('public-label')

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -39,7 +39,19 @@ class PublicIndexingTest extends TestCase
         $this->assertStringNotContainsString('no-cache', $cacheControl);
     }
 
-    public function test_authenticated_public_page_responses_keep_private_cache_headers(): void
+    public function test_indexable_public_routes_do_not_start_sessions_or_queue_cookies(): void
+    {
+        foreach (self::indexablePublicRouteProvider() as [$routeName]) {
+            $testResponse = $this->withCookie(config('session.cookie'), 'existing-session-id')
+                ->get(route($routeName));
+
+            $testResponse->assertOk();
+            $testResponse->assertHeaderMissing('Set-Cookie');
+            $this->assertEmpty($testResponse->headers->getCookies());
+        }
+    }
+
+    public function test_authenticated_public_page_responses_are_served_as_sessionless_public_pages(): void
     {
         Package::factory()->create();
         $user = User::factory()->create();
@@ -50,8 +62,11 @@ class PublicIndexingTest extends TestCase
 
         $cacheControl = (string) $testResponse->headers->get('Cache-Control');
 
-        $this->assertStringNotContainsString('public', $cacheControl);
-        $this->assertStringContainsString('private', $cacheControl);
+        $this->assertStringContainsString('public', $cacheControl);
+        $this->assertStringNotContainsString('private', $cacheControl);
+        $testResponse->assertSeeText(__('welcome.nav.login'));
+        $testResponse->assertDontSeeHtml(route('dashboard'));
+        $testResponse->assertDontSeeHtml('name="csrf-token"');
     }
 
     public function test_sitemap_does_not_list_robots_blocked_legal_pages(): void

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -51,6 +51,25 @@ class PublicIndexingTest extends TestCase
         }
     }
 
+    public function test_indexable_public_routes_are_publicly_cacheable_for_head_requests(): void
+    {
+        foreach (self::indexablePublicRouteProvider() as [$routeName]) {
+            $testResponse = $this->withCookie(config('session.cookie'), 'existing-session-id')
+                ->head(route($routeName));
+
+            $testResponse->assertOk();
+            $testResponse->assertHeaderMissing('Set-Cookie');
+
+            $cacheControl = (string) $testResponse->headers->get('Cache-Control');
+
+            $this->assertStringContainsString('public', $cacheControl);
+            $this->assertStringContainsString('max-age=300', $cacheControl);
+            $this->assertStringContainsString('s-maxage=3600', $cacheControl);
+            $this->assertStringNotContainsString('private', $cacheControl);
+            $this->assertStringNotContainsString('no-cache', $cacheControl);
+        }
+    }
+
     public function test_authenticated_public_page_responses_are_served_as_sessionless_public_pages(): void
     {
         Package::factory()->create();

--- a/tests/Feature/ThemePreferenceTest.php
+++ b/tests/Feature/ThemePreferenceTest.php
@@ -21,7 +21,7 @@ class ThemePreferenceTest extends TestCase
         $testResponse->assertSeeHtml('data-theme="system"');
     }
 
-    public function test_authenticated_user_theme_comes_from_database_and_not_session(): void
+    public function test_sessionless_welcome_page_uses_system_theme_for_authenticated_light_theme_user(): void
     {
         Package::factory()->create();
         $user = User::factory()->create([
@@ -33,10 +33,10 @@ class ThemePreferenceTest extends TestCase
             ->get('/');
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml('data-theme="light"');
+        $testResponse->assertSeeHtml('data-theme="system"');
     }
 
-    public function test_authenticated_dark_theme_from_database_sets_dark_class(): void
+    public function test_sessionless_welcome_page_uses_system_theme_for_authenticated_dark_theme_user(): void
     {
         Package::factory()->create();
         $user = User::factory()->create([
@@ -48,6 +48,6 @@ class ThemePreferenceTest extends TestCase
             ->get('/');
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml('class="dark" data-theme="dark"');
+        $testResponse->assertSeeHtml('class="" data-theme="system"');
     }
 }


### PR DESCRIPTION
## Summary

- Remove session, shared error, and CSRF/XSRF middleware from the indexable public routes: `/`, `/monitoring-locations`, and `/sitemap.xml`.
- Stop the marketing layout from touching the session by removing the CSRF meta tag and auth-aware dashboard/login switch.
- Keep public cache headers on those routes while ensuring they no longer emit `XSRF-TOKEN` or `webguard_session` cookies.
- Guard locale middleware so it only checks the authenticated user when a session is actually present.
- Cover both GET and HEAD requests, since external header checks often use `curl -I`.
- Align welcome theme expectations with the new sessionless public page behavior.

## Root Cause

The prior cache header fix still let the `web` session stack run on public pages. Laravel's request forgery middleware adds an `XSRF-TOKEN` cookie on GET responses, and `StartSession` can add the app session cookie. HEAD-based measurements can also miss Laravel's body-dependent cache header middleware path unless the public cache wrapper normalizes the response after the route runs.

Because `/` is now deliberately sessionless, authenticated users receive the same cacheable marketing HTML as guests. That means user theme personalization is not applied on the indexable welcome page anymore.

## Validation

- `./vendor/bin/pint app/Http/Middleware/SetLocaleMiddleware.php app/Http/Middleware/SetPublicCacheHeaders.php routes/web.php resources/views/components/marketing-layout.blade.php tests/Feature/PublicIndexingTest.php`
- `./vendor/bin/pint tests/Feature/ThemePreferenceTest.php`
- `php artisan test tests/Feature/AuthEntryPointsTest.php tests/Feature/PublicIndexingTest.php tests/Feature/ImprintPageTest.php tests/Feature/TermsOfUsePageTest.php tests/Feature/GdprPageTest.php tests/Feature/MonitoringLocationsPageTest.php tests/Feature/LocalePreferenceTest.php`
- `php artisan test tests/Feature/ThemePreferenceTest.php tests/Feature/PublicIndexingTest.php tests/Feature/AuthEntryPointsTest.php tests/Feature/LocalePreferenceTest.php`
- Local HTTP checks after `bun run build`:
  - `GET /` returned `Cache-Control: max-age=300, public, s-maxage=3600` and no `Set-Cookie` headers.
  - `HEAD /` returned `Cache-Control: max-age=300, public, s-maxage=3600` and no `Set-Cookie` headers.
  - `GET /sitemap.xml` returned `Cache-Control: max-age=300, public, s-maxage=3600` and no `Set-Cookie` headers.
  - `HEAD /sitemap.xml` returned `Cache-Control: max-age=300, public, s-maxage=3600` and no `Set-Cookie` headers.