### PR TITLE
Publish changelogs for tags

### DIFF
--- a/.github/scripts/generate-changelog.php
+++ b/.github/scripts/generate-changelog.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Generate release notes for a tag from git history.
+ *
+ * The output is intentionally based on local git data only so it can be used
+ * from tag workflows and from manual backfills for existing tags.
+ */
+$options = getopt('', [
+    'tag:',
+    'repository::',
+    'output::',
+]);
+
+$tag = isset($options['tag']) ? mb_trim((string) $options['tag']) : '';
+$repository = isset($options['repository']) ? mb_trim((string) $options['repository']) : '';
+$output = isset($options['output']) ? mb_trim((string) $options['output']) : '';
+
+if ($tag === '') {
+    $tag = mb_trim(run(['git', 'describe', '--tags', '--abbrev=0']));
+}
+
+assertTagExists($tag);
+
+$previousTag = previousTag($tag);
+$date = mb_trim(run(['git', 'log', '-1', '--format=%cs', $tag]));
+$commits = commitsForTag($tag, $previousTag);
+$sections = groupConventionalCommits($commits);
+$mergedBranches = mergedBranches($commits, $repository);
+
+$markdown = renderChangelog($tag, $date, $previousTag, $sections, $mergedBranches);
+
+if ($output !== '') {
+    file_put_contents($output, $markdown);
+
+    exit(0);
+}
+
+echo $markdown;
+
+/**
+ * @param  list<string>  $command
+ */
+function run(array $command): string
+{
+    $process = proc_open(
+        $command,
+        [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ],
+        $pipes
+    );
+
+    if (! is_resource($process)) {
+        fwrite(STDERR, 'Unable to start process: ' . implode(' ', $command) . PHP_EOL);
+
+        exit(1);
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    $exitCode = proc_close($process);
+
+    if ($exitCode !== 0) {
+        fwrite(STDERR, mb_trim((string) $stderr) . PHP_EOL);
+
+        exit($exitCode);
+    }
+
+    return (string) $stdout;
+}
+
+function assertTagExists(string $tag): void
+{
+    run(['git', 'rev-parse', '--verify', '--quiet', $tag]);
+}
+
+function previousTag(string $tag): ?string
+{
+    $tags = array_values(array_filter(explode(PHP_EOL, mb_trim(run(['git', 'tag', '--sort=version:refname'])))));
+    $index = array_search($tag, $tags, true);
+
+    if ($index === false || $index === 0) {
+        return null;
+    }
+
+    return $tags[$index - 1];
+}
+
+/**
+ * @return list<array{hash: string, subject: string, body: string}>
+ */
+function commitsForTag(string $tag, ?string $previousTag): array
+{
+    $range = $previousTag ? "{$previousTag}..{$tag}" : $tag;
+    $rawLog = run(['git', 'log', '--reverse', '--format=%H%x1f%s%x1f%b%x1e', $range]);
+    $records = array_filter(explode("\x1e", $rawLog), static fn (string $record): bool => mb_trim($record) !== '');
+
+    return array_values(array_map(function (string $record): array {
+        [$hash, $subject, $body] = array_pad(explode("\x1f", $record, 3), 3, '');
+
+        return [
+            'hash' => mb_trim($hash),
+            'subject' => mb_trim($subject),
+            'body' => mb_trim($body),
+        ];
+    }, $records));
+}
+
+/**
+ * @param  list<array{hash: string, subject: string, body: string}>  $commits
+ * @return array<string, list<string>>
+ */
+function groupConventionalCommits(array $commits): array
+{
+    $groups = [
+        'Features' => [],
+        'Fixes' => [],
+        'Performance' => [],
+        'Refactoring' => [],
+        'Documentation' => [],
+        'Tests' => [],
+        'CI and Build' => [],
+        'Maintenance' => [],
+        'Breaking Changes' => [],
+        'Other Changes' => [],
+    ];
+
+    foreach ($commits as $commit) {
+        if (str_starts_with($commit['subject'], 'Merge pull request ')) {
+            continue;
+        }
+
+        if (! preg_match('/^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?:\s*(?<description>.+)$/', $commit['subject'], $matches)) {
+            $groups['Other Changes'][] = entry($commit['subject'], $commit['hash']);
+
+            continue;
+        }
+
+        $description = $matches['description'];
+        $scope = $matches['scope'] ?? '';
+
+        if ($scope !== '') {
+            $description = "**{$scope}:** {$description}";
+        }
+
+        $entry = entry($description, $commit['hash']);
+        $groups[groupName($matches['type'])][] = $entry;
+
+        if (($matches['breaking'] ?? '') === '!' || str_contains($commit['body'], 'BREAKING CHANGE')) {
+            $groups['Breaking Changes'][] = $entry;
+        }
+    }
+
+    return array_filter($groups, static fn (array $entries): bool => $entries !== []);
+}
+
+function groupName(string $type): string
+{
+    return match ($type) {
+        'feat' => 'Features',
+        'fix' => 'Fixes',
+        'perf' => 'Performance',
+        'refactor' => 'Refactoring',
+        'docs' => 'Documentation',
+        'test' => 'Tests',
+        'ci', 'build' => 'CI and Build',
+        'chore' => 'Maintenance',
+        default => 'Other Changes',
+    };
+}
+
+function entry(string $description, string $hash): string
+{
+    return sprintf('- %s (`%s`)', $description, mb_substr($hash, 0, 7));
+}
+
+/**
+ * @param  list<array{hash: string, subject: string, body: string}>  $commits
+ * @return list<string>
+ */
+function mergedBranches(array $commits, string $repository): array
+{
+    $branches = [];
+
+    foreach ($commits as $commit) {
+        if (! preg_match('/^Merge pull request #(?<number>\d+) from (?<branch>.+)$/', $commit['subject'], $matches)) {
+            continue;
+        }
+
+        $pullRequest = '#' . $matches['number'];
+
+        if ($repository !== '') {
+            $pullRequest = sprintf('[#%s](https://github.com/%s/pull/%s)', $matches['number'], $repository, $matches['number']);
+        }
+
+        $branches[] = sprintf('- `%s` via %s', $matches['branch'], $pullRequest);
+    }
+
+    return $branches;
+}
+
+/**
+ * @param  array<string, list<string>>  $sections
+ * @param  list<string>  $mergedBranches
+ */
+function renderChangelog(string $tag, string $date, ?string $previousTag, array $sections, array $mergedBranches): string
+{
+    $range = $previousTag ? "`{$previousTag}...{$tag}`" : "`{$tag}`";
+    $lines = [
+        "## {$tag} - {$date}",
+        '',
+        "Generated from Conventional Commits and merged branch metadata for {$range}.",
+        '',
+    ];
+
+    if ($sections === [] && $mergedBranches === []) {
+        $lines[] = '_No commits found for this tag._';
+        $lines[] = '';
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    foreach ($sections as $heading => $entries) {
+        $lines[] = "### {$heading}";
+        array_push($lines, ...$entries);
+        $lines[] = '';
+    }
+
+    if ($mergedBranches !== []) {
+        $lines[] = '### Merged Branches';
+        array_push($lines, ...$mergedBranches);
+        $lines[] = '';
+    }
+
+    return implode(PHP_EOL, $lines);
+}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -5,6 +5,17 @@ on:
     workflows: [ "CI" ]
     types:
     - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Optional single tag to regenerate release notes for. Leave empty to use all tags when backfill is enabled."
+        required: false
+        type: string
+      backfill:
+        description: "Regenerate release notes for all existing tags."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -15,6 +26,8 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -25,3 +38,77 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         default_bump: "patch"
+
+  publish-changelog:
+    name: "Publish Tag Changelog"
+    needs: create-tag
+    if: >
+      needs.create-tag.outputs.new_tag != ''
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Generate changelog
+      run: |
+        php .github/scripts/generate-changelog.php \
+          --tag="${{ needs.create-tag.outputs.new_tag }}" \
+          --repository="${{ github.repository }}" \
+          --output=release-notes.md
+
+    - name: Publish GitHub release notes
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.create-tag.outputs.new_tag }}
+      run: |
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          gh release edit "$TAG" --title "$TAG" --notes-file release-notes.md
+        else
+          gh release create "$TAG" --title "$TAG" --notes-file release-notes.md
+        fi
+
+  backfill-changelogs:
+    name: "Backfill Tag Changelogs"
+    if: >
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Resolve tags
+      id: tags
+      env:
+        REQUESTED_TAG: ${{ inputs.tag }}
+        BACKFILL: ${{ inputs.backfill }}
+      run: |
+        if [ -n "$REQUESTED_TAG" ]; then
+          printf '%s\n' "$REQUESTED_TAG" > tags.txt
+        elif [ "$BACKFILL" = "true" ]; then
+          git tag --sort=version:refname > tags.txt
+        else
+          git describe --tags --abbrev=0 > tags.txt
+        fi
+
+    - name: Publish release notes for resolved tags
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        while IFS= read -r TAG; do
+          if [ -z "$TAG" ]; then
+            continue
+          fi
+
+          php .github/scripts/generate-changelog.php \
+            --tag="$TAG" \
+            --repository="${{ github.repository }}" \
+            --output=release-notes.md
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TAG" --notes-file release-notes.md
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file release-notes.md
+          fi
+        done < tags.txt

