### PR TITLE
Add demo user monitoring management

### DIFF
--- a/app/Console/Commands/Notifications/PruneDemoNotificationsCommand.php
+++ b/app/Console/Commands/Notifications/PruneDemoNotificationsCommand.php
@@ -9,21 +9,21 @@ use App\Models\MonitoringNotification;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Database\Query\Builder;
 
-class PruneGuestNotificationsCommand extends Command
+class PruneDemoNotificationsCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'notifications:prune-guest';
+    protected $signature = 'notifications:prune-demo';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Delete all notifications for guest users older than one week';
+    protected $description = 'Delete all notifications for demo users older than one week';
 
     /**
      * Execute the console command.
@@ -32,12 +32,12 @@ class PruneGuestNotificationsCommand extends Command
     {
         $deleted = MonitoringNotification::query()
             ->whereHas('monitoring.user', function (Builder $builder) {
-                $builder->where('role', UserRole::GUEST);
+                $builder->where('role', UserRole::DEMO);
             })
             ->where('created_at', '<', now()->subWeek())
             ->delete();
 
-        $this->info("Deleted {$deleted} old guest notifications.");
+        $this->info("Deleted {$deleted} old demo user notifications.");
 
         return Command::SUCCESS;
     }

--- a/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
+++ b/app/Console/Commands/Notifications/SendUnreadNotificationsReminderCommand.php
@@ -23,7 +23,7 @@ class SendUnreadNotificationsReminderCommand extends Command
     /**
      * @var string
      */
