### PR TITLE
Add server health monitoring

### DIFF
--- a/app/Console/Commands/Monitoring/ArchiveMonitoringResponsesCommand.php
+++ b/app/Console/Commands/Monitoring/ArchiveMonitoringResponsesCommand.php
@@ -65,6 +65,9 @@ class ArchiveMonitoringResponsesCommand extends Command
                             'status' => $status,
                             'http_status_code' => $httpStatusCode,
                             'response_time' => $monitoringResponse->response_time,
+                            'server_health_metrics' => $monitoringResponse->server_health_metrics !== null
+                                ? json_encode($monitoringResponse->server_health_metrics, JSON_THROW_ON_ERROR)
+                                : null,
                             'created_at' => $monitoringResponse->created_at,
                             'updated_at' => $monitoringResponse->updated_at,
                         ];

--- a/app/Enums/MonitoringType.php
+++ b/app/Enums/MonitoringType.php
@@ -12,6 +12,7 @@ namespace App\Enums;
  * - PING: Verifies if a host is reachable via ICMP (ping).
  * - KEYWORD: Looks for a specific keyword in the response of a web request.
  * - PORT: Checks if a specific port on a host is open and accepting connections.
+ * - SERVER_HEALTH: Accepts pushed server CPU, memory, and storage usage reports.
  * - DOMAIN_EXPIRATION: Checks if a domain registration is still valid and not close to expiry.
  * - DNS_RECORD: Checks whether DNS records still match the expected values.
  */
@@ -22,6 +23,7 @@ enum MonitoringType: string
     case KEYWORD = 'keyword';
     case PORT = 'port';
     case HEARTBEAT = 'heartbeat';
+    case SERVER_HEALTH = 'server_health';
     case DOMAIN_EXPIRATION = 'domain_expiration';
     case DNS_RECORD = 'dns_record';
 

--- a/app/Http/Controllers/Api/Internal/MonitoringListController.php
+++ b/app/Http/Controllers/Api/Internal/MonitoringListController.php
@@ -37,7 +37,10 @@ class MonitoringListController extends Controller
         if ($type) {
             $builder->where('type', $type);
         } else {
-            $builder->where('type', '!=', MonitoringType::HEARTBEAT->value);
+            $builder->whereNotIn('type', [
+                MonitoringType::HEARTBEAT->value,
+                MonitoringType::SERVER_HEALTH->value,
+            ]);
         }
 
         $monitorings = $builder->get();

--- a/app/Http/Controllers/Api/ServerHealthReportController.php
+++ b/app/Http/Controllers/Api/ServerHealthReportController.php
@@ -123,11 +123,11 @@ class ServerHealthReportController extends Controller
 
         $metrics = [];
 
