### PR TITLE
Fix tag changelog workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,6 +3,7 @@ name: Tag
 on:
   workflow_run:
     workflows: [ "CI" ]
+    branches: [ main ]
     types:
     - completed
   workflow_dispatch:
@@ -31,6 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
+        ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0
     - name: Create tag
       uses: mathieudutour/github-tag-action@v6.2
@@ -48,7 +50,11 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
+        ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0
+
+    - name: Fetch release tags
+      run: git fetch --force --tags origin
 
     - name: Generate changelog
       run: |

--- a/tests/Feature/TagChangelogGenerationTest.php
+++ b/tests/Feature/TagChangelogGenerationTest.php
@@ -82,13 +82,25 @@ class TagChangelogGenerationTest extends TestCase
         $workflow = Yaml::parseFile(base_path('.github/workflows/tag.yml'));
 
         $this->assertArrayHasKey('workflow_dispatch', $workflow['on']);
+        $this->assertSame(['main'], $workflow['on']['workflow_run']['branches']);
         $this->assertSame('Create Tag', $workflow['jobs']['create-tag']['name']);
         $this->assertSame('${{ steps.tag_version.outputs.new_tag }}', $workflow['jobs']['create-tag']['outputs']['new_tag']);
 
+        $createCheckout = collect($workflow['jobs']['create-tag']['steps'])->firstWhere('uses', 'actions/checkout@v6');
+
+        $this->assertIsArray($createCheckout);
+        $this->assertSame('${{ github.event.workflow_run.head_sha }}', $createCheckout['with']['ref']);
+
         $publishSteps = $workflow['jobs']['publish-changelog']['steps'];
+        $publishCheckout = collect($publishSteps)->firstWhere('uses', 'actions/checkout@v6');
+        $fetchTags = collect($publishSteps)->firstWhere('name', 'Fetch release tags');
         $publishScript = collect($publishSteps)->firstWhere('name', 'Generate changelog');
         $publishRelease = collect($publishSteps)->firstWhere('name', 'Publish GitHub release notes');
 
+        $this->assertIsArray($publishCheckout);
+        $this->assertSame('${{ github.event.workflow_run.head_sha }}', $publishCheckout['with']['ref']);
+        $this->assertIsArray($fetchTags);
+        $this->assertSame('git fetch --force --tags origin', $fetchTags['run']);
         $this->assertIsArray($publishScript);
         $this->assertStringContainsString('.github/scripts/generate-changelog.php', $publishScript['run']);
         $this->assertStringContainsString('needs.create-tag.outputs.new_tag', $publishScript['run']);


### PR DESCRIPTION
## Summary
- Limit the tag workflow trigger to completed CI runs on `main`.
- Check out the CI-tested commit for tag creation and release-note publishing.
- Fetch tags before running the changelog generator so the newly created tag is available.
- Extend the workflow test to cover the release wiring.

## Root cause
The tag workflow was triggered by every completed CI workflow run and relied on the default checkout ref in follow-up jobs. That produced noisy skipped runs and made the changelog publish path less deterministic around the tag created by the previous job.

## Validation
- `php artisan test tests/Feature/TagChangelogGenerationTest.php`
- `./vendor/bin/pint --test tests/Feature/TagChangelogGenerationTest.php .github/scripts/generate-changelog.php`

## Notes
Composer was installed locally with `--ignore-platform-req=ext-redis` because this machine does not have the Redis PHP extension enabled; GitHub CI installs it.