### PR TITLE
Show public maintenance windows

### DIFF
--- a/app/Http/Controllers/PublicLabelController.php
+++ b/app/Http/Controllers/PublicLabelController.php
@@ -8,6 +8,7 @@ use App\Enums\MonitoringStatus;
 use App\Enums\MonitoringType;
 use App\Models\Monitoring;
 use App\Services\MonitoringResultService;
+use Carbon\CarbonInterface;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Date;
 use Illuminate\View\View;
@@ -70,7 +71,28 @@ class PublicLabelController extends Controller
             'incidents' => $incidents,
             'displayTarget' => $monitoring->type === MonitoringType::HEARTBEAT ? null : $monitoring->target,
             'isUnderMaintenance' => $monitoring->isUnderMaintenance(),
+            'maintenanceWindow' => $this->maintenanceWindow($monitoring),
         ]);
+    }
+
+    /**
+     * @return array{starts_at: CarbonInterface, ends_at: CarbonInterface|null, active: bool}|null
+     */
+    private function maintenanceWindow(Monitoring $monitoring): ?array
+    {
+        if (! $monitoring->maintenance_from) {
+            return null;
+        }
+
+        if ($monitoring->maintenance_until && $monitoring->maintenance_until->isPast()) {
+            return null;
+        }
+
+        return [
+            'starts_at' => $monitoring->maintenance_from,
+            'ends_at' => $monitoring->maintenance_until,
+            'active' => $monitoring->isUnderMaintenance(),
+        ];
     }
 
     private function normalizeStatus(mixed $status): string

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,7 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 - **Admin panel:** manage users, subscription packages, and API usage logs.
 - **REST API:** access monitoring data programmatically and integrate WebGuard with external systems.
 - **Embeddable widget:** display website monitoring status on external sites with a JavaScript widget.
