### PR TITLE
Load notifications asynchronously

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -22,31 +22,12 @@ class NotificationController extends Controller
 
     private const int MAX_NOTIFICATION_LIMIT = 100;
 
-    public function index(Request $request, NotificationBoardService $notificationBoardService): View
+    public function index(Request $request): View
     {
         $showRead = $request->boolean('show_read', false);
         $limit = $this->resolveRequestedLimit($request);
 
-        [$statusBoardEntries, $statusChangeHasMore] = $this->loadStatusBoardEntries(
-            $notificationBoardService,
-            $showRead,
-            0,
-            $limit
-        );
-
-        [$sslExpiryNotifications, $sslExpiryHasMore] = $this->loadSslExpiryNotifications($showRead, 0, $limit);
-        [$domainExpiryNotifications, $domainExpiryHasMore] = $this->loadDomainExpiryNotifications($showRead, 0, $limit);
-        [$deliveryHistory, $deliveryHistoryHasMore] = $this->loadDeliveryHistory(0, $limit);
-
         return view('notifications.index', compact(
-            'statusBoardEntries',
-            'statusChangeHasMore',
-            'sslExpiryNotifications',
-            'sslExpiryHasMore',
-            'domainExpiryNotifications',
-            'domainExpiryHasMore',
-            'deliveryHistory',
-            'deliveryHistoryHasMore',
             'showRead',
             'limit'
         ));
@@ -89,12 +70,13 @@ class NotificationController extends Controller
         $validated = $request->validate([
             'type' => ['required', 'string', Rule::in($this->loadMoreTypes())],
             'offset' => ['nullable', 'integer', 'min:0'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:' . self::MAX_NOTIFICATION_LIMIT],
             'show_read' => ['nullable', 'boolean'],
         ]);
 
         $type = (string) $validated['type'];
         $offset = (int) ($validated['offset'] ?? 0);
-        $limit = self::DEFAULT_NOTIFICATION_LIMIT;
+        $limit = (int) ($validated['limit'] ?? self::DEFAULT_NOTIFICATION_LIMIT);
         $showRead = (bool) ($validated['show_read'] ?? false);
 
         if ($type === NotificationType::STATUS_CHANGE->value) {

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -29,12 +29,39 @@
     </x-slot>
 
     <x-main x-data="{
-        statusChangeOffset: {{ $statusBoardEntries->count() }},
-        sslExpiryOffset: {{ $sslExpiryNotifications->count() }},
-        domainExpiryOffset: {{ $domainExpiryNotifications->count() }},
-        deliveryHistoryOffset: {{ $deliveryHistory->count() }},
+        statusChangeOffset: 0,
+        sslExpiryOffset: 0,
+        domainExpiryOffset: 0,
+        deliveryHistoryOffset: 0,
         currentLimit: {{ $limit }},
-        isEmpty: {{ $sslExpiryNotifications->isEmpty() && $domainExpiryNotifications->isEmpty() && $statusBoardEntries->isEmpty() && $deliveryHistory->isEmpty() ? 'true' : 'false' }},
+        isEmpty: false,
+        isLoading: true,
+        sections: [
+            {
+                type: 'ssl_expiry',
+                sectionId: 'ssl-expiry-section',
+                containerId: 'ssl-expiry-notifications',
+                loadMoreContainerId: 'ssl-expiry-load-more-container',
+            },
+            {
+                type: 'domain_expiry',
+                sectionId: 'domain-expiry-section',
+                containerId: 'domain-expiry-notifications',
+                loadMoreContainerId: 'domain-expiry-load-more-container',
+            },
+            {
+                type: 'status_change',
+                sectionId: 'status-change-section',
+                containerId: 'status-change-notifications',
+                loadMoreContainerId: 'status-change-load-more-container',
+            },
+            {
+                type: 'delivery_history',
+                sectionId: 'delivery-history-section',
+                containerId: 'delivery-history-notifications',
+                loadMoreContainerId: 'delivery-history-load-more-container',
+            },
+        ],
         getOffsetForType(type) {
             if (type === 'status_change') {
                 return this.statusChangeOffset;
@@ -50,6 +77,17 @@
 
             return this.sslExpiryOffset;
         },
+        setOffsetForType(type, offset) {
+            if (type === 'status_change') {
+                this.statusChangeOffset = offset;
+            } else if (type === 'domain_expiry') {
+                this.domainExpiryOffset = offset;
+            } else if (type === 'delivery_history') {
+                this.deliveryHistoryOffset = offset;
+            } else {
+                this.sslExpiryOffset = offset;
+            }
+        },
         syncLimitWithUrl(limit) {
             const parsedLimit = Number.parseInt(limit, 10);
             const nextLimit = Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : 5;
@@ -61,33 +99,61 @@
         updateEmptyState() {
             this.isEmpty = this.$root.querySelectorAll('.notification-entry').length === 0;
         },
-        loadMoreNotifications(type) {
-            const offset = this.getOffsetForType(type);
-            axios.post('{{ route('notifications.loadMore') }}', {
-                    type: type,
-                    offset: offset,
-                    show_read: {{ $showRead ? 'true' : 'false' }}
-                })
-                .then(response => {
-                    document.getElementById(type.replace('_', '-') + '-notifications').insertAdjacentHTML('beforeend', response.data.html);
-                    if (type === 'status_change') {
-                        this.statusChangeOffset += response.data.count;
-                        if (!response.data.hasMore) document.getElementById('status-change-load-more-container').style.display = 'none';
-                    } else if (type === 'domain_expiry') {
-                        this.domainExpiryOffset += response.data.count;
-                        if (!response.data.hasMore) document.getElementById('domain-expiry-load-more-container').style.display = 'none';
-                    } else if (type === 'delivery_history') {
-                        this.deliveryHistoryOffset += response.data.count;
-                        if (!response.data.hasMore) document.getElementById('delivery-history-load-more-container').style.display = 'none';
-                    } else {
-                        this.sslExpiryOffset += response.data.count;
-                        if (!response.data.hasMore) document.getElementById('ssl-expiry-load-more-container').style.display = 'none';
-                    }
-                    const updatedOffset = this.getOffsetForType(type);
-                    this.currentLimit = Math.max(this.currentLimit, updatedOffset);
-                    this.syncLimitWithUrl(this.currentLimit);
+        sectionForType(type) {
+            return this.sections.find((section) => section.type === type);
+        },
+        loadInitialNotifications() {
+            this.isLoading = true;
+
+            Promise.all(this.sections.map((section) => this.loadNotificationSection(section.type, true)))
+                .finally(() => {
+                    this.isLoading = false;
                     this.updateEmptyState();
                 });
+        },
+        loadNotificationSection(type, initial = false) {
+            const section = this.sectionForType(type);
+            const offset = initial ? 0 : this.getOffsetForType(type);
+            const payload = {
+                type: type,
+                offset: offset,
+                show_read: {{ $showRead ? 'true' : 'false' }},
+            };
+
+            if (initial) {
+                payload.limit = this.currentLimit;
+            }
+
+            return axios.post('{{ route('notifications.loadMore') }}', payload)
+                .then(response => {
+                    const sectionElement = document.getElementById(section.sectionId);
+                    const container = document.getElementById(section.containerId);
+                    const loadMoreContainer = document.getElementById(section.loadMoreContainerId);
+
+                    if (initial) {
+                        container.innerHTML = '';
+                    }
+
+                    container.insertAdjacentHTML('beforeend', response.data.html);
+
+                    const nextOffset = initial
+                        ? response.data.count
+                        : this.getOffsetForType(type) + response.data.count;
+                    this.setOffsetForType(type, nextOffset);
+
+                    sectionElement.style.display = response.data.count > 0 ? '' : 'none';
+                    loadMoreContainer.style.display = response.data.hasMore ? '' : 'none';
+
+                    if (!initial) {
+                        this.currentLimit = Math.max(this.currentLimit, nextOffset);
+                        this.syncLimitWithUrl(this.currentLimit);
+                    }
+
+                    this.updateEmptyState();
+                });
+        },
+        loadMoreNotifications(type) {
+            this.loadNotificationSection(type);
         },
         markAsRead(event, notificationId, route, type) {
             event.preventDefault();
@@ -99,91 +165,56 @@
                     }
 
                     entry.remove();
-                    if (type === 'status_change') {
-                        this.statusChangeOffset = Math.max(0, this.statusChangeOffset - 1);
-                    } else if (type === 'domain_expiry') {
-                        this.domainExpiryOffset = Math.max(0, this.domainExpiryOffset - 1);
-                    } else {
-                        this.sslExpiryOffset = Math.max(0, this.sslExpiryOffset - 1);
-                    }
+                    this.setOffsetForType(type, Math.max(0, this.getOffsetForType(type) - 1));
                     this.updateEmptyState();
+
+                    const section = this.sectionForType(type);
+                    if (section && document.getElementById(section.containerId).querySelectorAll('.notification-entry').length === 0) {
+                        document.getElementById(section.sectionId).style.display = 'none';
+                    }
                 });
         }
-    }" x-init="syncLimitWithUrl(currentLimit)">
-        <x-container id="notifications-empty-state" x-cloak x-show="isEmpty">
+    }" x-init="syncLimitWithUrl(currentLimit); loadInitialNotifications()">
+        <x-container id="notifications-loading-state" x-cloak x-show="isLoading">
+            <x-loading-indicator />
+        </x-container>
+
+        <x-container id="notifications-empty-state" x-cloak x-show="!isLoading && isEmpty">
             <x-paragraph>{{ __('notifications.no_notifications') }}</x-paragraph>
         </x-container>
 
-        <div x-cloak x-show="!isEmpty">
-            @if ($sslExpiryNotifications->isNotEmpty())
-                <div class="mb-8">
-                    <x-heading type="h2" space=true>{{ __('notifications.ssl_expiry_notifications') }}</x-heading>
-                    <div id="ssl-expiry-notifications">
-                        @include('notifications.partials.notification_list', [
-                            'notifications' => $sslExpiryNotifications,
-                            'type' => 'ssl_expiry',
-                        ])
-                    </div>
-                    @if ($sslExpiryHasMore)
-                        <div class="mt-4 text-center" id="ssl-expiry-load-more-container">
-                            <x-primary-button
-                                @click="loadMoreNotifications('ssl_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
-                        </div>
-                    @endif
+        <div x-cloak x-show="!isLoading && !isEmpty">
+            <div class="mb-8" id="ssl-expiry-section" style="display: none;">
+                <x-heading type="h2" space=true>{{ __('notifications.ssl_expiry_notifications') }}</x-heading>
+                <div id="ssl-expiry-notifications"></div>
+                <div class="mt-4 text-center" id="ssl-expiry-load-more-container" style="display: none;">
+                    <x-primary-button @click="loadMoreNotifications('ssl_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
                 </div>
-            @endif
+            </div>
 
-            @if ($domainExpiryNotifications->isNotEmpty())
-                <div class="mb-8">
-                    <x-heading type="h2" space=true>{{ __('notifications.domain_expiry_notifications') }}</x-heading>
-                    <div id="domain-expiry-notifications">
-                        @include('notifications.partials.notification_list', [
-                            'notifications' => $domainExpiryNotifications,
-                            'type' => 'domain_expiry',
-                        ])
-                    </div>
-                    @if ($domainExpiryHasMore)
-                        <div class="mt-4 text-center" id="domain-expiry-load-more-container">
-                            <x-primary-button
-                                @click="loadMoreNotifications('domain_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
-                        </div>
-                    @endif
+            <div class="mb-8" id="domain-expiry-section" style="display: none;">
+                <x-heading type="h2" space=true>{{ __('notifications.domain_expiry_notifications') }}</x-heading>
+                <div id="domain-expiry-notifications"></div>
+                <div class="mt-4 text-center" id="domain-expiry-load-more-container" style="display: none;">
+                    <x-primary-button @click="loadMoreNotifications('domain_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
                 </div>
-            @endif
+            </div>
 
-            @if ($statusBoardEntries->isNotEmpty())
-                <div class="mb-8">
-                    <x-heading type="h2" space=true>{{ __('notifications.status_change_notifications') }}</x-heading>
-                    <div id="status-change-notifications">
-                        @include('notifications.partials.status_board_list', [
-                            'entries' => $statusBoardEntries,
-                        ])
-                    </div>
-                    @if ($statusChangeHasMore)
-                        <div class="mt-4 text-center" id="status-change-load-more-container">
-                            <x-primary-button
-                                @click="loadMoreNotifications('status_change')">{{ __('notifications.load_more') }}</x-primary-button>
-                        </div>
-                    @endif
+            <div class="mb-8" id="status-change-section" style="display: none;">
+                <x-heading type="h2" space=true>{{ __('notifications.status_change_notifications') }}</x-heading>
+                <div id="status-change-notifications"></div>
+                <div class="mt-4 text-center" id="status-change-load-more-container" style="display: none;">
+                    <x-primary-button @click="loadMoreNotifications('status_change')">{{ __('notifications.load_more') }}</x-primary-button>
                 </div>
-            @endif
+            </div>
 
-            @if ($deliveryHistory->isNotEmpty())
-                <div class="mb-8">
-                    <x-heading type="h2" space=true>{{ __('notifications.delivery_history.heading') }}</x-heading>
-                    <div id="delivery-history-notifications">
-                        @include('notifications.partials.delivery_history_list', [
-                            'deliveries' => $deliveryHistory,
-                        ])
-                    </div>
-                    @if ($deliveryHistoryHasMore)
-                        <div class="mt-4 text-center" id="delivery-history-load-more-container">
-                            <x-primary-button
-                                @click="loadMoreNotifications('delivery_history')">{{ __('notifications.load_more') }}</x-primary-button>
-                        </div>
-                    @endif
+            <div class="mb-8" id="delivery-history-section" style="display: none;">
+                <x-heading type="h2" space=true>{{ __('notifications.delivery_history.heading') }}</x-heading>
+                <div id="delivery-history-notifications"></div>
+                <div class="mt-4 text-center" id="delivery-history-load-more-container" style="display: none;">
+                    <x-primary-button @click="loadMoreNotifications('delivery_history')">{{ __('notifications.load_more') }}</x-primary-button>
                 </div>
-            @endif
+            </div>
         </div>
     </x-main>
 </x-app-layout>

--- a/tests/Feature/Notifications/NotificationDeliveryHistoryTest.php
+++ b/tests/Feature/Notifications/NotificationDeliveryHistoryTest.php
@@ -20,7 +20,7 @@ class NotificationDeliveryHistoryTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_notifications_index_shows_delivery_history_for_authenticated_user_only(): void
+    public function test_notifications_async_delivery_history_shows_authenticated_user_entries_only(): void
     {
         Date::setTestNow('2026-04-06 10:00:00');
 
@@ -98,15 +98,26 @@ class NotificationDeliveryHistoryTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('notifications.delivery_history.heading'));
-        $testResponse->assertSeeHtml('id="' . $notificationChannelDelivery->id . '"');
-        $testResponse->assertSeeHtml('id="' . $payloadOnlyDelivery->id . '"');
-        $testResponse->assertDontSeeHtml('id="' . $hiddenDelivery->id . '"');
-        $testResponse->assertSeeText('Primary API');
-        $testResponse->assertSeeText('Worker API');
-        $testResponse->assertSeeText(__('notifications.channels.slack'));
-        $testResponse->assertSeeText(__('notifications.events.incident'));
-        $testResponse->assertSeeText(__('notifications.delivery_status.failed'));
-        $testResponse->assertSeeText('Webhook responded with HTTP 500.');
+        $testResponse->assertDontSeeText('Primary API');
+        $testResponse->assertSee('loadInitialNotifications()');
+
+        $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => 'delivery_history',
+            'offset' => 0,
+        ]);
+
+        $sectionResponse->assertOk();
+        $html = (string) $sectionResponse->json('html');
+
+        $this->assertStringContainsString('id="' . $notificationChannelDelivery->id . '"', $html);
+        $this->assertStringContainsString('id="' . $payloadOnlyDelivery->id . '"', $html);
+        $this->assertStringNotContainsString('id="' . $hiddenDelivery->id . '"', $html);
+        $this->assertStringContainsString('Primary API', $html);
+        $this->assertStringContainsString('Worker API', $html);
+        $this->assertStringContainsString(__('notifications.channels.slack'), $html);
+        $this->assertStringContainsString(__('notifications.events.incident'), $html);
+        $this->assertStringContainsString(__('notifications.delivery_status.failed'), $html);
+        $this->assertStringContainsString('Webhook responded with HTTP 500.', $html);
     }
 
     public function test_notifications_load_more_returns_additional_delivery_history_entries(): void
