### PR TITLE
Allow managing demo user monitorings

### DIFF
--- a/app/Http/Controllers/Admin/DemoMonitoringController.php
+++ b/app/Http/Controllers/Admin/DemoMonitoringController.php
@@ -95,11 +95,11 @@ class DemoMonitoringController extends Controller
         ]);
     }
 
-    public function update(DemoMonitoringRequest $request, string $demoMonitoring): RedirectResponse
+    public function update(DemoMonitoringRequest $demoMonitoringRequest, string $demoMonitoring): RedirectResponse
     {
         $demoUser = $this->demoUser();
         $monitoring = $this->demoMonitoring($demoUser, $demoMonitoring);
-        $validated = $request->validated();
+        $validated = $demoMonitoringRequest->validated();
         unset($validated['target']);
 
         $validated = MonitoringPayload::prepareUpdate($validated, $monitoring);

--- a/app/Http/Controllers/Admin/DemoMonitoringController.php
+++ b/app/Http/Controllers/Admin/DemoMonitoringController.php
@@ -76,10 +76,55 @@ class DemoMonitoringController extends Controller
             ->with('success', __('admin.demo_monitorings.messages.created'));
     }
 
+    public function edit(string $demoMonitoring): View
+    {
+        $demoUser = $this->demoUser();
+        $monitoring = $this->demoMonitoring($demoUser, $demoMonitoring);
+        $serverInstances = ServerInstance::query()
+            ->where('is_active', true)
+            ->orWhere('code', $monitoring->preferred_location)
+            ->orderBy('code')
+            ->get(['code']);
+
+        return view('admin.demo-monitorings.edit', [
+            'demoUser' => $demoUser,
+            'monitoring' => $monitoring,
+            'types' => MonitoringType::cases(),
+            'serverInstances' => $serverInstances,
+            'enabledNotificationChannels' => $demoUser->enabledNotificationChannelKeys(),
+        ]);
+    }
+
+    public function update(DemoMonitoringRequest $request, string $demoMonitoring): RedirectResponse
+    {
+        $demoUser = $this->demoUser();
+        $monitoring = $this->demoMonitoring($demoUser, $demoMonitoring);
+        $validated = $request->validated();
+        unset($validated['target']);
+
+        $validated = MonitoringPayload::prepareUpdate($validated, $monitoring);
+
+        if (! isset($validated['public_label_enabled']) || ! $validated['public_label_enabled']) {
+            $validated['public_label_enabled'] = false;
+        }
+
+        $monitoring->update($validated);
+
+        return to_route('admin.demo-monitorings.index')
+            ->with('success', __('admin.demo_monitorings.messages.updated'));
+    }
+
     private function demoUser(): User
     {
         return User::query()
             ->where('role', UserRole::DEMO)
+            ->firstOrFail();
+    }
+
+    private function demoMonitoring(User $demoUser, string $monitoringId): Monitoring
+    {
+        return $this->demoMonitoringsQuery($demoUser)
+            ->whereKey($monitoringId)
             ->firstOrFail();
     }
 

--- a/app/Http/Controllers/Admin/DemoMonitoringController.php
+++ b/app/Http/Controllers/Admin/DemoMonitoringController.php
@@ -114,6 +114,17 @@ class DemoMonitoringController extends Controller
             ->with('success', __('admin.demo_monitorings.messages.updated'));
     }
 
