### PR TITLE
Update sitemap crawling and API reference

### DIFF
--- a/app/Console/Commands/Sitemap/GenerateSitemapCommand.php
+++ b/app/Console/Commands/Sitemap/GenerateSitemapCommand.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Console\Commands\Sitemap;
 
+use App\Support\SitemapPages;
 use Illuminate\Console\Command;
-use Spatie\Sitemap\Sitemap;
-use Spatie\Sitemap\Tags\Url;
 
 class GenerateSitemapCommand extends Command
 {
@@ -29,10 +28,7 @@ class GenerateSitemapCommand extends Command
      */
     public function handle()
     {
-        Sitemap::create()
-            ->add(Url::create(route('welcome')))
-            ->add(Url::create(route('monitoring-locations')))
-            ->writeToFile(public_path('sitemap.xml'));
+        SitemapPages::sitemap()->writeToFile(public_path('sitemap.xml'));
 
         return Command::SUCCESS;
     }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
 /**
- * @group Public API
+ * @group Monitoring API
  *
  * This controller is responsible for handling all API requests related to monitoring data.
  * It provides endpoints for retrieving uptime/downtime, response times, incidents, and other monitoring statistics.

--- a/app/Support/SitemapPages.php
+++ b/app/Support/SitemapPages.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Spatie\Sitemap\Sitemap;
+use Spatie\Sitemap\Tags\Url;
+
+final class SitemapPages
+{
+    /**
+     * @return list<string>
+     */
+    public static function routeNames(): array
+    {
+        return [
+            'welcome',
+            'monitoring-locations',
+            'imprint',
+            'terms-of-use',
+            'gdpr',
+        ];
+    }
+
+    public static function sitemap(): Sitemap
+    {
+        $sitemap = Sitemap::create();
+
+        foreach (self::routeNames() as $routeName) {
+            $sitemap->add(Url::create(route($routeName)));
+        }
+
+        return $sitemap;
+    }
+}

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -15,10 +15,10 @@ use function Knuckles\Scribe\Config\removeStrategies;
 
 return [
     // The HTML <title> for the generated documentation.
-    'title' => config('app.name') . ' API Documentation',
+    'title' => config('app.name') . ' API Reference',
 
     // A short description of your API. Will be included in the docs webpage, Postman collection and OpenAPI spec.
-    'description' => '',
+    'description' => 'Programmatic access to monitoring status, uptime history, incidents, SSL metadata, and server health reports.',
 
     // The base URL displayed in the docs.
     // If you're using `laravel` type, you can set this to a dynamic string, like '{{ config("app.tenant_url") }}' to get a dynamic base URL.
@@ -68,7 +68,7 @@ return [
 
         // URL path to use for the docs endpoint (if `add_routes` is true).
         // By default, `/docs` opens the HTML page, `/docs.postman` opens the Postman collection, and `/docs.openapi` the OpenAPI spec.
-        'docs_url' => '/api/docs',
+        'docs_url' => '/api/reference',
 
         // Directory within `public` in which to store CSS and JS assets.
         // By default, assets are stored in `public/vendor/scribe`.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,13 +1,4 @@
 User-agent: *
-
 Allow: /
-Disallow: /api/
-Disallow: /imprint
-Disallow: /impressum
-Disallow: /terms-of-use
-Disallow: /agb
-Disallow: /gdpr
-Disallow: /privacy-policy
-Disallow: /datenschutz
 
 Sitemap: https://webguard.m-breuer.dev/sitemap.xml

--- a/resources/lang/de/api.php
+++ b/resources/lang/de/api.php
@@ -35,8 +35,8 @@ return [
         ],
     ],
     'docs' => [
-        'heading' => 'API-Dokumentation',
-        'description' => 'Alle verfügbaren Endpunkte, Authentifizierung und Nutzungsbeispiele.',
-        'link' => 'Entdecken Sie die neueste Dokumentation hier.',
+        'heading' => 'API-Referenz',
+        'description' => 'Prüfen Sie Monitoring-Endpunkte, Authentifizierung und Request-Beispiele für Ihre Integrationen.',
+        'link' => 'API-Referenz öffnen.',
     ],
 ];

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -167,7 +167,7 @@ return [
             'heading' => 'Server-Zustand-Endpunkt',
             'endpoint' => 'Report-URL',
             'last_report' => 'Letzter empfangener Report',
-            'docs_link' => 'API-Dokumentation zum Server-Zustand öffnen',
+            'docs_link' => 'Monitoring-API-Referenz öffnen',
         ],
         'domain' => [
             'heading' => 'Domain-Ablauf',
@@ -242,7 +242,7 @@ return [
         'heartbeat_ping_url_help' => 'Verwenden Sie diese private Ping-URL in Ihrem Cronjob oder Worker. Sie wird automatisch erzeugt und kann nicht manuell geändert werden.',
         'server_health_target_generated' => 'Die Server-Zustand-Report-URL wird nach dem Speichern automatisch erzeugt.',
         'server_health_help' => 'WebGuard erzeugt für diesen Monitor einen privaten API-Endpunkt. Senden Sie CPU-, RAM-, Speicher- und optionale Zustandswerte von Ihrem Server-Agent oder Cron-Skript.',
-        'server_health_docs_link' => 'API-Dokumentation zum Payload-Format öffnen',
+        'server_health_docs_link' => 'Monitoring-API-Referenz zum Payload-Format öffnen',
         'server_health_endpoint_help' => 'Verwenden Sie diesen privaten API-Endpunkt, um Server-Zustand-Reports zu senden. Er wird automatisch erzeugt und kann nicht manuell geändert werden.',
         'placeholders' => [
             'http_target' => 'z.B. https://example.com',

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -35,8 +35,8 @@ return [
         ],
     ],
     'docs' => [
-        'heading' => 'API Documentation',
-        'description' => 'All available endpoints, authentication, and usage examples.',
-        'link' => 'Explore the latest documentation here.',
+        'heading' => 'API Reference',
+        'description' => 'Review the monitoring endpoints, authentication flow, and request examples for your integrations.',
+        'link' => 'Open the API reference.',
     ],
 ];

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -167,7 +167,7 @@ return [
             'heading' => 'Server Health Endpoint',
             'endpoint' => 'Report URL',
             'last_report' => 'Last report received',
-            'docs_link' => 'Open server health API documentation',
+            'docs_link' => 'Open the monitoring API reference',
         ],
         'domain' => [
             'heading' => 'Domain Expiration',
@@ -242,7 +242,7 @@ return [
         'heartbeat_ping_url_help' => 'Use this private ping URL in your cron job or worker. It is generated automatically and cannot be edited manually.',
         'server_health_target_generated' => 'The server health report URL will be generated automatically after saving.',
         'server_health_help' => 'WebGuard creates a private API endpoint for this monitor. Post CPU, RAM, storage, and optional health values from your server agent or cron script.',
-        'server_health_docs_link' => 'Open the API documentation for the payload format',
+        'server_health_docs_link' => 'Open the monitoring API reference for the payload format',
         'server_health_endpoint_help' => 'Use this private API endpoint to post server health reports. It is generated automatically and cannot be edited manually.',
         'placeholders' => [
             'http_target' => 'e.g. https://example.com',

--- a/resources/views/gdpr.blade.php
+++ b/resources/views/gdpr.blade.php
@@ -13,7 +13,6 @@
     <x-slot:keywords>{{ __('gdpr.seo.keywords') }}</x-slot:keywords>
     <x-slot:ogTitle>{{ __('gdpr.seo.og_title') }}</x-slot:ogTitle>
     <x-slot:ogDescription>{{ __('gdpr.seo.og_description') }}</x-slot:ogDescription>
-    <x-slot:robots>noindex, nofollow</x-slot:robots>
     <x-slot:canonical>{{ route('gdpr') }}</x-slot:canonical>
 
     <main class="py-14 lg:py-20">

--- a/resources/views/imprint.blade.php
+++ b/resources/views/imprint.blade.php
@@ -4,7 +4,6 @@
     <x-slot:keywords>{{ __('imprint.seo.keywords') }}</x-slot:keywords>
     <x-slot:ogTitle>{{ __('imprint.seo.og_title') }}</x-slot:ogTitle>
     <x-slot:ogDescription>{{ __('imprint.seo.og_description') }}</x-slot:ogDescription>
-    <x-slot:robots>noindex, nofollow</x-slot:robots>
     <x-slot:canonical>{{ route('imprint') }}</x-slot:canonical>
 
     <main class="py-14 lg:py-20">

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -172,7 +172,7 @@
     <template x-if="type === '{{ MonitoringType::SERVER_HEALTH->value }}'">
         <div class="mt-4 rounded-md border border-gray-200 p-4 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300">
             <p>{{ __('monitoring.form.server_health_help') }}</p>
-            <a href="{{ url('/api/docs') }}" target="_blank" rel="noopener"
+            <a href="{{ route('scribe') }}" target="_blank" rel="noopener"
                 class="mt-2 inline-block text-purple-800 underline dark:text-purple-400">
                 {{ __('monitoring.form.server_health_docs_link') }}
             </a>

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -243,7 +243,7 @@
                         </x-paragraph>
                     @endif
                     <x-paragraph class="mt-3 text-sm text-gray-600 dark:text-gray-300">
-                        <a href="{{ url('/api/docs') }}" target="_blank" rel="noopener"
+                        <a href="{{ route('scribe') }}" target="_blank" rel="noopener"
                             class="text-purple-800 underline dark:text-purple-400">
                             {{ __('monitoring.detail.server_health.docs_link') }}
                         </a>

--- a/resources/views/terms-of-use.blade.php
+++ b/resources/views/terms-of-use.blade.php
@@ -4,7 +4,6 @@
     <x-slot:keywords>{{ __('legal.terms_of_use.seo.keywords') }}</x-slot:keywords>
     <x-slot:ogTitle>{{ __('legal.terms_of_use.seo.og_title') }}</x-slot:ogTitle>
     <x-slot:ogDescription>{{ __('legal.terms_of_use.seo.og_description') }}</x-slot:ogDescription>
-    <x-slot:robots>noindex, nofollow</x-slot:robots>
     <x-slot:canonical>{{ route('terms-of-use') }}</x-slot:canonical>
 
     <main class="py-14 lg:py-20">

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,12 +21,11 @@ use App\Http\Controllers\PublicStatusPageController;
 use App\Http\Controllers\StatusPageController;
 use App\Http\Controllers\StatusPageIncidentUpdateController;
 use App\Http\Controllers\StatusPageSubscriberController;
+use App\Support\SitemapPages;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
-use Spatie\Sitemap\Sitemap;
-use Spatie\Sitemap\Tags\Url;
 
 $sessionlessPublicRoutes = [
     PreventRequestForgery::class,
@@ -45,19 +44,26 @@ Route::get('/monitoring-locations', MonitoringLocationsController::class)
     ->withoutMiddleware($sessionlessPublicRoutes)
     ->middleware('public.cache')
     ->name('monitoring-locations');
-Route::get('/imprint', [LegalController::class, 'imprint'])->name('imprint');
-Route::get('/terms-of-use', [LegalController::class, 'termsOfUse'])->name('terms-of-use');
-Route::get('/gdpr', [LegalController::class, 'gdpr'])->name('gdpr');
+Route::get('/imprint', [LegalController::class, 'imprint'])
+    ->withoutMiddleware($sessionlessPublicRoutes)
+    ->middleware('public.cache')
+    ->name('imprint');
+Route::get('/terms-of-use', [LegalController::class, 'termsOfUse'])
+    ->withoutMiddleware($sessionlessPublicRoutes)
+    ->middleware('public.cache')
+    ->name('terms-of-use');
+Route::get('/gdpr', [LegalController::class, 'gdpr'])
+    ->withoutMiddleware($sessionlessPublicRoutes)
+    ->middleware('public.cache')
+    ->name('gdpr');
 
 Route::match(['get', 'post'], '/locale', [LocaleController::class, 'update'])->name('locale.switch');
 Route::match(['get', 'post'], '/heartbeat/{token}', HeartbeatPingController::class)->name('monitorings.heartbeat.ping');
+Route::permanentRedirect('/api/docs', '/api/reference')->name('api.docs.redirect');
 
 // Public sitemap.xml
 Route::get('/sitemap.xml', function () {
-    return Sitemap::create()
-        ->add(Url::create(route('welcome')))
-        ->add(Url::create(route('monitoring-locations')))
-        ->toResponse(request());
+    return SitemapPages::sitemap()->toResponse(request());
 })
     ->withoutMiddleware($sessionlessPublicRoutes)
     ->middleware('public.cache')

--- a/tests/Feature/Api/MonitoringDataAccessTest.php
+++ b/tests/Feature/Api/MonitoringDataAccessTest.php
@@ -29,14 +29,14 @@ class MonitoringDataAccessTest extends TestCase
         Package::factory()->create();
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create([
-            'name' => 'Public API',
+            'name' => 'Public Monitoring',
             'public_label_enabled' => true,
         ]);
 
         $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/status');
 
         $testResponse->assertOk()
-            ->assertJsonPath('monitoring.name', 'Public API');
+            ->assertJsonPath('monitoring.name', 'Public Monitoring');
     }
 
     public function test_shared_monitoring_data_endpoint_allows_private_monitoring_for_owner(): void

--- a/tests/Feature/GdprPageTest.php
+++ b/tests/Feature/GdprPageTest.php
@@ -30,7 +30,7 @@ class GdprPageTest extends TestCase
         $testResponse->assertDontSeeText('+49 1512 3456789');
         $testResponse->assertSeeHtml('data-email-payload=');
         $testResponse->assertSeeHtml('data-phone-payload=');
-        $testResponse->assertSeeHtml('<meta name="robots" content="noindex, nofollow">');
+        $testResponse->assertSeeHtml('<meta name="robots" content="index, follow">');
     }
 
     public function test_gdpr_contact_section_uses_the_default_card_style(): void
@@ -88,12 +88,12 @@ class GdprPageTest extends TestCase
         $testResponse->assertRedirect(route('gdpr'));
     }
 
-    public function test_gdpr_page_is_excluded_from_sitemap_because_it_is_noindexed(): void
+    public function test_gdpr_page_is_included_in_sitemap(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
         $testResponse->assertOk();
-        $testResponse->assertDontSeeHtml(route('gdpr'));
+        $testResponse->assertSeeHtml(route('gdpr'));
     }
 
     public function test_footer_contains_gdpr_link(): void
@@ -105,14 +105,14 @@ class GdprPageTest extends TestCase
         $testResponse->assertSeeHtml(route('gdpr'));
     }
 
-    public function test_robots_txt_blocks_gdpr_routes(): void
+    public function test_robots_txt_allows_gdpr_routes(): void
     {
         $robotsContent = file_get_contents(public_path('robots.txt'));
 
         $this->assertIsString($robotsContent);
-        $this->assertStringContainsString('Disallow: /gdpr', $robotsContent);
-        $this->assertStringContainsString('Disallow: /datenschutz', $robotsContent);
-        $this->assertStringContainsString('Disallow: /privacy-policy', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /gdpr', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /datenschutz', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /privacy-policy', $robotsContent);
     }
 
     public function test_accept_language_header_is_used_for_gdpr_page(): void
@@ -125,7 +125,7 @@ class GdprPageTest extends TestCase
         $testResponse->assertSeeText(__('gdpr.hero.title', [], 'de'));
     }
 
-    public function test_authenticated_user_locale_from_profile_has_priority_on_gdpr_page(): void
+    public function test_authenticated_gdpr_page_is_served_as_sessionless_public_page(): void
     {
         Package::factory()->create();
         $user = User::factory()->create([
@@ -137,8 +137,14 @@ class GdprPageTest extends TestCase
             ->get(route('gdpr'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml('lang="en"');
-        $testResponse->assertSeeText(__('gdpr.hero.title', [], 'en'));
+        $testResponse->assertSeeHtml('lang="de"');
+        $testResponse->assertSeeText(__('gdpr.hero.title', [], 'de'));
+        $testResponse->assertDontSeeHtml('name="csrf-token"');
+
+        $cacheControl = (string) $testResponse->headers->get('Cache-Control');
+
+        $this->assertStringContainsString('public', $cacheControl);
+        $this->assertStringNotContainsString('private', $cacheControl);
     }
 
     private function configureImprint(): void

--- a/tests/Feature/ImprintPageTest.php
+++ b/tests/Feature/ImprintPageTest.php
@@ -25,6 +25,7 @@ class ImprintPageTest extends TestCase
         $testResponse->assertSeeHtml('data-phone-payload=');
         $testResponse->assertSeeText(__('imprint.sections.disclaimer'));
         $testResponse->assertSeeText(__('imprint.disclaimer'));
+        $testResponse->assertSeeHtml('<meta name="robots" content="index, follow">');
         $testResponse->assertSeeHtml('rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900/70 sm:p-10');
     }
 
@@ -35,12 +36,12 @@ class ImprintPageTest extends TestCase
         $testResponse->assertRedirect(route('imprint'));
     }
 
-    public function test_imprint_page_is_excluded_from_sitemap_because_it_is_noindexed(): void
+    public function test_imprint_page_is_included_in_sitemap(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
         $testResponse->assertOk();
-        $testResponse->assertDontSeeHtml(route('imprint'));
+        $testResponse->assertSeeHtml(route('imprint'));
     }
 
     public function test_footer_contains_imprint_link(): void
@@ -52,13 +53,13 @@ class ImprintPageTest extends TestCase
         $testResponse->assertSeeHtml(route('imprint'));
     }
 
-    public function test_robots_txt_blocks_imprint_routes(): void
+    public function test_robots_txt_allows_imprint_routes(): void
     {
         $robotsContent = file_get_contents(public_path('robots.txt'));
 
         $this->assertIsString($robotsContent);
-        $this->assertStringContainsString('Disallow: /imprint', $robotsContent);
-        $this->assertStringContainsString('Disallow: /impressum', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /imprint', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /impressum', $robotsContent);
     }
 
     private function configureImprint(): void

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -6,12 +6,20 @@ namespace Tests\Feature;
 
 use App\Models\Package;
 use App\Models\User;
+use App\Support\SitemapPages;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleXMLElement;
 use Tests\TestCase;
 
 class PublicIndexingTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configureImprint();
+    }
+
     /**
      * @return array<string, array{0: string}>
      */
@@ -88,7 +96,7 @@ class PublicIndexingTest extends TestCase
         $testResponse->assertDontSeeHtml('name="csrf-token"');
     }
 