@@ -173,6 +184,7 @@ class NotificationDeliveryHistoryTest extends TestCase
         $testResponse->assertSeeHtml('getOffsetForType(type)');
         $testResponse->assertSeeHtml("if (type === 'delivery_history') {");
         $testResponse->assertSeeHtml('return this.deliveryHistoryOffset;');
-        $testResponse->assertSeeHtml('const offset = this.getOffsetForType(type);');
+        $testResponse->assertSeeHtml('const offset = initial ? 0 : this.getOffsetForType(type);');
+        $testResponse->assertSeeHtml("loadMoreNotifications('delivery_history')");
     }
 }

--- a/tests/Feature/Notifications/NotificationPaginationStateTest.php
+++ b/tests/Feature/Notifications/NotificationPaginationStateTest.php
@@ -17,7 +17,7 @@ class NotificationPaginationStateTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_notifications_index_uses_default_limit_of_five_when_no_query_parameter_is_present(): void
+    public function test_notifications_async_section_uses_default_limit_of_five_when_no_limit_is_present(): void
     {
         Date::setTestNow('2026-03-24 12:00:00');
 
@@ -29,20 +29,26 @@ class NotificationPaginationStateTest extends TestCase
         $visibleNotificationIds = array_map(fn (MonitoringNotification $monitoringNotification): string => $monitoringNotification->id, array_slice($sortedByNewest, 0, 5));
         $hiddenNotificationIds = array_map(fn (MonitoringNotification $monitoringNotification): string => $monitoringNotification->id, array_slice($sortedByNewest, 5));
 
-        $testResponse = $this->actingAs($user)->get(route('notifications.index'));
+        $testResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::SSL_EXPIRY->value,
+            'offset' => 0,
+        ]);
 
         $testResponse->assertOk();