+    public function destroy(string $demoMonitoring): RedirectResponse
+    {
+        $demoUser = $this->demoUser();
+        $monitoring = $this->demoMonitoring($demoUser, $demoMonitoring);
+
+        $monitoring->delete();
+
+        return to_route('admin.demo-monitorings.index')
+            ->with('success', __('admin.demo_monitorings.messages.deleted'));
+    }
+
     private function demoUser(): User
     {
         return User::query()

--- a/resources/lang/de/admin.php
+++ b/resources/lang/de/admin.php
@@ -38,6 +38,7 @@ return [
         ],
         'fields' => [
             'created_at' => 'Erstellt',
+            'actions' => 'Aktionen',
         ],
         'summary' => [
             'demo_user' => 'Demo-Benutzer',
@@ -47,10 +48,14 @@ return [
         'messages' => [
             'empty' => 'Keine Monitorings für den Demo-Benutzer gefunden.',
             'created' => 'Demo-Benutzer-Monitoring erfolgreich erstellt.',
+            'updated' => 'Demo-Benutzer-Monitoring erfolgreich aktualisiert.',
         ],
         'create' => [
             'title' => 'Demo-Benutzer-Monitoring erstellen',
             'demo_user' => 'Monitoring-Besitzer',
+        ],
+        'edit' => [
+            'title' => ':monitoring bearbeiten',
         ],
     ],
     'activity_logs' => [

--- a/resources/lang/de/admin.php
+++ b/resources/lang/de/admin.php
@@ -47,8 +47,10 @@ return [
         ],
         'messages' => [
             'empty' => 'Keine Monitorings für den Demo-Benutzer gefunden.',
+            'confirm_delete' => 'Möchten Sie dieses Demo-Benutzer-Monitoring wirklich löschen?',
             'created' => 'Demo-Benutzer-Monitoring erfolgreich erstellt.',
             'updated' => 'Demo-Benutzer-Monitoring erfolgreich aktualisiert.',
+            'deleted' => 'Demo-Benutzer-Monitoring erfolgreich gelöscht.',
         ],
         'create' => [
             'title' => 'Demo-Benutzer-Monitoring erstellen',

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -38,6 +38,7 @@ return [
         ],
         'fields' => [
             'created_at' => 'Created',
+            'actions' => 'Actions',
         ],
         'summary' => [
             'demo_user' => 'Demo User',
@@ -47,10 +48,14 @@ return [
         'messages' => [
             'empty' => 'No demo user monitorings found.',
             'created' => 'Demo user monitoring created successfully.',
+            'updated' => 'Demo user monitoring updated successfully.',
         ],
         'create' => [
             'title' => 'Create Demo User Monitoring',
             'demo_user' => 'Monitoring owner',
+        ],
+        'edit' => [
+            'title' => 'Edit :monitoring',
         ],
     ],
     'activity_logs' => [

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -47,8 +47,10 @@ return [
         ],
         'messages' => [
             'empty' => 'No demo user monitorings found.',
+            'confirm_delete' => 'Are you sure you want to delete this demo user monitoring?',
             'created' => 'Demo user monitoring created successfully.',
             'updated' => 'Demo user monitoring updated successfully.',
+            'deleted' => 'Demo user monitoring deleted successfully.',
         ],
         'create' => [
             'title' => 'Create Demo User Monitoring',

--- a/resources/views/admin/demo-monitorings/edit.blade.php
+++ b/resources/views/admin/demo-monitorings/edit.blade.php
@@ -1,0 +1,27 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading>
+            {{ __('admin.demo_monitorings.edit.title', ['monitoring' => $monitoring->name]) }}
+            <small>({{ strtoupper($monitoring->type->value) }})</small>
+        </x-heading>
+
+        <x-secondary-button :href="route('admin.demo-monitorings.index')" class="sm:ml-auto">
+            {{ __('button.back') }}
+        </x-secondary-button>
+    </x-slot>
+
+    <x-main>
+        <x-container>
+            <div class="mb-6">
+                <x-heading type="h2">{{ __('admin.demo_monitorings.create.demo_user') }}</x-heading>
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                    {{ $demoUser->name }} - {{ $demoUser->email }}
+                </p>
+            </div>
+
+            <form method="POST" action="{{ route('admin.demo-monitorings.update', $monitoring) }}">
+                @include('monitorings._form')
+            </form>
+        </x-container>
+    </x-main>
+</x-app-layout>

--- a/resources/views/admin/demo-monitorings/index.blade.php
+++ b/resources/views/admin/demo-monitorings/index.blade.php
@@ -42,6 +42,7 @@
                 <x-table.heading>{{ __('monitoring.index.table.status') }}</x-table.heading>
                 <x-table.heading>{{ __('monitoring.form.preferred_location') }}</x-table.heading>
                 <x-table.heading>{{ __('admin.demo_monitorings.fields.created_at') }}</x-table.heading>
+                <x-table.heading>{{ __('admin.demo_monitorings.fields.actions') }}</x-table.heading>
             </x-slot>
 
             <x-slot name="body">
@@ -57,10 +58,16 @@
                         <x-table.cell>{{ ucfirst($monitoring->status->value) }}</x-table.cell>
                         <x-table.cell>{{ $monitoring->preferred_location }}</x-table.cell>
                         <x-table.cell>{{ $monitoring->created_at?->format('Y-m-d H:i') }}</x-table.cell>
+                        <x-table.cell>
+                            <a href="{{ route('admin.demo-monitorings.edit', $monitoring) }}"
+                                class="text-purple-600 hover:underline">
+                                {{ __('button.edit') }}
+                            </a>
+                        </x-table.cell>
                     </x-table.row>
                 @empty
                     <x-table.row>
-                        <x-table.cell colspan="6">
+                        <x-table.cell colspan="7">
                             {{ __('admin.demo_monitorings.messages.empty') }}
                         </x-table.cell>
                     </x-table.row>

--- a/resources/views/admin/demo-monitorings/index.blade.php
+++ b/resources/views/admin/demo-monitorings/index.blade.php
@@ -59,10 +59,23 @@
                         <x-table.cell>{{ $monitoring->preferred_location }}</x-table.cell>
                         <x-table.cell>{{ $monitoring->created_at?->format('Y-m-d H:i') }}</x-table.cell>
                         <x-table.cell>
-                            <a href="{{ route('admin.demo-monitorings.edit', $monitoring) }}"
-                                class="text-purple-600 hover:underline">
-                                {{ __('button.edit') }}
-                            </a>
+                            <div class="flex items-center gap-3">
+                                <a href="{{ route('admin.demo-monitorings.edit', $monitoring) }}"
+                                    class="inline-flex min-h-10 items-center text-purple-600 hover:underline">
+                                    {{ __('button.edit') }}
+                                </a>
+                                <form action="{{ route('admin.demo-monitorings.destroy', $monitoring) }}" method="POST"
+                                    class="inline-flex"
+                                    data-confirm-message="{{ __('admin.demo_monitorings.messages.confirm_delete') }}">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="inline-flex min-h-10 cursor-pointer items-center text-red-600 hover:underline"
+                                        data-testid="delete-demo-monitoring-{{ $monitoring->id }}">
+                                        {{ __('button.delete') }}
+                                    </button>
+                                </form>
+                            </div>
                         </x-table.cell>
                     </x-table.row>
                 @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,7 +106,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         Route::resource('/packages', PackageController::class)->except(['show'])->names('packages');
         Route::resource('/server-instances', ServerInstanceController::class)->except(['show'])->names('server-instances');
         Route::resource('/apis', AdminApiController::class)->only(['index'])->names('apis');
-        Route::resource('/demo-monitorings', DemoMonitoringController::class)->except(['show', 'destroy'])->names('demo-monitorings');
+        Route::resource('/demo-monitorings', DemoMonitoringController::class)->except(['show'])->names('demo-monitorings');
         Route::get('/audit-logs', [ActivityLogController::class, 'index'])->name('activity-logs.index');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,7 +106,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         Route::resource('/packages', PackageController::class)->except(['show'])->names('packages');
         Route::resource('/server-instances', ServerInstanceController::class)->except(['show'])->names('server-instances');
         Route::resource('/apis', AdminApiController::class)->only(['index'])->names('apis');
-        Route::resource('/demo-monitorings', DemoMonitoringController::class)->only(['index', 'create', 'store'])->names('demo-monitorings');
+        Route::resource('/demo-monitorings', DemoMonitoringController::class)->except(['show', 'destroy'])->names('demo-monitorings');
         Route::get('/audit-logs', [ActivityLogController::class, 'index'])->name('activity-logs.index');
     });
 });

--- a/tests/Feature/Admin/DemoMonitoringAdminTest.php
+++ b/tests/Feature/Admin/DemoMonitoringAdminTest.php
@@ -51,6 +51,8 @@ class DemoMonitoringAdminTest extends TestCase
         $testResponse->assertDontSeeText('Admin Private Check');
         $testResponse->assertSeeText($demoUser->email);
         $testResponse->assertSeeHtml('href="' . route('admin.demo-monitorings.edit', $demoMonitoring) . '"');
+        $testResponse->assertSeeHtml('action="' . route('admin.demo-monitorings.destroy', $demoMonitoring) . '"');
+        $testResponse->assertSeeHtml('data-confirm-message');
     }
 
     public function test_admin_can_create_monitoring_for_demo_user(): void
@@ -157,6 +159,45 @@ class DemoMonitoringAdminTest extends TestCase
         $this->actingAs($admin)
             ->get(route('admin.demo-monitorings.edit', $monitoring))
             ->assertNotFound();
+    }
+
+    public function test_admin_can_delete_monitoring_for_demo_user(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $demoUser = User::factory()->create(['role' => UserRole::DEMO]);
+        $monitoring = Monitoring::factory()->for($demoUser)->create([
+            'name' => 'Delete Demo Check',
+        ]);
+
+        $testResponse = $this->actingAs($admin)
+            ->delete(route('admin.demo-monitorings.destroy', $monitoring));
+
+        $testResponse->assertRedirect(route('admin.demo-monitorings.index'));
+        $testResponse->assertSessionHas('success', __('admin.demo_monitorings.messages.deleted'));
+        $this->assertSoftDeleted('monitorings', [
+            'id' => $monitoring->id,
+            'user_id' => $demoUser->id,
+        ]);
+    }
+
+    public function test_admin_cannot_delete_non_demo_monitoring_through_demo_management(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $regularUser = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($regularUser)->create([
+            'name' => 'Regular Delete Check',
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('admin.demo-monitorings.destroy', $monitoring))
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'deleted_at' => null,
+        ]);
     }
 
     public function test_demo_user_still_cannot_create_monitorings_directly(): void