--- a/tests/Feature/TagChangelogGenerationTest.php
+++ b/tests/Feature/TagChangelogGenerationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+class TagChangelogGenerationTest extends TestCase
+{
+    private string $repositoryPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repositoryPath = sys_get_temp_dir() . '/webguard-changelog-' . bin2hex(random_bytes(6));
+        mkdir($this->repositoryPath);
+
+        $this->runCommand(['git', 'init', '-b', 'main']);
+        $this->runCommand(['git', 'config', 'user.email', 'tests@example.test']);
+        $this->runCommand(['git', 'config', 'user.name', 'WebGuard Tests']);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->repositoryPath) && is_dir($this->repositoryPath)) {
+            $this->removeDirectory($this->repositoryPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_changelog_is_generated_from_conventional_commits_and_merged_branches(): void
+    {
+        $this->commitFile('README.md', 'initial', 'chore: initial release');
+        $this->runCommand(['git', 'tag', 'v1.0.0']);
+
+        $this->runCommand(['git', 'checkout', '-b', 'feature/status-components']);
+        $this->commitFile('status.txt', 'components', 'feat(status): add component status pages');
+
+        $this->runCommand(['git', 'checkout', 'main']);
+        $this->runCommand(['git', 'merge', '--no-ff', 'feature/status-components', '-m', 'Merge pull request #12 from example/feature/status-components']);
+        $this->commitFile('alerts.txt', 'retry', 'fix(alerts): retry failed delivery');
+        $this->runCommand(['git', 'tag', 'v1.1.0']);
+
+        $notesPath = $this->repositoryPath . '/release-notes.md';
+        $process = new Process([
+            PHP_BINARY,
+            base_path('.github/scripts/generate-changelog.php'),
+            '--tag=v1.1.0',
+            '--repository=example/webguard',
+            '--output=' . $notesPath,
+        ], $this->repositoryPath);
+
+        $process->run();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput());
+
+        $notes = file_get_contents($notesPath);
+
+        $this->assertIsString($notes);
+        $this->assertStringContainsString('## v1.1.0 - ', $notes);
+        $this->assertStringContainsString('Generated from Conventional Commits and merged branch metadata for `v1.0.0...v1.1.0`.', $notes);
+        $this->assertStringContainsString('### Features', $notes);
+        $this->assertStringContainsString('**status:** add component status pages', $notes);
+        $this->assertStringContainsString('### Fixes', $notes);
+        $this->assertStringContainsString('**alerts:** retry failed delivery', $notes);
+        $this->assertStringContainsString('### Merged Branches', $notes);
+        $this->assertStringContainsString('`example/feature/status-components` via [#12](https://github.com/example/webguard/pull/12)', $notes);
+    }
+
+    public function test_tag_workflow_publishes_new_and_historical_changelogs(): void
+    {
+        $workflow = \Symfony\Component\Yaml\Yaml::parseFile(base_path('.github/workflows/tag.yml'));
+
+        $this->assertArrayHasKey('workflow_dispatch', $workflow['on']);
+        $this->assertSame('Create Tag', $workflow['jobs']['create-tag']['name']);
+        $this->assertSame('${{ steps.tag_version.outputs.new_tag }}', $workflow['jobs']['create-tag']['outputs']['new_tag']);
+
+        $publishSteps = $workflow['jobs']['publish-changelog']['steps'];
+        $publishScript = collect($publishSteps)->firstWhere('name', 'Generate changelog');
+        $publishRelease = collect($publishSteps)->firstWhere('name', 'Publish GitHub release notes');
+
+        $this->assertIsArray($publishScript);
+        $this->assertStringContainsString('.github/scripts/generate-changelog.php', $publishScript['run']);
+        $this->assertStringContainsString('needs.create-tag.outputs.new_tag', $publishScript['run']);
+        $this->assertIsArray($publishRelease);
+        $this->assertStringContainsString('gh release create', $publishRelease['run']);
+        $this->assertStringContainsString('gh release edit', $publishRelease['run']);
+
+        $backfillSteps = $workflow['jobs']['backfill-changelogs']['steps'];
+        $resolveTags = collect($backfillSteps)->firstWhere('name', 'Resolve tags');
+        $backfillRelease = collect($backfillSteps)->firstWhere('name', 'Publish release notes for resolved tags');
+
+        $this->assertIsArray($resolveTags);
+        $this->assertStringContainsString('git tag --sort=version:refname', $resolveTags['run']);
+        $this->assertIsArray($backfillRelease);
+        $this->assertStringContainsString('done < tags.txt', $backfillRelease['run']);
+    }
+
+    private function commitFile(string $file, string $contents, string $message): void
+    {
+        file_put_contents($this->repositoryPath . '/' . $file, $contents);
+
+        $this->runCommand(['git', 'add', $file]);
+        $this->runCommand(['git', 'commit', '-m', $message]);
+    }
+
+    /**
+     * @param  list<string>  $command
+     */
+    private function runCommand(array $command): void
+    {
+        $process = new Process($command, $this->repositoryPath);
+        $process->run();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput());
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        $items = scandir($directory);
+
+        $this->assertIsArray($items);
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $directory . DIRECTORY_SEPARATOR . $item;
+
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+
+                continue;
+            }
+
+            unlink($path);
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Feature/TagChangelogGenerationTest.php
+++ b/tests/Feature/TagChangelogGenerationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
 use Tests\TestCase;
 
 class TagChangelogGenerationTest extends TestCase
