### PR TITLE
Fix notification board read flag parsing

### DIFF
--- a/app/Http/Controllers/Api/NotificationBoardController.php
+++ b/app/Http/Controllers/Api/NotificationBoardController.php
@@ -13,6 +13,14 @@ class NotificationBoardController extends Controller
 {
     public function __invoke(Request $request, NotificationBoardService $notificationBoardService): JsonResponse
     {
+        if ($request->has('show_read') && is_string($request->input('show_read'))) {
+            $showRead = mb_strtolower($request->input('show_read'));
+
+            if (in_array($showRead, ['true', 'false'], true)) {
+                $request->merge(['show_read' => $showRead === 'true']);
+            }
+        }
+
         $validated = $request->validate([
             'offset' => ['nullable', 'integer', 'min:0'],
             'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
@@ -21,7 +29,7 @@ class NotificationBoardController extends Controller
 
         $offset = (int) ($validated['offset'] ?? 0);
         $limit = (int) ($validated['limit'] ?? 10);
-        $showRead = (bool) ($validated['show_read'] ?? false);
+        $showRead = $request->boolean('show_read');
 
         $entries = $notificationBoardService->getStatusBoardEntries($showRead, $offset, $limit);
         $hasMore = $entries->count() > $limit;

--- a/tests/Feature/Notifications/NotificationStatusBoardTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardTest.php
@@ -135,7 +135,7 @@ class NotificationStatusBoardTest extends TestCase
             'updated_at' => Date::now()->subMinutes(3),
         ]);
 
-        $unreadNotification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'DOWN',
@@ -159,7 +159,7 @@ class NotificationStatusBoardTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertJsonPath('meta.count', 1);
-        $testResponse->assertJsonPath('data.0.notification_id', $unreadNotification->id);
+        $testResponse->assertJsonPath('data.0.notification_id', $monitoringNotification->id);
         $testResponse->assertJsonPath('data.0.read', false);
         $this->assertNotSame($readNotification->id, $testResponse->json('data.0.notification_id'));
     }

--- a/tests/Feature/Notifications/NotificationStatusBoardTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardTest.php
@@ -117,6 +117,52 @@ class NotificationStatusBoardTest extends TestCase
         $this->assertSame('neutral', $dataByMonitoring[$entries['maintenance']]['badge_type']);
     }
 
+    public function test_status_board_api_treats_false_show_read_query_string_as_unread_only(): void
+    {
+        Date::setTestNow('2026-03-24 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'http_status_code' => 503,
+            'response_time' => 250.0,
+            'created_at' => Date::now()->subMinutes(3),
+            'updated_at' => Date::now()->subMinutes(3),
+        ]);
+
+        $unreadNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => false,
+            'created_at' => Date::now()->subMinutes(2),
+            'updated_at' => Date::now()->subMinutes(2),
+        ]);
+
+        $readNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'UP',
+            'read' => true,
+            'sent' => false,
+            'created_at' => Date::now()->subMinute(),
+            'updated_at' => Date::now()->subMinute(),
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/notifications/status-board?show_read=false');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('meta.count', 1);
+        $testResponse->assertJsonPath('data.0.notification_id', $unreadNotification->id);
+        $testResponse->assertJsonPath('data.0.read', false);
+        $this->assertNotSame($readNotification->id, $testResponse->json('data.0.notification_id'));
+    }
+
     public function test_status_board_respects_active_locale_for_labels_and_status_texts(): void
     {
         Date::setTestNow('2026-03-24 12:00:00');


### PR DESCRIPTION
## Summary

- normalize explicit `true`/`false` `show_read` query strings before validation
- parse the notification board read flag through Laravel's request boolean helper
- add a focused API regression test for `show_read=false` returning unread-only board entries

## Validation

- `./vendor/bin/pint app/Http/Controllers/Api/NotificationBoardController.php tests/Feature/Notifications/NotificationStatusBoardTest.php`
- `php artisan test tests/Feature/Notifications/NotificationStatusBoardTest.php`

## Notes

- `composer install` initially failed because the local PHP Redis extension is missing; dependencies were installed with `--ignore-platform-req=ext-redis` to run the focused tests.