+        $testResponse->assertJsonPath('count', 5);
+        $testResponse->assertJsonPath('hasMore', true);
+        $html = (string) $testResponse->json('html');
 
         foreach ($visibleNotificationIds as $visibleNotificationId) {
-            $testResponse->assertSeeHtml('id="' . $visibleNotificationId . '"');
+            $this->assertStringContainsString('id="' . $visibleNotificationId . '"', $html);
         }
 
         foreach ($hiddenNotificationIds as $hiddenNotificationId) {
-            $testResponse->assertDontSeeHtml('id="' . $hiddenNotificationId . '"');
+            $this->assertStringNotContainsString('id="' . $hiddenNotificationId . '"', $html);
         }
     }
 
-    public function test_notifications_index_uses_limit_query_parameter_for_initial_render_count(): void
+    public function test_notifications_index_passes_limit_query_parameter_to_initial_async_load(): void
     {
         Date::setTestNow('2026-03-24 12:00:00');
 
@@ -58,17 +64,29 @@ class NotificationPaginationStateTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSee('currentLimit: 6');
+        $testResponse->assertSee('payload.limit = this.currentLimit');
+
+        $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::SSL_EXPIRY->value,
+            'offset' => 0,
+            'limit' => 6,
+        ]);
+
+        $sectionResponse->assertOk();
+        $sectionResponse->assertJsonPath('count', 6);
+        $sectionResponse->assertJsonPath('hasMore', true);
+        $html = (string) $sectionResponse->json('html');
 
         foreach ($visibleNotificationIds as $visibleNotificationId) {
-            $testResponse->assertSeeHtml('id="' . $visibleNotificationId . '"');
+            $this->assertStringContainsString('id="' . $visibleNotificationId . '"', $html);
         }
 
         foreach ($hiddenNotificationIds as $hiddenNotificationId) {
-            $testResponse->assertDontSeeHtml('id="' . $hiddenNotificationId . '"');
+            $this->assertStringNotContainsString('id="' . $hiddenNotificationId . '"', $html);
         }
     }
 