-        foreach ($metricKeys as $key) {
-            if (array_key_exists($key, $validated) && $validated[$key] !== null) {
-                $metrics[$key] = is_numeric($validated[$key])
-                    ? (float) $validated[$key]
-                    : $validated[$key];
+        foreach ($metricKeys as $metricKey) {
+            if (array_key_exists($metricKey, $validated) && $validated[$metricKey] !== null) {
+                $metrics[$metricKey] = is_numeric($validated[$metricKey])
+                    ? (float) $validated[$metricKey]
+                    : $validated[$metricKey];
             }
         }
 

--- a/app/Http/Controllers/Api/ServerHealthReportController.php
+++ b/app/Http/Controllers/Api/ServerHealthReportController.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Http\Controllers\Controller;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class ServerHealthReportController extends Controller
+{
+    /**
+     * Store a server health report.
+     *
+     * Use the private endpoint generated for a Server Health monitoring. Send
+     * CPU, RAM, and storage percentages from your server agent or cron script.
+     * If no explicit status is supplied, WebGuard marks the report down when
+     * any percentage metric is at or above 90%.
+     *
+     * @group Server Health
+     *
+     * @unauthenticated
+     *
+     * @urlParam token string required The private server health token generated when the monitoring is created. Example: 01HXZ7Q92W3K7VY9E6JQFM4XPC
+     *
+     * @bodyParam status string Optional explicit status. One of up, down, unknown. Example: up
+     * @bodyParam cpu_usage_percent number CPU usage as a percentage from 0 to 100. Example: 42.5
+     * @bodyParam ram_usage_percent number RAM usage as a percentage from 0 to 100. Example: 68.2
+     * @bodyParam storage_usage_percent number Storage usage as a percentage from 0 to 100. Example: 74.1
+     * @bodyParam load_average number Optional system load average. Example: 1.42
+     * @bodyParam uptime_seconds integer Optional server uptime in seconds. Example: 86400
+     * @bodyParam extra_metrics object Optional additional numeric or string metrics. Example: {"swap_usage_percent": 12.4}
+     *
+     * @response {
+     *   "message": "Server health report accepted.",
+     *   "status": "up",
+     *   "metrics": {
+     *     "cpu_usage_percent": 42.5,
+     *     "ram_usage_percent": 68.2,
+     *     "storage_usage_percent": 74.1
+     *   }
+     * }
+     */
+    public function __invoke(Request $request, string $token): JsonResponse
+    {
+        $monitoring = Monitoring::query()
+            ->where('type', MonitoringType::SERVER_HEALTH->value)
+            ->where('server_health_token', $token)
+            ->firstOrFail();
+
+        $validated = $request->validate([
+            'status' => ['nullable', Rule::enum(MonitoringStatus::class)],
+            'cpu_usage_percent' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'ram_usage_percent' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'storage_usage_percent' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'load_average' => ['nullable', 'numeric', 'min:0'],
+            'uptime_seconds' => ['nullable', 'integer', 'min:0'],
+            'extra_metrics' => ['nullable', 'array'],
+            'extra_metrics.*' => ['nullable'],
+        ]);
+
+        $metrics = $this->extractMetrics($validated);
+
+        if ($metrics === [] && ! isset($validated['status'])) {
+            return response()->json([
+                'message' => 'Provide at least one server health metric or an explicit status.',
+                'errors' => [
+                    'metrics' => ['Provide at least one server health metric or an explicit status.'],
+                ],
+            ], 422);
+        }
+
+        $status = isset($validated['status'])
+            ? MonitoringStatus::from($validated['status'])
+            : $this->statusFromMetrics($metrics);
+
+        $timestamp = now();
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => $status,
+            'http_status_code' => match ($status) {
+                MonitoringStatus::UP => 200,
+                MonitoringStatus::DOWN => 503,
+                MonitoringStatus::UNKNOWN => null,
+            },
+            'response_time' => null,
+            'server_health_metrics' => $metrics,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        $monitoring->forceFill([
+            'server_health_last_reported_at' => $timestamp,
+        ])->save();
+
+        return response()->json([
+            'message' => 'Server health report accepted.',
+            'status' => $status->value,
+            'metrics' => $metrics,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    private function extractMetrics(array $validated): array
+    {
+        $metricKeys = [
+            'cpu_usage_percent',
+            'ram_usage_percent',
+            'storage_usage_percent',
+            'load_average',
+            'uptime_seconds',
+        ];
+
+        $metrics = [];
+
+        foreach ($metricKeys as $key) {
+            if (array_key_exists($key, $validated) && $validated[$key] !== null) {
+                $metrics[$key] = is_numeric($validated[$key])
+                    ? (float) $validated[$key]
+                    : $validated[$key];
+            }
+        }
+
+        if (isset($validated['extra_metrics']) && is_array($validated['extra_metrics'])) {
+            $metrics['extra_metrics'] = $validated['extra_metrics'];
+        }
+
+        return $metrics;
+    }
+
+    /**
+     * @param  array<string, mixed>  $metrics
+     */
+    private function statusFromMetrics(array $metrics): MonitoringStatus
+    {
+        foreach (['cpu_usage_percent', 'ram_usage_percent', 'storage_usage_percent'] as $key) {
+            if (isset($metrics[$key]) && (float) $metrics[$key] >= 90.0) {
+                return MonitoringStatus::DOWN;
+            }
+        }
+
+        return MonitoringStatus::UP;
+    }
+}

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -696,7 +696,7 @@ class ApiController extends Controller
         ?Carbon $endDate
     ): QueryBuilder {
         $builder = DB::table($table)
-            ->selectRaw("'{$source}' as source, id, status, http_status_code, response_time, created_at")
+            ->selectRaw("'{$source}' as source, id, status, http_status_code, response_time, server_health_metrics, created_at")
             ->where('monitoring_id', $monitoringId);
 
         if ($startDate !== null && $endDate !== null) {
@@ -708,12 +708,18 @@ class ApiController extends Controller
 
     /**
      * @param  Collection<int, object>  $rows
-     * @return array<int, array{id: string, checked_at: string, status: string, http_status_code: int|null, response_time: float|null, status_identifier: string, status_key: string, source: string}>
+     * @return array<int, array{id: string, checked_at: string, status: string, http_status_code: int|null, response_time: float|null, server_health_metrics: array<string, mixed>|null, status_identifier: string, status_key: string, source: string}>
      */
     private function formatCheckRows(Collection $rows): array
     {
         return $rows->map(function (object $row): array {
             $httpStatusCode = $row->http_status_code !== null ? (int) $row->http_status_code : null;
+            $serverHealthMetrics = null;
+
+            if (isset($row->server_health_metrics)) {
+                $decodedMetrics = json_decode((string) $row->server_health_metrics, true);
+                $serverHealthMetrics = is_array($decodedMetrics) ? $decodedMetrics : null;
+            }
 
             return [
                 'id' => (string) $row->id,
@@ -721,6 +727,7 @@ class ApiController extends Controller
                 'status' => (string) $row->status,
                 'http_status_code' => $httpStatusCode,
                 'response_time' => $row->response_time !== null ? (float) $row->response_time : null,
+                'server_health_metrics' => $serverHealthMetrics,
                 'status_identifier' => MonitoringStatusMeta::statusIdentifier($httpStatusCode),
                 'status_key' => MonitoringStatusMeta::statusKey($httpStatusCode),
                 'source' => (string) $row->source,
@@ -730,7 +737,7 @@ class ApiController extends Controller
 
     /**
      * @param  Collection<int, object>  $rows
-     * @return array{data: array<int, array{id: string, checked_at: string, status: string, http_status_code: int|null, response_time: float|null, status_identifier: string, status_key: string, source: string}>, has_more: bool, next_offset: int|null}
+     * @return array{data: array<int, array{id: string, checked_at: string, status: string, http_status_code: int|null, response_time: float|null, server_health_metrics: array<string, mixed>|null, status_identifier: string, status_key: string, source: string}>, has_more: bool, next_offset: int|null}
      */
     private function paginateCheckRows(Collection $rows, int $limit, int $offset): array
     {

--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -281,14 +281,18 @@ class MonitoringRequest extends FormRequest
     private function targetRules(): array
     {
         return [
-            Rule::requiredIf(fn (): bool => MonitoringType::tryFrom((string) $this->input('type')) !== MonitoringType::HEARTBEAT),
+            Rule::requiredIf(fn (): bool => ! in_array(
+                MonitoringType::tryFrom((string) $this->input('type')),
+                [MonitoringType::HEARTBEAT, MonitoringType::SERVER_HEALTH],
+                true
+            )),
             'nullable',
             'string',
             'max:255',
             function ($attribute, $value, $fail): void {
                 $type = $this->input('type');
 
-                if ($type === MonitoringType::HEARTBEAT->value) {
+                if (in_array($type, [MonitoringType::HEARTBEAT->value, MonitoringType::SERVER_HEALTH->value], true)) {
                     return;
                 }
 

--- a/app/Http/Resources/Instance/MonitoringResource.php
+++ b/app/Http/Resources/Instance/MonitoringResource.php
@@ -42,6 +42,8 @@ class MonitoringResource extends JsonResource
             'heartbeat_interval_minutes' => $this->heartbeat_interval_minutes,
             'heartbeat_grace_minutes' => $this->heartbeat_grace_minutes,
             'heartbeat_last_ping_at' => $this->heartbeat_last_ping_at,
+            'server_health_last_reported_at' => $this->server_health_last_reported_at,
+            'latest_server_health_metrics' => $this->whenLoaded('latestResponseResult', fn () => $this->latestResponseResult?->server_health_metrics),
             'domain_expires_at' => $this->whenLoaded('domainResult', fn () => $this->domainResult?->expires_at),
             'domain_registrar' => $this->whenLoaded('domainResult', fn () => $this->domainResult?->registrar),
             'latest_http_status_code' => $this->whenLoaded('latestResponseResult', fn () => $this->latestResponseResult?->http_status_code),

--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -60,6 +60,8 @@ use Spatie\Activitylog\Support\LogOptions;
     'heartbeat_interval_minutes',
     'heartbeat_grace_minutes',
     'heartbeat_last_ping_at',
+    'server_health_token',
+    'server_health_last_reported_at',
 ])]
 #[Table(name: 'monitorings', key: 'id', keyType: 'string')]
 class Monitoring extends Model
@@ -177,6 +179,7 @@ class Monitoring extends Model
             ->dontLogEmptyChanges()
             ->dontLogIfAttributesChangedOnly([
                 'heartbeat_last_ping_at',
+                'server_health_last_reported_at',
                 'updated_at',
             ])
             ->setDescriptionForEvent(fn (string $eventName): string => 'monitoring_' . $eventName);
@@ -235,6 +238,11 @@ class Monitoring extends Model
     public function isHeartbeat(): bool
     {
         return $this->type === MonitoringType::HEARTBEAT;
+    }
+
+    public function isServerHealth(): bool
+    {
+        return $this->type === MonitoringType::SERVER_HEALTH;
     }
 
     /**
@@ -320,6 +328,7 @@ class Monitoring extends Model
             'maintenance_from' => 'datetime',
             'maintenance_until' => 'datetime',
             'heartbeat_last_ping_at' => 'datetime',
+            'server_health_last_reported_at' => 'datetime',
         ];
     }
 }

--- a/app/Models/MonitoringResponse.php
+++ b/app/Models/MonitoringResponse.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Carbon;
     'status',
     'http_status_code',
     'response_time',
+    'server_health_metrics',
 ])]
 #[Table(name: 'monitoring_response_results', key: 'id', keyType: 'string')]
 class MonitoringResponse extends Model
@@ -85,6 +86,7 @@ class MonitoringResponse extends Model
             'status' => MonitoringStatus::class,
             'http_status_code' => 'integer',
             'response_time' => 'float',
+            'server_health_metrics' => 'array',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];

--- a/app/Models/MonitoringResponseArchived.php
+++ b/app/Models/MonitoringResponseArchived.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
     'status',
     'http_status_code',
     'response_time',
+    'server_health_metrics',
     'created_at',
     'updated_at',
 ])]
@@ -51,6 +52,7 @@ class MonitoringResponseArchived extends Model
         return [
             'http_status_code' => 'integer',
             'response_time' => 'float',
+            'server_health_metrics' => 'array',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];

--- a/app/Support/MonitoringPayload.php
+++ b/app/Support/MonitoringPayload.php
@@ -32,6 +32,15 @@ final class MonitoringPayload
             return $validated;
         }
 
+        if ($type === MonitoringType::SERVER_HEALTH) {
+            $serverHealthToken = (string) Str::ulid();
+
+            $validated['server_health_token'] = $serverHealthToken;
+            $validated['target'] = route('v1.server-health.store', ['token' => $serverHealthToken]);
+
+            return self::applyNonHttpDefaults($validated);
+        }
+
         if ($type !== MonitoringType::HEARTBEAT) {
             $validated['expected_http_statuses'] = null;
 
@@ -68,6 +77,12 @@ final class MonitoringPayload
             $validated['expected_http_statuses'] = HttpStatusCodeRanges::normalize($validated['expected_http_statuses'] ?? null);
 
             return $validated;
+        }
+
+        if ($monitoring->isServerHealth()) {
+            $validated['target'] = $monitoring->target;
+
+            return self::applyNonHttpDefaults($validated);
         }
 
         if (! $monitoring->isHeartbeat()) {

--- a/database/factories/MonitoringFactory.php
+++ b/database/factories/MonitoringFactory.php
@@ -75,6 +75,27 @@ class MonitoringFactory extends Factory
         });
     }
 
+    public function serverHealth(): static
+    {
+        return $this->state(function (): array {
+            return [
+                'type' => MonitoringType::SERVER_HEALTH,
+                'target' => 'https://webguard.test/api/v1/server-health/example-token',
+                'server_health_token' => 'example-token',
+                'server_health_last_reported_at' => null,
+                'timeout' => 5,
+                'expected_http_statuses' => null,
+                'http_method' => null,
+                'http_headers' => null,
+                'http_body' => null,
+                'auth_username' => null,
+                'auth_password' => null,
+                'port' => null,
+                'keyword' => null,
+            ];
+        });
+    }
+
     public function domainExpiration(): static
     {
         return $this->state(fn (): array => [

--- a/database/migrations/2026_05_14_160000_add_server_health_monitoring_fields.php
+++ b/database/migrations/2026_05_14_160000_add_server_health_monitoring_fields.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->string('server_health_token')->nullable()->unique()->after('heartbeat_last_ping_at');
+            $table->timestamp('server_health_last_reported_at')->nullable()->after('server_health_token');
+        });
+
+        Schema::table('monitoring_response_results', function (Blueprint $table): void {
+            $table->json('server_health_metrics')->nullable()->after('response_time');
+        });
+
+        Schema::table('monitoring_response_archived', function (Blueprint $table): void {
+            $table->json('server_health_metrics')->nullable()->after('response_time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('monitoring_response_archived', function (Blueprint $table): void {
+            $table->dropColumn('server_health_metrics');
+        });
+
+        Schema::table('monitoring_response_results', function (Blueprint $table): void {
+            $table->dropColumn('server_health_metrics');
+        });
+
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->dropUnique(['server_health_token']);
+            $table->dropColumn([
+                'server_health_token',
+                'server_health_last_reported_at',
+            ]);
+        });
+    }
+};

--- a/resources/js/components/monitoring-detail.ts
+++ b/resources/js/components/monitoring-detail.ts
@@ -12,6 +12,7 @@ interface MonitoringDetailComponent {
         status: string;
         httpStatusCode: number | null;
         responseTime: number | null;
+        serverHealthMetrics: Record<string, any> | null;
         statusIdentifier: string;
         source: string;
     }>;
@@ -67,6 +68,7 @@ interface MonitoringDetailComponent {
     resolveCheckStatusClass(this: MonitoringDetailComponent, statusIdentifier: string): string;
     resolveCheckSourceLabel(this: MonitoringDetailComponent, source: string): string;
     formatResponseTime(this: MonitoringDetailComponent, responseTime: number | null): string;
+    formatServerHealthMetrics(this: MonitoringDetailComponent, metrics: Record<string, any> | null): string;
 }
 
 interface AlpineThisContext extends MonitoringDetailComponent {
@@ -82,6 +84,7 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
         status: string;
         httpStatusCode: number | null;
         responseTime: number | null;
+        serverHealthMetrics: Record<string, any> | null;
         statusIdentifier: string;
         source: string;
     }>,
@@ -240,6 +243,7 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
                     status: string;
                     http_status_code: number | null;
                     response_time: number | null;
+                    server_health_metrics: Record<string, any> | null;
                     status_identifier: string;
                     source: string;
                 }>;
@@ -256,6 +260,7 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
                 status: check.status,
                 httpStatusCode: check.http_status_code,
                 responseTime: check.response_time,
+                serverHealthMetrics: check.server_health_metrics,
                 statusIdentifier: check.status_identifier,
                 source: check.source,
             }));
@@ -596,6 +601,31 @@ export default (monitoringId: string, chartLabels: Record<string, string>): Moni
         }
 
         return `${Math.round(responseTime)} ms`;
+    },
+
+    formatServerHealthMetrics(this: MonitoringDetailComponent, metrics: Record<string, any> | null): string {
+        if (!metrics) {
+            return '—';
+        }
+
+        const labels: Record<string, string> = {
+            cpu_usage_percent: 'CPU',
+            ram_usage_percent: 'RAM',
+            storage_usage_percent: 'Storage',
+            load_average: 'Load',
+            uptime_seconds: 'Uptime',
+        };
+
+        return Object.entries(metrics)
+            .filter(([key]) => key !== 'extra_metrics')
+            .map(([key, value]) => {
+                if (key.endsWith('_percent')) {
+                    return `${labels[key] ?? key}: ${Number(value).toFixed(1)}%`;
+                }
+
+                return `${labels[key] ?? key}: ${value}`;
+            })
+            .join(' | ') || '—';
     },
 
     chartLabels: chartLabels

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -11,6 +11,7 @@ return [
         'keyword' => 'Schlüsselwort',
         'port' => 'Port',
         'heartbeat' => 'Heartbeat',
+        'server_health' => 'Server-Zustand',
         'domain_expiration' => 'Domain-Ablauf',
         'dns_record' => 'DNS-Eintrag',
     ],
@@ -133,6 +134,7 @@ return [
             'labels' => [
                 'status_code' => 'Statuscode',
                 'response_time' => 'Antwortzeit',
+                'server_health' => 'Server-Zustand',
                 'source' => 'Quelle',
                 'raw_status' => 'Rohstatus',
             ],
@@ -160,6 +162,12 @@ return [
             'cadence' => 'Erwartet alle :minutes Minute|Erwartet alle :minutes Minuten',
             'grace' => 'Kulanzzeit: :minutes Minute|Kulanzzeit: :minutes Minuten',
             'last_ping' => 'Letzter empfangener Ping',
+        ],
+        'server_health' => [
+            'heading' => 'Server-Zustand-Endpunkt',
+            'endpoint' => 'Report-URL',
+            'last_report' => 'Letzter empfangener Report',
+            'docs_link' => 'API-Dokumentation zum Server-Zustand öffnen',
         ],
         'domain' => [
             'heading' => 'Domain-Ablauf',
@@ -232,6 +240,10 @@ return [
         'maintenance' => 'Wartung',
         'heartbeat_help' => 'WebGuard erzeugt für diesen Monitor eine private Ping-URL. Diese URL muss von einem Cronjob oder Hintergrundprozess innerhalb des erwarteten Intervalls aufgerufen werden.',
         'heartbeat_ping_url_help' => 'Verwenden Sie diese private Ping-URL in Ihrem Cronjob oder Worker. Sie wird automatisch erzeugt und kann nicht manuell geändert werden.',
+        'server_health_target_generated' => 'Die Server-Zustand-Report-URL wird nach dem Speichern automatisch erzeugt.',
+        'server_health_help' => 'WebGuard erzeugt für diesen Monitor einen privaten API-Endpunkt. Senden Sie CPU-, RAM-, Speicher- und optionale Zustandswerte von Ihrem Server-Agent oder Cron-Skript.',
+        'server_health_docs_link' => 'API-Dokumentation zum Payload-Format öffnen',
+        'server_health_endpoint_help' => 'Verwenden Sie diesen privaten API-Endpunkt, um Server-Zustand-Reports zu senden. Er wird automatisch erzeugt und kann nicht manuell geändert werden.',
         'placeholders' => [
             'http_target' => 'z.B. https://example.com',
             'ping_target' => 'z.B. 8.8.8.8',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -11,6 +11,7 @@ return [
         'keyword' => 'Keyword',
         'port' => 'Port',
         'heartbeat' => 'Heartbeat',
+        'server_health' => 'Server Health',
         'domain_expiration' => 'Domain Expiration',
         'dns_record' => 'DNS Record',
     ],
@@ -133,6 +134,7 @@ return [
             'labels' => [
                 'status_code' => 'Status code',
                 'response_time' => 'Response time',
+                'server_health' => 'Server health',
                 'source' => 'Source',
                 'raw_status' => 'Raw status',
             ],
@@ -160,6 +162,12 @@ return [
             'cadence' => 'Expected every :minutes minute|Expected every :minutes minutes',
             'grace' => 'Grace period: :minutes minute|Grace period: :minutes minutes',
             'last_ping' => 'Last ping received',
+        ],
+        'server_health' => [
+            'heading' => 'Server Health Endpoint',
+            'endpoint' => 'Report URL',
+            'last_report' => 'Last report received',
+            'docs_link' => 'Open server health API documentation',
         ],
         'domain' => [
             'heading' => 'Domain Expiration',
@@ -232,6 +240,10 @@ return [
         'maintenance' => 'Maintenance',
         'heartbeat_help' => 'WebGuard creates a private ping URL for this monitor. Call it from a cron job or background process within the expected interval.',
         'heartbeat_ping_url_help' => 'Use this private ping URL in your cron job or worker. It is generated automatically and cannot be edited manually.',
+        'server_health_target_generated' => 'The server health report URL will be generated automatically after saving.',
+        'server_health_help' => 'WebGuard creates a private API endpoint for this monitor. Post CPU, RAM, storage, and optional health values from your server agent or cron script.',
+        'server_health_docs_link' => 'Open the API documentation for the payload format',
+        'server_health_endpoint_help' => 'Use this private API endpoint to post server health reports. It is generated automatically and cannot be edited manually.',
         'placeholders' => [
             'http_target' => 'e.g. https://example.com',
             'ping_target' => 'e.g. 8.8.8.8',

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -16,6 +16,7 @@
     }
 
     $heartbeatTypeValue = MonitoringType::HEARTBEAT->value;
+    $serverHealthTypeValue = MonitoringType::SERVER_HEALTH->value;
     $enabledNotificationChannels = $enabledNotificationChannels ?? [];
     $selectedNotificationChannels = old(
         'notification_channels',
@@ -41,7 +42,7 @@
                 this.target = 'https://';
             } else if (this.type === '{{ MonitoringType::PING->value }}' || this.type === '{{ MonitoringType::PORT->value }}' || this.type === '{{ MonitoringType::DOMAIN_EXPIRATION->value }}' || this.type === '{{ MonitoringType::DNS_RECORD->value }}') {
                 this.target = '';
-            } else if (this.type === '{{ MonitoringType::HEARTBEAT->value }}') {
+            } else if (this.type === '{{ MonitoringType::HEARTBEAT->value }}' || this.type === '{{ MonitoringType::SERVER_HEALTH->value }}') {
                 this.target = '';
             }
         }
@@ -49,7 +50,7 @@
 }" x-init="$watch('type', value => {
     if ((value === '{{ MonitoringType::HTTP->value }}' || value === '{{ MonitoringType::KEYWORD->value }}') && (!target || !target.startsWith('http'))) {
         target = 'https://';
-    } else if (value === '{{ MonitoringType::PING->value }}' || value === '{{ MonitoringType::HEARTBEAT->value }}' || value === '{{ MonitoringType::DOMAIN_EXPIRATION->value }}' || value === '{{ MonitoringType::DNS_RECORD->value }}') {
+    } else if (value === '{{ MonitoringType::PING->value }}' || value === '{{ MonitoringType::HEARTBEAT->value }}' || value === '{{ MonitoringType::SERVER_HEALTH->value }}' || value === '{{ MonitoringType::DOMAIN_EXPIRATION->value }}' || value === '{{ MonitoringType::DNS_RECORD->value }}') {
         target = '';
     }
 })">
@@ -89,12 +90,18 @@
             <x-text-input id="target" type="text" :value="$monitoring->target" readonly disabled
                 class="cursor-not-allowed" />
             <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                {{ $monitoring->type === MonitoringType::HEARTBEAT ? __('monitoring.form.heartbeat_ping_url_help') : __('monitoring.form.target_immutable_help') }}
+                @if ($monitoring->type === MonitoringType::HEARTBEAT)
+                    {{ __('monitoring.form.heartbeat_ping_url_help') }}
+                @elseif ($monitoring->type === MonitoringType::SERVER_HEALTH)
+                    {{ __('monitoring.form.server_health_endpoint_help') }}
+                @else
+                    {{ __('monitoring.form.target_immutable_help') }}
+                @endif
             </x-paragraph>
         @else
-            <div x-show="type !== '{{ $heartbeatTypeValue }}'">
+            <div x-show="type !== '{{ $heartbeatTypeValue }}' && type !== '{{ $serverHealthTypeValue }}'">
                 <x-text-input id="target" type="text" name="target" x-model="target"
-                    x-bind:required="type !== '{{ $heartbeatTypeValue }}'"
+                    x-bind:required="type !== '{{ $heartbeatTypeValue }}' && type !== '{{ $serverHealthTypeValue }}'"
                     x-bind:placeholder="type === '{{ MonitoringType::HTTP->value }}' ? '{{ __('monitoring.form.placeholders.http_target') }}' :
                     type === '{{ MonitoringType::PING->value }}' ?
                     '{{ __('monitoring.form.placeholders.ping_target') }}' :
@@ -110,6 +117,10 @@
             <div x-show="type === '{{ $heartbeatTypeValue }}'"
                 class="mt-2 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-600 dark:border-gray-600 dark:text-gray-300">
                 {{ __('monitoring.form.heartbeat_target_generated') }}
+            </div>
+            <div x-show="type === '{{ $serverHealthTypeValue }}'"
+                class="mt-2 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-600 dark:border-gray-600 dark:text-gray-300">
+                {{ __('monitoring.form.server_health_target_generated') }}
             </div>
             <x-input-error :messages="$errors->get('target')" />
         @endif
@@ -155,6 +166,16 @@
             <p class="text-sm text-gray-600 dark:text-gray-400 md:col-span-2">
                 {{ __('monitoring.form.heartbeat_help') }}
             </p>
+        </div>
+    </template>
+
+    <template x-if="type === '{{ MonitoringType::SERVER_HEALTH->value }}'">
+        <div class="mt-4 rounded-md border border-gray-200 p-4 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300">
+            <p>{{ __('monitoring.form.server_health_help') }}</p>
+            <a href="{{ url('/api/docs') }}" target="_blank" rel="noopener"
+                class="mt-2 inline-block text-purple-800 underline dark:text-purple-400">
+                {{ __('monitoring.form.server_health_docs_link') }}
+            </a>
         </div>
     </template>
 

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -232,6 +232,25 @@
                 </x-container>
             @endif
 
+            @if ($monitoring->type === MonitoringType::SERVER_HEALTH)
+                <x-container>
+                    <x-heading type="h2">{{ __('monitoring.detail.server_health.heading') }}</x-heading>
+                    <x-paragraph class="mt-2 text-sm text-gray-500">{{ __('monitoring.detail.server_health.endpoint') }}</x-paragraph>
+                    <x-paragraph class="break-all font-mono text-sm text-gray-800 dark:text-gray-100">{{ $monitoring->target }}</x-paragraph>
+                    @if ($monitoring->server_health_last_reported_at)
+                        <x-paragraph class="mt-3 text-sm text-gray-600 dark:text-gray-300">
+                            {{ __('monitoring.detail.server_health.last_report') }} {{ $monitoring->server_health_last_reported_at->diffForHumans() }}
+                        </x-paragraph>
+                    @endif
+                    <x-paragraph class="mt-3 text-sm text-gray-600 dark:text-gray-300">
+                        <a href="{{ url('/api/docs') }}" target="_blank" rel="noopener"
+                            class="text-purple-800 underline dark:text-purple-400">
+                            {{ __('monitoring.detail.server_health.docs_link') }}
+                        </a>
+                    </x-paragraph>
+                </x-container>
+            @endif
+
             <x-container>
                 <x-heading type="h2">{{ __('monitoring.detail.last_24_hours') }}</x-heading>
                 <div id="heatmap">
@@ -305,7 +324,7 @@
             </template>
         </div>
 
-        @if (! in_array($monitoring->type, [MonitoringType::PING, MonitoringType::HEARTBEAT, MonitoringType::DOMAIN_EXPIRATION], true))
+        @if (! in_array($monitoring->type, [MonitoringType::PING, MonitoringType::HEARTBEAT, MonitoringType::SERVER_HEALTH, MonitoringType::DOMAIN_EXPIRATION], true))
             <div class="mb-2 flex items-center justify-between">
                 <x-heading type="h2">{{ __('monitoring.detail.response_time.heading') }}</x-heading>
 
@@ -455,7 +474,7 @@
                                     x-text="resolveCheckStatusLabel(check.statusIdentifier)"></x-span>
                             </div>
 
-                            <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
+                            <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-5">
                                 <div>
                                     <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
                                         {{ __('monitoring.detail.checks.labels.status_code') }}
@@ -469,6 +488,13 @@
                                     </x-span>
                                     <x-span class="text-sm text-gray-800 dark:text-gray-200"
                                         x-text="formatResponseTime(check.responseTime)"></x-span>
+                                </div>
+                                <div>
+                                    <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                        {{ __('monitoring.detail.checks.labels.server_health') }}
+                                    </x-span>
+                                    <x-span class="text-sm text-gray-800 dark:text-gray-200"
+                                        x-text="formatServerHealthMetrics(check.serverHealthMetrics)"></x-span>
                                 </div>
                                 <div>
                                     <x-span class="block text-xs font-semibold uppercase tracking-wide text-gray-500">

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,12 +2,17 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\ServerHealthReportController;
 use App\Http\Controllers\ApiController;
 use App\Http\Middleware\TrackApiUsage;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/public/monitorings/{monitoring}/widget', [ApiController::class, 'widget'])
     ->name('public.monitorings.widget');
+
+Route::post('/v1/server-health/{token}', ServerHealthReportController::class)
+    ->middleware('throttle:60,1')
+    ->name('v1.server-health.store');
 
 Route::group(['prefix' => 'v1', 'as' => 'v1.', 'middleware' => ['auth:sanctum', TrackApiUsage::class]], function (): void {
     require __DIR__ . '/api/external.php';

--- a/tests/Feature/Api/Internal/HeartbeatMonitoringListCompatibilityTest.php
+++ b/tests/Feature/Api/Internal/HeartbeatMonitoringListCompatibilityTest.php
@@ -39,6 +39,13 @@ class HeartbeatMonitoringListCompatibilityTest extends TestCase
             'target' => route('monitorings.heartbeat.ping', ['token' => 'heartbeat-token']),
         ]);
 
+        $serverHealthMonitoring = Monitoring::factory()->serverHealth()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'server_health_token' => 'server-health-token',
+            'target' => route('v1.server-health.store', ['token' => 'server-health-token']),
+        ]);
+
         $testResponse = $this->withHeaders([
             'X-INSTANCE-CODE' => $serverInstance->code,
             'X-API-KEY' => 'test-token-1234567890',
@@ -47,6 +54,7 @@ class HeartbeatMonitoringListCompatibilityTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertJsonFragment(['id' => $httpMonitoring->id]);
         $testResponse->assertJsonMissing(['id' => $heartbeatMonitoring->id]);
+        $testResponse->assertJsonMissing(['id' => $serverHealthMonitoring->id]);
 
         $heartbeatResponse = $this->withHeaders([
             'X-INSTANCE-CODE' => $serverInstance->code,
@@ -60,5 +68,16 @@ class HeartbeatMonitoringListCompatibilityTest extends TestCase
         $heartbeatResponse->assertJsonFragment(['id' => $heartbeatMonitoring->id]);
         $heartbeatResponse->assertJsonFragment(['heartbeat_interval_minutes' => 60]);
         $heartbeatResponse->assertJsonFragment(['heartbeat_grace_minutes' => 10]);
+
+        $serverHealthResponse = $this->withHeaders([
+            'X-INSTANCE-CODE' => $serverInstance->code,
+            'X-API-KEY' => 'test-token-1234567890',
+        ])->getJson(route('v1.internal.monitorings.list', [
+            'location' => $serverInstance->code,
+            'type' => MonitoringType::SERVER_HEALTH->value,
+        ]));
+
+        $serverHealthResponse->assertOk();
+        $serverHealthResponse->assertJsonFragment(['id' => $serverHealthMonitoring->id]);
     }
 }

--- a/tests/Feature/ServerHealthMonitoringTest.php
+++ b/tests/Feature/ServerHealthMonitoringTest.php
@@ -98,12 +98,12 @@ class ServerHealthMonitoringTest extends TestCase
         $monitoring->refresh();
         $this->assertSame(Date::now()->toIso8601String(), $monitoring->server_health_last_reported_at?->toIso8601String());
 
-        $response = MonitoringResponse::query()->where('monitoring_id', $monitoring->id)->firstOrFail();
-        $this->assertSame(MonitoringStatus::UP, $response->status);
-        $this->assertSame(200, $response->http_status_code);
-        $this->assertSame(42.5, $response->server_health_metrics['cpu_usage_percent']);
-        $this->assertSame(68.2, $response->server_health_metrics['ram_usage_percent']);
-        $this->assertSame(74.1, $response->server_health_metrics['storage_usage_percent']);
+        $monitoringResponse = MonitoringResponse::query()->where('monitoring_id', $monitoring->id)->firstOrFail();
+        $this->assertSame(MonitoringStatus::UP, $monitoringResponse->status);
+        $this->assertSame(200, $monitoringResponse->http_status_code);
+        $this->assertSame(42.5, $monitoringResponse->server_health_metrics['cpu_usage_percent']);
+        $this->assertSame(68.2, $monitoringResponse->server_health_metrics['ram_usage_percent']);
+        $this->assertSame(74.1, $monitoringResponse->server_health_metrics['storage_usage_percent']);
     }
 
     public function test_server_health_endpoint_marks_report_down_when_usage_crosses_default_threshold(): void

--- a/tests/Feature/ServerHealthMonitoringTest.php
+++ b/tests/Feature/ServerHealthMonitoringTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class ServerHealthMonitoringTest extends TestCase
+{
+    private User $user;
+
+    private ServerInstance $serverInstance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $this->user = User::factory()->create(['package_id' => $package->id]);
+
+        $this->serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $this->serverInstance->update([
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_create_page_links_api_documentation_for_server_health_monitoring(): void
+    {
+        $testResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSee(__('monitoring.types.server_health'));
+        $testResponse->assertSee(__('monitoring.form.server_health_docs_link'));
+        $testResponse->assertSee(url('/api/docs'));
+    }
+
+    public function test_it_creates_server_health_monitoring_with_generated_report_url(): void
+    {
+        $testResponse = $this->actingAs($this->user)->post(route('monitorings.store'), [
+            'name' => 'Production Server',
+            'type' => MonitoringType::SERVER_HEALTH->value,
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $testResponse->assertRedirect(route('monitorings.index'));
+
+        $monitoring = Monitoring::query()->where('name', 'Production Server')->firstOrFail();
+
+        $this->assertSame(MonitoringType::SERVER_HEALTH, $monitoring->type);
+        $this->assertNotNull($monitoring->server_health_token);
+        $this->assertSame(
+            route('v1.server-health.store', ['token' => $monitoring->server_health_token]),
+            $monitoring->target
+        );
+    }
+
+    public function test_server_health_endpoint_stores_metrics_and_updates_last_report_timestamp(): void
+    {
+        Date::setTestNow('2026-05-14 12:00:00');
+
+        $monitoring = $this->createServerHealthMonitoring();
+
+        $testResponse = $this->postJson(route('v1.server-health.store', ['token' => $monitoring->server_health_token]), [
+            'cpu_usage_percent' => 42.5,
+            'ram_usage_percent' => 68.2,
+            'storage_usage_percent' => 74.1,
+            'load_average' => 1.42,
+            'uptime_seconds' => 86400,
+        ]);
+
+        $testResponse->assertOk()
+            ->assertJsonPath('message', 'Server health report accepted.')
+            ->assertJsonPath('status', MonitoringStatus::UP->value)
+            ->assertJsonPath('metrics.cpu_usage_percent', 42.5);
+
+        $monitoring->refresh();
+        $this->assertSame(Date::now()->toIso8601String(), $monitoring->server_health_last_reported_at?->toIso8601String());
+
+        $response = MonitoringResponse::query()->where('monitoring_id', $monitoring->id)->firstOrFail();
+        $this->assertSame(MonitoringStatus::UP, $response->status);
+        $this->assertSame(200, $response->http_status_code);
+        $this->assertSame(42.5, $response->server_health_metrics['cpu_usage_percent']);
+        $this->assertSame(68.2, $response->server_health_metrics['ram_usage_percent']);
+        $this->assertSame(74.1, $response->server_health_metrics['storage_usage_percent']);
+    }
+
+    public function test_server_health_endpoint_marks_report_down_when_usage_crosses_default_threshold(): void
+    {
+        $monitoring = $this->createServerHealthMonitoring();
+
+        $testResponse = $this->postJson(route('v1.server-health.store', ['token' => $monitoring->server_health_token]), [
+            'cpu_usage_percent' => 35.0,
+            'ram_usage_percent' => 91.0,
+            'storage_usage_percent' => 70.0,
+        ]);
+
+        $testResponse->assertOk()
+            ->assertJsonPath('status', MonitoringStatus::DOWN->value);
+
+        $this->assertDatabaseHas('monitoring_response_results', [
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::DOWN->value,
+            'http_status_code' => 503,
+        ]);
+    }
+
+    public function test_server_health_endpoint_rejects_empty_reports(): void
+    {
+        $monitoring = $this->createServerHealthMonitoring();
+
+        $this->postJson(route('v1.server-health.store', ['token' => $monitoring->server_health_token]), [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['metrics']);
+    }
+
+    private function createServerHealthMonitoring(): Monitoring
+    {
+        $token = (string) fake()->unique()->uuid();
+
+        return Monitoring::factory()
+            ->serverHealth()
+            ->for($this->user)
+            ->create([
+                'preferred_location' => $this->serverInstance->code,
+                'status' => MonitoringLifecycleStatus::ACTIVE,
+                'server_health_token' => $token,
+                'target' => route('v1.server-health.store', ['token' => $token]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a passive Server Health monitoring type with a generated private API endpoint for reporting CPU, RAM, storage, and optional health metrics.

## Changes

- Add `server_health` monitoring type, token generation, and persistence for health report metrics.
- Add `POST /api/v1/server-health/{token}` with Scribe documentation annotations.
- Show the API documentation link and generated endpoint guidance on the monitoring create/edit/detail UI.
- Include server health metrics in recent checks and preserve them during response archiving.
- Exclude passive server health monitorings from the internal polling list by default, with explicit type filtering still supported.

## Validation

- `php artisan test tests/Feature/ServerHealthMonitoringTest.php tests/Feature/Api/Internal/HeartbeatMonitoringListCompatibilityTest.php`
- `bun run build`
- `./vendor/bin/pint --dirty`
- `git diff --check`

Note: local Composer dependency installation required `--ignore-platform-req=ext-redis` because the PHP CLI environment does not have the Redis extension enabled.