### PR TITLE
Add component-based status pages

### DIFF
--- a/app/Http/Controllers/PublicStatusPageController.php
+++ b/app/Http/Controllers/PublicStatusPageController.php
@@ -25,8 +25,8 @@ class PublicStatusPageController extends Controller
                 ->with(['latestIncident', 'latestResponseResult']),
         ]);
 
-        $components = $statusPage->components->map(function (StatusPageComponent $component): array {
-            $monitorings = $component->monitorings->map(function (Monitoring $monitoring): array {
+        $components = $statusPage->components->map(function (StatusPageComponent $statusPageComponent): array {
+            $monitorings = $statusPageComponent->monitorings->map(function (Monitoring $monitoring): array {
                 $status = $this->monitoringStatus($monitoring);
 
                 return [
@@ -41,7 +41,7 @@ class PublicStatusPageController extends Controller
             $status = $this->aggregateStatus($monitorings->pluck('status'));
 
             return [
-                'model' => $component,
+                'model' => $statusPageComponent,
                 'status' => $status,
                 'badgeType' => $this->statusBadgeType($status),
                 'monitorings' => $monitorings,
@@ -116,7 +116,7 @@ class PublicStatusPageController extends Controller
     private function recentIncidents(StatusPage $statusPage): Collection
     {
         $monitoringIds = $statusPage->components
-            ->flatMap(static fn (StatusPageComponent $component): Collection => $component->monitorings->pluck('id'))
+            ->flatMap(static fn (StatusPageComponent $statusPageComponent): Collection => $statusPageComponent->monitorings->pluck('id'))
             ->unique()
             ->values();
 

--- a/app/Http/Controllers/PublicStatusPageController.php
+++ b/app/Http/Controllers/PublicStatusPageController.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\MonitoringStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\StatusPage;
+use App\Models\StatusPageComponent;
+use App\Services\MonitoringResultService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+use Illuminate\View\View;
+
+class PublicStatusPageController extends Controller
+{
+    public function __invoke(StatusPage $statusPage): View
+    {
+        abort_unless($statusPage->is_public, 404);
+
+        $statusPage->loadMissing([
+            'components.monitorings' => fn ($query) => $query->withoutGlobalScope('user')
+                ->with(['latestIncident', 'latestResponseResult']),
+        ]);
+
+        $components = $statusPage->components->map(function (StatusPageComponent $component): array {
+            $monitorings = $component->monitorings->map(function (Monitoring $monitoring): array {
+                $status = $this->monitoringStatus($monitoring);
+
+                return [
+                    'model' => $monitoring,
+                    'status' => $status,
+                    'badgeType' => $this->statusBadgeType($status),
+                    'isUnderMaintenance' => $monitoring->isUnderMaintenance(),
+                    'lastCheckedAt' => $monitoring->latestResponseResult?->updated_at,
+                ];
+            });
+
+            $status = $this->aggregateStatus($monitorings->pluck('status'));
+
+            return [
+                'model' => $component,
+                'status' => $status,
+                'badgeType' => $this->statusBadgeType($status),
+                'monitorings' => $monitorings,
+                'hasMaintenance' => $monitorings->contains(
+                    static fn (array $monitoring): bool => $monitoring['isUnderMaintenance'] === true
+                ),
+            ];
+        });
+
+        $pageStatus = $this->aggregateStatus($components->pluck('status'));
+
+        return view('status-pages.public-show', [
+            'statusPage' => $statusPage,
+            'pageStatus' => $pageStatus,
+            'pageStatusBadgeType' => $this->statusBadgeType($pageStatus),
+            'components' => $components,
+            'incidents' => $this->recentIncidents($statusPage),
+        ]);
+    }
+
+    private function monitoringStatus(Monitoring $monitoring): string
+    {
+        $statusSince = MonitoringResultService::getStatusSince($monitoring);
+        $statusNow = MonitoringResultService::getStatusNow($monitoring);
+
+        return $this->normalizeStatus($statusSince['status'] ?? $statusNow['status'] ?? MonitoringStatus::UNKNOWN->value);
+    }
+
+    /**
+     * @param  Collection<int, string>  $statuses
+     */
+    private function aggregateStatus(Collection $statuses): string
+    {
+        if ($statuses->isEmpty()) {
+            return MonitoringStatus::UNKNOWN->value;
+        }
+
+        if ($statuses->contains(MonitoringStatus::DOWN->value)) {
+            return MonitoringStatus::DOWN->value;
+        }
+
+        if ($statuses->contains(MonitoringStatus::UNKNOWN->value)) {
+            return MonitoringStatus::UNKNOWN->value;
+        }
+
+        return MonitoringStatus::UP->value;
+    }
+
+    private function normalizeStatus(mixed $status): string
+    {
+        if ($status instanceof MonitoringStatus) {
+            return $status->value;
+        }
+
+        $normalized = mb_strtolower((string) $status);
+
+        return MonitoringStatus::tryFrom($normalized)?->value ?? MonitoringStatus::UNKNOWN->value;
+    }
+
+    private function statusBadgeType(string $status): string
+    {
+        return match ($status) {
+            MonitoringStatus::UP->value => 'success',
+            MonitoringStatus::DOWN->value => 'danger',
+            default => 'warning',
+        };
+    }
+
+    /**
+     * @return Collection<int, Incident>
+     */
+    private function recentIncidents(StatusPage $statusPage): Collection
+    {
+        $monitoringIds = $statusPage->components
+            ->flatMap(static fn (StatusPageComponent $component): Collection => $component->monitorings->pluck('id'))
+            ->unique()
+            ->values();
+
+        if ($monitoringIds->isEmpty()) {
+            return collect();
+        }
+
+        return Incident::query()
+            ->with(['monitoring' => fn ($query) => $query->withoutGlobalScope('user')])
+            ->whereIn('monitoring_id', $monitoringIds)
+            ->whereBetween('down_at', [Date::now()->subDays(90)->startOfDay(), Date::now()->endOfDay()])
+            ->latest('down_at')
+            ->limit(10)
+            ->get();
+    }
+}

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StatusPages\StatusPageRequest;
+use App\Models\Monitoring;
+use App\Models\StatusPage;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class StatusPageController extends Controller
+{
+    public function index(): View
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return view('status-pages.index', [
+            'statusPages' => $user->statusPages()
+                ->withCount('components')
+                ->latest()
+                ->paginate(10),
+        ]);
+    }
+
+    public function create(): View
+    {
+        abort_if(Auth::user()->isDemo(), 403);
+
+        return view('status-pages.create', [
+            'monitorings' => $this->monitoringOptions(),
+            'defaultComponents' => $this->defaultComponents(),
+        ]);
+    }
+
+    public function store(StatusPageRequest $request): RedirectResponse
+    {
+        abort_if(Auth::user()->isDemo(), 403);
+
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validated();
+
+        $statusPage = $user->statusPages()->create([
+            'name' => $validated['name'],
+            'slug' => $validated['slug'],
+            'description' => $validated['description'] ?? null,
+            'is_public' => $validated['is_public'],
+        ]);
+
+        $this->syncComponents($statusPage, $validated['components']);
+
+        return to_route('status-pages.show', $statusPage)
+            ->with('success', __('status_page.messages.created'));
+    }
+
+    public function show(StatusPage $statusPage): View
+    {
+        $this->authorizeOwner($statusPage);
+
+        $statusPage->loadMissing('components.monitorings');
+
+        return view('status-pages.show', [
+            'statusPage' => $statusPage,
+        ]);
+    }
+
+    public function edit(StatusPage $statusPage): View
+    {
+        abort_if(Auth::user()->isDemo(), 403);
+        $this->authorizeOwner($statusPage);
+
+        $statusPage->loadMissing('components.monitorings');
+
+        return view('status-pages.edit', [
+            'statusPage' => $statusPage,
+            'monitorings' => $this->monitoringOptions(),
+            'defaultComponents' => [],
+        ]);
+    }
+
+    public function update(StatusPageRequest $request, StatusPage $statusPage): RedirectResponse
+    {
+        abort_if(Auth::user()->isDemo(), 403);
+        $this->authorizeOwner($statusPage);
+
+        $validated = $request->validated();
+
+        $statusPage->update([
+            'name' => $validated['name'],
+            'slug' => $validated['slug'],
+            'description' => $validated['description'] ?? null,
+            'is_public' => $validated['is_public'],
+        ]);
+
+        $this->syncComponents($statusPage, $validated['components']);
+
+        return to_route('status-pages.show', $statusPage)
+            ->with('success', __('status_page.messages.updated'));
+    }
+
+    public function destroy(StatusPage $statusPage): RedirectResponse
+    {
+        abort_if(Auth::user()->isDemo(), 403);
+        $this->authorizeOwner($statusPage);
+
+        $statusPage->delete();
+
+        return to_route('status-pages.index')
+            ->with('success', __('status_page.messages.deleted'));
+    }
+
+    private function authorizeOwner(StatusPage $statusPage): void
+    {
+        abort_unless($statusPage->user_id === Auth::id(), 404);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection<int, Monitoring>
+     */
+    private function monitoringOptions()
+    {
+        return Monitoring::query()
+            ->orderBy('name')
+            ->get(['id', 'name', 'type', 'target']);
+    }
+
+    /**
+     * @param  list<array{name: string, description: string|null, monitoring_ids: list<string>}>  $components
+     */
+    private function syncComponents(StatusPage $statusPage, array $components): void
+    {
+        $statusPage->components()->delete();
+
+        foreach (array_values($components) as $componentPosition => $componentData) {
+            $component = $statusPage->components()->create([
+                'name' => $componentData['name'],
+                'description' => $componentData['description'] ?? null,
+                'position' => $componentPosition,
+            ]);
+
+            $syncPayload = [];
+            foreach (array_values($componentData['monitoring_ids']) as $monitoringPosition => $monitoringId) {
+                $syncPayload[$monitoringId] = ['position' => $monitoringPosition];
+            }
+
+            $component->monitorings()->sync($syncPayload);
+        }
+    }
+
+    /**
+     * @return list<array{name: string, description: string|null, monitoring_ids: list<string>}>
+     */
+    private function defaultComponents(): array
+    {
+        return [
+            ['name' => 'API', 'description' => null, 'monitoring_ids' => []],
+            ['name' => 'Web App', 'description' => null, 'monitoring_ids' => []],
+            ['name' => 'Workers', 'description' => null, 'monitoring_ids' => []],
+            ['name' => 'Database', 'description' => null, 'monitoring_ids' => []],
+        ];
+    }
+}

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\StatusPages\StatusPageRequest;
 use App\Models\Monitoring;
 use App\Models\StatusPage;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -37,13 +38,13 @@ class StatusPageController extends Controller
         ]);
     }
 
-    public function store(StatusPageRequest $request): RedirectResponse
+    public function store(StatusPageRequest $statusPageRequest): RedirectResponse
     {
         abort_if(Auth::user()->isDemo(), 403);
 
         /** @var User $user */
-        $user = $request->user();
-        $validated = $request->validated();
+        $user = $statusPageRequest->user();
+        $validated = $statusPageRequest->validated();
 
         $statusPage = $user->statusPages()->create([
             'name' => $validated['name'],
@@ -83,12 +84,12 @@ class StatusPageController extends Controller
         ]);
     }
 
-    public function update(StatusPageRequest $request, StatusPage $statusPage): RedirectResponse
+    public function update(StatusPageRequest $statusPageRequest, StatusPage $statusPage): RedirectResponse
     {
         abort_if(Auth::user()->isDemo(), 403);
         $this->authorizeOwner($statusPage);
 
-        $validated = $request->validated();
+        $validated = $statusPageRequest->validated();
 
         $statusPage->update([
             'name' => $validated['name'],
@@ -120,7 +121,7 @@ class StatusPageController extends Controller
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Collection<int, Monitoring>
+     * @return Collection<int, Monitoring>
      */
     private function monitoringOptions()
     {

--- a/app/Http/Requests/StatusPages/StatusPageRequest.php
+++ b/app/Http/Requests/StatusPages/StatusPageRequest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\StatusPages;
+
+use App\Models\StatusPage;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StatusPageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        /** @var StatusPage|null $statusPage */
+        $statusPage = $this->route('statusPage');
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'alpha_dash:ascii',
+                Rule::unique('status_pages', 'slug')->ignore($statusPage?->id),
+            ],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'is_public' => ['boolean'],
+            'components' => ['required', 'array', 'min:1'],
+            'components.*.name' => ['required', 'string', 'max:255'],
+            'components.*.description' => ['nullable', 'string', 'max:1000'],
+            'components.*.monitoring_ids' => ['required', 'array', 'min:1'],
+            'components.*.monitoring_ids.*' => [
+                'required',
+                'string',
+                Rule::exists('monitorings', 'id')->where('user_id', $this->user()?->id),
+            ],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'slug' => str($this->input('slug') ?: $this->input('name'))->slug()->toString(),
+            'is_public' => $this->boolean('is_public'),
+            'components' => $this->normalizeComponents(),
+        ]);
+    }
+
+    /**
+     * @return list<array{name: string, description: string|null, monitoring_ids: list<string>}>
+     */
+    private function normalizeComponents(): array
+    {
+        $components = $this->input('components', []);
+
+        if (! is_array($components)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($components as $component) {
+            if (! is_array($component)) {
+                continue;
+            }
+
+            $name = mb_trim((string) ($component['name'] ?? ''));
+            $description = mb_trim((string) ($component['description'] ?? ''));
+            $monitoringIds = $component['monitoring_ids'] ?? [];
+
+            if (! is_array($monitoringIds)) {
+                $monitoringIds = [$monitoringIds];
+            }
+
+            $monitoringIds = array_values(array_unique(array_filter(
+                array_map(static fn (mixed $monitoringId): string => (string) $monitoringId, $monitoringIds),
+                static fn (string $monitoringId): bool => $monitoringId !== ''
+            )));
+
+            if ($name === '' && $monitoringIds === []) {
+                continue;
+            }
+
+            $normalized[] = [
+                'name' => $name,
+                'description' => $description !== '' ? $description : null,
+                'monitoring_ids' => $monitoringIds,
+            ];
+        }
+
+        return $normalized;
+    }
+}

--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -193,6 +194,16 @@ class Monitoring extends Model
     public function archivedResponseResults(): HasMany
     {
         return $this->hasMany(MonitoringResponseArchived::class, 'monitoring_id');
+    }
+
+    /**
+     * @return BelongsToMany<StatusPageComponent, $this>
+     */
+    public function statusPageComponents(): BelongsToMany
+    {
+        return $this->belongsToMany(StatusPageComponent::class, 'status_page_component_monitoring')
+            ->withPivot('position')
+            ->withTimestamps();
     }
 
     /**

--- a/app/Models/StatusPage.php
+++ b/app/Models/StatusPage.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'user_id',
+    'name',
+    'slug',
+    'description',
+    'is_public',
+])]
+class StatusPage extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    public $incrementing = false;
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return HasMany<StatusPageComponent, $this>
+     */
+    public function components(): HasMany
+    {
+        return $this->hasMany(StatusPageComponent::class)->orderBy('position');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_public' => 'boolean',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/StatusPageComponent.php
+++ b/app/Models/StatusPageComponent.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable([
+    'status_page_id',
+    'name',
+    'description',
+    'position',
+])]
+class StatusPageComponent extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    public $incrementing = false;
+
+    /**
+     * @return BelongsTo<StatusPage, $this>
+     */
+    public function statusPage(): BelongsTo
+    {
+        return $this->belongsTo(StatusPage::class);
+    }
+
+    /**
+     * @return BelongsToMany<Monitoring, $this>
+     */
+    public function monitorings(): BelongsToMany
+    {
+        return $this->belongsToMany(Monitoring::class, 'status_page_component_monitoring')
+            ->withPivot('position')
+            ->withTimestamps()
+            ->orderByPivot('position');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -102,6 +102,14 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
+     * @return HasMany<StatusPage, $this>
+     */
+    public function statusPages(): HasMany
+    {
+        return $this->hasMany(StatusPage::class);
+    }
+
+    /**
      * Get the API logs associated with the user.
      *
      * @return HasMany<ApiLog, $this>

--- a/database/migrations/2026_05_14_130000_create_status_pages_table.php
+++ b/database/migrations/2026_05_14_130000_create_status_pages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('status_pages', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->boolean('is_public')->default(true);
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('status_pages');
+    }
+};

--- a/database/migrations/2026_05_14_131000_create_status_page_components_table.php
+++ b/database/migrations/2026_05_14_131000_create_status_page_components_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\StatusPage;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('status_page_components', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignIdFor(StatusPage::class)->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->index(['status_page_id', 'position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('status_page_components');
+    }
+};

--- a/database/migrations/2026_05_14_132000_create_status_page_component_monitoring_table.php
+++ b/database/migrations/2026_05_14_132000_create_status_page_component_monitoring_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Monitoring;
+use App\Models\StatusPageComponent;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('status_page_component_monitoring', function (Blueprint $table): void {
+            $table->foreignIdFor(StatusPageComponent::class);
+            $table->foreignIdFor(Monitoring::class);
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->primary(['status_page_component_id', 'monitoring_id'], 'status_page_component_monitoring_pk');
+            $table->index(['monitoring_id', 'status_page_component_id'], 'status_page_component_monitoring_monitoring_idx');
+            $table->foreign('status_page_component_id', 'status_page_component_monitoring_component_fk')
+                ->references('id')
+                ->on('status_page_components')
+                ->cascadeOnDelete();
+            $table->foreign('monitoring_id', 'status_page_component_monitoring_monitoring_fk')
+                ->references('id')
+                ->on('monitorings')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('status_page_component_monitoring');
+    }
+};

--- a/resources/lang/de/status_page.php
+++ b/resources/lang/de/status_page.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Statusseiten',
+    'components_count' => ':count Komponente|:count Komponenten',
+    'state' => [
+        'public' => 'Öffentlich',
+        'private' => 'Privat',
+    ],
+    'empty' => [
+        'title' => 'Noch keine Statusseiten',
+        'text' => 'Gruppieren Sie Überwachungen in kundenorientierte Komponenten wie API, Web App, Worker oder Datenbank.',
+    ],
+    'create' => [
+        'title' => 'Statusseite erstellen',
+    ],
+    'edit' => [
+        'title' => 'Statusseite bearbeiten: :statusPage',
+    ],
+    'form' => [
+        'name' => 'Name',
+        'slug' => 'Slug',
+        'slug_placeholder' => 'Wird aus dem Namen erzeugt, wenn leer',
+        'description' => 'Beschreibung',
+        'is_public' => 'Diese Statusseite veröffentlichen',
+        'components' => 'Komponenten',
+        'component_name' => 'Komponentenname',
+        'component_description' => 'Komponentenbeschreibung',
+        'monitorings' => 'Überwachungen',
+        'add_component' => 'Komponente hinzufügen',
+        'remove_component' => 'Komponente entfernen',
+    ],
+    'actions' => [
+        'public_page' => 'Öffentliche Seite',
+        'delete_confirmation' => 'Sind Sie sicher, dass Sie diese Statusseite löschen möchten?',
+    ],
+    'messages' => [
+        'created' => 'Statusseite erfolgreich erstellt.',
+        'updated' => 'Statusseite erfolgreich aktualisiert.',
+        'deleted' => 'Statusseite erfolgreich gelöscht.',
+    ],
+    'public' => [
+        'title' => ':statusPage - Status',
+        'overall_status' => 'Gesamtstatus',
+        'recent_incidents' => 'Letzte Vorfälle',
+    ],
+    'validation' => [
+        'fix_errors' => 'Bitte korrigieren Sie die markierten Statusseiten-Einstellungen.',
+    ],
+];

--- a/resources/lang/en/status_page.php
+++ b/resources/lang/en/status_page.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Status Pages',
+    'components_count' => ':count component|:count components',
+    'state' => [
+        'public' => 'Public',
+        'private' => 'Private',
+    ],
+    'empty' => [
+        'title' => 'No status pages yet',
+        'text' => 'Group monitorings into customer-facing components such as API, Web App, Workers, or Database.',
+    ],
+    'create' => [
+        'title' => 'Create Status Page',
+    ],
+    'edit' => [
+        'title' => 'Edit :statusPage',
+    ],
+    'form' => [
+        'name' => 'Name',
+        'slug' => 'Slug',
+        'slug_placeholder' => 'Generated from the name when empty',
+        'description' => 'Description',
+        'is_public' => 'Publish this status page',
+        'components' => 'Components',
+        'component_name' => 'Component name',
+        'component_description' => 'Component description',
+        'monitorings' => 'Monitorings',
+        'add_component' => 'Add component',
+        'remove_component' => 'Remove component',
+    ],
+    'actions' => [
+        'public_page' => 'Public page',
+        'delete_confirmation' => 'Are you sure you want to delete this status page?',
+    ],
+    'messages' => [
+        'created' => 'Status page created successfully.',
+        'updated' => 'Status page updated successfully.',
+        'deleted' => 'Status page deleted successfully.',
+    ],
+    'public' => [
+        'title' => ':statusPage - Status',
+        'overall_status' => 'Overall status',
+        'recent_incidents' => 'Recent Incidents',
+    ],
+    'validation' => [
+        'fix_errors' => 'Please fix the highlighted status page settings.',
+    ],
+];

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -16,6 +16,10 @@
                         {{ __('monitoring.title') }}
                     </x-nav-link>
 
+                    <x-nav-link :href="route('status-pages.index')" :active="request()->routeIs('status-pages.*')">
+                        {{ __('status_page.title') }}
+                    </x-nav-link>
+
                     <x-nav-link :href="route('notifications.index')" :active="request()->routeIs('notifications.*')" class="relative">
                         {{ __('notifications.title') }}
                         @if (isset($unreadNotificationsCount) && $unreadNotificationsCount > 0)
@@ -93,6 +97,10 @@
         <div class="space-y-1 pb-3 pt-2">
             <x-responsive-nav-link :href="route('monitorings.index')" :active="request()->routeIs('monitorings.*')">
                 {{ __('monitoring.title') }}
+            </x-responsive-nav-link>
+
+            <x-responsive-nav-link :href="route('status-pages.index')" :active="request()->routeIs('status-pages.*')">
+                {{ __('status_page.title') }}
             </x-responsive-nav-link>
 
             <x-responsive-nav-link :href="route('notifications.index')" :active="request()->routeIs('notifications.*')">

--- a/resources/views/status-pages/_form.blade.php
+++ b/resources/views/status-pages/_form.blade.php
@@ -1,0 +1,127 @@
+@php
+    $componentValues = old(
+        'components',
+        isset($statusPage)
+            ? $statusPage->components->map(
+                fn ($component) => [
+                    'name' => $component->name,
+                    'description' => $component->description,
+                    'monitoring_ids' => $component->monitorings->pluck('id')->values()->all(),
+                ],
+            )->values()->all()
+            : $defaultComponents,
+    );
+@endphp
+
+<x-container>
+    @if ($errors->any())
+        <div class="mb-4 text-sm text-red-600 dark:text-red-400">
+            {{ __('status_page.validation.fix_errors') }}
+        </div>
+    @endif
+
+    <form method="POST" action="{{ $action }}">
+        @csrf
+        @isset($method)
+            @method($method)
+        @endisset
+
+        <div class="space-y-6"
+            x-data="{
+                components: @js($componentValues),
+                addComponent() {
+                    this.components.push({ name: '', description: '', monitoring_ids: [] });
+                },
+                removeComponent(index) {
+                    this.components.splice(index, 1);
+                }
+            }">
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                    <x-input-label for="name" :value="__('status_page.form.name')" />
+                    <x-text-input id="name" name="name" type="text" :value="old('name', $statusPage->name ?? '')" required />
+                    <x-input-error :messages="$errors->get('name')" />
+                </div>
+
+                <div>
+                    <x-input-label for="slug" :value="__('status_page.form.slug')" />
+                    <x-text-input id="slug" name="slug" type="text" :value="old('slug', $statusPage->slug ?? '')"
+                        placeholder="{{ __('status_page.form.slug_placeholder') }}" />
+                    <x-input-error :messages="$errors->get('slug')" />
+                </div>
+            </div>
+
+            <div>
+                <x-input-label for="description" :value="__('status_page.form.description')" />
+                <x-textarea id="description" name="description" rows="3">{{ old('description', $statusPage->description ?? '') }}</x-textarea>
+                <x-input-error :messages="$errors->get('description')" />
+            </div>
+
+            <label class="inline-flex items-center gap-2">
+                <x-checkbox-input name="is_public" value="1" :checked="old('is_public', $statusPage->is_public ?? true)" />
+                <span class="text-sm text-gray-700 dark:text-gray-300">{{ __('status_page.form.is_public') }}</span>
+            </label>
+
+            <div class="space-y-4">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <x-heading type="h2">{{ __('status_page.form.components') }}</x-heading>
+                    <x-secondary-button type="button" @click="addComponent()">
+                        {{ __('status_page.form.add_component') }}
+                    </x-secondary-button>
+                </div>
+                <x-input-error :messages="$errors->get('components')" />
+
+                <template x-for="(component, index) in components" :key="index">
+                    <div class="rounded-md border border-gray-200 p-4 dark:border-gray-700">
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            <div>
+                                <x-input-label x-bind:for="'component-name-' + index"
+                                    :value="__('status_page.form.component_name')" />
+                                <x-text-input x-bind:id="'component-name-' + index" type="text"
+                                    x-bind:name="'components[' + index + '][name]'" x-model="component.name"
+                                    required />
+                            </div>
+
+                            <div>
+                                <x-input-label x-bind:for="'component-monitorings-' + index"
+                                    :value="__('status_page.form.monitorings')" />
+                                <select x-bind:id="'component-monitorings-' + index"
+                                    x-bind:name="'components[' + index + '][monitoring_ids][]'"
+                                    x-model="component.monitoring_ids" multiple required
+                                    class="mt-1 w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+                                    @foreach ($monitorings as $monitoring)
+                                        <option value="{{ $monitoring->id }}">
+                                            {{ $monitoring->name }} ({{ __('monitoring.types.' . $monitoring->type->value) }})
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label x-bind:for="'component-description-' + index"
+                                :value="__('status_page.form.component_description')" />
+                            <textarea x-bind:id="'component-description-' + index"
+                                x-bind:name="'components[' + index + '][description]'" rows="2" x-model="component.description"
+                                class="form-textarea mt-1 w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"></textarea>
+                        </div>
+
+                        <button type="button" @click="removeComponent(index)"
+                            class="mt-3 text-sm font-medium text-red-600 hover:text-red-700 dark:text-red-400">
+                            {{ __('status_page.form.remove_component') }}
+                        </button>
+                    </div>
+                </template>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+                <x-primary-button>
+                    {{ $submitLabel }}
+                </x-primary-button>
+                <x-secondary-button :href="route('status-pages.index')">
+                    {{ __('button.cancel') }}
+                </x-secondary-button>
+            </div>
+        </div>
+    </form>
+</x-container>

--- a/resources/views/status-pages/create.blade.php
+++ b/resources/views/status-pages/create.blade.php
@@ -1,0 +1,12 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('status_page.create.title') }}</x-heading>
+    </x-slot>
+
+    <x-main>
+        @include('status-pages._form', [
+            'action' => route('status-pages.store'),
+            'submitLabel' => __('button.create'),
+        ])
+    </x-main>
+</x-app-layout>

--- a/resources/views/status-pages/edit.blade.php
+++ b/resources/views/status-pages/edit.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('status_page.edit.title', ['statusPage' => $statusPage->name]) }}</x-heading>
+    </x-slot>
+
+    <x-main>
+        @include('status-pages._form', [
+            'action' => route('status-pages.update', $statusPage),
+            'method' => 'PATCH',
+            'submitLabel' => __('button.update'),
+        ])
+    </x-main>
+</x-app-layout>

--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -1,0 +1,58 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('status_page.title') }}</x-heading>
+
+        @if (!Auth::user()->isDemo())
+            <x-primary-button :href="route('status-pages.create')" class="sm:ml-auto">
+                {{ __('button.create') }}
+            </x-primary-button>
+        @endif
+    </x-slot>
+
+    <x-main>
+        @if ($statusPages->isEmpty())
+            <x-container class="text-center">
+                <x-heading type="h2">{{ __('status_page.empty.title') }}</x-heading>
+                <x-paragraph space="true">{{ __('status_page.empty.text') }}</x-paragraph>
+                @if (!Auth::user()->isDemo())
+                    <x-primary-button :href="route('status-pages.create')">
+                        {{ __('button.create') }}
+                    </x-primary-button>
+                @endif
+            </x-container>
+        @else
+            <div class="space-y-4">
+                @foreach ($statusPages as $statusPage)
+                    <x-container>
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <x-heading type="h2">{{ $statusPage->name }}</x-heading>
+                                <div class="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                                    <x-badge :type="$statusPage->is_public ? 'success' : 'warning'">
+                                        {{ $statusPage->is_public ? __('status_page.state.public') : __('status_page.state.private') }}
+                                    </x-badge>
+                                    <span>{{ trans_choice('status_page.components_count', $statusPage->components_count, ['count' => $statusPage->components_count]) }}</span>
+                                </div>
+                            </div>
+
+                            <div class="flex flex-wrap gap-2">
+                                @if ($statusPage->is_public)
+                                    <x-secondary-button :href="route('public-status-pages.show', $statusPage->slug)" target="_blank">
+                                        {{ __('status_page.actions.public_page') }}
+                                    </x-secondary-button>
+                                @endif
+                                <x-secondary-button :href="route('status-pages.show', $statusPage)">
+                                    {{ __('button.show') }}
+                                </x-secondary-button>
+                            </div>
+                        </div>
+                    </x-container>
+                @endforeach
+            </div>
+
+            <div class="mt-4">
+                {{ $statusPages->links() }}
+            </div>
+        @endif
+    </x-main>
+</x-app-layout>

--- a/resources/views/status-pages/public-show.blade.php
+++ b/resources/views/status-pages/public-show.blade.php
@@ -1,0 +1,105 @@
+<x-public-layout>
+    <x-slot name="head">
+        <meta name="robots" content="noindex">
+        <title>{{ __('status_page.public.title', ['statusPage' => $statusPage->name]) }}</title>
+    </x-slot>
+
+    <x-slot name="header">
+        <div>
+            <x-heading>{{ $statusPage->name }}</x-heading>
+            @if ($statusPage->description)
+                <p class="mt-2 max-w-3xl text-sm text-gray-500 dark:text-gray-300">{{ $statusPage->description }}</p>
+            @endif
+        </div>
+        <x-badge :type="$pageStatusBadgeType">
+            {{ __('status_page.public.overall_status') }}: {{ mb_strtoupper($pageStatus) }}
+        </x-badge>
+    </x-slot>
+
+    <x-main>
+        <div class="space-y-6">
+            <section class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                @foreach ($components as $statusPageComponent)
+                    <x-container id="status-page-component-{{ $statusPageComponent['model']->id }}">
+                        <div class="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <x-heading type="h2">{{ $statusPageComponent['model']->name }}</x-heading>
+                                @if ($statusPageComponent['model']->description)
+                                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                                        {{ $statusPageComponent['model']->description }}
+                                    </p>
+                                @endif
+                            </div>
+                            <div class="flex flex-wrap gap-2">
+                                @if ($statusPageComponent['hasMaintenance'])
+                                    <x-badge type="info">{{ __('monitoring.index.table.maintenance') }}</x-badge>
+                                @endif
+                                <x-badge :type="$statusPageComponent['badgeType']">{{ mb_strtoupper($statusPageComponent['status']) }}</x-badge>
+                            </div>
+                        </div>
+
+                        <div class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($statusPageComponent['monitorings'] as $monitoringItem)
+                                <div class="flex flex-wrap items-center justify-between gap-3 py-3">
+                                    <div>
+                                        <p class="font-medium text-gray-900 dark:text-gray-100">
+                                            {{ $monitoringItem['model']->name }}
+                                        </p>
+                                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                            {{ __('monitoring.types.' . $monitoringItem['model']->type->value) }}
+                                            @if ($monitoringItem['lastCheckedAt'])
+                                                - {{ __('monitoring.detail.last_check') }}
+                                                {{ $monitoringItem['lastCheckedAt']->diffForHumans() }}
+                                            @endif
+                                        </p>
+                                    </div>
+                                    <div class="flex flex-wrap gap-2">
+                                        @if ($monitoringItem['isUnderMaintenance'])
+                                            <x-badge type="info">{{ __('monitoring.index.table.maintenance') }}</x-badge>
+                                        @endif
+                                        <x-badge :type="$monitoringItem['badgeType']">{{ mb_strtoupper($monitoringItem['status']) }}</x-badge>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </x-container>
+                @endforeach
+            </section>
+
+            <section id="status-page-incidents">
+                <x-container>
+                    <x-heading type="h2">{{ __('status_page.public.recent_incidents') }}</x-heading>
+
+                    @if ($incidents->isEmpty())
+                        <p class="mt-4 text-gray-500 dark:text-gray-400">
+                            {{ __('monitoring.detail.incidents.no_incidents') }}
+                        </p>
+                    @else
+                        <div class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($incidents as $incident)
+                                <div class="py-3">
+                                    <div class="flex flex-wrap items-center justify-between gap-2">
+                                        <span class="font-medium text-gray-900 dark:text-gray-100">
+                                            {{ $incident->monitoring->name }}
+                                        </span>
+                                        <x-badge :type="$incident->up_at ? 'success' : 'danger'">
+                                            {{ $incident->up_at ? __('monitoring.public_label.resolved') : __('monitoring.public_label.ongoing') }}
+                                        </x-badge>
+                                    </div>
+                                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                        {{ __('monitoring.detail.incidents.incident.down_at') }}:
+                                        {{ $incident->down_at->toDayDateTimeString() }}
+                                        @if ($incident->up_at)
+                                            - {{ __('monitoring.detail.incidents.incident.up_at') }}
+                                            {{ $incident->up_at->toDayDateTimeString() }}
+                                        @endif
+                                    </p>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </x-container>
+            </section>
+        </div>
+    </x-main>
+</x-public-layout>

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -1,0 +1,72 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div>
+            <x-heading type="h1">{{ $statusPage->name }}</x-heading>
+            <div class="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                <x-badge :type="$statusPage->is_public ? 'success' : 'warning'">
+                    {{ $statusPage->is_public ? __('status_page.state.public') : __('status_page.state.private') }}
+                </x-badge>
+                @if ($statusPage->is_public)
+                    <a href="{{ route('public-status-pages.show', $statusPage->slug) }}" target="_blank"
+                        class="break-all hover:text-gray-700 dark:hover:text-white">
+                        {{ route('public-status-pages.show', $statusPage->slug) }}
+                    </a>
+                @endif
+            </div>
+        </div>
+
+        <div class="ml-auto flex flex-wrap gap-2">
+            @if (!Auth::user()->isDemo())
+                <x-secondary-button :href="route('status-pages.edit', $statusPage)">
+                    {{ __('button.edit') }}
+                </x-secondary-button>
+                <form method="POST" action="{{ route('status-pages.destroy', $statusPage) }}"
+                    data-confirm-message="{{ __('status_page.actions.delete_confirmation') }}">
+                    @csrf
+                    @method('DELETE')
+                    <x-danger-button>
+                        {{ __('button.delete') }}
+                    </x-danger-button>
+                </form>
+            @endif
+            <x-secondary-button :href="route('status-pages.index')">
+                {{ __('button.back') }}
+            </x-secondary-button>
+        </div>
+    </x-slot>
+
+    <x-main>
+        <div class="space-y-4">
+            @if ($statusPage->description)
+                <x-container>
+                    <x-paragraph>{{ $statusPage->description }}</x-paragraph>
+                </x-container>
+            @endif
+
+            @foreach ($statusPage->components as $statusPageComponent)
+                <x-container>
+                    <x-heading type="h2">{{ $statusPageComponent->name }}</x-heading>
+                    @if ($statusPageComponent->description)
+                        <x-paragraph space="true">{{ $statusPageComponent->description }}</x-paragraph>
+                    @endif
+
+                    <div class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach ($statusPageComponent->monitorings as $monitoring)
+                            <div class="flex flex-wrap items-center justify-between gap-3 py-3">
+                                <div>
+                                    <a href="{{ route('monitorings.show', $monitoring) }}"
+                                        class="font-medium text-gray-900 hover:text-purple-600 dark:text-gray-100 dark:hover:text-purple-300">
+                                        {{ $monitoring->name }}
+                                    </a>
+                                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                        {{ __('monitoring.types.' . $monitoring->type->value) }}
+                                    </p>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-container>
+            @endforeach
+        </div>
+    </x-main>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,8 @@ use App\Http\Controllers\MonitoringLocationsController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PublicLabelController;
+use App\Http\Controllers\PublicStatusPageController;
+use App\Http\Controllers\StatusPageController;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
@@ -62,6 +64,8 @@ Route::get('/sitemap.xml', function () {
 Route::get('/label/{monitoring}', PublicLabelController::class)
     ->name('public-label')
     ->scopeBindings();
+Route::get('/status/{statusPage:slug}', PublicStatusPageController::class)
+    ->name('public-status-pages.show');
 
 Route::get('/widget.js', function () {
     return response(file_get_contents(public_path('js/widget.js')))->header('Content-Type', 'application/javascript');
@@ -88,6 +92,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     });
 
     Route::resource('monitorings', MonitoringController::class)->names('monitorings');
+    Route::resource('status-pages', StatusPageController::class)
+        ->parameters(['status-pages' => 'statusPage'])
+        ->names('status-pages');
 
     Route::delete('/monitorings/{monitoring}/reset', [MonitoringController::class, 'destroyResults'])
         ->name('monitorings.destroyResults');

--- a/tests/Feature/ComponentStatusPageTest.php
+++ b/tests/Feature/ComponentStatusPageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\StatusPage;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class ComponentStatusPageTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_public_component_status_page_groups_monitorings_and_aggregates_status(): void
+    {
+        Date::setTestNow('2026-05-14 09:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $apiMonitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://api.example.test/secret-path',
+            'created_at' => Date::now()->subDays(10),
+        ]);
+        $workerMonitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Queue Worker',
+            'created_at' => Date::now()->subDays(10),
+        ]);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $apiMonitoring->id,
+            'status' => MonitoringStatus::UP,
+            'response_time' => 120,
+            'created_at' => Date::now()->subMinutes(5),
+            'updated_at' => Date::now()->subMinutes(5),
+        ]);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $workerMonitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'response_time' => null,
+            'created_at' => Date::now()->subMinutes(3),
+            'updated_at' => Date::now()->subMinutes(3),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $workerMonitoring->id,
+            'down_at' => Date::now()->subMinutes(30),
+            'up_at' => null,
+        ]);
+
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'slug' => 'acme-status',
+            'description' => 'Public operating status',
+            'is_public' => true,
+        ]);
+        $apiComponent = $statusPage->components()->create(['name' => 'API', 'position' => 0]);
+        $apiComponent->monitorings()->attach($apiMonitoring->id, ['position' => 0]);
+        $workerComponent = $statusPage->components()->create(['name' => 'Workers', 'position' => 1]);
+        $workerComponent->monitorings()->attach($workerMonitoring->id, ['position' => 0]);
+
+        $response = $this->get(route('public-status-pages.show', $statusPage->slug));
+
+        $response->assertOk();
+        $response->assertSeeText('Acme Status');
+        $response->assertSeeText(__('status_page.public.overall_status') . ': DOWN');
+        $response->assertSeeTextInOrder(['API', 'UP', 'Workers', 'DOWN']);
+        $response->assertSeeText('Primary API');
+        $response->assertSeeText('Queue Worker');
+        $response->assertSeeText(__('status_page.public.recent_incidents'));
+        $response->assertSeeText(__('monitoring.public_label.ongoing'));
+        $response->assertDontSeeText('https://api.example.test/secret-path');
+    }
+
+    public function test_private_component_status_page_returns_not_found_publicly(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Private Status',
+            'slug' => 'private-status',
+            'is_public' => false,
+        ]);
+
+        $response = $this->get(route('public-status-pages.show', $statusPage->slug));
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/ComponentStatusPageTest.php
+++ b/tests/Feature/ComponentStatusPageTest.php
@@ -68,22 +68,22 @@ class ComponentStatusPageTest extends TestCase
             'description' => 'Public operating status',
             'is_public' => true,
         ]);
-        $apiComponent = $statusPage->components()->create(['name' => 'API', 'position' => 0]);
-        $apiComponent->monitorings()->attach($apiMonitoring->id, ['position' => 0]);
+        $statusPageComponent = $statusPage->components()->create(['name' => 'API', 'position' => 0]);
+        $statusPageComponent->monitorings()->attach($apiMonitoring->id, ['position' => 0]);
         $workerComponent = $statusPage->components()->create(['name' => 'Workers', 'position' => 1]);
         $workerComponent->monitorings()->attach($workerMonitoring->id, ['position' => 0]);
 
-        $response = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $testResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
 
-        $response->assertOk();
-        $response->assertSeeText('Acme Status');
-        $response->assertSeeText(__('status_page.public.overall_status') . ': DOWN');
-        $response->assertSeeTextInOrder(['API', 'UP', 'Workers', 'DOWN']);
-        $response->assertSeeText('Primary API');
-        $response->assertSeeText('Queue Worker');
-        $response->assertSeeText(__('status_page.public.recent_incidents'));
-        $response->assertSeeText(__('monitoring.public_label.ongoing'));
-        $response->assertDontSeeText('https://api.example.test/secret-path');
+        $testResponse->assertOk();
+        $testResponse->assertSeeText('Acme Status');
+        $testResponse->assertSeeText(__('status_page.public.overall_status') . ': DOWN');
+        $testResponse->assertSeeTextInOrder(['API', 'UP', 'Workers', 'DOWN']);
+        $testResponse->assertSeeText('Primary API');
+        $testResponse->assertSeeText('Queue Worker');
+        $testResponse->assertSeeText(__('status_page.public.recent_incidents'));
+        $testResponse->assertSeeText(__('monitoring.public_label.ongoing'));
+        $testResponse->assertDontSeeText('https://api.example.test/secret-path');
     }
 
     public function test_private_component_status_page_returns_not_found_publicly(): void
@@ -97,8 +97,8 @@ class ComponentStatusPageTest extends TestCase
             'is_public' => false,
         ]);
 
-        $response = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $testResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
 
-        $response->assertNotFound();
+        $testResponse->assertNotFound();
     }
 }

--- a/tests/Feature/MysqlMigrationCompatibilityTest.php
+++ b/tests/Feature/MysqlMigrationCompatibilityTest.php
@@ -17,4 +17,17 @@ class MysqlMigrationCompatibilityTest extends TestCase
         $this->assertLessThanOrEqual(64, mb_strlen($foreignKeyName));
         $this->assertStringContainsString("->foreign('monitoring_notification_id', '{$foreignKeyName}')", $migration);
     }
+
+    public function test_status_page_component_pivot_foreign_key_names_fit_mysql_identifier_limit(): void
+    {
+        $migration = file_get_contents(base_path('database/migrations/2026_05_14_132000_create_status_page_component_monitoring_table.php'));
+        $componentForeignKeyName = 'status_page_component_monitoring_component_fk';
+        $monitoringForeignKeyName = 'status_page_component_monitoring_monitoring_fk';
+
+        $this->assertIsString($migration);
+        $this->assertLessThanOrEqual(64, mb_strlen($componentForeignKeyName));
+        $this->assertLessThanOrEqual(64, mb_strlen($monitoringForeignKeyName));
+        $this->assertStringContainsString("->foreign('status_page_component_id', '{$componentForeignKeyName}')", $migration);
+        $this->assertStringContainsString("->foreign('monitoring_id', '{$monitoringForeignKeyName}')", $migration);
+    }
 }

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\StatusPage;
+use App\Models\User;
+use Tests\TestCase;
+
+class StatusPageManagementTest extends TestCase
+{
+    public function test_status_page_form_renders_available_monitorings_and_default_components(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
+
+        $response = $this->actingAs($user)->get(route('status-pages.create'));
+
+        $response->assertOk();
+        $response->assertSeeText(__('status_page.form.components'));
+        $response->assertSee('API', false);
+        $response->assertSee('Web App', false);
+        $response->assertSee('Workers', false);
+        $response->assertSee('Database', false);
+        $response->assertSeeText('Primary API');
+    }
+
+    public function test_user_can_create_component_based_status_page(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $apiMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
+        $workerMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Queue Worker']);
+
+        $response = $this->actingAs($user)->post(route('status-pages.store'), [
+            'name' => 'Acme Status',
+            'slug' => 'acme-status',
+            'description' => 'Customer-facing status page',
+            'is_public' => '1',
+            'components' => [
+                [
+                    'name' => 'API',
+                    'monitoring_ids' => [$apiMonitoring->id],
+                ],
+                [
+                    'name' => 'Workers',
+                    'monitoring_ids' => [$workerMonitoring->id],
+                ],
+            ],
+        ]);
+
+        $statusPage = StatusPage::query()->firstOrFail();
+
+        $response->assertRedirect(route('status-pages.show', $statusPage));
+        $this->assertDatabaseHas('status_pages', [
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'slug' => 'acme-status',
+            'is_public' => true,
+        ]);
+        $this->assertDatabaseHas('status_page_components', [
+            'status_page_id' => $statusPage->id,
+            'name' => 'API',
+            'position' => 0,
+        ]);
+        $this->assertDatabaseHas('status_page_components', [
+            'status_page_id' => $statusPage->id,
+            'name' => 'Workers',
+            'position' => 1,
+        ]);
+        $this->assertDatabaseHas('status_page_component_monitoring', [
+            'monitoring_id' => $apiMonitoring->id,
+            'position' => 0,
+        ]);
+    }
+
+    public function test_status_page_components_cannot_reference_another_users_monitorings(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $otherUser = User::factory()->create(['package_id' => $package->id]);
+        $otherMonitoring = Monitoring::factory()->for($otherUser)->create();
+
+        $response = $this->from(route('status-pages.create'))
+            ->actingAs($user)
+            ->post(route('status-pages.store'), [
+                'name' => 'Acme Status',
+                'slug' => 'acme-status',
+                'is_public' => '1',
+                'components' => [
+                    [
+                        'name' => 'API',
+                        'monitoring_ids' => [$otherMonitoring->id],
+                    ],
+                ],
+            ]);
+
+        $response->assertRedirect(route('status-pages.create'));
+        $response->assertSessionHasErrors(['components.0.monitoring_ids.0']);
+        $this->assertDatabaseMissing('status_pages', ['slug' => 'acme-status']);
+    }
+
+    public function test_user_cannot_view_another_users_status_page_management_screen(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $owner = User::factory()->create(['package_id' => $package->id]);
+        $otherUser = User::factory()->create(['package_id' => $package->id]);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $owner->id,
+            'name' => 'Owner Status',
+            'slug' => 'owner-status',
+            'is_public' => true,
+        ]);
+
+        $response = $this->actingAs($otherUser)->get(route('status-pages.show', $statusPage));
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -18,15 +18,15 @@ class StatusPageManagementTest extends TestCase
         $user = User::factory()->create(['package_id' => $package->id]);
         Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
 
-        $response = $this->actingAs($user)->get(route('status-pages.create'));
+        $testResponse = $this->actingAs($user)->get(route('status-pages.create'));
 
-        $response->assertOk();
-        $response->assertSeeText(__('status_page.form.components'));
-        $response->assertSee('API', false);
-        $response->assertSee('Web App', false);
-        $response->assertSee('Workers', false);
-        $response->assertSee('Database', false);
-        $response->assertSeeText('Primary API');
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('status_page.form.components'));
+        $testResponse->assertSeeHtml('API');
+        $testResponse->assertSeeHtml('Web App');
+        $testResponse->assertSeeHtml('Workers');
+        $testResponse->assertSeeHtml('Database');
+        $testResponse->assertSeeText('Primary API');
     }
 
     public function test_user_can_create_component_based_status_page(): void
@@ -36,7 +36,7 @@ class StatusPageManagementTest extends TestCase
         $apiMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
         $workerMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Queue Worker']);
 
-        $response = $this->actingAs($user)->post(route('status-pages.store'), [
+        $testResponse = $this->actingAs($user)->post(route('status-pages.store'), [
             'name' => 'Acme Status',
             'slug' => 'acme-status',
             'description' => 'Customer-facing status page',
@@ -55,7 +55,7 @@ class StatusPageManagementTest extends TestCase
 
         $statusPage = StatusPage::query()->firstOrFail();
 
-        $response->assertRedirect(route('status-pages.show', $statusPage));
+        $testResponse->assertRedirect(route('status-pages.show', $statusPage));
         $this->assertDatabaseHas('status_pages', [
             'user_id' => $user->id,
             'name' => 'Acme Status',
@@ -85,7 +85,7 @@ class StatusPageManagementTest extends TestCase
         $otherUser = User::factory()->create(['package_id' => $package->id]);
         $otherMonitoring = Monitoring::factory()->for($otherUser)->create();
 
-        $response = $this->from(route('status-pages.create'))
+        $testResponse = $this->from(route('status-pages.create'))
             ->actingAs($user)
             ->post(route('status-pages.store'), [
                 'name' => 'Acme Status',
@@ -99,8 +99,8 @@ class StatusPageManagementTest extends TestCase
                 ],
             ]);
 
-        $response->assertRedirect(route('status-pages.create'));
-        $response->assertSessionHasErrors(['components.0.monitoring_ids.0']);
+        $testResponse->assertRedirect(route('status-pages.create'));
+        $testResponse->assertSessionHasErrors(['components.0.monitoring_ids.0']);
         $this->assertDatabaseMissing('status_pages', ['slug' => 'acme-status']);
     }
 
@@ -116,8 +116,8 @@ class StatusPageManagementTest extends TestCase
             'is_public' => true,
         ]);
 
-        $response = $this->actingAs($otherUser)->get(route('status-pages.show', $statusPage));
+        $testResponse = $this->actingAs($otherUser)->get(route('status-pages.show', $statusPage));
 
-        $response->assertNotFound();
+        $testResponse->assertNotFound();
     }
 }


### PR DESCRIPTION
## Summary
- Add managed status pages that group multiple monitorings into user-defined components such as API, Web App, Workers, and Database.
- Add public `/status/{slug}` pages with aggregate page/component health, maintenance indicators, recent incidents, and no monitoring target/secret exposure.
- Add localized management UI, navigation, Eloquent relations, migrations, and MySQL-safe foreign key names for the component-monitoring pivot table.

## Tests
- `vendor/bin/pint --dirty --test`
- `php artisan test`