-    public function test_notifications_index_falls_back_to_default_limit_when_limit_query_parameter_is_invalid(): void
+    public function test_notifications_index_falls_back_to_default_async_limit_when_limit_query_parameter_is_invalid(): void
     {
         Date::setTestNow('2026-03-24 12:00:00');
 
@@ -85,12 +103,23 @@ class NotificationPaginationStateTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSee('currentLimit: 5');
 
+        $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::SSL_EXPIRY->value,
+            'offset' => 0,
+            'limit' => 5,
+        ]);
+
+        $sectionResponse->assertOk();
+        $sectionResponse->assertJsonPath('count', 5);
+        $sectionResponse->assertJsonPath('hasMore', true);
+        $html = (string) $sectionResponse->json('html');
+
         foreach ($visibleNotificationIds as $visibleNotificationId) {
-            $testResponse->assertSeeHtml('id="' . $visibleNotificationId . '"');
+            $this->assertStringContainsString('id="' . $visibleNotificationId . '"', $html);
         }
 
         foreach ($hiddenNotificationIds as $hiddenNotificationId) {
-            $testResponse->assertDontSeeHtml('id="' . $hiddenNotificationId . '"');
+            $this->assertStringNotContainsString('id="' . $hiddenNotificationId . '"', $html);
         }
     }
 