-    public function test_sitemap_does_not_list_robots_blocked_legal_pages(): void
+    public function test_sitemap_lists_all_crawlable_public_pages(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
@@ -96,10 +104,6 @@ class PublicIndexingTest extends TestCase
         foreach (self::expectedIndexablePageRouteNames() as $routeName) {
             $testResponse->assertSeeHtml(route($routeName));
         }
-
-        $testResponse->assertDontSeeHtml(route('imprint'));
-        $testResponse->assertDontSeeHtml(route('terms-of-use'));
-        $testResponse->assertDontSeeHtml(route('gdpr'));
     }
 
     public function test_dynamic_sitemap_lists_exactly_the_indexable_public_pages(): void
@@ -114,7 +118,7 @@ class PublicIndexingTest extends TestCase
         );
     }
 
-    public function test_generated_sitemap_does_not_list_robots_blocked_legal_pages(): void
+    public function test_generated_sitemap_lists_all_crawlable_public_pages(): void
     {
         $sitemapPath = public_path('sitemap.xml');
 
@@ -131,11 +135,18 @@ class PublicIndexingTest extends TestCase
             $this->assertStringContainsString(route($routeName), $sitemapContent);
         }
 
-        $this->assertStringNotContainsString(route('imprint'), $sitemapContent);
-        $this->assertStringNotContainsString(route('terms-of-use'), $sitemapContent);
-        $this->assertStringNotContainsString(route('gdpr'), $sitemapContent);
-
         unlink($sitemapPath);
