### PR TITLE
Scope notification board aggregate

### DIFF
--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -37,10 +37,16 @@ class NotificationBoardService
     {
         $latestStatusChangeTimestamps = MonitoringNotification::query()
             ->withoutGlobalScopes()
-            ->selectRaw('monitoring_id, max(created_at) as latest_created_at')
-            ->statusChange()
-            ->when(! $showRead, fn (Builder $builder): Builder => $builder->unread())
-            ->groupBy('monitoring_id');
+            ->selectRaw('monitoring_notifications.monitoring_id, max(monitoring_notifications.created_at) as latest_created_at')
+            ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
+            ->when(auth()->check(), function (Builder $builder): Builder {
+                return $builder
+                    ->join('monitorings as status_change_monitorings', 'monitoring_notifications.monitoring_id', '=', 'status_change_monitorings.id')
+                    ->where('status_change_monitorings.user_id', auth()->id())
+                    ->whereNull('status_change_monitorings.deleted_at');
+            })
+            ->when(! $showRead, fn (Builder $builder): Builder => $builder->where('monitoring_notifications.read', false))
+            ->groupBy('monitoring_notifications.monitoring_id');
 
         $monitorings = Monitoring::query()
             ->select([

--- a/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
@@ -45,6 +45,9 @@ class NotificationStatusBoardPerformanceTest extends TestCase
             ->values();
 
         $this->assertCount(1, $selectQueries);
+        $this->assertTrue($selectQueries->contains(
+            fn (string $query): bool => str_contains($query, 'status_change_monitorings')
+        ));
         $this->assertSame([$secondMonitoring->id, $firstMonitoring->id], $entries->pluck('monitoring_id')->all());
     }
 


### PR DESCRIPTION
## Summary

- Scope the notification status-board timestamp aggregate to the authenticated user’s non-deleted monitorings.
- Qualify notification columns in that derived table so the added join remains unambiguous across SQLite/MySQL.
- Add a regression assertion that the status-board load remains a single select and includes the scoped aggregate join.

## Validation

- `./vendor/bin/pint --dirty --test`
- `php artisan test tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php`
- `php artisan test tests/Feature/Notifications`
- `php artisan test`

## Notes

No production trace was available for this audit; the performance finding is grounded in the generated SQL shape and existing query-count tests.
