### PR TITLE
Fix maintenance in digest availability

### DIFF
--- a/app/Services/WeeklyMonitoringDigestService.php
+++ b/app/Services/WeeklyMonitoringDigestService.php
@@ -62,14 +62,18 @@ class WeeklyMonitoringDigestService
                 true,
                 false
             );
+            $maintenanceWindow = $this->getOverlappingMaintenanceWindow($monitoring, $periodStart, $periodEnd);
+            $maintenanceMinutes = $this->getMaintenanceMinutes($maintenanceWindow);
 
-            $incidentDurations = $this->getOverlappingIncidentDurations($monitoring, $periodStart, $periodEnd);
+            $incidentDurations = $this->getOverlappingIncidentDurations($monitoring, $periodStart, $periodEnd, $maintenanceWindow);
             $incidentsCount = count($incidentDurations);
             $monitoringLongestDowntimeMinutes = empty($incidentDurations) ? 0 : max($incidentDurations);
 
             $uptimeMinutes = (int) ($uptimeDowntime['uptime']['minutes'] ?? 0);
             $downtimeMinutes = (int) ($uptimeDowntime['downtime']['minutes'] ?? 0);
             $unknownMinutes = (int) ($uptimeDowntime['unknown']['minutes'] ?? 0);
+            $this->removeMaintenanceMinutes($maintenanceMinutes, $uptimeMinutes, $downtimeMinutes, $unknownMinutes);
+            $monitoringTrackedMinutes = $uptimeMinutes + $downtimeMinutes + $unknownMinutes;
 
             $totalUptimeMinutes += $uptimeMinutes;
             $totalDowntimeMinutes += $downtimeMinutes;
@@ -80,7 +84,7 @@ class WeeklyMonitoringDigestService
             $monitoringRows[] = [
                 'name' => $monitoring->name,
                 'target' => $monitoring->target,
-                'uptime_percentage' => $uptimeDowntime['uptime']['percentage'] ?? null,
+                'uptime_percentage' => $monitoringTrackedMinutes > 0 ? ($uptimeMinutes / $monitoringTrackedMinutes) * 100 : null,
                 'incidents_count' => $incidentsCount,
                 'downtime_minutes' => $downtimeMinutes,
                 'longest_downtime_minutes' => $monitoringLongestDowntimeMinutes,
@@ -114,10 +118,15 @@ class WeeklyMonitoringDigestService
     }
 
     /**
+     * @param  array{from: Carbon, until: Carbon}|null  $maintenanceWindow
      * @return list<int>
      */