+    }
+
+    public function test_robots_txt_allows_all_pages_to_be_crawled(): void
+    {
+        $robotsContent = file_get_contents(public_path('robots.txt'));
+
+        $this->assertIsString($robotsContent);
+        $this->assertStringContainsString('User-agent: *', $robotsContent);
+        $this->assertStringContainsString('Allow: /', $robotsContent);
+        $this->assertStringContainsString('Sitemap: https://webguard.m-breuer.dev/sitemap.xml', $robotsContent);
+        $this->assertStringNotContainsString('Disallow:', $robotsContent);
     }
 
     public function test_generated_sitemap_lists_exactly_the_indexable_public_pages(): void
@@ -164,10 +175,7 @@ class PublicIndexingTest extends TestCase
      */
     private static function expectedIndexablePageRouteNames(): array
     {
-        return [
-            'welcome',
-            'monitoring-locations',
-        ];
+        return SitemapPages::routeNames();
     }
 
     /**
@@ -216,5 +224,16 @@ class PublicIndexingTest extends TestCase
         sort($locations);
 
         return $locations;
+    }
+
+    private function configureImprint(): void
+    {
+        config()->set('imprint.operator_name', 'Max Mustermann');
+        config()->set('imprint.street', 'Musterstrasse 1');
+        config()->set('imprint.postal_code', '10115');
+        config()->set('imprint.city', 'Berlin');
+        config()->set('imprint.country', 'Germany');
+        config()->set('imprint.email', 'max@example.test');
+        config()->set('imprint.phone', '+49 1512 3456789');
     }
 }

--- a/tests/Feature/ServerHealthMonitoringTest.php
+++ b/tests/Feature/ServerHealthMonitoringTest.php
@@ -52,7 +52,15 @@ class ServerHealthMonitoringTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSee(__('monitoring.types.server_health'));
         $testResponse->assertSee(__('monitoring.form.server_health_docs_link'));
-        $testResponse->assertSee(url('/api/docs'));
+        $testResponse->assertSee(route('scribe'));
+    }
+
+    public function test_api_reference_uses_the_renamed_documentation_path(): void
+    {
+        $this->assertSame('/api/reference', config('scribe.laravel.docs_url'));
+        $this->assertSame(url('/api/reference'), route('scribe'));
+
+        $this->get('/api/docs')->assertRedirect(url('/api/reference'));
     }
 
     public function test_it_creates_server_health_monitoring_with_generated_report_url(): void

--- a/tests/Feature/TermsOfUsePageTest.php
+++ b/tests/Feature/TermsOfUsePageTest.php
@@ -23,7 +23,7 @@ class TermsOfUsePageTest extends TestCase
         $testResponse->assertDontSeeText('legal@example.test');
         $testResponse->assertSeeHtml('data-email-payload=');
         $testResponse->assertSeeHtml('data-phone-payload=');
-        $testResponse->assertSeeHtml('<meta name="robots" content="noindex, nofollow">');
+        $testResponse->assertSeeHtml('<meta name="robots" content="index, follow">');
     }
 
     public function test_terms_of_use_describe_current_monitoring_and_notification_features(): void
@@ -59,12 +59,12 @@ class TermsOfUsePageTest extends TestCase
         $testResponse->assertRedirect(route('terms-of-use'));
     }
 
-    public function test_terms_of_use_page_is_excluded_from_sitemap_because_it_is_noindexed(): void
+    public function test_terms_of_use_page_is_included_in_sitemap(): void
     {
         $testResponse = $this->get(route('sitemap'));
 
         $testResponse->assertOk();
-        $testResponse->assertDontSeeHtml(route('terms-of-use'));
+        $testResponse->assertSeeHtml(route('terms-of-use'));
     }
 
     public function test_footer_contains_terms_of_use_link(): void
@@ -76,13 +76,13 @@ class TermsOfUsePageTest extends TestCase
         $testResponse->assertSeeHtml(route('terms-of-use'));
     }
 
-    public function test_robots_txt_blocks_terms_of_use_routes(): void
+    public function test_robots_txt_allows_terms_of_use_routes(): void
     {
         $robotsContent = file_get_contents(public_path('robots.txt'));
 
         $this->assertIsString($robotsContent);
-        $this->assertStringContainsString('Disallow: /terms-of-use', $robotsContent);
-        $this->assertStringContainsString('Disallow: /agb', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /terms-of-use', $robotsContent);
+        $this->assertStringNotContainsString('Disallow: /agb', $robotsContent);
     }
 
     private function configureImprintContact(): void


### PR DESCRIPTION
## Summary
- include all crawlable static public pages in a shared sitemap source used by the route and generator
- allow crawling globally in `robots.txt` and make legal pages indexable public pages
- rename the Scribe docs path to `/api/reference`, keep `/api/docs` as a permanent redirect, and update API wording to Monitoring API / API Reference

## Validation
- `vendor/bin/pint --dirty`
- `php artisan test`