@@ -117,6 +146,14 @@ class NotificationPaginationStateTest extends TestCase
         $afterMarkResponse = $this->actingAs($user)->get(route('notifications.index'));
         $afterMarkResponse->assertOk();
         $afterMarkResponse->assertSee('Nothing to discover. Everything is up to date.');
+
+        $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::SSL_EXPIRY->value,
+            'offset' => 0,
+        ]);
+
+        $sectionResponse->assertOk();
+        $sectionResponse->assertJsonPath('count', 0);
     }
 
     public function test_notifications_navigation_uses_bell_icon_before_language_switch(): void

--- a/tests/Feature/Notifications/NotificationRenderingPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationRenderingPerformanceTest.php
@@ -14,6 +14,7 @@ use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -21,7 +22,7 @@ class NotificationRenderingPerformanceTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_notifications_index_renders_without_lazy_loading_for_status_change_messages(): void
+    public function test_notifications_index_defers_status_change_messages_to_async_sections(): void
     {
         $package = Package::factory()->create();
         $user = User::factory()->for($package)->create();
@@ -38,7 +39,52 @@ class NotificationRenderingPerformanceTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('notifications.index'));
 
         $testResponse->assertOk();
-        $testResponse->assertSee($monitoring->name);
+        $testResponse->assertSee('loadInitialNotifications()');
+        $testResponse->assertSeeHtml('id="status-change-notifications"');
+        $testResponse->assertDontSee($monitoring->name);
+    }
+
+    public function test_notifications_index_does_not_load_section_queries_on_initial_render(): void
+    {
+        $package = Package::factory()->create();
+        $user = User::factory()->for($package)->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'SSL_EXPIRING',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        NotificationChannelDelivery::query()->forceCreate([
+            'user_id' => $user->id,
+            'monitoring_notification_id' => null,
+            'channel' => 'webhook',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::SENT->value,
+        ]);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $testResponse = $this->actingAs($user)->get(route('notifications.index'));
+
+        $testResponse->assertOk();
+
+        $selectQueries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->map(static fn (string $query): string => mb_strtolower($query))
+            ->filter(static fn (string $query): bool => str_starts_with($query, 'select'))
+            ->values();
+
+        $this->assertFalse($selectQueries->contains(
+            fn (string $query): bool => str_contains($query, 'notification_channel_deliveries')
+        ));
+        $this->assertFalse($selectQueries->contains(
+            fn (string $query): bool => str_contains($query, 'latest_status_notifications')
+        ));
     }
 
     public function test_notification_board_tables_have_indexes_for_initial_page_pagination(): void
