### PR TITLE
test: cover permanent api docs redirect

### DIFF
--- a/tests/Feature/ServerHealthMonitoringTest.php
+++ b/tests/Feature/ServerHealthMonitoringTest.php
@@ -60,7 +60,9 @@ class ServerHealthMonitoringTest extends TestCase
         $this->assertSame('/api/reference', config('scribe.laravel.docs_url'));
         $this->assertSame(url('/api/reference'), route('scribe'));
 
-        $this->get('/api/docs')->assertRedirect(url('/api/reference'));
+        $this->get('/api/docs')
+            ->assertMovedPermanently()
+            ->assertRedirect(url('/api/reference'));
     }
 
     public function test_it_creates_server_health_monitoring_with_generated_report_url(): void


### PR DESCRIPTION
## Summary

- Tightens the API reference route regression test to assert that the legacy `/api/docs` path returns a permanent redirect.
- Keeps coverage scoped to the recent API reference rename and legacy route behavior.

## Validation

- `php artisan test tests/Feature/ServerHealthMonitoringTest.php`

Note: dependencies were installed with `composer install --ignore-platform-req=ext-redis` because the local PHP runtime does not have the Redis extension enabled.