### PR TITLE
Fix notification status query timeout

### DIFF
--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -9,8 +9,6 @@ use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
 use App\Models\MonitoringResponse;
 use App\Support\MonitoringStatusMeta;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 
@@ -35,131 +33,79 @@ class NotificationBoardService
      */
     public function getStatusBoardEntries(bool $showRead, int $offset = 0, int $limit = 5): Collection
     {
-        $latestStatusChangeTimestamps = MonitoringNotification::query()
-            ->withoutGlobalScopes()
-            ->selectRaw('monitoring_notifications.monitoring_id, max(monitoring_notifications.created_at) as latest_created_at')
-            ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
-            ->when(auth()->check(), function (Builder $builder): Builder {
-                return $builder
-                    ->join('monitorings as status_change_monitorings', 'monitoring_notifications.monitoring_id', '=', 'status_change_monitorings.id')
-                    ->where('status_change_monitorings.user_id', auth()->id())
-                    ->whereNull('status_change_monitorings.deleted_at');
-            })
-            ->when(! $showRead, fn (Builder $builder): Builder => $builder->where('monitoring_notifications.read', false))
-            ->groupBy('monitoring_notifications.monitoring_id');
+        $notificationRelation = $showRead
+            ? 'latestStatusChangeNotification'
+            : 'latestUnreadStatusChangeNotification';
 
         $monitorings = Monitoring::query()
             ->select([
-                'monitorings.id',
-                'monitorings.name',
-                'monitorings.target',
-                'monitorings.type',
-                'monitorings.maintenance_from',
-                'monitorings.maintenance_until',
+                'id',
+                'name',
+                'target',
+                'type',
+                'maintenance_from',
+                'maintenance_until',
             ])
-            ->joinSub(
-                MonitoringNotification::query()
-                    ->withoutGlobalScopes()
-                    ->from('monitoring_notifications as status_notifications')
-                    ->select([
-                        'status_notifications.id',
-                        'status_notifications.monitoring_id',
-                        'status_notifications.message',
-                        'status_notifications.read',
-                        'status_notifications.created_at',
-                    ])
-                    ->joinSub($latestStatusChangeTimestamps, 'latest_status_change_timestamps', function (JoinClause $joinClause): void {
-                        $joinClause->on(
-                            'latest_status_change_timestamps.monitoring_id',
-                            '=',
-                            'status_notifications.monitoring_id'
-                        )->on(
-                            'latest_status_change_timestamps.latest_created_at',
-                            '=',
-                            'status_notifications.created_at'
-                        );
-                    })
-                    ->where('status_notifications.type', NotificationType::STATUS_CHANGE->value)
-                    ->unless($showRead, fn (Builder $builder): Builder => $builder->where('status_notifications.read', false))
-                    ->leftJoin('monitoring_notifications as newer_status_notifications', function (JoinClause $joinClause) use ($showRead): void {
-                        $joinClause->on(
-                            'newer_status_notifications.monitoring_id',
-                            '=',
-                            'status_notifications.monitoring_id'
-                        )->on(
-                            'newer_status_notifications.created_at',
-                            '=',
-                            'status_notifications.created_at'
-                        )->whereColumn(
-                            'newer_status_notifications.id',
-                            '>',
-                            'status_notifications.id'
-                        )->where(
-                            'newer_status_notifications.type',
-                            NotificationType::STATUS_CHANGE->value
-                        );
+            ->where('user_id', auth()->id())
+            ->with([
+                $notificationRelation => fn ($builder) => $builder->select([
+                    'monitoring_notifications.id',
+                    'monitoring_notifications.monitoring_id',
+                    'monitoring_notifications.message',
+                    'monitoring_notifications.read',
+                    'monitoring_notifications.created_at',
+                ]),
+                'latestResponseResult' => fn ($builder) => $builder->select([
+                    'monitoring_response_results.id',
+                    'monitoring_response_results.monitoring_id',
+                    'monitoring_response_results.http_status_code',
+                    'monitoring_response_results.created_at',
+                ]),
+            ])
+            ->get()
+            ->filter(fn (Monitoring $monitoring): bool => $monitoring->getRelation($notificationRelation) !== null)
+            ->sort(function (Monitoring $left, Monitoring $right) use ($notificationRelation): int {
+                /** @var MonitoringNotification $leftNotification */
+                $leftNotification = $left->getRelation($notificationRelation);
+                /** @var MonitoringNotification $rightNotification */
+                $rightNotification = $right->getRelation($notificationRelation);
 
-                        if (! $showRead) {
-                            $joinClause->where('newer_status_notifications.read', false);
-                        }
-                    })
-                    ->whereNull('newer_status_notifications.id'),
-                'latest_status_notifications',
-                fn (JoinClause $joinClause): JoinClause => $joinClause->on(
-                    'latest_status_notifications.monitoring_id',
-                    '=',
-                    'monitorings.id'
-                )
-            )
-            ->selectSub(
-                MonitoringResponse::query()
-                    ->select('http_status_code')
-                    ->whereColumn('monitoring_response_results.monitoring_id', 'monitorings.id')
-                    ->latest('created_at')
-                    ->latest('id')
-                    ->limit(1),
-                'latest_status_code'
-            )
-            ->selectSub(
-                MonitoringResponse::query()
-                    ->select('created_at')
-                    ->whereColumn('monitoring_response_results.monitoring_id', 'monitorings.id')
-                    ->latest('created_at')
-                    ->latest('id')
-                    ->limit(1),
-                'latest_checked_at'
-            )
-            ->selectRaw('latest_status_notifications.id as notification_id')
-            ->selectRaw('latest_status_notifications.message as status_change_message')
-            ->selectRaw('latest_status_notifications.read as notification_read')
-            ->selectRaw('latest_status_notifications.created_at as latest_status_change_at')
-            ->latest('latest_status_notifications.created_at')
-            ->orderByDesc('latest_status_notifications.id')
-            ->offset($offset)
-            ->limit($limit + 1)
-            ->get();
+                return [
+                    $rightNotification->created_at?->getTimestamp() ?? 0,
+                    $rightNotification->id,
+                ] <=> [
+                    $leftNotification->created_at?->getTimestamp() ?? 0,
+                    $leftNotification->id,
+                ];
+            })
+            ->slice($offset, $limit + 1)
+            ->values();
 
-        return $monitorings->map(function (Monitoring $monitoring): array {
-            $latestStatusCode = $monitoring->getAttribute('latest_status_code');
+        return $monitorings->map(function (Monitoring $monitoring) use ($notificationRelation): array {
+            /** @var MonitoringNotification $latestStatusNotification */
+            $latestStatusNotification = $monitoring->getRelation($notificationRelation);
+            /** @var MonitoringResponse|null $latestResponse */
+            $latestResponse = $monitoring->getRelation('latestResponseResult');
+            $latestStatusCode = $latestResponse?->http_status_code;
             $maintenanceActive = $monitoring->isUnderMaintenance();
 
             $statusIdentifier = MonitoringStatusMeta::identifier($latestStatusCode !== null ? (int) $latestStatusCode : null, $maintenanceActive);
-            $statusChangeMessage = (string) $monitoring->getAttribute('status_change_message');
-            $latestCheckedAt = $monitoring->getAttribute('latest_checked_at');
-            $latestStatusChangeAt = $monitoring->getAttribute('latest_status_change_at');
+            $statusChangeMessage = $latestStatusNotification->message;
+            $latestCheckedAt = $latestResponse?->created_at;
+            $latestStatusChangeAt = $latestStatusNotification->created_at;
             $statusChangeIdentifier = $maintenanceActive
                 ? 'maintenance'
                 : MonitoringNotification::extractStatusChangeIdentifierFromMessage($statusChangeMessage);
 
             return [
-                'notification_id' => (string) $monitoring->getAttribute('notification_id'),
+                'notification_id' => $latestStatusNotification->id,
                 'monitoring_id' => $monitoring->id,
                 'monitor_name' => $monitoring->name,
                 'target' => $monitoring->target,
                 'type' => $monitoring->type->value,
                 'latest_status_code' => $latestStatusCode !== null ? (int) $latestStatusCode : null,
-                'latest_checked_at' => $latestCheckedAt ? Date::parse((string) $latestCheckedAt)->toIso8601String() : null,
-                'latest_status_change_at' => $latestStatusChangeAt ? Date::parse((string) $latestStatusChangeAt)->toIso8601String() : null,
+                'latest_checked_at' => $latestCheckedAt ? Date::parse($latestCheckedAt)->toIso8601String() : null,
+                'latest_status_change_at' => $latestStatusChangeAt ? Date::parse($latestStatusChangeAt)->toIso8601String() : null,
                 'status_identifier' => MonitoringStatusMeta::statusIdentifier(
                     $latestStatusCode !== null ? (int) $latestStatusCode : null,
                     $maintenanceActive
@@ -170,7 +116,7 @@ class NotificationBoardService
                 ),
                 'status_change_key' => 'notifications.status_change.' . $statusChangeIdentifier,
                 'badge_type' => MonitoringStatusMeta::badgeType($statusIdentifier),
-                'read' => (bool) $monitoring->getAttribute('notification_read'),
+                'read' => $latestStatusNotification->read,
             ];
         });
     }

--- a/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
@@ -22,7 +22,7 @@ class NotificationStatusBoardPerformanceTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_status_board_entries_load_in_a_single_select_query(): void
+    public function test_status_board_entries_load_with_scoped_latest_relation_queries(): void
     {
         Date::setTestNow('2026-04-19 10:00:00');
 
@@ -42,17 +42,20 @@ class NotificationStatusBoardPerformanceTest extends TestCase
         $selectQueries = collect(DB::getQueryLog())
             ->filter(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'))
             ->values();
-        $statusBoardQuery = $selectQueries->sole();
-        $normalizedStatusBoardSql = str_replace(['"', '`'], '', $statusBoardQuery['query']);
+        $normalizedSql = $selectQueries
+            ->pluck('query')
+            ->map(static fn (string $query): string => str_replace(['"', '`'], '', $query))
+            ->implode("\n");
 
-        $this->assertCount(1, $selectQueries);
-        $this->assertStringContainsString('status_change_monitorings.user_id = ?', $normalizedStatusBoardSql);
-        $this->assertStringContainsString('status_change_monitorings.deleted_at is null', $normalizedStatusBoardSql);
-        $this->assertContains($user->id, $statusBoardQuery['bindings']);
+        $this->assertCount(3, $selectQueries);
+        $this->assertStringContainsString('from monitorings where user_id = ?', $normalizedSql);
+        $this->assertStringContainsString('monitoring_notifications.monitoring_id in', $normalizedSql);
+        $this->assertStringNotContainsString('latest_status_change_timestamps', $normalizedSql);
+        $this->assertStringNotContainsString('status_change_monitorings', $normalizedSql);
         $this->assertSame([$secondMonitoring->id, $firstMonitoring->id], $entries->pluck('monitoring_id')->all());
     }
 
-    public function test_status_board_aggregate_is_scoped_to_the_authenticated_users_active_monitorings(): void
+    public function test_status_board_latest_notification_query_is_scoped_to_the_authenticated_users_active_monitorings(): void
     {
         Date::setTestNow('2026-04-19 10:00:00');
 
@@ -61,7 +64,7 @@ class NotificationStatusBoardPerformanceTest extends TestCase
         $otherUser = User::factory()->for($package)->create();
 
         $monitoring = $this->createStatusBoardMonitoring($user, 204, Date::now()->copy()->subMinutes(3));
-        $this->createStatusBoardMonitoring($otherUser, 503, Date::now()->copy()->subMinutes(2));
+        $otherUserMonitoring = $this->createStatusBoardMonitoring($otherUser, 503, Date::now()->copy()->subMinutes(2));
         $deletedMonitoring = $this->createStatusBoardMonitoring($user, 503, Date::now()->copy()->subMinute());
         $deletedMonitoring->delete();
 
@@ -72,16 +75,26 @@ class NotificationStatusBoardPerformanceTest extends TestCase
 
         $entries = resolve(NotificationBoardService::class)->getStatusBoardEntries(showRead: true, limit: 5);
 
-        $selectQuery = collect(DB::getQueryLog())
-            ->first(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'));
+        $selectQueries = collect(DB::getQueryLog())
+            ->filter(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'))
+            ->values();
+        $monitoringQuery = $selectQueries->first();
+        $notificationQuery = $selectQueries->first(
+            fn (array $query): bool => str_contains($query['query'], 'monitoring_notifications')
+        );
 
-        $normalizedSql = str_replace(['"', '`'], '', $selectQuery['query']);
+        $normalizedMonitoringSql = str_replace(['"', '`'], '', $monitoringQuery['query']);
+        $normalizedNotificationSql = str_replace(['"', '`'], '', $notificationQuery['query']);
 
         $this->assertSame([$monitoring->id], $entries->pluck('monitoring_id')->all());
-        $this->assertStringContainsString('status_change_monitorings.user_id', $normalizedSql);
-        $this->assertStringContainsString('status_change_monitorings.deleted_at is null', $normalizedSql);
-        $this->assertContains($user->id, $selectQuery['bindings']);
-        $this->assertNotContains($otherUser->id, $selectQuery['bindings']);
+        $this->assertStringContainsString('from monitorings where user_id = ?', $normalizedMonitoringSql);
+        $this->assertStringContainsString('monitorings.deleted_at is null', $normalizedMonitoringSql);
+        $this->assertStringContainsString('monitoring_notifications.monitoring_id in', $normalizedNotificationSql);
+        $this->assertContains($user->id, $monitoringQuery['bindings']);
+        $this->assertContains($monitoring->id, $notificationQuery['bindings']);
+        $this->assertNotContains($otherUser->id, $monitoringQuery['bindings']);
+        $this->assertNotContains($otherUserMonitoring->id, $notificationQuery['bindings']);
+        $this->assertNotContains($deletedMonitoring->id, $notificationQuery['bindings']);
     }
 
     public function test_status_board_orders_entries_by_notification_id_when_status_change_timestamps_match(): void


### PR DESCRIPTION
## Summary
- Rewrite the status-change board loader behind `/notifications/load-more` to start from the authenticated user's active monitorings.
- Load each monitoring's latest status notification and latest response through scoped latest relations instead of aggregating the full notification history before pagination.
- Preserve unread/read behavior, status and response tie-breakers, API payload shape, and existing pagination semantics.
- Update performance tests to assert the latest notification lookup is scoped to the active user's monitoring ids.

## Validation
- `php artisan test tests/Feature/Notifications --stop-on-failure`
- `php artisan test tests/Feature --stop-on-failure`
- `./vendor/bin/pint --dirty --test`