### PR TITLE
test: assert notification board aggregate scope

### DIFF
--- a/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
@@ -40,14 +40,15 @@ class NotificationStatusBoardPerformanceTest extends TestCase
         $entries = resolve(NotificationBoardService::class)->getStatusBoardEntries(showRead: true, limit: 5);
 
         $selectQueries = collect(DB::getQueryLog())
-            ->pluck('query')
-            ->filter(fn (string $query): bool => str_starts_with(mb_strtolower($query), 'select'))
+            ->filter(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'))
             ->values();
+        $statusBoardQuery = $selectQueries->sole();
+        $normalizedStatusBoardSql = str_replace(['"', '`'], '', $statusBoardQuery['query']);
 
         $this->assertCount(1, $selectQueries);
-        $this->assertTrue($selectQueries->contains(
-            fn (string $query): bool => str_contains($query, 'status_change_monitorings')
-        ));
+        $this->assertStringContainsString('status_change_monitorings.user_id = ?', $normalizedStatusBoardSql);
+        $this->assertStringContainsString('status_change_monitorings.deleted_at is null', $normalizedStatusBoardSql);
+        $this->assertContains($user->id, $statusBoardQuery['bindings']);
         $this->assertSame([$secondMonitoring->id, $firstMonitoring->id], $entries->pluck('monitoring_id')->all());
     }
 


### PR DESCRIPTION
## Summary

Adds a tighter regression assertion around the recent notification board aggregate query optimization.

The performance test now verifies the single status-board select query also:
- constrains the status-change aggregate through `status_change_monitorings.user_id`
- excludes soft-deleted monitorings in that aggregate
- binds the authenticated user's id into the query

## Validation

- `php artisan test tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php`

Dependency note: `vendor/` was missing in this worktree. `composer install --no-interaction --prefer-dist` failed because local PHP lacks `ext-redis`; dependencies were installed with `--ignore-platform-req=ext-redis` for local test execution.