### PR TITLE
test: cover status board api pagination metadata

### DIFF
--- a/tests/Feature/Notifications/NotificationStatusBoardTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardTest.php
@@ -11,6 +11,7 @@ use App\Models\MonitoringNotification;
 use App\Models\MonitoringResponse;
 use App\Models\Package;
 use App\Models\User;
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
 use Tests\TestCase;
@@ -117,6 +118,33 @@ class NotificationStatusBoardTest extends TestCase
         $this->assertSame('neutral', $dataByMonitoring[$entries['maintenance']]['badge_type']);
     }
 
+    public function test_status_board_api_reports_has_more_without_returning_the_extra_entry(): void
+    {
+        Date::setTestNow('2026-03-24 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $oldestMonitoring = $this->createStatusBoardMonitoring($user, 503, notificationTime: Date::now()->subMinutes(10));
+        $secondMonitoring = $this->createStatusBoardMonitoring($user, 204, notificationTime: Date::now()->subMinutes(5));
+        $newestMonitoring = $this->createStatusBoardMonitoring($user, 200, notificationTime: Date::now()->subMinute());
+
+        $testResponse = $this->actingAs($user)->getJson('/api/notifications/status-board?show_read=1&limit=2');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('meta.has_more', true);
+        $testResponse->assertJsonPath('meta.count', 2);
+
+        $this->assertSame(
+            [$newestMonitoring->id, $secondMonitoring->id],
+            collect($testResponse->json('data'))->pluck('monitoring_id')->all()
+        );
+        $this->assertNotContains(
+            $oldestMonitoring->id,
+            collect($testResponse->json('data'))->pluck('monitoring_id')->all()
+        );
+    }
+
     public function test_status_board_respects_active_locale_for_labels_and_status_texts(): void
     {
         Date::setTestNow('2026-03-24 12:00:00');
@@ -139,8 +167,14 @@ class NotificationStatusBoardTest extends TestCase
         $this->assertStringContainsString($monitoring->name, $html);
     }
 
-    private function createStatusBoardMonitoring(User $user, ?int $statusCode, bool $maintenance = false): Monitoring
-    {
+    private function createStatusBoardMonitoring(
+        User $user,
+        ?int $statusCode,
+        bool $maintenance = false,
+        ?CarbonInterface $notificationTime = null
+    ): Monitoring {
+        $notificationTime ??= Date::now()->subMinute();
+
         $monitoring = Monitoring::factory()->for($user)->create([
             'maintenance_from' => $maintenance ? Date::now()->subHour() : null,
             'maintenance_until' => $maintenance ? Date::now()->addHour() : null,
@@ -151,8 +185,8 @@ class NotificationStatusBoardTest extends TestCase
             'status' => MonitoringStatus::DOWN,
             'http_status_code' => $statusCode,
             'response_time' => 250.0,
-            'created_at' => Date::now()->subMinutes(2),
-            'updated_at' => Date::now()->subMinutes(2),
+            'created_at' => $notificationTime->copy()->subMinute(),
+            'updated_at' => $notificationTime->copy()->subMinute(),
         ]);
 
         MonitoringNotification::query()->create([
@@ -161,8 +195,8 @@ class NotificationStatusBoardTest extends TestCase
             'message' => 'DOWN',
             'read' => false,
             'sent' => false,
-            'created_at' => Date::now()->subMinute(),
-            'updated_at' => Date::now()->subMinute(),
+            'created_at' => $notificationTime,
+            'updated_at' => $notificationTime,
         ]);
 
         return $monitoring;


### PR DESCRIPTION
## Summary
- adds status board API coverage for the `limit + 1` pagination sentinel
- verifies `meta.has_more` is true while only the requested number of entries is returned
- makes the status board test helper support deterministic notification timestamps

## Validation
- php artisan test tests/Feature/Notifications/NotificationStatusBoardTest.php
- php artisan test tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
- ./vendor/bin/pint --dirty --test

## Notes
- local dependency install required `--ignore-platform-req=ext-redis` because the CLI PHP environment lacks the Redis extension