### PR TITLE
Fix status page unsubscribe email normalization

### DIFF
--- a/app/Http/Controllers/StatusPageSubscriberController.php
+++ b/app/Http/Controllers/StatusPageSubscriberController.php
@@ -77,6 +77,10 @@ class StatusPageSubscriberController extends Controller
 
     public function destroy(Monitoring $monitoring, string $token, Request $request): RedirectResponse
     {
+        $request->merge([
+            'email' => Str::lower((string) $request->string('email')),
+        ]);
+
         $request->validate([
             'email' => [
                 'required',
@@ -89,7 +93,7 @@ class StatusPageSubscriberController extends Controller
         ]);
 
         $monitoring->statusPageSubscribers()
-            ->where('email', Str::lower((string) $request->string('email')))
+            ->where('email', $request->string('email'))
             ->where('unsubscribe_token', $token)
             ->delete();
 

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -208,6 +208,34 @@ class PublicStatusPageTest extends TestCase
         ]);
     }
 
+    public function test_public_status_page_unsubscribe_email_match_is_case_insensitive(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'public_label_enabled' => true,
+        ]);
+        $statusPageSubscriber = StatusPageSubscriber::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'email' => 'customer@example.com',
+            'confirmation_token_hash' => null,
+            'unsubscribe_token' => 'unsubscribe-token',
+            'verified_at' => Date::now(),
+        ]);
+
+        $testResponse = $this->delete(route('public-label.subscribers.destroy', [
+            'monitoring' => $monitoring,
+            'token' => $statusPageSubscriber->unsubscribe_token,
+        ]), [
+            'email' => 'Customer@Example.com',
+        ]);
+
+        $testResponse->assertRedirect(route('public-label', $monitoring));
+        $this->assertDatabaseMissing('status_page_subscribers', [
+            'id' => $statusPageSubscriber->id,
+        ]);
+    }
+
     public function test_status_page_unsubscribe_link_works_after_public_page_is_disabled(): void
     {
         Package::factory()->create();


### PR DESCRIPTION
## Summary
- normalize unsubscribe email input before validation
- cover mixed-case unsubscribe email submissions with a focused feature test

## Validation
- php artisan test --filter=PublicStatusPageTest

## Notes
- Composer install required --ignore-platform-req=ext-redis locally because the PHP redis extension is missing.