-    protected $description = 'Sends email reminders to non-guest users with unread board notifications according to their profile settings.';
+    protected $description = 'Sends email reminders to users with unread board notifications according to their profile settings.';
 
     public function __construct(private readonly NotificationBoardService $notificationBoardService)
     {

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -10,13 +10,13 @@ namespace App\Enums;
  * Defines available user roles within the application:
  * - ADMIN: Full administrative access to all features and settings.
  * - REGULAR: Standard user access to monitoring features.
- * - GUEST: Limited access, typically read-only or restricted functionality.
+ * - DEMO: Limited access, typically read-only or restricted functionality.
  */
 enum UserRole: string
 {
     case ADMIN = 'admin';
     case REGULAR = 'regular';
-    case GUEST = 'guest';
+    case DEMO = 'demo';
 
     /**
      * Get all enum values as a simple array of strings.

--- a/app/Http/Controllers/Admin/DemoMonitoringController.php
+++ b/app/Http/Controllers/Admin/DemoMonitoringController.php
@@ -21,14 +21,14 @@ class DemoMonitoringController extends Controller
     public function index(): View
     {
         $demoUser = $this->demoUser();
-        $monitorings = $this->demoMonitoringsQuery($demoUser)
+        $lengthAwarePaginator = $this->demoMonitoringsQuery($demoUser)
             ->orderBy('status')
             ->orderBy('name')
             ->paginate(10);
 
         return view('admin.demo-monitorings.index', [
             'demoUser' => $demoUser,
-            'monitorings' => $monitorings,
+            'monitorings' => $lengthAwarePaginator,
         ]);
     }
 
@@ -56,7 +56,7 @@ class DemoMonitoringController extends Controller
         ]);
     }
 
-    public function store(DemoMonitoringRequest $request): RedirectResponse
+    public function store(DemoMonitoringRequest $demoMonitoringRequest): RedirectResponse
     {
         $demoUser = $this->demoUser()->loadMissing('package');
 
@@ -65,7 +65,7 @@ class DemoMonitoringController extends Controller
                 ->withErrors(['limit' => __('monitoring.messages.limit_reached')]);
         }
 
-        $validated = MonitoringPayload::prepareStore($request->validated());
+        $validated = MonitoringPayload::prepareStore($demoMonitoringRequest->validated());
         $validated['user_id'] = $demoUser->id;
 
         Monitoring::query()

--- a/app/Http/Controllers/Admin/DemoMonitoringController.php
+++ b/app/Http/Controllers/Admin/DemoMonitoringController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\MonitoringType;
+use App\Enums\UserRole;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\DemoMonitoringRequest;
+use App\Models\Monitoring;
+use App\Models\ServerInstance;
+use App\Models\User;
+use App\Support\MonitoringPayload;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class DemoMonitoringController extends Controller
+{
+    public function index(): View
+    {
+        $demoUser = $this->demoUser();
+        $monitorings = $this->demoMonitoringsQuery($demoUser)
+            ->orderBy('status')
+            ->orderBy('name')
+            ->paginate(10);
+
+        return view('admin.demo-monitorings.index', [
+            'demoUser' => $demoUser,
+            'monitorings' => $monitorings,
+        ]);
+    }
+
+    public function create(): View|RedirectResponse
+    {
+        $demoUser = $this->demoUser()->loadMissing('package');
+
+        if ($this->demoMonitoringsQuery($demoUser)->count() >= (int) $demoUser->package->monitoring_limit) {
+            return to_route('admin.demo-monitorings.index')
+                ->withErrors(['limit' => __('monitoring.messages.limit_reached')]);
+        }
+
+        $serverInstances = ServerInstance::query()->active()->orderBy('code')->get(['code']);
+
+        if ($serverInstances->isEmpty()) {
+            return to_route('admin.demo-monitorings.index')
+                ->withErrors(['preferred_location' => __('monitoring.messages.no_server_instances')]);
+        }
+
+        return view('admin.demo-monitorings.create', [
+            'demoUser' => $demoUser,
+            'types' => MonitoringType::cases(),
+            'serverInstances' => $serverInstances,
+            'enabledNotificationChannels' => $demoUser->enabledNotificationChannelKeys(),
+        ]);
+    }
+
+    public function store(DemoMonitoringRequest $request): RedirectResponse
+    {
+        $demoUser = $this->demoUser()->loadMissing('package');
+
+        if ($this->demoMonitoringsQuery($demoUser)->count() >= (int) $demoUser->package->monitoring_limit) {
+            return to_route('admin.demo-monitorings.index')
+                ->withErrors(['limit' => __('monitoring.messages.limit_reached')]);
+        }
+
+        $validated = MonitoringPayload::prepareStore($request->validated());
+        $validated['user_id'] = $demoUser->id;
+
+        Monitoring::query()
+            ->withoutGlobalScope('user')
+            ->create($validated);
+
+        return to_route('admin.demo-monitorings.index')
+            ->with('success', __('admin.demo_monitorings.messages.created'));
+    }
+
+    private function demoUser(): User
+    {
+        return User::query()
+            ->where('role', UserRole::DEMO)
+            ->firstOrFail();
+    }
+
+    /**
+     * @return Builder<Monitoring>
+     */
+    private function demoMonitoringsQuery(User $demoUser): Builder
+    {
+        return Monitoring::query()
+            ->withoutGlobalScope('user')
+            ->where('user_id', $demoUser->id);
+    }
+}

--- a/app/Http/Controllers/Auth/DemoLoginController.php
+++ b/app/Http/Controllers/Auth/DemoLoginController.php
@@ -9,16 +9,16 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 
-class GuestLoginController extends Controller
+class DemoLoginController extends Controller
 {
     public function __invoke(): JsonResponse
     {
-        $guest = User::query()->where('role', UserRole::GUEST)->first();
+        $demoUser = User::query()->where('role', UserRole::DEMO)->first();
 
-        if (! $guest) {
+        if (! $demoUser) {
             return response()->json(['error' => __('auth.guest_login.no_guest_user_found')], 404);
         }
 
-        return response()->json(['email' => $guest->email]);
+        return response()->json(['email' => $demoUser->email]);
     }
 }

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -11,13 +11,12 @@ use App\Jobs\DeleteMonitoringResults;
 use App\Models\Monitoring;
 use App\Models\ServerInstance;
 use App\Models\User;
-use App\Support\HttpStatusCodeRanges;
+use App\Support\MonitoringPayload;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
@@ -91,7 +90,7 @@ class MonitoringController extends Controller
             ? $currentUser->monitorings()->count()
             : $lengthAwarePaginator->total();
         $monitoringLimit = (int) $currentUser->package->monitoring_limit;
-        $canCreateMonitoring = ! $currentUser->isGuest() && $monitoringsTotal < $monitoringLimit;
+        $canCreateMonitoring = ! $currentUser->isDemo() && $monitoringsTotal < $monitoringLimit;
 
         if (! $hasActiveFilters && $monitoringsTotal === 0) {
             $request->attributes->set('unread_notifications_count', 0);
@@ -118,7 +117,7 @@ class MonitoringController extends Controller
      */
     public function create(): View|RedirectResponse
     {
-        abort_if(Auth::user()->isGuest(), 403);
+        abort_if(Auth::user()->isDemo(), 403);
 
         if (Auth::user()->monitorings()->count() >= Auth::user()->package->monitoring_limit) {
             return to_route('monitorings.index')
@@ -148,7 +147,7 @@ class MonitoringController extends Controller
      */
     public function store(MonitoringRequest $monitoringRequest): RedirectResponse
     {
-        abort_if(Auth::user()->isGuest(), 403);
+        abort_if(Auth::user()->isDemo(), 403);
 
         if (Auth::user()->monitorings()->count() >= Auth::user()->package->monitoring_limit) {
             return to_route('monitorings.index')
@@ -156,7 +155,7 @@ class MonitoringController extends Controller
         }
 
         $validated = $monitoringRequest->validated();
-        $validated = $this->prepareStorePayload($validated);
+        $validated = MonitoringPayload::prepareStore($validated);
 
         Auth::user()->monitorings()->create($validated);
 
@@ -186,7 +185,7 @@ class MonitoringController extends Controller
      */
     public function edit(Monitoring $monitoring): View
     {
-        abort_if(Auth::user()->isGuest(), 403);
+        abort_if(Auth::user()->isDemo(), 403);
 
         $types = MonitoringType::cases();
         $serverInstances = ServerInstance::query()
@@ -212,11 +211,11 @@ class MonitoringController extends Controller
      */
     public function update(MonitoringRequest $monitoringRequest, Monitoring $monitoring): RedirectResponse
     {
-        abort_if(Auth::user()->isGuest(), 403);
+        abort_if(Auth::user()->isDemo(), 403);
 
         $validated = $monitoringRequest->validated();
         unset($validated['target']);
-        $validated = $this->prepareUpdatePayload($validated, $monitoring);
+        $validated = MonitoringPayload::prepareUpdate($validated, $monitoring);
 
         if (! isset($validated['public_label_enabled']) || ! $validated['public_label_enabled']) {
             $validated['public_label_enabled'] = false;
@@ -235,7 +234,7 @@ class MonitoringController extends Controller
      */
     public function destroy(Monitoring $monitoring): RedirectResponse
     {
-        abort_if(Auth::user()->isGuest(), 403);
+        abort_if(Auth::user()->isDemo(), 403);
 
         $monitoring->delete();
 
@@ -250,7 +249,7 @@ class MonitoringController extends Controller
      */
     public function destroyResults(Monitoring $monitoring): RedirectResponse
     {
-        abort_if(Auth::user()->isGuest(), 403);
+        abort_if(Auth::user()->isDemo(), 403);
 
         if (cache()->getStore() instanceof TaggableStore) {
             cache()->tags(['monitoring:' . $monitoring->id])->flush();
@@ -265,102 +264,5 @@ class MonitoringController extends Controller
         dispatch(new DeleteMonitoringResults($monitoring));
 
         return to_route('monitorings.show', $monitoring)->with('success', __('monitoring.messages.results_deleted'));
-    }
-
-    /**
-     * @param  array<string, mixed>  $validated
-     * @return array<string, mixed>
-     */
-    private function prepareStorePayload(array $validated): array
-    {
-        $type = MonitoringType::tryFrom((string) ($validated['type'] ?? ''));
-
-        if ($type === MonitoringType::DOMAIN_EXPIRATION) {
-            $validated['target'] = mb_strtolower(mb_trim((string) $validated['target']));
-            $validated['timeout'] = 5;
-            $validated['http_method'] = null;
-            $validated['expected_http_statuses'] = null;
-            $validated['http_headers'] = null;
-            $validated['http_body'] = null;
-            $validated['auth_username'] = null;
-            $validated['auth_password'] = null;
-            $validated['port'] = null;
-            $validated['keyword'] = null;
-        }
-
-        if (in_array($type, [MonitoringType::HTTP, MonitoringType::KEYWORD], true)) {
-            $validated['expected_http_statuses'] = HttpStatusCodeRanges::normalize($validated['expected_http_statuses'] ?? null);
-
-            return $validated;
-        }
-
-        if ($type !== MonitoringType::HEARTBEAT) {
-            $validated['expected_http_statuses'] = null;
-
-            return $validated;
-        }
-
-        $heartbeatToken = (string) Str::ulid();
-
-        $validated['heartbeat_token'] = $heartbeatToken;
-        $validated['target'] = route('monitorings.heartbeat.ping', ['token' => $heartbeatToken]);
-        $validated['timeout'] = 5;
-        $validated['http_method'] = null;
-        $validated['expected_http_statuses'] = null;
-        $validated['http_headers'] = null;
-        $validated['http_body'] = null;
-        $validated['auth_username'] = null;
-        $validated['auth_password'] = null;
-        $validated['port'] = null;
-        $validated['keyword'] = null;
-
-        return $validated;
-    }
-
-    /**
-     * @param  array<string, mixed>  $validated
-     * @return array<string, mixed>
-     */
-    private function prepareUpdatePayload(array $validated, Monitoring $monitoring): array
-    {
-        if ($monitoring->type === MonitoringType::DOMAIN_EXPIRATION) {
-            $validated['target'] = $monitoring->target;
-            $validated['timeout'] = 5;
-            $validated['http_method'] = null;
-            $validated['expected_http_statuses'] = null;
-            $validated['http_headers'] = null;
-            $validated['http_body'] = null;
-            $validated['auth_username'] = null;
-            $validated['auth_password'] = null;
-            $validated['port'] = null;
-            $validated['keyword'] = null;
-
-            return $validated;
-        }
-
-        if (in_array($monitoring->type, [MonitoringType::HTTP, MonitoringType::KEYWORD], true)) {
-            $validated['expected_http_statuses'] = HttpStatusCodeRanges::normalize($validated['expected_http_statuses'] ?? null);
-
-            return $validated;
-        }
-
-        if (! $monitoring->isHeartbeat()) {
-            $validated['expected_http_statuses'] = null;
-
-            return $validated;
-        }
-
-        $validated['target'] = $monitoring->target;
-        $validated['timeout'] = 5;
-        $validated['http_method'] = null;
-        $validated['expected_http_statuses'] = null;
-        $validated['http_headers'] = null;
-        $validated['http_body'] = null;
-        $validated['auth_username'] = null;
-        $validated['auth_password'] = null;
-        $validated['port'] = null;
-        $validated['keyword'] = null;
-
-        return $validated;
     }
 }

--- a/app/Http/Requests/Admin/DemoMonitoringRequest.php
+++ b/app/Http/Requests/Admin/DemoMonitoringRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\UserRole;
+use App\Http\Requests\MonitoringRequest;
+use App\Models\User;
+
+class DemoMonitoringRequest extends MonitoringRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() === true;
+    }
+
+    protected function notificationChannelUser(): ?User
+    {
+        return User::query()
+            ->where('role', UserRole::DEMO)
+            ->first();
+    }
+}

--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests;
 use App\Enums\HttpMethod;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
+use App\Models\User;
 use App\Support\HttpStatusCodeRanges;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -172,7 +173,7 @@ class MonitoringRequest extends FormRequest
             'notification_channels' => ['nullable', 'array'],
             'notification_channels.*' => [
                 'string',
-                Rule::in($this->user()?->enabledNotificationChannelKeys() ?? []),
+                Rule::in($this->notificationChannelUser()?->enabledNotificationChannelKeys() ?? []),
             ],
             'ssl_expiry_warning_days' => ['required', 'integer', 'min:1', 'max:365'],
             'maintenance_from' => ['nullable', 'date'],
@@ -184,6 +185,11 @@ class MonitoringRequest extends FormRequest
         }
 
         return $rules;
+    }
+
+    protected function notificationChannelUser(): ?User
+    {
+        return $this->user();
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -138,11 +138,19 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
-     * Determine if the user has guest role.
+     * Determine if the user has demo role.
+     */
+    public function isDemo(): bool
+    {
+        return $this->role === UserRole::DEMO;
+    }
+
+    /**
+     * @deprecated Use isDemo().
      */
     public function isGuest(): bool
     {
-        return $this->role === UserRole::GUEST;
+        return $this->isDemo();
     }
 
     /**

--- a/app/Support/MonitoringPayload.php
+++ b/app/Support/MonitoringPayload.php
@@ -19,9 +19,7 @@ final class MonitoringPayload
         $type = MonitoringType::tryFrom((string) ($validated['type'] ?? ''));
 
         if ($type === MonitoringType::DOMAIN_EXPIRATION) {
-            $validated = self::applyDomainDefaults($validated);
-
-            return $validated;
+            return self::applyDomainDefaults($validated);
         }
 
         if (in_array($type, [MonitoringType::HTTP, MonitoringType::KEYWORD], true)) {

--- a/app/Support/MonitoringPayload.php
+++ b/app/Support/MonitoringPayload.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use Illuminate\Support\Str;
+
+final class MonitoringPayload
+{
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    public static function prepareStore(array $validated): array
+    {
+        $type = MonitoringType::tryFrom((string) ($validated['type'] ?? ''));
+
+        if ($type === MonitoringType::DOMAIN_EXPIRATION) {
+            $validated = self::applyDomainDefaults($validated);
+
+            return $validated;
+        }
+
+        if (in_array($type, [MonitoringType::HTTP, MonitoringType::KEYWORD], true)) {
+            $validated['expected_http_statuses'] = HttpStatusCodeRanges::normalize($validated['expected_http_statuses'] ?? null);
+
+            return $validated;
+        }
+
+        if ($type !== MonitoringType::HEARTBEAT) {
+            $validated['expected_http_statuses'] = null;
+
+            return $validated;
+        }
+
+        $heartbeatToken = (string) Str::ulid();
+
+        $validated['heartbeat_token'] = $heartbeatToken;
+        $validated['target'] = route('monitorings.heartbeat.ping', ['token' => $heartbeatToken]);
+
+        return self::applyNonHttpDefaults($validated);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    public static function prepareUpdate(array $validated, Monitoring $monitoring): array
+    {
+        if ($monitoring->type === MonitoringType::DOMAIN_EXPIRATION) {
+            $validated['target'] = $monitoring->target;
+
+            return self::applyDomainDefaults($validated);
+        }
+
+        if (in_array($monitoring->type, [MonitoringType::HTTP, MonitoringType::KEYWORD], true)) {
+            $validated['expected_http_statuses'] = HttpStatusCodeRanges::normalize($validated['expected_http_statuses'] ?? null);
+
+            return $validated;
+        }
+
+        if (! $monitoring->isHeartbeat()) {
+            $validated['expected_http_statuses'] = null;
+
+            return $validated;
+        }
+
+        $validated['target'] = $monitoring->target;
+
+        return self::applyNonHttpDefaults($validated);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    private static function applyDomainDefaults(array $validated): array
+    {
+        $validated['target'] = mb_strtolower(mb_trim((string) $validated['target']));
+
+        return self::applyNonHttpDefaults($validated);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    private static function applyNonHttpDefaults(array $validated): array
+    {
+        $validated['timeout'] = 5;
+        $validated['http_method'] = null;
+        $validated['expected_http_statuses'] = null;
+        $validated['http_headers'] = null;
+        $validated['http_body'] = null;
+        $validated['auth_username'] = null;
+        $validated['auth_password'] = null;
+        $validated['port'] = null;
+        $validated['keyword'] = null;
+
+        return $validated;
+    }
+}

--- a/database/migrations/2026_05_14_120000_rename_guest_role_to_demo.php
+++ b/database/migrations/2026_05_14_120000_rename_guest_role_to_demo.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! DB::table('users')->where('email', 'demo@example.com')->exists()) {
+            DB::table('users')
+                ->where('email', 'guest@example.com')
+                ->update([
+                    'name' => 'Demo User',
+                    'email' => 'demo@example.com',
+                ]);
+        }
+
+        DB::table('users')
+            ->where('role', 'guest')
+            ->update([
+                'name' => 'Demo User',
+                'role' => UserRole::DEMO->value,
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! DB::table('users')->where('email', 'guest@example.com')->exists()) {
+            DB::table('users')
+                ->where('email', 'demo@example.com')
+                ->update([
+                    'name' => 'Guest User',
+                    'email' => 'guest@example.com',
+                ]);
+        }
+
+        DB::table('users')
+            ->where('role', UserRole::DEMO->value)
+            ->update([
+                'name' => 'Guest User',
+                'role' => 'guest',
+            ]);
+    }
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -28,11 +28,13 @@ class UserSeeder extends Seeder
             'role' => UserRole::ADMIN->value,
         ]);
 
-        User::factory()->create([
-            'name' => 'Guest User',
-            'email' => 'guest@example.com',
-            'password' => 'password',
-            'role' => UserRole::GUEST->value,
-        ]);
+        User::query()->updateOrCreate(
+            ['email' => 'demo@example.com'],
+            [
+                'name' => 'Demo User',
+                'password' => 'password',
+                'role' => UserRole::DEMO->value,
+            ]
+        );
     }
 }

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -13,7 +13,7 @@ import Chart from 'chart.js/auto';
 import monitoringCardLoader from './components/monitoring-cards';
 import monitoringDetail from './components/monitoring-detail';
 import uptimeCalendar from './components/uptime-calendar';
-import guestLogin from './components/guestLogin';
+import demoLogin from './components/demoLogin';
 import asyncTable from './components/async-table';
 import confirmDialog, { registerConfirmableForms } from './components/confirm-dialog';
 
@@ -64,7 +64,7 @@ document.addEventListener('click', (event: MouseEvent): void => {
 Alpine.data('monitoringDetail', monitoringDetail);
 Alpine.data('monitoringCardLoader', monitoringCardLoader);
 Alpine.data('uptimeCalendar', uptimeCalendar);
-Alpine.data('guestLogin', guestLogin);
+Alpine.data('demoLogin', demoLogin);
 Alpine.data('asyncTable', asyncTable);
 Alpine.data('confirmDialog', confirmDialog);
 

--- a/resources/js/components/demoLogin.ts
+++ b/resources/js/components/demoLogin.ts
@@ -1,36 +1,36 @@
 import axios from 'axios';
 
-interface GuestLoginComponent {
+interface DemoLoginComponent {
     mode: string;
     email: string;
-    guestLoaded: boolean;
+    demoLoaded: boolean;
     usingDemoCredentials: boolean;
     savedEmail: string;
     savedPassword: string;
-    init(this: GuestLoginComponent): void;
-    switchMode(this: GuestLoginComponent, nextMode: string): void;
-    fetchGuestCredentials(this: GuestLoginComponent): Promise<void>;
-    fillLoginForm(this: GuestLoginComponent): void;
-    captureLoginFormState(this: GuestLoginComponent): void;
-    restoreLoginFormState(this: GuestLoginComponent): void;
+    init(this: DemoLoginComponent): void;
+    switchMode(this: DemoLoginComponent, nextMode: string): void;
+    fetchDemoCredentials(this: DemoLoginComponent): Promise<void>;
+    fillLoginForm(this: DemoLoginComponent): void;
+    captureLoginFormState(this: DemoLoginComponent): void;
+    restoreLoginFormState(this: DemoLoginComponent): void;
 }
 
-export default (initialMode: string = 'login'): GuestLoginComponent => ({
+export default (initialMode: string = 'login'): DemoLoginComponent => ({
     mode: initialMode,
     email: '',
-    guestLoaded: false,
+    demoLoaded: false,
     usingDemoCredentials: false,
     savedEmail: '',
     savedPassword: '',
 
-    init(this: GuestLoginComponent): void {
+    init(this: DemoLoginComponent): void {
         if (this.mode === 'demo') {
             this.captureLoginFormState();
-            this.fetchGuestCredentials();
+            this.fetchDemoCredentials();
         }
     },
 
-    switchMode(this: GuestLoginComponent, nextMode: string): void {
+    switchMode(this: DemoLoginComponent, nextMode: string): void {
         const previousMode = this.mode;
 
         if (previousMode === 'demo' && nextMode !== 'demo' && this.usingDemoCredentials) {
@@ -46,27 +46,27 @@ export default (initialMode: string = 'login'): GuestLoginComponent => ({
 
         this.captureLoginFormState();
 
-        if (this.guestLoaded) {
+        if (this.demoLoaded) {
             this.fillLoginForm();
             return;
         }
 
-        this.fetchGuestCredentials();
+        this.fetchDemoCredentials();
     },
 
-    async fetchGuestCredentials(this: GuestLoginComponent): Promise<void> {
+    async fetchDemoCredentials(this: DemoLoginComponent): Promise<void> {
         try {
-            const response = await axios.get('/guest-login-credentials');
+            const response = await axios.get('/demo-login-credentials');
             this.email = response.data.email;
-            this.guestLoaded = true;
+            this.demoLoaded = true;
             this.fillLoginForm();
         } catch (error) {
-            console.error('Failed to fetch guest credentials:', error);
-            alert('Could not find guest user credentials.');
+            console.error('Failed to fetch demo credentials:', error);
+            alert('Could not find demo user credentials.');
         }
     },
 
-    fillLoginForm(this: GuestLoginComponent): void {
+    fillLoginForm(this: DemoLoginComponent): void {
         const emailInput = document.getElementById('email') as HTMLInputElement;
         const passwordInput = document.getElementById('password') as HTMLInputElement;
 
@@ -77,7 +77,7 @@ export default (initialMode: string = 'login'): GuestLoginComponent => ({
         }
     },
 
-    captureLoginFormState(this: GuestLoginComponent): void {
+    captureLoginFormState(this: DemoLoginComponent): void {
         const emailInput = document.getElementById('email') as HTMLInputElement;
         const passwordInput = document.getElementById('password') as HTMLInputElement;
 
@@ -89,7 +89,7 @@ export default (initialMode: string = 'login'): GuestLoginComponent => ({
         this.savedPassword = passwordInput.value;
     },
 
-    restoreLoginFormState(this: GuestLoginComponent): void {
+    restoreLoginFormState(this: DemoLoginComponent): void {
         const emailInput = document.getElementById('email') as HTMLInputElement;
         const passwordInput = document.getElementById('password') as HTMLInputElement;
 

--- a/resources/lang/de/admin.php
+++ b/resources/lang/de/admin.php
@@ -22,9 +22,35 @@ return [
             'heading' => 'Serverinstanzen verwalten',
             'description' => 'Crawler-Instanz-Codes und interne API-Schlüssel verwalten.',
         ],
+        'demo_monitorings' => [
+            'heading' => 'Demo-Monitorings verwalten',
+            'description' => 'Monitorings des Demo-Benutzers anzeigen und hinzufügen.',
+        ],
         'activity_logs' => [
             'heading' => 'Audit-Protokolle',
             'description' => 'Konto-, Profil-, API-Token- und Monitoring-Änderungen prüfen.',
+        ],
+    ],
+    'demo_monitorings' => [
+        'title' => 'Demo-Benutzer-Monitorings',
+        'actions' => [
+            'create' => 'Demo-Monitoring hinzufügen',
+        ],
+        'fields' => [
+            'created_at' => 'Erstellt',
+        ],
+        'summary' => [
+            'demo_user' => 'Demo-Benutzer',
+            'monitorings' => 'Monitorings',
+            'package_limit' => 'Paketlimit',
+        ],
+        'messages' => [
+            'empty' => 'Keine Monitorings für den Demo-Benutzer gefunden.',
+            'created' => 'Demo-Benutzer-Monitoring erfolgreich erstellt.',
+        ],
+        'create' => [
+            'title' => 'Demo-Benutzer-Monitoring erstellen',
+            'demo_user' => 'Monitoring-Besitzer',
         ],
     ],
     'activity_logs' => [

--- a/resources/lang/de/auth.php
+++ b/resources/lang/de/auth.php
@@ -76,6 +76,6 @@ return [
         'expired' => 'Die GitHub-Anmeldung ist abgelaufen. Bitte starten Sie den Login erneut.',
     ],
     'guest_login' => [
-        'no_guest_user_found' => 'Kein Gastbenutzer gefunden.',
+        'no_guest_user_found' => 'Kein Demo-Benutzer gefunden.',
     ],
 ];

--- a/resources/lang/de/gdpr.php
+++ b/resources/lang/de/gdpr.php
@@ -99,7 +99,7 @@ return [
         ],
         'retention' => [
             'title' => '7. Speicherdauer',
-            'lead' => 'Personenbezogene Daten werden nur so lange gespeichert, wie dies für vertragliche, gesetzliche und betriebliche Zwecke erforderlich ist. In der aktuellen App-Konfiguration werden z. B. gelesene Benachrichtigungen regelmäßig nach rund einem Monat gelöscht und Gast-Benachrichtigungen nach rund einer Woche entfernt. Audit-Log-Einträge zu nutzergesteuerten Konto-, Profil-, API-Token- und Monitoring-Änderungen werden nach 30 Tagen gelöscht. Ältere Roh-Monitoringdaten werden regelmäßig in eine Archivtabelle überführt. Zustellhistorien und technische Fehlerdaten werden für Nachvollziehbarkeit und Fehleranalyse vorübergehend gespeichert. Bei Löschung von Konten oder Monitorings werden zugehörige Daten im Rahmen der technischen Löschprozesse entfernt.',
+            'lead' => 'Personenbezogene Daten werden nur so lange gespeichert, wie dies für vertragliche, gesetzliche und betriebliche Zwecke erforderlich ist. In der aktuellen App-Konfiguration werden z. B. gelesene Benachrichtigungen regelmäßig nach rund einem Monat gelöscht und Demo-Benutzer-Benachrichtigungen nach rund einer Woche entfernt. Audit-Log-Einträge zu nutzergesteuerten Konto-, Profil-, API-Token- und Monitoring-Änderungen werden nach 30 Tagen gelöscht. Ältere Roh-Monitoringdaten werden regelmäßig in eine Archivtabelle überführt. Zustellhistorien und technische Fehlerdaten werden für Nachvollziehbarkeit und Fehleranalyse vorübergehend gespeichert. Bei Löschung von Konten oder Monitorings werden zugehörige Daten im Rahmen der technischen Löschprozesse entfernt.',
         ],
         'security' => [
             'title' => '8. Sicherheitsmaßnahmen',

--- a/resources/lang/de/legal.php
+++ b/resources/lang/de/legal.php
@@ -29,7 +29,7 @@ return [
                     'Kanalbasierte Benachrichtigungen für Incidents, Recovery, SSL- und Domain-Ablaufereignisse (z. B. E-Mail, Slack, Telegram, Discord, Custom Webhooks) einschließlich Testversand, Versandhistorie, Wochen-Digest und Erinnerungen an ungelesene Benachrichtigungen.',
                     'Tokenbasierter API-Zugriff für freigegebene Endpunkte sowie öffentliche Widget-Endpunkte für aktivierte Public Labels.',
                     'Anzeige von Monitoring-Standorten und Betrieb mehrerer Serverinstanzen zur Durchführung von Checks.',
-                    'Optionale Anmeldung über GitHub sowie Demo-/Gastzugang.',
+                    'Optionale Anmeldung über GitHub sowie Demo-Zugang.',
                 ],
             ],
             'obligations' => [

--- a/resources/lang/de/welcome.php
+++ b/resources/lang/de/welcome.php
@@ -26,7 +26,7 @@ return [
         'title' => 'WebGuard bietet professionelles Monitoring für Teams und Einzelprojekte.',
         'subtitle' => 'Die Plattform unterstützt die zuverlässige Überwachung von Services und Infrastruktur und kann ohne Lizenzkosten genutzt werden.',
         'primary_cta' => 'Kostenfrei starten',
-        'secondary_cta' => 'Gastzugang nutzen',
+        'secondary_cta' => 'Demo-Zugang nutzen',
         'metrics' => [
             '1' => [
                 'label' => 'Lizenz',
@@ -197,14 +197,14 @@ return [
 
     'final_cta' => [
         'title' => 'WebGuard kostenfrei nutzen',
-        'text' => 'Die Software steht ohne Kaufmodell zur Verfügung. Login oder Gastzugang reichen aus, um die zentralen Funktionen auszuprobieren.',
+        'text' => 'Die Software steht ohne Kaufmodell zur Verfügung. Login oder Demo-Zugang reichen aus, um die zentralen Funktionen auszuprobieren.',
         'primary' => 'Zum Login',
-        'secondary' => 'Gastzugang öffnen',
+        'secondary' => 'Demo-Zugang öffnen',
     ],
 
     'guest_login' => [
         'title' => 'WebGuard ausprobieren',
-        'text' => 'Melden Sie sich mit dem Gastkonto an und erkunden Sie Dashboards, Checks und Benachrichtigungen direkt im laufenden Beispiel. Keine Registrierung erforderlich.',
-        'button' => 'Als Gast anmelden',
+        'text' => 'Melden Sie sich mit dem Demo-Benutzer an und erkunden Sie Dashboards, Checks und Benachrichtigungen direkt im laufenden Beispiel. Keine Registrierung erforderlich.',
+        'button' => 'Als Demo-Benutzer anmelden',
     ],
 ];

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -22,9 +22,35 @@ return [
             'heading' => 'Manage Server Instances',
             'description' => 'Manage crawler instance codes and internal API keys.',
         ],
+        'demo_monitorings' => [
+            'heading' => 'Manage Demo Monitorings',
+            'description' => 'View and add monitorings for the demo user.',
+        ],
         'activity_logs' => [
             'heading' => 'Audit Logs',
             'description' => 'Review account, profile, API-token, and monitoring changes.',
+        ],
+    ],
+    'demo_monitorings' => [
+        'title' => 'Demo User Monitorings',
+        'actions' => [
+            'create' => 'Add Demo Monitoring',
+        ],
+        'fields' => [
+            'created_at' => 'Created',
+        ],
+        'summary' => [
+            'demo_user' => 'Demo User',
+            'monitorings' => 'Monitorings',
+            'package_limit' => 'Package Limit',
+        ],
+        'messages' => [
+            'empty' => 'No demo user monitorings found.',
+            'created' => 'Demo user monitoring created successfully.',
+        ],
+        'create' => [
+            'title' => 'Create Demo User Monitoring',
+            'demo_user' => 'Monitoring owner',
         ],
     ],
     'activity_logs' => [

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -76,6 +76,6 @@ return [
         'expired' => 'The GitHub login flow expired. Please start again.',
     ],
     'guest_login' => [
-        'no_guest_user_found' => 'No guest user found.',
+        'no_guest_user_found' => 'No demo user found.',
     ],
 ];

--- a/resources/lang/en/gdpr.php
+++ b/resources/lang/en/gdpr.php
@@ -99,7 +99,7 @@ return [
         ],
         'retention' => [
             'title' => '7. Storage Duration',
-            'lead' => 'Personal data is stored only as long as needed for contractual, legal, and operational purposes. In the current app configuration, read notifications are regularly deleted after about one month, and guest notifications are removed after about one week. Audit log entries for user-controlled account, profile, API-token, and monitoring changes are deleted after 30 days. Older raw monitoring responses are regularly moved to an archive table. Delivery histories and technical error data are stored temporarily for auditability and troubleshooting. When accounts or monitorings are deleted, related data is removed as part of technical deletion workflows.',
+            'lead' => 'Personal data is stored only as long as needed for contractual, legal, and operational purposes. In the current app configuration, read notifications are regularly deleted after about one month, and demo user notifications are removed after about one week. Audit log entries for user-controlled account, profile, API-token, and monitoring changes are deleted after 30 days. Older raw monitoring responses are regularly moved to an archive table. Delivery histories and technical error data are stored temporarily for auditability and troubleshooting. When accounts or monitorings are deleted, related data is removed as part of technical deletion workflows.',
         ],
         'security' => [
             'title' => '8. Security Measures',

--- a/resources/lang/en/legal.php
+++ b/resources/lang/en/legal.php
@@ -29,7 +29,7 @@ return [
                     'Channel-based notifications for incidents, recoveries, SSL events, and domain-expiration events (for example email, Slack, Telegram, Discord, custom webhooks), including test delivery, delivery history, weekly digest, and unread-notification reminders.',
                     'Token-based API access for supported endpoints and public widget endpoints for enabled public labels.',
                     'Monitoring-location display and multiple server instances used to perform checks.',
-                    'Optional GitHub sign-in and demo/guest access.',
+                    'Optional GitHub sign-in and demo access.',
                 ],
             ],
             'obligations' => [

--- a/resources/lang/en/welcome.php
+++ b/resources/lang/en/welcome.php
@@ -26,7 +26,7 @@ return [
         'title' => 'WebGuard delivers professional monitoring for teams and individual projects.',
         'subtitle' => 'The platform supports reliable monitoring for services and infrastructure and is available without license costs.',
         'primary_cta' => 'Start for Free',
-        'secondary_cta' => 'Use Guest Access',
+        'secondary_cta' => 'Use Demo Access',
         'metrics' => [
             '1' => [
                 'label' => 'License',
@@ -197,14 +197,14 @@ return [
 
     'final_cta' => [
         'title' => 'Use WebGuard for free',
-        'text' => 'The software is available without a purchase model. Login or guest access is enough to explore the core features.',
+        'text' => 'The software is available without a purchase model. Login or demo access is enough to explore the core features.',
         'primary' => 'Go to Login',
-        'secondary' => 'Open Guest Access',
+        'secondary' => 'Open Demo Access',
     ],
 
     'guest_login' => [
         'title' => 'Try WebGuard',
-        'text' => 'Sign in with the guest account and explore dashboards, checks, and notifications in a live example environment. No registration required.',
-        'button' => 'Login as Guest',
+        'text' => 'Sign in with the demo user and explore dashboards, checks, and notifications in a live example environment. No registration required.',
+        'button' => 'Login as Demo User',
     ],
 ];

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -35,6 +35,13 @@
                 </x-container>
             </a>
 
+            <a href="{{ route('admin.demo-monitorings.index') }}">
+                <x-container class="h-full">
+                    <x-heading type="h2" space="true">{{ __('admin.dashboard.demo_monitorings.heading') }}</x-heading>
+                    <x-paragraph>{{ __('admin.dashboard.demo_monitorings.description') }}</x-paragraph>
+                </x-container>
+            </a>
+
             <a href="{{ route('admin.activity-logs.index') }}">
                 <x-container class="h-full">
                     <x-heading type="h2" space="true">{{ __('admin.dashboard.activity_logs.heading') }}</x-heading>

--- a/resources/views/admin/demo-monitorings/create.blade.php
+++ b/resources/views/admin/demo-monitorings/create.blade.php
@@ -1,0 +1,26 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">
+            {{ __('admin.demo_monitorings.create.title') }}
+        </x-heading>
+
+        <x-secondary-button :href="route('admin.demo-monitorings.index')" class="sm:ml-auto">
+            {{ __('button.back') }}
+        </x-secondary-button>
+    </x-slot>
+
+    <x-main>
+        <x-container>
+            <div class="mb-6">
+                <x-heading type="h2">{{ __('admin.demo_monitorings.create.demo_user') }}</x-heading>
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                    {{ $demoUser->name }} - {{ $demoUser->email }}
+                </p>
+            </div>
+
+            <form method="POST" action="{{ route('admin.demo-monitorings.store') }}">
+                @include('monitorings._form')
+            </form>
+        </x-container>
+    </x-main>
+</x-app-layout>

--- a/resources/views/admin/demo-monitorings/index.blade.php
+++ b/resources/views/admin/demo-monitorings/index.blade.php
@@ -1,0 +1,75 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">
+            {{ __('admin.demo_monitorings.title') }}
+        </x-heading>
+
+        <x-secondary-button :href="route('admin.dashboard')" class="sm:ml-auto">
+            {{ __('button.back') }}
+        </x-secondary-button>
+    </x-slot>
+
+    <x-main>
+        <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+            <x-container>
+                <x-heading type="h2">{{ __('admin.demo_monitorings.summary.demo_user') }}</x-heading>
+                <p class="mt-2 font-semibold text-gray-900 dark:text-gray-100">{{ $demoUser->name }}</p>
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ $demoUser->email }}</p>
+            </x-container>
+
+            <x-container>
+                <x-heading type="h2">{{ __('admin.demo_monitorings.summary.monitorings') }}</x-heading>
+                <p class="mt-2 text-2xl font-bold text-purple-600 dark:text-purple-300">{{ $monitorings->total() }}</p>
+            </x-container>
+
+            <x-container>
+                <x-heading type="h2">{{ __('admin.demo_monitorings.summary.package_limit') }}</x-heading>
+                <p class="mt-2 text-2xl font-bold text-purple-600 dark:text-purple-300">{{ $demoUser->package?->monitoring_limit ?? '-' }}</p>
+            </x-container>
+        </div>
+
+        <div class="mb-4 flex justify-end">
+            <x-primary-button :href="route('admin.demo-monitorings.create')">
+                {{ __('admin.demo_monitorings.actions.create') }}
+            </x-primary-button>
+        </div>
+
+        <x-table>
+            <x-slot name="head">
+                <x-table.heading>{{ __('monitoring.index.table.name') }}</x-table.heading>
+                <x-table.heading>{{ __('monitoring.index.table.type') }}</x-table.heading>
+                <x-table.heading>{{ __('monitoring.index.table.target') }}</x-table.heading>
+                <x-table.heading>{{ __('monitoring.index.table.status') }}</x-table.heading>
+                <x-table.heading>{{ __('monitoring.form.preferred_location') }}</x-table.heading>
+                <x-table.heading>{{ __('admin.demo_monitorings.fields.created_at') }}</x-table.heading>
+            </x-slot>
+
+            <x-slot name="body">
+                @forelse ($monitorings as $monitoring)
+                    <x-table.row>
+                        <x-table.cell>{{ $monitoring->name }}</x-table.cell>
+                        <x-table.cell>{{ __('monitoring.types.' . $monitoring->type->value) }}</x-table.cell>
+                        <x-table.cell>
+                            <span class="block max-w-xs truncate" title="{{ $monitoring->target }}">
+                                {{ $monitoring->target }}
+                            </span>
+                        </x-table.cell>
+                        <x-table.cell>{{ ucfirst($monitoring->status->value) }}</x-table.cell>
+                        <x-table.cell>{{ $monitoring->preferred_location }}</x-table.cell>
+                        <x-table.cell>{{ $monitoring->created_at?->format('Y-m-d H:i') }}</x-table.cell>
+                    </x-table.row>
+                @empty
+                    <x-table.row>
+                        <x-table.cell colspan="6">
+                            {{ __('admin.demo_monitorings.messages.empty') }}
+                        </x-table.cell>
+                    </x-table.row>
+                @endforelse
+            </x-slot>
+        </x-table>
+
+        <div class="mt-4">
+            {{ $monitorings->links() }}
+        </div>
+    </x-main>
+</x-app-layout>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -17,7 +17,7 @@
 @endphp
 
 <x-guest-layout card-width="sm:max-w-7xl">
-    <div x-data="guestLogin(@js($initialMode))" x-init="init()" data-initial-mode="{{ $initialMode }}">
+    <div x-data="demoLogin(@js($initialMode))" x-init="init()" data-initial-mode="{{ $initialMode }}">
         <x-auth-session-status class="mb-4" :status="session('status')" />
 
         <div class="grid gap-6 lg:grid-cols-[17rem_minmax(0,1fr)]">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -53,7 +53,7 @@
                     </x-slot>
 
                     <x-slot name="content">
-                        @if (!Auth::user()->isGuest())
+                        @if (!Auth::user()->isDemo())
                             <x-dropdown-link :href="route('profile.edit')">
                                 {{ __('profile.title') }}
                             </x-dropdown-link>
@@ -116,7 +116,7 @@
             </div>
 
             <div class="mt-3 space-y-1">
-                @if (!Auth::user()->isGuest())
+                @if (!Auth::user()->isDemo())
                     <x-responsive-nav-link :href="route('profile.edit')">
                         {{ __('profile.title') }}
                     </x-responsive-nav-link>

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -33,7 +33,7 @@
 
         <div class="ml-auto flex flex-wrap items-start gap-2 sm:items-center">
 
-            @if (!Auth::user()->isGuest())
+            @if (!Auth::user()->isDemo())
                 <div class="relative" x-data="{ open: false }">
                     <x-secondary-button @click="open = !open">
                         {{ __('monitoring.actions.heading') }}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -49,7 +49,7 @@
                             class="bg-emerald-500 px-6 py-3 text-base font-semibold text-white normal-case tracking-normal shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-600 focus:ring-emerald-500 dark:bg-emerald-400 dark:text-slate-950 dark:hover:bg-emerald-300 dark:focus:ring-emerald-300">
                             {{ __('button.login') }}
                         </x-primary-button>
-                        <x-secondary-button :href="route('login', ['guest' => 'true'])"
+                        <x-secondary-button :href="route('login', ['mode' => 'demo'])"
                             class="border-slate-300 bg-white px-6 py-3 text-base font-semibold text-slate-700 normal-case tracking-normal transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:border-slate-500 dark:hover:bg-slate-800">
                             {{ __('welcome.hero.secondary_cta') }}
                         </x-secondary-button>
@@ -257,7 +257,7 @@
                             class="bg-emerald-500 px-6 py-3 text-base font-semibold text-white normal-case tracking-normal shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-600 focus:ring-emerald-500 dark:bg-emerald-400 dark:text-slate-950 dark:hover:bg-emerald-300 dark:focus:ring-emerald-300">
                             {{ __('welcome.final_cta.primary') }}
                         </x-primary-button>
-                        <x-secondary-button :href="route('login', ['guest' => 'true'])"
+                        <x-secondary-button :href="route('login', ['mode' => 'demo'])"
                             class="border-slate-300 bg-white px-6 py-3 text-base font-semibold text-slate-700 normal-case tracking-normal transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-950/70 dark:text-slate-100 dark:hover:border-slate-500 dark:hover:bg-slate-900">
                             {{ __('welcome.final_cta.secondary') }}
                         </x-secondary-button>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Auth\ConfirmablePasswordController;
+use App\Http\Controllers\Auth\DemoLoginController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\EmailVerificationPromptController;
-use App\Http\Controllers\Auth\GuestLoginController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
@@ -15,7 +15,8 @@ use App\Http\Controllers\Auth\SocialiteConsentController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('guest-login-credentials', GuestLoginController::class)->name('guest-login.credentials');
+Route::get('demo-login-credentials', DemoLoginController::class)->name('demo-login.credentials');
+Route::get('guest-login-credentials', DemoLoginController::class)->name('guest-login.credentials');
 
 Route::middleware('guest')->group(function (): void {
     Route::get('register', [RegisteredUserController::class, 'create'])->name('register');

--- a/routes/console.php
+++ b/routes/console.php
@@ -29,8 +29,8 @@ Schedule::command('notifications:send-weekly-monitoring-digest')->dailyAt('08:30
 // Prune old read notifications daily.
 Schedule::command('notifications:prune-read')->dailyAt('01:00');
 
-// Prune old guest notifications daily.
-Schedule::command('notifications:prune-guest')
+// Prune old demo user notifications daily.
+Schedule::command('notifications:prune-demo')
     ->dailyAt('01:30')
     ->withoutOverlapping();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Admin\ActivityLogController;
 use App\Http\Controllers\Admin\ApiController as AdminApiController;
+use App\Http\Controllers\Admin\DemoMonitoringController;
 use App\Http\Controllers\Admin\PackageController;
 use App\Http\Controllers\Admin\ServerInstanceController;
 use App\Http\Controllers\Admin\UserController;
@@ -105,6 +106,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         Route::resource('/packages', PackageController::class)->except(['show'])->names('packages');
         Route::resource('/server-instances', ServerInstanceController::class)->except(['show'])->names('server-instances');
         Route::resource('/apis', AdminApiController::class)->only(['index'])->names('apis');
+        Route::resource('/demo-monitorings', DemoMonitoringController::class)->only(['index', 'create', 'store'])->names('demo-monitorings');
         Route::get('/audit-logs', [ActivityLogController::class, 'index'])->name('activity-logs.index');
     });
 });

--- a/tests/Feature/Admin/AsyncAdminTablesTest.php
+++ b/tests/Feature/Admin/AsyncAdminTablesTest.php
@@ -111,7 +111,7 @@ class AsyncAdminTablesTest extends TestCase
         User::factory()->create([
             'name' => 'Sortable Zulu',
             'email' => 'zulu@example.test',
-            'role' => UserRole::GUEST,
+            'role' => UserRole::DEMO,
         ]);
 
         foreach (range(1, 6) as $index) {
@@ -131,7 +131,7 @@ class AsyncAdminTablesTest extends TestCase
         $this->assertLessThan(mb_strpos($sortedHtml, 'Sortable Alpha'), mb_strpos($sortedHtml, 'Sortable Zulu'));
 
         $filteredResponse = $this->actingAs($admin)->getJson(route('admin.users.index', [
-            'role' => UserRole::GUEST->value,
+            'role' => UserRole::DEMO->value,
             'per_page' => 5,
         ]));
 

--- a/tests/Feature/Admin/DemoMonitoringAdminTest.php
+++ b/tests/Feature/Admin/DemoMonitoringAdminTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringType;
+use App\Enums\UserRole;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Tests\TestCase;
+
+class DemoMonitoringAdminTest extends TestCase
+{
+    public function test_admin_dashboard_links_to_demo_monitoring_management(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        $testResponse = $this->actingAs($admin)->get(route('admin.dashboard'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('admin.dashboard.demo_monitorings.heading'));
+        $testResponse->assertSeeHtml('href="' . route('admin.demo-monitorings.index') . '"');
+    }
+
+    public function test_admin_can_list_demo_user_monitorings_without_admin_monitorings(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $demoUser = User::factory()->create(['role' => UserRole::DEMO]);
+
+        Monitoring::factory()->for($demoUser)->create([
+            'name' => 'Demo HTTP Check',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://demo.example.test',
+        ]);
+        Monitoring::factory()->for($admin)->create([
+            'name' => 'Admin Private Check',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://admin.example.test',
+        ]);
+
+        $testResponse = $this->actingAs($admin)->get(route('admin.demo-monitorings.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText('Demo HTTP Check');
+        $testResponse->assertDontSeeText('Admin Private Check');
+        $testResponse->assertSeeText($demoUser->email);
+    }
+
+    public function test_admin_can_create_monitoring_for_demo_user(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+        ServerInstance::query()->create([
+            'code' => 'admin-demo-1',
+            'ip_address' => '10.0.0.10',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $testResponse = $this->actingAs($admin)->post(route('admin.demo-monitorings.store'), [
+            'name' => 'Demo Managed Check',
+            'type' => MonitoringType::HTTP->value,
+            'target' => 'https://demo-managed.example.test',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'timeout' => 5,
+            'http_method' => 'get',
+            'expected_http_statuses' => '200-299',
+            'preferred_location' => 'admin-demo-1',
+            'notification_on_failure' => '1',
+            'ssl_expiry_warning_days' => 7,
+        ]);
+
+        $testResponse->assertRedirect(route('admin.demo-monitorings.index'));
+        $testResponse->assertSessionHas('success', __('admin.demo_monitorings.messages.created'));
+
+        $this->assertDatabaseHas('monitorings', [
+            'user_id' => $demoUser->id,
+            'name' => 'Demo Managed Check',
+            'target' => 'https://demo-managed.example.test',
+            'type' => MonitoringType::HTTP->value,
+        ]);
+    }
+
+    public function test_demo_user_still_cannot_create_monitorings_directly(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+
+        $this->actingAs($demoUser)
+            ->get(route('monitorings.create'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/AuthEntryPointsTest.php
+++ b/tests/Feature/AuthEntryPointsTest.php
@@ -53,7 +53,7 @@ class AuthEntryPointsTest extends TestCase
         $this->assertStringNotContainsString('public', $cacheControl);
     }
 
-    public function test_guest_query_opens_unified_auth_view_in_demo_mode(): void
+    public function test_legacy_guest_query_opens_unified_auth_view_in_demo_mode(): void
     {
         $testResponse = $this->get(route('login', ['guest' => 'true']));
 
@@ -66,12 +66,12 @@ class AuthEntryPointsTest extends TestCase
         $this->get('/demo')->assertNotFound();
     }
 
-    public function test_welcome_secondary_ctas_point_to_guest_login(): void
+    public function test_welcome_secondary_ctas_point_to_demo_login(): void
     {
         $testResponse = $this->get(route('welcome'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml('href="' . route('login', ['guest' => 'true']) . '"');
+        $testResponse->assertSeeHtml('href="' . route('login', ['mode' => 'demo']) . '"');
     }
 
     public function test_register_mode_contains_combined_legal_consent_checkbox(): void

--- a/tests/Feature/Console/NotificationsScheduleTest.php
+++ b/tests/Feature/Console/NotificationsScheduleTest.php
@@ -53,4 +53,15 @@ class NotificationsScheduleTest extends TestCase
         $this->assertSame('0 6 * * *', $event->expression);
         $this->assertTrue($event->withoutOverlapping);
     }
+
+    public function test_demo_notification_pruning_is_scheduled_daily_without_overlap(): void
+    {
+        /** @var Event|null $event */
+        $event = collect(resolve(Schedule::class)->events())
+            ->first(fn (Event $event): bool => str_contains((string) $event->command, 'notifications:prune-demo'));
+
+        $this->assertNotNull($event);
+        $this->assertSame('30 1 * * *', $event->expression);
+        $this->assertTrue($event->withoutOverlapping);
+    }
 }

--- a/tests/Feature/DemoLoginCredentialsTest.php
+++ b/tests/Feature/DemoLoginCredentialsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\UserRole;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DemoLoginCredentialsTest extends TestCase
+{
+    public function test_demo_login_credentials_route_returns_demo_user_email(): void
+    {
+        Package::factory()->create();
+        $demoUser = User::factory()->create([
+            'email' => 'demo@example.test',
+            'role' => UserRole::DEMO,
+        ]);
+
+        $testResponse = $this->getJson(route('demo-login.credentials'));
+
+        $testResponse->assertOk()
+            ->assertJson(['email' => $demoUser->email]);
+    }
+
+    public function test_legacy_guest_login_credentials_route_still_returns_demo_user_email(): void
+    {
+        Package::factory()->create();
+        $demoUser = User::factory()->create([
+            'email' => 'demo@example.test',
+            'role' => UserRole::DEMO,
+        ]);
+
+        $testResponse = $this->getJson(route('guest-login.credentials'));
+
+        $testResponse->assertOk()
+            ->assertJson(['email' => $demoUser->email]);
+    }
+
+    public function test_guest_role_migration_renames_existing_demo_account_history(): void
+    {
+        $package = Package::factory()->create();
+
+        DB::table('users')->insert([
+            'id' => (string) Str::ulid(),
+            'name' => 'Guest User',
+            'email' => 'guest@example.com',
+            'email_verified_at' => now(),
+            'password' => Hash::make('password'),
+            'remember_token' => Str::random(10),
+            'role' => 'guest',
+            'package_id' => $package->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_05_14_120000_rename_guest_role_to_demo.php');
+        $migration->up();
+
+        $this->assertDatabaseHas('users', [
+            'name' => 'Demo User',
+            'email' => 'demo@example.com',
+            'role' => UserRole::DEMO->value,
+        ]);
+        $this->assertDatabaseMissing('users', [
+            'email' => 'guest@example.com',
+            'role' => 'guest',
+        ]);
+    }
+}

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -12,15 +12,15 @@ use Tests\TestCase;
 
 class MonitoringIndexEmptyStateTest extends TestCase
 {
-    public function test_guest_user_sees_empty_state_without_create_button(): void
+    public function test_demo_user_sees_empty_state_without_create_button(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);
-        $guestUser = User::factory()->create([
+        $demoUser = User::factory()->create([
             'package_id' => $package->id,
-            'role' => UserRole::GUEST->value,
+            'role' => UserRole::DEMO->value,
         ]);
 
-        $testResponse = $this->actingAs($guestUser)->get(route('monitorings.index'));
+        $testResponse = $this->actingAs($demoUser)->get(route('monitorings.index'));
 
         $testResponse->assertOk();
         $testResponse->assertSee(__('monitoring.no_monitoring.title'));
@@ -63,15 +63,15 @@ class MonitoringIndexEmptyStateTest extends TestCase
         $this->assertSame(1, $monitoringCountQueries, $queries->implode(PHP_EOL));
     }
 
-    public function test_guest_user_cannot_access_monitoring_create_route(): void
+    public function test_demo_user_cannot_access_monitoring_create_route(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);
-        $guestUser = User::factory()->create([
+        $demoUser = User::factory()->create([
             'package_id' => $package->id,
-            'role' => UserRole::GUEST->value,
+            'role' => UserRole::DEMO->value,
         ]);
 
-        $testResponse = $this->actingAs($guestUser)->get(route('monitorings.create'));
+        $testResponse = $this->actingAs($demoUser)->get(route('monitorings.create'));
 
         $testResponse->assertForbidden();
     }

--- a/tests/Feature/Notifications/PruneDemoNotificationsCommandTest.php
+++ b/tests/Feature/Notifications/PruneDemoNotificationsCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Enums\NotificationType;
+use App\Enums\UserRole;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class PruneDemoNotificationsCommandTest extends TestCase
+{
+    public function test_prunes_old_demo_user_notifications_only(): void
+    {
+        Package::factory()->create();
+        $demoUser = User::factory()->create(['role' => UserRole::DEMO]);
+        $regularUser = User::factory()->create();
+        $demoMonitoring = Monitoring::factory()->for($demoUser)->create();
+        $regularMonitoring = Monitoring::factory()->for($regularUser)->create();
+
+        $oldDemoNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $demoMonitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+        ]);
+        $oldDemoNotification->forceFill([
+            'created_at' => now()->subDays(8),
+            'updated_at' => now()->subDays(8),
+        ])->save();
+        $recentDemoNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $demoMonitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
+        ]);
+        $recentDemoNotification->forceFill([
+            'created_at' => now()->subDays(2),
+            'updated_at' => now()->subDays(2),
+        ])->save();
+        $oldRegularNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $regularMonitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+        ]);
+        $oldRegularNotification->forceFill([
+            'created_at' => now()->subDays(8),
+            'updated_at' => now()->subDays(8),
+        ])->save();
+
+        Artisan::call('notifications:prune-demo');
+
+        $this->assertDatabaseMissing('monitoring_notifications', ['id' => $oldDemoNotification->id]);
+        $this->assertDatabaseHas('monitoring_notifications', ['id' => $recentDemoNotification->id]);
+        $this->assertDatabaseHas('monitoring_notifications', ['id' => $oldRegularNotification->id]);
+    }
+}

--- a/tests/Feature/Notifications/PruneDemoNotificationsCommandTest.php
+++ b/tests/Feature/Notifications/PruneDemoNotificationsCommandTest.php
@@ -23,12 +23,12 @@ class PruneDemoNotificationsCommandTest extends TestCase
         $demoMonitoring = Monitoring::factory()->for($demoUser)->create();
         $regularMonitoring = Monitoring::factory()->for($regularUser)->create();
 
-        $oldDemoNotification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $demoMonitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'DOWN',
         ]);
-        $oldDemoNotification->forceFill([
+        $monitoringNotification->forceFill([
             'created_at' => now()->subDays(8),
             'updated_at' => now()->subDays(8),
         ])->save();
@@ -53,7 +53,7 @@ class PruneDemoNotificationsCommandTest extends TestCase
 
         Artisan::call('notifications:prune-demo');
 
-        $this->assertDatabaseMissing('monitoring_notifications', ['id' => $oldDemoNotification->id]);
+        $this->assertDatabaseMissing('monitoring_notifications', ['id' => $monitoringNotification->id]);
         $this->assertDatabaseHas('monitoring_notifications', ['id' => $recentDemoNotification->id]);
         $this->assertDatabaseHas('monitoring_notifications', ['id' => $oldRegularNotification->id]);
     }

--- a/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
+++ b/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
@@ -21,7 +21,7 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_sends_daily_reminder_to_non_guest_users_with_unread_notifications(): void
+    public function test_sends_daily_reminder_to_users_with_unread_notifications(): void
     {
         Package::factory()->create();
 
@@ -76,17 +76,17 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
         });
     }
 
-    public function test_sends_reminder_to_guest_users_when_profile_setting_is_enabled(): void
+    public function test_sends_reminder_to_demo_users_when_profile_setting_is_enabled(): void
     {
         Package::factory()->create();
 
-        $guestUser = User::factory()->create([
-            'role' => UserRole::GUEST,
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
             'unread_notifications_reminder_enabled' => true,
             'unread_notifications_reminder_frequency' => 'daily',
         ]);
 
-        $monitoring = Monitoring::factory()->for($guestUser)->create();
+        $monitoring = Monitoring::factory()->for($demoUser)->create();
 
         MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
@@ -100,8 +100,8 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
 
         Artisan::call('notifications:remind-unread-weekly');
 
-        Mail::assertSent(UnreadNotificationsReminderMail::class, function (UnreadNotificationsReminderMail $unreadNotificationsReminderMail) use ($guestUser): bool {
-            return $unreadNotificationsReminderMail->hasTo($guestUser->email)
+        Mail::assertSent(UnreadNotificationsReminderMail::class, function (UnreadNotificationsReminderMail $unreadNotificationsReminderMail) use ($demoUser): bool {
+            return $unreadNotificationsReminderMail->hasTo($demoUser->email)
                 && $unreadNotificationsReminderMail->unreadNotificationsCount === 1;
         });
     }

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -165,16 +165,16 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         $this->assertStringContainsString('overflow-wrap: anywhere;', $rendered);
     }
 
-    public function test_sends_weekly_digest_to_guest_users_when_profile_setting_is_enabled(): void
+    public function test_sends_weekly_digest_to_demo_users_when_profile_setting_is_enabled(): void
     {
         Date::setTestNow('2026-04-20 09:00:00');
         Package::factory()->create();
 
-        $guestUser = User::factory()->create([
-            'role' => UserRole::GUEST,
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
             'monitoring_digest_enabled' => true,
         ]);
-        Monitoring::factory()->for($guestUser)->create();
+        Monitoring::factory()->for($demoUser)->create();
 
         Mail::fake();
 
@@ -182,8 +182,8 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
             '--period-end' => '2026-04-19',
         ]);
 
-        Mail::assertSent(WeeklyMonitoringDigestMail::class, function (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail) use ($guestUser): bool {
-            return $weeklyMonitoringDigestMail->hasTo($guestUser->email)
+        Mail::assertSent(WeeklyMonitoringDigestMail::class, function (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail) use ($demoUser): bool {
+            return $weeklyMonitoringDigestMail->hasTo($demoUser->email)
                 && $weeklyMonitoringDigestMail->digest['overview']['monitorings_count'] === 1;
         });
     }


### PR DESCRIPTION
## Summary
- rename the limited access account from guest to demo user across role, seed data, login copy, and notification pruning
- add admin dashboard management for demo user monitorings, including listing, creating, and editing monitorings for the demo user
- migrate existing guest role/account history to demo and add focused coverage for the admin flow and pruning command

## Testing
- ./vendor/bin/pint --dirty
- php artisan test
- php artisan test tests/Feature/Admin/DemoMonitoringAdminTest.php
- php artisan route:list --name=admin.demo-monitorings
- bun install --frozen-lockfile
- bun run build

## Rollout notes
- Run migrations so existing users with role `guest` are converted to `demo`.
