### PR TITLE
Test maintenance window edge coverage

### DIFF
--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -426,4 +426,37 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         $this->assertNull($maintenanceRow['uptime_percentage']);
         $this->assertSame(0, $maintenanceRow['downtime_minutes']);
     }
+
+    public function test_weekly_digest_excludes_maintenance_overlap_from_incident_downtime(): void
+    {
+        Date::setTestNow('2026-05-11 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Maintenance incident monitor',
+            'target' => 'https://maintenance.example.com',
+            'type' => MonitoringType::HTTP,
+            'maintenance_from' => Date::parse('2026-05-06 10:00:00'),
+            'maintenance_until' => Date::parse('2026-05-06 11:00:00'),
+        ]);
+
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-05-06 09:30:00',
+            'up_at' => '2026-05-06 11:30:00',
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => '2026-05-06 10:15:00',
+            'up_at' => '2026-05-06 10:45:00',
+        ]);
+
+        $digest = resolve(WeeklyMonitoringDigestService::class)->buildForUser($user, Date::parse('2026-05-10'));
+
+        $this->assertSame(1, $digest['overview']['incidents_count']);
+        $this->assertSame(60, $digest['overview']['longest_downtime_minutes']);
+        $this->assertSame(1, $digest['monitorings'][0]['incidents_count']);
+        $this->assertSame(60, $digest['monitorings'][0]['longest_downtime_minutes']);
+    }
 }

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -134,6 +134,32 @@ class PublicStatusPageTest extends TestCase
         $testResponse->assertDontSeeText(__('monitoring.public_label.maintenance.upcoming'));
     }
 
+    public function test_public_status_page_shows_open_ended_maintenance_window(): void
+    {
+        Date::setTestNow('2026-05-03 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'public_label_enabled' => true,
+            'maintenance_from' => Date::now()->subHour(),
+            'maintenance_until' => null,
+        ]);
+
+        $testResponse = $this->get(route('public-label', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.heading'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.active'));
+        $testResponse->assertSeeText(__('monitoring.public_label.maintenance.open_ended'));
+        $testResponse->assertSeeText('Sun, May 3, 2026 11:00 AM');
+        $testResponse->assertDontSeeText(__('monitoring.public_label.maintenance.upcoming'));
+    }
+
     public function test_public_status_page_returns_not_found_when_public_label_is_disabled(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## Summary
- add public status coverage for open-ended maintenance windows
- add digest coverage for incident downtime that overlaps maintenance

## Validation
- php artisan test tests/Feature/PublicStatusPageTest.php
- php artisan test tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php

Note: dependencies were installed with `composer install --ignore-platform-req=ext-redis` because the local PHP CLI is missing `ext-redis`. The digest test run emitted a Pest cache warning: `mkdir(): File exists`, but the suite passed.