@@ -73,7 +74,7 @@ class TagChangelogGenerationTest extends TestCase
 
     public function test_tag_workflow_publishes_new_and_historical_changelogs(): void
     {
-        $workflow = \Symfony\Component\Yaml\Yaml::parseFile(base_path('.github/workflows/tag.yml'));
+        $workflow = Yaml::parseFile(base_path('.github/workflows/tag.yml'));
 
         $this->assertArrayHasKey('workflow_dispatch', $workflow['on']);
         $this->assertSame('Create Tag', $workflow['jobs']['create-tag']['name']);
@@ -126,10 +127,12 @@ class TagChangelogGenerationTest extends TestCase
         $this->assertIsArray($items);
 
         foreach ($items as $item) {
-            if ($item === '.' || $item === '..') {
+            if ($item === '.') {
                 continue;
             }
-
+            if ($item === '..') {
+                continue;
+            }
             $path = $directory . DIRECTORY_SEPARATOR . $item;
 
             if (is_dir($path)) {


### PR DESCRIPTION
## Summary
- Generate GitHub release notes whenever the tag workflow creates a new tag.
- Add a manual workflow_dispatch path to regenerate release notes for one tag, the latest tag, or all historical tags.
- Add a local PHP changelog generator that groups Conventional Commits and includes merged branch/PR metadata from git history.
- Add tests for the generator and workflow wiring.

## Motivation
Tags already exist and are created from Conventional Commits. This makes every tag produce a readable changelog while also allowing historical tags to be backfilled without changing old commits or moving tags.

## Testing
- ./vendor/bin/pint --test .github/scripts/generate-changelog.php tests/Feature/TagChangelogGenerationTest.php
- php artisan test tests/Feature/TagChangelogGenerationTest.php tests/Feature/CiWorkflowRedisExtensionTest.php
- php .github/scripts/generate-changelog.php --tag=v0.53.2 --repository=m-breuer/webguard
- php artisan test

## Backfill
Run the Tag workflow manually with `backfill=true` to regenerate release notes for all existing tags. Set `tag=vX.Y.Z` to regenerate a single tag.