--- a/tests/Feature/Admin/DemoMonitoringAdminTest.php
+++ b/tests/Feature/Admin/DemoMonitoringAdminTest.php
@@ -33,7 +33,7 @@ class DemoMonitoringAdminTest extends TestCase
         $admin = User::factory()->create(['role' => UserRole::ADMIN]);
         $demoUser = User::factory()->create(['role' => UserRole::DEMO]);
 
-        Monitoring::factory()->for($demoUser)->create([
+        $demoMonitoring = Monitoring::factory()->for($demoUser)->create([
             'name' => 'Demo HTTP Check',
             'type' => MonitoringType::HTTP,
             'target' => 'https://demo.example.test',
@@ -50,6 +50,7 @@ class DemoMonitoringAdminTest extends TestCase
         $testResponse->assertSeeText('Demo HTTP Check');
         $testResponse->assertDontSeeText('Admin Private Check');
         $testResponse->assertSeeText($demoUser->email);
+        $testResponse->assertSeeHtml('href="' . route('admin.demo-monitorings.edit', $demoMonitoring) . '"');
     }
 
     public function test_admin_can_create_monitoring_for_demo_user(): void
@@ -89,6 +90,73 @@ class DemoMonitoringAdminTest extends TestCase
             'target' => 'https://demo-managed.example.test',
             'type' => MonitoringType::HTTP->value,
         ]);
+    }
+
+    public function test_admin_can_edit_monitoring_for_demo_user(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+        ServerInstance::query()->create([
+            'code' => 'admin-demo-edit',
+            'ip_address' => '10.0.0.11',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+        $monitoring = Monitoring::factory()->for($demoUser)->create([
+            'name' => 'Original Demo Check',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://original-demo.example.test',
+            'preferred_location' => 'admin-demo-edit',
+            'timeout' => 5,
+            'http_method' => 'get',
+            'expected_http_statuses' => '200-299',
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.demo-monitorings.edit', $monitoring))
+            ->assertOk()
+            ->assertSeeText('Original Demo Check')
+            ->assertSeeText($demoUser->email);
+
+        $testResponse = $this->actingAs($admin)->patch(route('admin.demo-monitorings.update', $monitoring), [
+            'name' => 'Updated Demo Check',
+            'type' => MonitoringType::HTTP->value,
+            'status' => MonitoringLifecycleStatus::PAUSED->value,
+            'timeout' => 10,
+            'http_method' => 'get',
+            'expected_http_statuses' => '200,204',
+            'preferred_location' => 'admin-demo-edit',
+            'notification_on_failure' => '1',
+            'ssl_expiry_warning_days' => 14,
+        ]);
+
+        $testResponse->assertRedirect(route('admin.demo-monitorings.index'));
+        $testResponse->assertSessionHas('success', __('admin.demo_monitorings.messages.updated'));
+
+        $monitoring->refresh();
+        $this->assertSame('Updated Demo Check', $monitoring->name);
+        $this->assertSame(MonitoringLifecycleStatus::PAUSED, $monitoring->status);
+        $this->assertSame(10, $monitoring->timeout);
+        $this->assertSame('200,204', $monitoring->expected_http_statuses);
+        $this->assertSame('https://original-demo.example.test', $monitoring->target);
+    }
+
+    public function test_admin_cannot_edit_non_demo_monitoring_through_demo_management(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $regularUser = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($regularUser)->create([
+            'name' => 'Regular User Check',
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.demo-monitorings.edit', $monitoring))
+            ->assertNotFound();
     }
 
     public function test_demo_user_still_cannot_create_monitorings_directly(): void


### PR DESCRIPTION
## Summary
- add edit, update, and delete actions for admin demo monitoring management
- add edit/delete controls to the demo monitoring table using the app confirm dialog for deletion
- scope demo edit/update/delete lookups to the demo user so non-demo monitorings return 404 through this area

## Testing
- ./vendor/bin/pint --dirty
- php artisan test tests/Feature/Admin/DemoMonitoringAdminTest.php
- php artisan route:list --name=admin.demo-monitorings
- php artisan test

## Rollout notes
- No migration required.