@@ -92,13 +138,16 @@ class NotificationRenderingPerformanceTest extends TestCase
             'updated_at' => $createdAt,
         ]);
 
-        $testResponse = $this->actingAs($user)->get(route('notifications.index'));
+        $testResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::SSL_EXPIRY->value,
+            'offset' => 0,
+        ]);
 
         $testResponse->assertOk();
         $this->assertAppearsBefore(
             'Higher id certificate',
             'Lower id certificate',
-            $testResponse->getContent() ?: ''
+            (string) $testResponse->json('html')
         );
     }
 
@@ -144,13 +193,16 @@ class NotificationRenderingPerformanceTest extends TestCase
             'updated_at' => $createdAt,
         ]);
 
-        $testResponse = $this->actingAs($user)->get(route('notifications.index'));
+        $testResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => 'delivery_history',
+            'offset' => 0,
+        ]);
 
         $testResponse->assertOk();
         $this->assertAppearsBefore(
             'Higher id delivery',
             'Lower id delivery',
-            $testResponse->getContent() ?: ''
+            (string) $testResponse->json('html')
         );
     }
 

--- a/tests/Feature/Notifications/NotificationStatusBoardTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardTest.php
@@ -19,7 +19,7 @@ class NotificationStatusBoardTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_status_board_shows_only_latest_status_change_per_monitoring(): void
+    public function test_async_status_board_shows_only_latest_status_change_per_monitoring(): void
     {
         Date::setTestNow('2026-03-24 12:00:00');
 
@@ -60,8 +60,19 @@ class NotificationStatusBoardTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('notifications.status_change_notifications'));
-        $testResponse->assertSeeHtml('id="' . $latestNotification->id . '"');
-        $testResponse->assertDontSeeHtml('id="' . $monitoringNotification->id . '"');
+        $testResponse->assertDontSeeHtml('id="' . $latestNotification->id . '"');
+
+        $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::STATUS_CHANGE->value,
+            'offset' => 0,
+            'show_read' => true,
+        ]);
+
+        $sectionResponse->assertOk();
+        $html = (string) $sectionResponse->json('html');
+
+        $this->assertStringContainsString('id="' . $latestNotification->id . '"', $html);
+        $this->assertStringNotContainsString('id="' . $monitoringNotification->id . '"', $html);
     }
 
     public function test_status_board_api_returns_status_category_keys_and_badges(): void
