### PR TITLE
Add Microsoft Teams notifications

### DIFF
--- a/app/Enums/NotificationChannel.php
+++ b/app/Enums/NotificationChannel.php
@@ -9,6 +9,7 @@ enum NotificationChannel: string
     case SLACK = 'slack';
     case TELEGRAM = 'telegram';
     case DISCORD = 'discord';
+    case TEAMS = 'teams';
     case WEBHOOK = 'webhook';
 
     /**

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -213,7 +213,11 @@ class ProfileController extends Controller
                 'enabled' => $profileRequest->boolean(sprintf('notification_channels.%s.enabled', $channel)),
             ];
 
-            if ($channel === NotificationChannel::SLACK->value || $channel === NotificationChannel::DISCORD->value) {
+            if (in_array($channel, [
+                NotificationChannel::SLACK->value,
+                NotificationChannel::DISCORD->value,
+                NotificationChannel::TEAMS->value,
+            ], true)) {
                 $channelConfig['webhook_url'] = mb_trim((string) $profileRequest->input(sprintf('notification_channels.%s.webhook_url', $channel)));
             }
 

--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -52,6 +52,7 @@ class ProfileRequest extends FormRequest
             'notification_channels.telegram.bot_token' => ['nullable', 'string', 'max:255'],
             'notification_channels.telegram.chat_id' => ['nullable', 'string', 'max:255'],
             'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048'],
+            'notification_channels.teams.webhook_url' => ['nullable', 'url', 'max:2048'],
             'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048'],
             'monitoring_digest_enabled' => ['nullable', 'boolean'],
             'monitoring_digest_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
@@ -77,6 +78,10 @@ class ProfileRequest extends FormRequest
 
             if ($this->boolean('notification_channels.discord.enabled') && blank($this->input('notification_channels.discord.webhook_url'))) {
                 $validator->errors()->add('notification_channels.discord.webhook_url', __('validation.required'));
+            }
+
+            if ($this->boolean('notification_channels.teams.enabled') && blank($this->input('notification_channels.teams.webhook_url'))) {
+                $validator->errors()->add('notification_channels.teams.webhook_url', __('validation.required'));
             }
 
             if ($this->boolean('notification_channels.webhook.enabled') && blank($this->input('notification_channels.webhook.url'))) {

--- a/app/Services/Notifications/Channels/TeamsChannelDriver.php
+++ b/app/Services/Notifications/Channels/TeamsChannelDriver.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Notifications\Channels;
+
+use App\Enums\NotificationChannel;
+use App\Services\Notifications\NotificationPayload;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class TeamsChannelDriver implements NotificationChannelDriver
+{
+    public function channel(): string
+    {
+        return NotificationChannel::TEAMS->value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function isConfigured(array $config): bool
+    {
+        return filled($config['webhook_url'] ?? null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function send(NotificationPayload $notificationPayload, array $config): void
+    {
+        $webhookUrl = (string) ($config['webhook_url'] ?? '');
+        $response = Http::timeout(10)->post($webhookUrl, $this->payload($notificationPayload));
+
+        if (! $response->successful()) {
+            throw new RuntimeException('Microsoft Teams notification failed with status ' . $response->status());
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(NotificationPayload $notificationPayload): array
+    {
+        $facts = [
+            [
+                'title' => 'Event',
+                'value' => $notificationPayload->eventType->value,
+            ],
+            [
+                'title' => 'Severity',
+                'value' => $notificationPayload->severity,
+            ],
+        ];
+
+        if ($notificationPayload->monitoringName !== null) {
+            $facts[] = [
+                'title' => 'Monitoring',
+                'value' => $notificationPayload->monitoringName,
+            ];
+        }
+
+        if ($notificationPayload->monitoringTarget !== null) {
+            $facts[] = [
+                'title' => 'Target',
+                'value' => $notificationPayload->monitoringTarget,
+            ];
+        }
+
+        return [
+            'type' => 'message',
+            'attachments' => [[
+                'contentType' => 'application/vnd.microsoft.card.adaptive',
+                'contentUrl' => null,
+                'content' => [
+                    '$schema' => 'http://adaptivecards.io/schemas/adaptive-card.json',
+                    'type' => 'AdaptiveCard',
+                    'version' => '1.0',
+                    'body' => [
+                        [
+                            'type' => 'TextBlock',
+                            'text' => $notificationPayload->title,
+                            'weight' => 'Bolder',
+                            'size' => 'Medium',
+                            'wrap' => true,
+                        ],
+                        [
+                            'type' => 'TextBlock',
+                            'text' => $notificationPayload->message,
+                            'wrap' => true,
+                        ],
+                        [
+                            'type' => 'FactSet',
+                            'facts' => $facts,
+                        ],
+                        [
+                            'type' => 'TextBlock',
+                            'text' => $notificationPayload->occurredAt->toIso8601String(),
+                            'isSubtle' => true,
+                            'size' => 'Small',
+                            'wrap' => true,
+                        ],
+                    ],
+                ],
+            ]],
+        ];
+    }
+}

--- a/app/Services/Notifications/NotificationChannelTestService.php
+++ b/app/Services/Notifications/NotificationChannelTestService.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use App\Services\Notifications\Channels\DiscordChannelDriver;
 use App\Services\Notifications\Channels\NotificationChannelDriver;
 use App\Services\Notifications\Channels\SlackChannelDriver;
+use App\Services\Notifications\Channels\TeamsChannelDriver;
 use App\Services\Notifications\Channels\TelegramChannelDriver;
 use App\Services\Notifications\Channels\WebhookChannelDriver;
 use InvalidArgumentException;
@@ -25,12 +26,14 @@ class NotificationChannelTestService
         SlackChannelDriver $slackChannelDriver,
         TelegramChannelDriver $telegramChannelDriver,
         DiscordChannelDriver $discordChannelDriver,
+        TeamsChannelDriver $teamsChannelDriver,
         WebhookChannelDriver $webhookChannelDriver
     ) {
         $this->drivers = [
             $slackChannelDriver->channel() => $slackChannelDriver,
             $telegramChannelDriver->channel() => $telegramChannelDriver,
             $discordChannelDriver->channel() => $discordChannelDriver,
+            $teamsChannelDriver->channel() => $teamsChannelDriver,
             $webhookChannelDriver->channel() => $webhookChannelDriver,
         ];
     }

--- a/app/Services/Notifications/NotificationRouter.php
+++ b/app/Services/Notifications/NotificationRouter.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use App\Services\Notifications\Channels\DiscordChannelDriver;
 use App\Services\Notifications\Channels\NotificationChannelDriver;
 use App\Services\Notifications\Channels\SlackChannelDriver;
+use App\Services\Notifications\Channels\TeamsChannelDriver;
 use App\Services\Notifications\Channels\TelegramChannelDriver;
 use App\Services\Notifications\Channels\WebhookChannelDriver;
 use Carbon\CarbonInterface;
@@ -27,12 +28,14 @@ class NotificationRouter
         SlackChannelDriver $slackChannelDriver,
         TelegramChannelDriver $telegramChannelDriver,
         DiscordChannelDriver $discordChannelDriver,
+        TeamsChannelDriver $teamsChannelDriver,
         WebhookChannelDriver $webhookChannelDriver
     ) {
         $this->drivers = [
             $slackChannelDriver->channel() => $slackChannelDriver,
             $telegramChannelDriver->channel() => $telegramChannelDriver,
             $discordChannelDriver->channel() => $discordChannelDriver,
+            $teamsChannelDriver->channel() => $teamsChannelDriver,
             $webhookChannelDriver->channel() => $webhookChannelDriver,
         ];
     }

--- a/docs/features.md
+++ b/docs/features.md
@@ -24,5 +24,5 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 
 ## Notifications
 
-- **Flexible notifications:** receive notifications for status changes, SSL expiry, and domain expiry through in-app notifications and configurable channels.
+- **Flexible notifications:** receive notifications for status changes, SSL expiry, and domain expiry through in-app notifications and configurable Slack, Telegram, Discord, Microsoft Teams, and webhook channels.
 - **Weekly monitoring digest:** email weekly uptime, incident, downtime, SSL, and domain expiry summaries to active users.

--- a/resources/lang/de/profile.php
+++ b/resources/lang/de/profile.php
@@ -84,6 +84,7 @@ return [
             'telegram_chat_id' => 'Telegram Chat ID',
             'slack_webhook_url' => 'Slack Webhook URL',
             'discord_webhook_url' => 'Discord Webhook URL',
+            'teams_webhook_url' => 'Microsoft Teams Webhook URL',
             'webhook_url' => 'Webhook URL',
         ],
         'channels' => [
@@ -98,6 +99,10 @@ return [
             'discord' => [
                 'title' => 'Discord',
                 'help' => 'Verwenden Sie eine Discord Webhook URL.',
+            ],
+            'teams' => [
+                'title' => 'Microsoft Teams',
+                'help' => 'Verwenden Sie eine Microsoft Teams Incoming Webhook URL.',
             ],
             'webhook' => [
                 'title' => 'Webhook',

--- a/resources/lang/en/profile.php
+++ b/resources/lang/en/profile.php
@@ -84,6 +84,7 @@ return [
             'telegram_chat_id' => 'Telegram Chat ID',
             'slack_webhook_url' => 'Slack Webhook URL',
             'discord_webhook_url' => 'Discord Webhook URL',
+            'teams_webhook_url' => 'Microsoft Teams Webhook URL',
             'webhook_url' => 'Webhook URL',
         ],
         'channels' => [
@@ -98,6 +99,10 @@ return [
             'discord' => [
                 'title' => 'Discord',
                 'help' => 'Use a Discord webhook URL.',
+            ],
+            'teams' => [
+                'title' => 'Microsoft Teams',
+                'help' => 'Use a Microsoft Teams incoming webhook URL.',
             ],
             'webhook' => [
                 'title' => 'Webhook',

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,7 +1,7 @@
 <x-container space="true">
     @php
         $notificationChannels = old('notification_channels', $user->notification_channels ?? []);
-        $notificationChannelKeys = ['slack', 'telegram', 'discord', 'webhook'];
+        $notificationChannelKeys = ['slack', 'telegram', 'discord', 'teams', 'webhook'];
     @endphp
 
     <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
@@ -164,6 +164,28 @@
                         <x-text-input id="notification_channels_discord_webhook_url" name="notification_channels[discord][webhook_url]" type="url"
                             :value="data_get($notificationChannels, 'discord.webhook_url')" placeholder="https://discord.com/api/webhooks/..." />
                         <x-input-error :messages="$errors->get('notification_channels.discord.webhook_url')" />
+                    </div>
+                </div>
+
+                <div class="rounded-xl border border-gray-200 bg-gray-50/60 p-5 shadow-xs dark:border-gray-700 dark:bg-gray-900/30">
+                    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+                        <x-heading type="h3">{{ __('profile.notification_settings.channels.teams.title') }}</x-heading>
+                        <x-text-checkbox id="notification_channels_teams_enabled" name="notification_channels[teams][enabled]"
+                            :checked="(bool) data_get($notificationChannels, 'teams.enabled', false)"
+                            :label="__('profile.notification_settings.enabled')" />
+                        <x-secondary-button form="test-teams-notification-channel" class="text-xs">
+                            {{ __('profile.notification_settings.test.action') }}
+                        </x-secondary-button>
+                    </div>
+                    <x-input-error :messages="$errors->get('notification_channels.teams')" />
+
+                    <x-paragraph class="text-sm text-gray-600 dark:text-gray-300">{{ __('profile.notification_settings.channels.teams.help') }}</x-paragraph>
+
+                    <div class="mt-4">
+                        <x-input-label for="notification_channels_teams_webhook_url" :value="__('profile.notification_settings.fields.teams_webhook_url')" />
+                        <x-text-input id="notification_channels_teams_webhook_url" name="notification_channels[teams][webhook_url]" type="url"
+                            :value="data_get($notificationChannels, 'teams.webhook_url')" placeholder="https://..." />
+                        <x-input-error :messages="$errors->get('notification_channels.teams.webhook_url')" />
                     </div>
                 </div>
 

--- a/tests/Feature/Notifications/NotificationRouterTest.php
+++ b/tests/Feature/Notifications/NotificationRouterTest.php
@@ -135,4 +135,46 @@ class NotificationRouterTest extends TestCase
             'status' => NotificationDeliveryStatus::SKIPPED->value,
         ]);
     }
+
+    public function test_router_sends_to_teams_channel(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'teams' => [
+                    'enabled' => true,
+                    'webhook_url' => 'https://teams.test/webhook/123',
+                ],
+            ],
+        ]);
+
+        Http::fake([
+            'https://teams.test/*' => Http::response([], 200),
+        ]);
+
+        $notificationPayload = new NotificationPayload(
+            eventType: NotificationEventType::INCIDENT,
+            title: 'Monitoring incident',
+            message: 'Service is down.',
+            severity: 'critical',
+            monitoringId: '01TEST',
+            monitoringName: 'API',
+            monitoringTarget: 'https://example.test',
+            occurredAt: now(),
+        );
+
+        $wasDelivered = resolve(NotificationRouter::class)->dispatch($user, $notificationPayload, ['teams']);
+
+        $this->assertTrue($wasDelivered);
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://teams.test/webhook/123'
+            && data_get($request->data(), 'type') === 'message'
+            && data_get($request->data(), 'attachments.0.contentType') === 'application/vnd.microsoft.card.adaptive'
+            && str_contains(json_encode($request->data(), JSON_THROW_ON_ERROR), 'Monitoring incident'));
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'channel' => 'teams',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::SENT->value,
+        ]);
+    }
 }

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -52,6 +52,16 @@ class ProfileNotificationSettingsTest extends TestCase
                 ],
                 'expectedUrl' => 'https://discord.test/api/webhooks/123/token',
             ],
+            'teams' => [
+                'channel' => 'teams',
+                'notificationChannels' => [
+                    'teams' => [
+                        'enabled' => false,
+                        'webhook_url' => 'https://teams.test/webhook/123',
+                    ],
+                ],
+                'expectedUrl' => 'https://teams.test/webhook/123',
+            ],
             'webhook' => [
                 'channel' => 'webhook',
                 'notificationChannels' => [
@@ -123,6 +133,10 @@ class ProfileNotificationSettingsTest extends TestCase
                     'enabled' => '0',
                     'webhook_url' => '',
                 ],
+                'teams' => [
+                    'enabled' => '1',
+                    'webhook_url' => 'https://teams.test/webhook/123',
+                ],
                 'webhook' => [
                     'enabled' => '1',
                     'url' => 'https://example.test/webhooks/webguard',
@@ -148,6 +162,8 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertSame('-1001234567', data_get($user->notification_channels, 'telegram.chat_id'));
         $this->assertNull(data_get($user->notification_channels, 'telegram.events'));
         $this->assertFalse((bool) data_get($user->notification_channels, 'discord.enabled'));
+        $this->assertTrue((bool) data_get($user->notification_channels, 'teams.enabled'));
+        $this->assertSame('https://teams.test/webhook/123', data_get($user->notification_channels, 'teams.webhook_url'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'webhook.enabled'));
         $this->assertSame('https://example.test/webhooks/webguard', data_get($user->notification_channels, 'webhook.url'));
         $this->assertNull(data_get($user->notification_channels, 'webhook.events'));
@@ -332,6 +348,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'slack']));
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'telegram']));
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'discord']));
+        $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'teams']));
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'webhook']));
     }
 
@@ -379,6 +396,28 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse->assertRedirect(route('profile.edit'));
         $testResponse->assertSessionHasErrors(['notification_channels.slack']);
         Http::assertNothingSent();
+    }
+
+    public function test_profile_update_requires_teams_webhook_url_when_channel_is_enabled(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'theme' => 'system',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+            'notification_channels' => [
+                'teams' => [
+                    'enabled' => '1',
+                    'webhook_url' => '',
+                ],
+            ],
+        ]);
+
+        $testResponse->assertSessionHasErrors(['notification_channels.teams.webhook_url']);
     }
 
     public function test_channel_test_reports_delivery_failure(): void


### PR DESCRIPTION
## Summary
- Add Microsoft Teams as a configurable notification channel.
- Send compact Adaptive Card webhook payloads for Teams alerts.
- Expose Teams configuration and test-send controls in profile settings.
- Document the new notification channel.

## Motivation
Teams is a common incident-notification destination, and the existing notification driver architecture already supports adding focused channel drivers without schema changes. Microsoft documents incoming webhooks as accepting JSON card payloads: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook

## Testing
- ./vendor/bin/pint --test
- php artisan test tests/Feature/ProfileNotificationSettingsTest.php tests/Feature/Notifications/NotificationRouterTest.php
- php artisan test tests/Feature/DocumentationStructureTest.php tests/Feature/ProfileNotificationSettingsTest.php tests/Feature/Notifications/NotificationRouterTest.php
- php artisan test

## Rollout
No migration required. Existing users can enable Teams by adding a Teams incoming webhook URL in profile notification settings.