### PR TITLE
Improve mobile auth layout

### DIFF
--- a/resources/lang/de/auth.php
+++ b/resources/lang/de/auth.php
@@ -63,7 +63,7 @@ return [
     'github_login' => 'Mit GitHub anmelden',
     'auth_switch' => [
         'title' => 'Zugang wählen',
-        'description' => 'Wählen Sie links den gewünschten Modus. Das Formular rechts passt sich direkt an.',
+        'description' => 'Wählen Sie den gewünschten Modus. Das Formular passt sich direkt an.',
         'login' => 'Anmelden',
         'register' => 'Registrieren',
         'demo' => 'Demo-Zugang',

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -63,7 +63,7 @@ return [
     'github_login' => 'Sign in with GitHub',
     'auth_switch' => [
         'title' => 'Choose your access',
-        'description' => 'Select what you want to do. The form updates on the right.',
+        'description' => 'Select what you want to do. The form updates directly.',
         'login' => 'Login',
         'register' => 'Register',
         'demo' => 'Demo access',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -21,7 +21,7 @@
         <x-auth-session-status class="mb-4" :status="session('status')" />
 
         <div class="grid gap-6 lg:grid-cols-[17rem_minmax(0,1fr)]">
-            <aside class="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900">
+            <aside class="order-2 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900 lg:order-1">
                 <x-heading type="h3" class="mb-1">{{ __('auth.auth_switch.title') }}</x-heading>
                 <x-paragraph class="text-sm text-gray-600 dark:text-gray-400">
                     {{ __('auth.auth_switch.description') }}
@@ -54,7 +54,7 @@
                 </div>
             </aside>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-xs dark:border-gray-700 dark:bg-gray-800">
+            <div class="order-1 rounded-xl border border-gray-200 bg-white p-6 shadow-xs dark:border-gray-700 dark:bg-gray-800 lg:order-2">
                 <div x-show="mode === 'login' || mode === 'demo'">
                     <div class="text-center">
                         <x-heading class="flex items-center justify-center">

--- a/tests/Feature/AuthEntryPointsTest.php
+++ b/tests/Feature/AuthEntryPointsTest.php
@@ -31,6 +31,15 @@ class AuthEntryPointsTest extends TestCase
         $testResponse->assertSeeText(__('auth.auth_switch.demo'));
     }
 
+    public function test_login_page_shows_auth_form_before_access_switch_on_mobile(): void
+    {
+        $testResponse = $this->get(route('login'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('class="order-2 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900 lg:order-1"');
+        $testResponse->assertSeeHtml('class="order-1 rounded-xl border border-gray-200 bg-white p-6 shadow-xs dark:border-gray-700 dark:bg-gray-800 lg:order-2"');
+    }
+
     public function test_register_route_opens_unified_auth_view_in_register_mode(): void
     {
         $testResponse = $this->get(route('register'));


### PR DESCRIPTION
## Summary

- Show the auth form before the access-mode switcher on mobile screens while preserving the desktop side-by-side order.
- Update German and English switcher copy so it no longer refers to left/right placement.
- Add a feature test that locks in the responsive order classes.

## Validation

- `./vendor/bin/pint --dirty`
- `php artisan test tests/Feature/AuthEntryPointsTest.php`
- `bun run build`
- Browser check at 390px width confirmed the form renders above the access switcher.