-    private function getOverlappingIncidentDurations(Monitoring $monitoring, Carbon $periodStart, Carbon $periodEnd): array
-    {
+    private function getOverlappingIncidentDurations(
+        Monitoring $monitoring,
+        Carbon $periodStart,
+        Carbon $periodEnd,
+        ?array $maintenanceWindow = null
+    ): array {
         return $monitoring->incidents()
             ->where('down_at', '<=', $periodEnd)
             ->where(function ($builder) use ($periodStart): void {
@@ -125,14 +134,91 @@ class WeeklyMonitoringDigestService
                     ->orWhereNull('up_at');
             })
             ->get(['down_at', 'up_at'])
-            ->map(function (Incident $incident) use ($periodStart, $periodEnd): int {
+            ->map(function (Incident $incident) use ($periodStart, $periodEnd, $maintenanceWindow): int {
                 $downAt = $incident->down_at->copy()->max($periodStart);
                 $upAt = ($incident->up_at ?? $periodEnd)->copy()->min($periodEnd);
+                $durationMinutes = max(0, (int) floor(($upAt->getTimestamp() - $downAt->getTimestamp()) / 60));
 
-                return max(0, (int) floor(($upAt->getTimestamp() - $downAt->getTimestamp()) / 60));
+                if ($durationMinutes === 0 || ! $maintenanceWindow) {
+                    return $durationMinutes;
+                }
+
+                $overlapStart = $downAt->copy()->max($maintenanceWindow['from']);
+                $overlapEnd = $upAt->copy()->min($maintenanceWindow['until']);
+                $maintenanceOverlapMinutes = $overlapStart->lt($overlapEnd)
+                    ? max(0, (int) floor(($overlapEnd->getTimestamp() - $overlapStart->getTimestamp()) / 60))
+                    : 0;
+
+                return max(0, $durationMinutes - $maintenanceOverlapMinutes);
             })
+            ->filter(static fn (int $durationMinutes): bool => $durationMinutes > 0)
             ->values()
             ->all();
+    }
+
+    /**
+     * @return array{from: Carbon, until: Carbon}|null
+     */
+    private function getOverlappingMaintenanceWindow(Monitoring $monitoring, Carbon $periodStart, Carbon $periodEnd): ?array
+    {
+        if (! $monitoring->maintenance_from) {
+            return null;
+        }
+
+        $maintenanceFrom = $monitoring->maintenance_from->copy();
+        $maintenanceUntil = ($monitoring->maintenance_until ?? $periodEnd)->copy();
+
+        if ($maintenanceUntil->lt($periodStart) || $maintenanceFrom->gt($periodEnd)) {
+            return null;
+        }
+
+        $overlapFrom = $maintenanceFrom->max($periodStart);
+        $overlapUntil = $maintenanceUntil->min($periodEnd);
+
+        if ($overlapFrom->gt($overlapUntil)) {
+            return null;
+        }
+
+        return [
+            'from' => $overlapFrom,
+            'until' => $overlapUntil,
+        ];
+    }
+
+    /**
+     * @param  array{from: Carbon, until: Carbon}|null  $maintenanceWindow
+     */
+    private function getMaintenanceMinutes(?array $maintenanceWindow): int
+    {
+        if (! $maintenanceWindow) {
+            return 0;
+        }
+
+        return max(0, (int) ceil(
+            ($maintenanceWindow['until']->getTimestamp() - $maintenanceWindow['from']->getTimestamp()) / 60
+        ));
+    }
+
+    private function removeMaintenanceMinutes(
+        int $maintenanceMinutes,
+        int &$uptimeMinutes,
+        int &$downtimeMinutes,
+        int &$unknownMinutes
+    ): void {
+        if ($maintenanceMinutes <= 0) {
+            return;
+        }
+
+        $removedUnknownMinutes = min($unknownMinutes, $maintenanceMinutes);
+        $unknownMinutes -= $removedUnknownMinutes;
+        $maintenanceMinutes -= $removedUnknownMinutes;
+
+        $removedDowntimeMinutes = min($downtimeMinutes, $maintenanceMinutes);
+        $downtimeMinutes -= $removedDowntimeMinutes;
+        $maintenanceMinutes -= $removedDowntimeMinutes;
+
+        $removedUptimeMinutes = min($uptimeMinutes, $maintenanceMinutes);
+        $uptimeMinutes -= $removedUptimeMinutes;
     }
 
     private function expiresSoonOrIsInvalid(MonitoringSslResult|MonitoringDomainResult|null $result, Carbon $warningThreshold): bool

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -362,4 +362,68 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         $this->assertSame(3, $digest['monitorings'][0]['incidents_count']);
         $this->assertSame(119, $digest['monitorings'][0]['longest_downtime_minutes']);
     }
+
+    public function test_weekly_digest_excludes_maintenance_windows_from_availability(): void
+    {
+        Date::setTestNow('2026-05-11 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->create();
+        $availableMonitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Available monitor',
+            'target' => 'https://available.example.com',
+            'type' => MonitoringType::HTTP,
+        ]);
+        $maintenanceMonitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Maintenance monitor',
+            'target' => 'https://maintenance.example.com',
+            'type' => MonitoringType::HTTP,
+            'maintenance_from' => Date::parse('2026-05-04 00:00:00'),
+            'maintenance_until' => Date::parse('2026-05-10 23:59:59'),
+        ]);
+
+        for ($day = 4; $day <= 10; $day++) {
+            MonitoringDailyResult::query()->create([
+                'monitoring_id' => $availableMonitoring->id,
+                'date' => '2026-05-' . mb_str_pad((string) $day, 2, '0', STR_PAD_LEFT),
+                'uptime_total' => 288,
+                'downtime_total' => 0,
+                'unknown_total' => 0,
+                'uptime_percentage' => 100,
+                'downtime_percentage' => 0,
+                'unknown_percentage' => 0,
+                'uptime_minutes' => 1440,
+                'downtime_minutes' => 0,
+                'unknown_minutes' => 0,
+                'avg_response_time' => 120,
+                'min_response_time' => 80,
+                'max_response_time' => 250,
+                'incidents_count' => 0,
+            ]);
+            MonitoringDailyResult::query()->create([
+                'monitoring_id' => $maintenanceMonitoring->id,
+                'date' => '2026-05-' . mb_str_pad((string) $day, 2, '0', STR_PAD_LEFT),
+                'uptime_total' => 0,
+                'downtime_total' => 0,
+                'unknown_total' => 288,
+                'uptime_percentage' => 0,
+                'downtime_percentage' => 0,
+                'unknown_percentage' => 100,
+                'uptime_minutes' => 0,
+                'downtime_minutes' => 0,
+                'unknown_minutes' => 1440,
+                'avg_response_time' => 0,
+                'min_response_time' => 0,
+                'max_response_time' => 0,
+                'incidents_count' => 0,
+            ]);
+        }
+
+        $digest = resolve(WeeklyMonitoringDigestService::class)->buildForUser($user, Date::parse('2026-05-10'));
+        $maintenanceRow = collect($digest['monitorings'])->firstWhere('name', 'Maintenance monitor');
+
+        $this->assertSame(100.0, round($digest['overview']['uptime_percentage'], 2));
+        $this->assertNull($maintenanceRow['uptime_percentage']);
+        $this->assertSame(0, $maintenanceRow['downtime_minutes']);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the weekly monitoring digest so maintenance windows are excluded from availability calculations instead of counting as unavailable or unknown tracked time.

## Root cause

The digest summed `unknown_minutes` into the total tracked minutes. Monitorings in maintenance are aggregated as unknown, so fully maintained monitorings reduced the overall availability even though they should be excluded for that maintenance period.

## Changes

- Clip each monitoring's maintenance window to the digest period.
- Remove maintenance minutes from the per-monitoring and total availability denominator.
- Exclude incident duration that overlaps maintenance from digest incident counts and longest downtime.
- Add a regression test for a weekly digest where one monitoring is fully in maintenance.

## Validation

- `vendor/bin/pint app/Services/WeeklyMonitoringDigestService.php tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`
- `php artisan test tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`