-- **Public status pages:** publish monitoring status for users and customers.
+- **Public status pages:** publish monitoring status, uptime, recent incidents, and active or upcoming maintenance windows for users and customers.
 - **Global language switch:** switch between supported languages from both public and authenticated top navigation.
 - **Landing navigation anchors:** landing-page menu links resolve correctly to homepage sections, even when clicked from other routes.
 

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -267,6 +267,16 @@ return [
         'range_days' => 'Letzter :days Tag|Letzte :days Tage',
         'recent_incidents' => 'Letzte Vorfälle',
         'resolved' => 'Behoben',
+        'maintenance' => [
+            'active' => 'Jetzt aktiv',
+            'active_description' => 'Verfügbarkeitsprüfungen können während dieses Wartungsfensters übersprungen werden.',
+            'ends_at' => 'Endet',
+            'heading' => 'Geplante Wartung',
+            'open_ended' => 'Keine Endzeit geplant',
+            'starts_at' => 'Beginnt',
+            'upcoming' => 'Bevorstehend',
+            'upcoming_description' => 'Für diese Überwachung ist ein Wartungsfenster geplant.',
+        ],
     ],
     'validation' => [
         'invalid_type' => 'Der ausgewählte Typ \':type\' ist ungültig.',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -267,6 +267,16 @@ return [
         'range_days' => 'Last :days day|Last :days days',
         'recent_incidents' => 'Recent Incidents',
         'resolved' => 'Resolved',
+        'maintenance' => [
+            'active' => 'Active now',
+            'active_description' => 'Availability checks may be skipped while this maintenance window is active.',
+            'ends_at' => 'Ends',
+            'heading' => 'Scheduled Maintenance',
+            'open_ended' => 'No end time scheduled',
+            'starts_at' => 'Starts',
+            'upcoming' => 'Upcoming',
+            'upcoming_description' => 'This monitor has a planned maintenance window.',
+        ],
     ],
     'validation' => [
         'invalid_type' => 'The selected type \':type\' is invalid.',

--- a/resources/views/monitorings/public-label.blade.php
+++ b/resources/views/monitorings/public-label.blade.php
@@ -84,6 +84,43 @@
                 </x-container>
             </section>
 
+            @if ($maintenanceWindow)
+                <section id="public-maintenance-window">
+                    <x-container>
+                        <div class="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <x-heading type="h2">{{ __('monitoring.public_label.maintenance.heading') }}</x-heading>
+                                <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                                    {{ $maintenanceWindow['active'] ? __('monitoring.public_label.maintenance.active_description') : __('monitoring.public_label.maintenance.upcoming_description') }}
+                                </p>
+                            </div>
+                            <x-badge :type="$maintenanceWindow['active'] ? 'info' : 'warning'">
+                                {{ $maintenanceWindow['active'] ? __('monitoring.public_label.maintenance.active') : __('monitoring.public_label.maintenance.upcoming') }}
+                            </x-badge>
+                        </div>
+
+                        <dl class="mt-4 grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
+                            <div>
+                                <dt class="font-medium text-gray-500 dark:text-gray-400">
+                                    {{ __('monitoring.public_label.maintenance.starts_at') }}
+                                </dt>
+                                <dd class="mt-1 text-gray-900 dark:text-gray-100">
+                                    {{ $maintenanceWindow['starts_at']->toDayDateTimeString() }}
+                                </dd>
+                            </div>
+                            <div>
+                                <dt class="font-medium text-gray-500 dark:text-gray-400">
+                                    {{ __('monitoring.public_label.maintenance.ends_at') }}
+                                </dt>
+                                <dd class="mt-1 text-gray-900 dark:text-gray-100">
+                                    {{ $maintenanceWindow['ends_at']?->toDayDateTimeString() ?? __('monitoring.public_label.maintenance.open_ended') }}
+                                </dd>
+                            </div>
+                        </dl>
+                    </x-container>
+                </section>
+            @endif
+
             <section class="grid grid-cols-1 gap-4 md:grid-cols-3">
                 @foreach ([7, 30, 90] as $days)
                     @php

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -72,12 +72,66 @@ class PublicStatusPageTest extends TestCase
         $testResponse->assertSeeText('UP');
         $testResponse->assertSeeText('HTTP 200');
         $testResponse->assertSeeText(__('monitoring.index.table.maintenance'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.heading'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.active'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.starts_at'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.ends_at'));
         $testResponse->assertSeeText('Last 7 days');
         $testResponse->assertSeeText('Last 30 days');
         $testResponse->assertSeeText('Last 90 days');
         $testResponse->assertSeeText('100.00%');
         $testResponse->assertSeeText(__('monitoring.detail.incidents.heading'));
         $testResponse->assertSeeText(__('monitoring.public_label.resolved'));
+    }
+
+    public function test_public_status_page_shows_upcoming_maintenance_window(): void
+    {
+        Date::setTestNow('2026-05-03 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'maintenance_from' => Date::now()->addDay(),
+            'maintenance_until' => Date::now()->addDay()->addHours(2),
+        ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.heading'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.upcoming'));
+        $testResponse->assertSeeText('Mon, May 4, 2026 12:00 PM');
+        $testResponse->assertSeeText('Mon, May 4, 2026 2:00 PM');
+        $testResponse->assertDontSeeText(__('monitoring.public_label.maintenance.active'));
+    }
+
+    public function test_public_status_page_hides_expired_maintenance_window(): void
+    {
+        Date::setTestNow('2026-05-03 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'maintenance_from' => Date::now()->subDays(2),
+            'maintenance_until' => Date::now()->subDay(),
+        ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertDontSeeText(__('monitoring.public_label.maintenance.heading'));
+        $testResponse->assertDontSeeText(__('monitoring.public_label.maintenance.active'));
+        $testResponse->assertDontSeeText(__('monitoring.public_label.maintenance.upcoming'));
     }
 
     public function test_public_status_page_returns_not_found_when_public_label_is_disabled(): void


### PR DESCRIPTION
## Summary
- Adds active and upcoming maintenance window details to public monitoring status pages.
- Adds localized English and German maintenance copy.
- Updates feature documentation for public status pages.

## Motivation
Public status pages already expose current status, uptime, and incidents. Showing planned maintenance improves customer-facing communication and makes existing maintenance configuration visible when it matters.

## Testing
- `./vendor/bin/pint app/Http/Controllers/PublicLabelController.php tests/Feature/PublicStatusPageTest.php`
- `php artisan test tests/Feature/PublicStatusPageTest.php`
- `php artisan test`

## Rollout Notes
No migration or configuration changes are required.