@@ -114,12 +125,18 @@ class NotificationStatusBoardTest extends TestCase
         $user = User::factory()->create(['locale' => 'de']);
         $monitoring = $this->createStatusBoardMonitoring($user, 503);
 
-        $testResponse = $this->actingAs($user)->get(route('notifications.index', ['show_read' => true]));
+        $testResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::STATUS_CHANGE->value,
+            'offset' => 0,
+            'show_read' => true,
+        ]);
 
         $testResponse->assertOk();
-        $testResponse->assertSee('Server-Fehler');
-        $testResponse->assertSee('Letzte Prüfung');
-        $testResponse->assertSee($monitoring->name);
+        $html = (string) $testResponse->json('html');
+
+        $this->assertStringContainsString('Server-Fehler', $html);
+        $this->assertStringContainsString('Letzte Prüfung', $html);
+        $this->assertStringContainsString($monitoring->name, $html);
     }
 
     private function createStatusBoardMonitoring(User $user, ?int $statusCode, bool $maintenance = false): Monitoring


### PR DESCRIPTION
## Summary
- Move `/notifications` section payloads off the initial server render.
- Use the existing `notifications.loadMore` endpoint for initial async section fetches, including an optional `limit` parameter.
- Keep the unread badge count server-rendered while SSL, domain, status, and delivery sections populate asynchronously.
- Update notification tests to assert the async shell and JSON section loading behavior.

## Validation
- `php artisan test tests/Feature/Notifications --stop-on-failure`
- `php artisan test tests/Feature --stop-on-failure`
- `./vendor/bin/pint --dirty --test`
- Browser smoke test against a temporary SQLite database: `/notifications` async-populated SSL/status sections and reported no console errors.