### PR TITLE
Redesign notifications page

### DIFF
--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -13,6 +13,49 @@ return [
     'delivery_history' => [
         'heading' => 'Zustellverlauf',
     ],
+    'overview' => [
+        'eyebrow' => 'Operations Inbox',
+        'description' => 'Prüfen Sie Monitor-Vorfälle, Ablauf-Risiken und Kanalzustellungen in einer fokussierten Kommandozentrale.',
+        'workflow_label' => 'Übersicht des Benachrichtigungs-Workflows',
+        'workflow' => [
+            'triage' => [
+                'label' => 'Triage',
+                'title' => 'Statusänderungen',
+                'description' => 'Wiederherstellungen und Vorfälle pro Monitor bündeln, damit der aktuelle Zustand sofort handlungsfähig ist.',
+            ],
+            'expiry' => [
+                'label' => 'Risiko',
+                'title' => 'Zertifikat- und Domain-Ablauf',
+                'description' => 'Sicherheits- und Besitzfristen sichtbar halten, bevor daraus Ausfälle entstehen.',
+            ],
+            'audit' => [
+                'label' => 'Audit',
+                'title' => 'Kanalzustellung',
+                'description' => 'Nachvollziehen, ob Slack-, Telegram-, Discord- und Webhook-Benachrichtigungen ihr Ziel erreicht haben.',
+            ],
+        ],
+    ],
+    'sections' => [
+        'ssl_expiry' => [
+            'description' => 'Zertifikatswarnungen, die Erneuerung oder Prüfung benötigen.',
+        ],
+        'domain_expiry' => [
+            'description' => 'Domain-Fristen und Ablaufwarnungen für überwachte Ziele.',
+        ],
+        'status_change' => [
+            'description' => 'Aktueller Vorfall- und Wiederherstellungsstatus pro Monitor, konsolidiert für schnellere Triage.',
+        ],
+        'delivery_history' => [
+            'description' => 'Aktuelle Zustellversuche über konfigurierte ausgehende Benachrichtigungskanäle.',
+        ],
+    ],
+    'loading' => [
+        'title' => 'Benachrichtigungsboard wird geladen',
+        'description' => 'Aktuelle Monitor-Updates und Zustellversuche werden abgerufen.',
+    ],
+    'empty_state' => [
+        'description' => 'Ungelesene Meldungen, Ablaufwarnungen und Zustellereignisse erscheinen hier, sobald sie Aufmerksamkeit benötigen.',
+    ],
     'load_more' => 'Mehr laden',
     'mark_as_read' => 'Als gelesen markieren',
     'mark_all_as_read' => 'Alle als gelesen markieren',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -13,6 +13,49 @@ return [
     'delivery_history' => [
         'heading' => 'Delivery History',
     ],
+    'overview' => [
+        'eyebrow' => 'Operations inbox',
+        'description' => 'Review monitor incidents, expiry risks, and channel deliveries from one focused command center.',
+        'workflow_label' => 'Notification workflow overview',
+        'workflow' => [
+            'triage' => [
+                'label' => 'Triage',
+                'title' => 'Status changes',
+                'description' => 'Group recoveries and incidents by monitor so the latest state is easy to act on.',
+            ],
+            'expiry' => [
+                'label' => 'Risk',
+                'title' => 'Certificate and domain expiry',
+                'description' => 'Keep security and ownership deadlines visible before they become outages.',
+            ],
+            'audit' => [
+                'label' => 'Audit',
+                'title' => 'Channel delivery',
+                'description' => 'Inspect whether Slack, Telegram, Discord, and webhook notifications reached their target.',
+            ],
+        ],
+    ],
+    'sections' => [
+        'ssl_expiry' => [
+            'description' => 'Certificate warnings that need renewal planning or verification.',
+        ],
+        'domain_expiry' => [
+            'description' => 'Domain ownership deadlines and expiry alerts for monitored targets.',
+        ],
+        'status_change' => [
+            'description' => 'Current incident and recovery state per monitor, consolidated for faster triage.',
+        ],
+        'delivery_history' => [
+            'description' => 'Recent delivery attempts across configured outbound notification channels.',
+        ],
+    ],
+    'loading' => [
+        'title' => 'Loading notification board',
+        'description' => 'Fetching the latest monitor updates and delivery attempts.',
+    ],
+    'empty_state' => [
+        'description' => 'Unread alerts, expiry warnings, and delivery events will appear here as soon as they need attention.',
+    ],
     'load_more' => 'Load More',
     'mark_as_read' => 'Mark as Read',
     'mark_all_as_read' => 'Mark all as read',

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -5,26 +5,88 @@
 
         $showReadDisabledQuery = request()->query();
         unset($showReadDisabledQuery['show_read']);
+
+        $notificationSections = [
+            [
+                'type' => 'ssl_expiry',
+                'sectionId' => 'ssl-expiry-section',
+                'containerId' => 'ssl-expiry-notifications',
+                'loadMoreContainerId' => 'ssl-expiry-load-more-container',
+                'title' => __('notifications.ssl_expiry_notifications'),
+                'description' => __('notifications.sections.ssl_expiry.description'),
+                'accent' => 'bg-amber-500',
+            ],
+            [
+                'type' => 'domain_expiry',
+                'sectionId' => 'domain-expiry-section',
+                'containerId' => 'domain-expiry-notifications',
+                'loadMoreContainerId' => 'domain-expiry-load-more-container',
+                'title' => __('notifications.domain_expiry_notifications'),
+                'description' => __('notifications.sections.domain_expiry.description'),
+                'accent' => 'bg-sky-500',
+            ],
+            [
+                'type' => 'status_change',
+                'sectionId' => 'status-change-section',
+                'containerId' => 'status-change-notifications',
+                'loadMoreContainerId' => 'status-change-load-more-container',
+                'title' => __('notifications.status_change_notifications'),
+                'description' => __('notifications.sections.status_change.description'),
+                'accent' => 'bg-emerald-500',
+            ],
+            [
+                'type' => 'delivery_history',
+                'sectionId' => 'delivery-history-section',
+                'containerId' => 'delivery-history-notifications',
+                'loadMoreContainerId' => 'delivery-history-load-more-container',
+                'title' => __('notifications.delivery_history.heading'),
+                'description' => __('notifications.sections.delivery_history.description'),
+                'accent' => 'bg-violet-500',
+            ],
+        ];
     @endphp
 
     <x-slot name="header">
-        <x-heading type="h1">
-            {{ __('notifications.title') }}
-        </x-heading>
+        <div id="notification-command-center" class="flex w-full flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+            <div class="flex min-w-0 items-start gap-4">
+                <span class="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20">
+                    <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2a2 2 0 0 1-.6 1.4L4 17h5" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 17a3 3 0 1 1-6 0" />
+                    </svg>
+                </span>
+                <div class="min-w-0">
+                    <x-paragraph class="text-sm font-semibold uppercase tracking-[0.08em] text-emerald-700 dark:text-emerald-300">
+                        {{ __('notifications.overview.eyebrow') }}
+                    </x-paragraph>
+                    <x-heading type="h1" class="mt-1 text-slate-950 dark:text-white">
+                        {{ __('notifications.title') }}
+                    </x-heading>
+                    <x-paragraph class="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base">
+                        {{ __('notifications.overview.description') }}
+                    </x-paragraph>
+                </div>
+            </div>
 
-        <div class="space-6 items-center sm:ml-auto sm:flex">
-            <label for="show_read" class="inline-flex items-center">
-                <input type="checkbox" id="show_read" name="show_read" value="1"
-                    class="shadow-xs focus:ring-3 rounded-sm border-gray-300 text-purple-600 focus:border-purple-300 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
-                    onchange="window.location.href = this.checked ? '{{ route('notifications.index', $showReadEnabledQuery) }}' : '{{ route('notifications.index', $showReadDisabledQuery) }}'"
-                    {{ $showRead ? 'checked' : '' }}>
-                <span class="ms-2">{{ __('notifications.show_read_notifications') }}</span>
-            </label>
+            <div class="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 sm:flex-row sm:items-center">
+                <label for="show_read" class="inline-flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-slate-700 dark:text-slate-200">
+                    <input type="checkbox" id="show_read" name="show_read" value="1"
+                        class="shadow-xs focus:ring-3 rounded-sm border-slate-300 text-emerald-600 focus:border-emerald-400 focus:ring-emerald-200 focus:ring-opacity-70 dark:border-slate-600 dark:bg-slate-800"
+                        onchange="window.location.href = this.checked ? '{{ route('notifications.index', $showReadEnabledQuery) }}' : '{{ route('notifications.index', $showReadDisabledQuery) }}'"
+                        {{ $showRead ? 'checked' : '' }}>
+                    <span>{{ __('notifications.show_read_notifications') }}</span>
+                </label>
 
-            <form method="POST" action="{{ route('notifications.markAllAsRead') }}" class="ms-2">
-                @csrf
-                <x-secondary-button type="submit">{{ __('notifications.mark_all_as_read') }}</x-secondary-button>
-            </form>
+                <form method="POST" action="{{ route('notifications.markAllAsRead') }}">
+                    @csrf
+                    <x-secondary-button type="submit" class="justify-center !border-slate-300 px-3 py-2 text-xs !normal-case !tracking-normal !text-slate-700 hover:!border-emerald-500 hover:!bg-emerald-50 hover:!text-emerald-700 dark:!border-slate-600 dark:!bg-slate-800 dark:!text-slate-100 dark:hover:!border-emerald-400 dark:hover:!bg-emerald-300/10 dark:hover:!text-emerald-300">
+                        <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
+                        </svg>
+                        {{ __('notifications.mark_all_as_read') }}
+                    </x-secondary-button>
+                </form>
+            </div>
         </div>
     </x-slot>
 
@@ -174,47 +236,103 @@
                     }
                 });
         }
-    }" x-init="syncLimitWithUrl(currentLimit); loadInitialNotifications()">
-        <x-container id="notifications-loading-state" x-cloak x-show="isLoading">
-            <x-loading-indicator />
+    }" x-init="syncLimitWithUrl(currentLimit); loadInitialNotifications()" class="space-y-6">
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-3" aria-label="{{ __('notifications.overview.workflow_label') }}">
+            @foreach (['triage', 'expiry', 'audit'] as $workflowItem)
+                <div class="rounded-lg border border-slate-200 bg-white/75 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/50">
+                    <x-paragraph class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
+                        {{ __('notifications.overview.workflow.' . $workflowItem . '.label') }}
+                    </x-paragraph>
+                    <x-heading type="h3" class="mt-2 text-base font-semibold text-slate-950 dark:text-white">
+                        {{ __('notifications.overview.workflow.' . $workflowItem . '.title') }}
+                    </x-heading>
+                    <x-paragraph class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                        {{ __('notifications.overview.workflow.' . $workflowItem . '.description') }}
+                    </x-paragraph>
+                </div>
+            @endforeach
+        </div>
+
+        <x-container id="notifications-loading-state" x-cloak x-show="isLoading" class="border border-slate-200 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+            <div class="flex items-center gap-4">
+                <x-loading-indicator />
+                <div>
+                    <x-heading type="h3" class="text-base font-semibold text-slate-950 dark:text-white">
+                        {{ __('notifications.loading.title') }}
+                    </x-heading>
+                    <x-paragraph class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                        {{ __('notifications.loading.description') }}
+                    </x-paragraph>
+                </div>
+            </div>
         </x-container>
 
-        <x-container id="notifications-empty-state" x-cloak x-show="!isLoading && isEmpty">
-            <x-paragraph>{{ __('notifications.no_notifications') }}</x-paragraph>
+        <x-container id="notifications-empty-state" x-cloak x-show="!isLoading && isEmpty" class="border border-emerald-200 bg-emerald-50/70 text-center shadow-sm dark:border-emerald-300/20 dark:bg-emerald-300/10">
+            <div class="mx-auto flex max-w-2xl flex-col items-center">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-lg bg-white text-emerald-700 shadow-sm ring-1 ring-emerald-200 dark:bg-slate-900 dark:text-emerald-300 dark:ring-emerald-300/20">
+                    <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
+                    </svg>
+                </span>
+                <x-heading type="h2" class="mt-4 text-xl font-semibold text-slate-950 dark:text-white">
+                    {{ __('notifications.no_notifications') }}
+                </x-heading>
+                <x-paragraph class="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                    {{ __('notifications.empty_state.description') }}
+                </x-paragraph>
+            </div>
         </x-container>
 
-        <div x-cloak x-show="!isLoading && !isEmpty">
-            <div class="mb-8" id="ssl-expiry-section" style="display: none;">
-                <x-heading type="h2" space=true>{{ __('notifications.ssl_expiry_notifications') }}</x-heading>
-                <div id="ssl-expiry-notifications"></div>
-                <div class="mt-4 text-center" id="ssl-expiry-load-more-container" style="display: none;">
-                    <x-primary-button @click="loadMoreNotifications('ssl_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
-                </div>
-            </div>
+        <div x-cloak x-show="!isLoading && !isEmpty" class="space-y-10">
+            @foreach ($notificationSections as $section)
+                <section class="notification-section" id="{{ $section['sectionId'] }}" data-notification-section="{{ $section['type'] }}" style="display: none;">
+                    <div class="mb-4 flex flex-col gap-3 border-b border-slate-200 pb-4 dark:border-slate-800 sm:flex-row sm:items-end sm:justify-between">
+                        <div class="flex min-w-0 items-start gap-3">
+                            <span class="{{ $section['accent'] }} mt-1 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white shadow-sm">
+                                @switch($section['type'])
+                                    @case('domain_expiry')
+                                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z" />
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 12h18M12 3c2.5 2.4 2.5 15.6 0 18" />
+                                        </svg>
+                                        @break
+                                    @case('status_change')
+                                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 12h4l3-6 4 12 2-6h3" />
+                                        </svg>
+                                        @break
+                                    @case('delivery_history')
+                                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M5 7h14M7 12h10M9 17h6" />
+                                        </svg>
+                                        @break
+                                    @default
+                                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 11V8a4 4 0 1 1 8 0v3" />
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M7 11h10v9H7z" />
+                                        </svg>
+                                @endswitch
+                            </span>
+                            <div class="min-w-0">
+                                <x-heading type="h2" class="text-xl font-semibold text-slate-950 dark:text-white">
+                                    {{ $section['title'] }}
+                                </x-heading>
+                                <x-paragraph class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                                    {{ $section['description'] }}
+                                </x-paragraph>
+                            </div>
+                        </div>
+                    </div>
 
-            <div class="mb-8" id="domain-expiry-section" style="display: none;">
-                <x-heading type="h2" space=true>{{ __('notifications.domain_expiry_notifications') }}</x-heading>
-                <div id="domain-expiry-notifications"></div>
-                <div class="mt-4 text-center" id="domain-expiry-load-more-container" style="display: none;">
-                    <x-primary-button @click="loadMoreNotifications('domain_expiry')">{{ __('notifications.load_more') }}</x-primary-button>
-                </div>
-            </div>
+                    <div id="{{ $section['containerId'] }}" class="space-y-3"></div>
 
-            <div class="mb-8" id="status-change-section" style="display: none;">
-                <x-heading type="h2" space=true>{{ __('notifications.status_change_notifications') }}</x-heading>
-                <div id="status-change-notifications"></div>
-                <div class="mt-4 text-center" id="status-change-load-more-container" style="display: none;">
-                    <x-primary-button @click="loadMoreNotifications('status_change')">{{ __('notifications.load_more') }}</x-primary-button>
-                </div>
-            </div>
-
-            <div class="mb-8" id="delivery-history-section" style="display: none;">
-                <x-heading type="h2" space=true>{{ __('notifications.delivery_history.heading') }}</x-heading>
-                <div id="delivery-history-notifications"></div>
-                <div class="mt-4 text-center" id="delivery-history-load-more-container" style="display: none;">
-                    <x-primary-button @click="loadMoreNotifications('delivery_history')">{{ __('notifications.load_more') }}</x-primary-button>
-                </div>
-            </div>
+                    <div class="mt-4 text-center" id="{{ $section['loadMoreContainerId'] }}" style="display: none;">
+                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!bg-emerald-600 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400">
+                            {{ __('notifications.load_more') }}
+                        </x-primary-button>
+                    </div>
+                </section>
+            @endforeach
         </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/notifications/partials/delivery_history_list.blade.php
+++ b/resources/views/notifications/partials/delivery_history_list.blade.php
@@ -20,48 +20,64 @@
             NotificationDeliveryStatus::FAILED => 'danger',
             NotificationDeliveryStatus::SKIPPED => 'warning',
         };
+        $statusAccent = match ($delivery->status) {
+            NotificationDeliveryStatus::SENT => 'bg-emerald-500',
+            NotificationDeliveryStatus::FAILED => 'bg-red-500',
+            NotificationDeliveryStatus::SKIPPED => 'bg-amber-500',
+        };
         $errorMessage = $delivery->error_message ? Str::limit($delivery->error_message, 180) : null;
     @endphp
 
-    <x-container space="true" class="notification-entry mb-3" id="{{ $delivery->id }}">
-        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div class="min-w-0 space-y-2">
-                <div class="flex flex-wrap items-center gap-2">
-                    <x-heading type="h3" class="truncate text-lg">
-                        {{ $monitoringName }}
-                    </x-heading>
-                    <x-badge type="{{ $statusBadgeType }}" class="border border-black/10 px-3 py-1 text-sm dark:border-white/20">
-                        {{ __('notifications.delivery_status.' . $delivery->status->value) }}
-                    </x-badge>
-                </div>
+    <x-container space="true" data-notification-card="delivery_history" class="notification-entry relative overflow-hidden border border-slate-200 bg-white/95 shadow-sm dark:border-slate-800 dark:bg-slate-900/80" id="{{ $delivery->id }}">
+        <span class="{{ $statusAccent }} notification-card-accent absolute inset-y-0 left-0 w-1" aria-hidden="true"></span>
 
-                <div class="grid grid-cols-1 gap-1 text-sm text-gray-600 dark:text-gray-300">
+        <div class="flex flex-col gap-5 pl-2 lg:flex-row lg:items-start lg:justify-between">
+            <div class="flex min-w-0 items-start gap-4">
+                <span class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700 ring-1 ring-violet-200 dark:bg-violet-300/10 dark:text-violet-300 dark:ring-violet-300/20">
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 7h14M7 12h10M9 17h6" />
+                    </svg>
+                </span>
+
+                <div class="min-w-0">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <x-heading type="h3" class="truncate text-lg font-semibold text-slate-950 dark:text-white">
+                            {{ $monitoringName }}
+                        </x-heading>
+                        <x-badge type="{{ $statusBadgeType }}" class="border border-black/10 px-3 py-1 text-sm dark:border-white/20">
+                            {{ __('notifications.delivery_status.' . $delivery->status->value) }}
+                        </x-badge>
+                    </div>
+
                     @if ($monitoringTarget)
-                        <x-paragraph class="break-all">
-                            <x-span class="font-semibold">{{ __('notifications.labels.host') }}:</x-span>
-                            <x-span>{{ $monitoringTarget }}</x-span>
+                        <x-paragraph class="mt-2 break-all text-sm text-slate-600 dark:text-slate-300">
+                            {{ $monitoringTarget }}
                         </x-paragraph>
                     @endif
-                    <x-paragraph>
-                        <x-span class="font-semibold">{{ __('notifications.labels.channel') }}:</x-span>
-                        <x-span>{{ __('notifications.channels.' . $delivery->channel) }}</x-span>
-                    </x-paragraph>
-                    <x-paragraph>
-                        <x-span class="font-semibold">{{ __('notifications.labels.event') }}:</x-span>
-                        <x-span>{{ __('notifications.events.' . $delivery->event_type) }}</x-span>
-                    </x-paragraph>
-                    <x-paragraph>
-                        <x-span class="font-semibold">{{ __('notifications.labels.attempted_at') }}:</x-span>
-                        <x-span>{{ $attemptedAt }}</x-span>
-                    </x-paragraph>
-                    @if ($delivery->status === NotificationDeliveryStatus::SENT)
-                        <x-paragraph>
-                            <x-span class="font-semibold">{{ __('notifications.labels.sent_at') }}:</x-span>
-                            <x-span>{{ $sentAt }}</x-span>
-                        </x-paragraph>
-                    @endif
+
+                    <dl class="mt-4 grid grid-cols-1 gap-3 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
+                        <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.channel') }}</dt>
+                            <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ __('notifications.channels.' . $delivery->channel) }}</dd>
+                        </div>
+                        <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.event') }}</dt>
+                            <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ __('notifications.events.' . $delivery->event_type) }}</dd>
+                        </div>
+                        <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.attempted_at') }}</dt>
+                            <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ $attemptedAt }}</dd>
+                        </div>
+                        @if ($delivery->status === NotificationDeliveryStatus::SENT)
+                            <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                                <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.sent_at') }}</dt>
+                                <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ $sentAt }}</dd>
+                            </div>
+                        @endif
+                    </dl>
+
                     @if ($errorMessage)
-                        <x-paragraph class="text-sm text-red-600 dark:text-red-400">
+                        <x-paragraph class="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-400/20 dark:bg-red-400/10 dark:text-red-300">
                             <x-span class="font-semibold">{{ __('notifications.labels.error') }}:</x-span>
                             <x-span>{{ $errorMessage }}</x-span>
                         </x-paragraph>
@@ -71,5 +87,5 @@
         </div>
     </x-container>
 @empty
-    <p>{{ __('notifications.no_notifications_of_this_type') }}</p>
+    <p class="rounded-lg border border-dashed border-slate-300 bg-white/70 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-400">{{ __('notifications.no_notifications_of_this_type') }}</p>
 @endforelse

--- a/resources/views/notifications/partials/notification_list.blade.php
+++ b/resources/views/notifications/partials/notification_list.blade.php
@@ -1,17 +1,67 @@
 @forelse($notifications as $notification)
-    <x-container space="true"
-        class="{{ $notification->read ? ' !text-gray-500 dark:!text-gray-500' : '' }} notification-entry block items-center justify-between sm:flex"
-        id="{{ $notification->id }}">
-        <div class="mb-4 sm:mb-0">
-            <x-paragraph bold=true>{{ $notification->translated_message }}</x-paragraph>
-            <x-paragraph class="text-sm">{{ $notification->created_at->diffForHumans() }}</x-paragraph>
-        </div>
+    @php
+        $isRead = (bool) $notification->read;
+        $accentClasses = match ($type) {
+            'domain_expiry' => 'bg-sky-500',
+            'status_change' => 'bg-emerald-500',
+            default => 'bg-amber-500',
+        };
+        $iconClasses = match ($type) {
+            'domain_expiry' => 'bg-sky-100 text-sky-700 ring-sky-200 dark:bg-sky-300/10 dark:text-sky-300 dark:ring-sky-300/20',
+            'status_change' => 'bg-emerald-100 text-emerald-700 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20',
+            default => 'bg-amber-100 text-amber-700 ring-amber-200 dark:bg-amber-300/10 dark:text-amber-300 dark:ring-amber-300/20',
+        };
+    @endphp
 
-        @if (!$notification->read)
-            <x-primary-button class="mark-as-read-button text-sm"
-                @click="markAsRead(event, '{{ $notification->id }}', '{{ route('notifications.markAsRead', $notification) }}', '{{ $type }}')">{{ __('notifications.mark_as_read') }}</x-primary-button>
-        @endif
+    <x-container space="true"
+        data-notification-card="{{ $type }}"
+        class="{{ $isRead ? 'opacity-70' : '' }} notification-entry relative overflow-hidden border border-slate-200 bg-white/95 shadow-sm dark:border-slate-800 dark:bg-slate-900/80"
+        id="{{ $notification->id }}">
+        <span class="{{ $accentClasses }} notification-card-accent absolute inset-y-0 left-0 w-1" aria-hidden="true"></span>
+
+        <div class="flex flex-col gap-4 pl-2 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex min-w-0 items-start gap-4">
+                <span class="{{ $iconClasses }} inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ring-1">
+                    @if ($type === 'domain_expiry')
+                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 12h18M12 3c2.5 2.4 2.5 15.6 0 18" />
+                        </svg>
+                    @else
+                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 11V8a4 4 0 1 1 8 0v3" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M7 11h10v9H7z" />
+                        </svg>
+                    @endif
+                </span>
+
+                <div class="min-w-0">
+                    <x-paragraph bold=true class="{{ $isRead ? 'text-slate-500 dark:text-slate-400' : 'text-slate-950 dark:text-white' }} leading-6">
+                        {{ $notification->translated_message }}
+                    </x-paragraph>
+                    <div class="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                        <span>{{ $notification->created_at->diffForHumans() }}</span>
+                        @if ($isRead)
+                            <x-badge type="info" class="bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                                {{ __('notifications.read') }}
+                            </x-badge>
+                        @endif
+                    </div>
+                </div>
+            </div>
+
+            @if (! $isRead)
+                <x-primary-button class="mark-as-read-button shrink-0 !bg-emerald-600 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400"
+                    aria-label="{{ __('notifications.mark_as_read') }}"
+                    @click="markAsRead(event, '{{ $notification->id }}', '{{ route('notifications.markAsRead', $notification) }}', '{{ $type }}')">
+                    <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
+                    </svg>
+                    {{ __('notifications.mark_as_read') }}
+                </x-primary-button>
+            @endif
+        </div>
     </x-container>
 @empty
-    <p>{{ __('notifications.no_notifications_of_this_type') }}</p>
+    <p class="rounded-lg border border-dashed border-slate-300 bg-white/70 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-400">{{ __('notifications.no_notifications_of_this_type') }}</p>
 @endforelse

--- a/resources/views/notifications/partials/status_board_list.blade.php
+++ b/resources/views/notifications/partials/status_board_list.blade.php
@@ -12,39 +12,60 @@
         $latestStatusChangeAt = $entry['latest_status_change_at']
             ? Carbon::parse($entry['latest_status_change_at'])->locale(app()->getLocale())->isoFormat('L LT')
             : __('notifications.labels.not_available');
+        $isRead = (bool) $entry['read'];
     @endphp
     <x-container space="true"
-        class="{{ $entry['read'] ? ' !text-gray-500 dark:!text-gray-500' : '' }} notification-board-entry notification-entry mb-3"
+        data-notification-card="status_change"
+        class="{{ $isRead ? 'opacity-70' : '' }} notification-board-entry notification-entry relative overflow-hidden border border-slate-200 bg-white/95 shadow-sm dark:border-slate-800 dark:bg-slate-900/80"
         id="{{ $entry['notification_id'] }}">
-        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div class="min-w-0 space-y-2">
-                <x-heading type="h3" class="truncate text-lg">
-                    {{ $entry['monitor_name'] }}
-                </x-heading>
-                <div class="grid grid-cols-1 gap-1 text-sm text-gray-600 dark:text-gray-300">
-                    <x-paragraph class="break-all">
-                        <x-span class="font-semibold">{{ __('notifications.labels.host') }}:</x-span>
-                        <x-span>{{ $entry['target'] }}</x-span>
+        <span class="notification-card-accent absolute inset-y-0 left-0 w-1 bg-emerald-500" aria-hidden="true"></span>
+
+        <div class="flex flex-col gap-5 pl-2 lg:flex-row lg:items-start lg:justify-between">
+            <div class="flex min-w-0 items-start gap-4">
+                <span class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20">
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 12h4l3-6 4 12 2-6h3" />
+                    </svg>
+                </span>
+
+                <div class="min-w-0">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <x-heading type="h3" class="{{ $isRead ? 'text-slate-500 dark:text-slate-400' : 'text-slate-950 dark:text-white' }} truncate text-lg font-semibold">
+                            {{ $entry['monitor_name'] }}
+                        </x-heading>
+                        @if ($isRead)
+                            <x-badge type="info" class="bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                                {{ __('notifications.read') }}
+                            </x-badge>
+                        @endif
+                    </div>
+
+                    <x-paragraph class="mt-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+                        {{ __($entry['status_change_key']) }}
                     </x-paragraph>
-                    <x-paragraph>
-                        <x-span class="font-semibold">{{ __('notifications.labels.monitor') }}:</x-span>
-                        <x-span>{{ strtoupper($entry['type']) }}</x-span>
-                    </x-paragraph>
-                    <x-paragraph>
-                        <x-span class="font-semibold">{{ __('notifications.labels.timestamp') }}:</x-span>
-                        <x-span>{{ $latestCheckedAt }}</x-span>
-                    </x-paragraph>
-                    <x-paragraph>
-                        <x-span class="font-semibold">{{ __('notifications.labels.latest_status_change') }}:</x-span>
-                        <x-span>{{ $latestStatusChangeAt }}</x-span>
-                    </x-paragraph>
+
+                    <dl class="mt-4 grid grid-cols-1 gap-3 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2">
+                        <div class="min-w-0 rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.host') }}</dt>
+                            <dd class="mt-1 break-all text-slate-800 dark:text-slate-100">{{ $entry['target'] }}</dd>
+                        </div>
+                        <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.monitor') }}</dt>
+                            <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ strtoupper($entry['type']) }}</dd>
+                        </div>
+                        <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.timestamp') }}</dt>
+                            <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ $latestCheckedAt }}</dd>
+                        </div>
+                        <div class="rounded-md bg-slate-50 p-3 dark:bg-slate-800/70">
+                            <dt class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">{{ __('notifications.labels.latest_status_change') }}</dt>
+                            <dd class="mt-1 text-slate-800 dark:text-slate-100">{{ $latestStatusChangeAt }}</dd>
+                        </div>
+                    </dl>
                 </div>
-                <x-paragraph class="text-sm font-medium text-gray-700 dark:text-gray-100">
-                    {{ __($entry['status_change_key']) }}
-                </x-paragraph>
             </div>
 
-            <div class="flex flex-col items-start gap-2 md:items-end">
+            <div class="flex shrink-0 flex-wrap items-center gap-2 lg:flex-col lg:items-end">
                 <x-badge type="{{ $entry['badge_type'] }}"
                     title="{{ __('notifications.tooltips.latest_status', ['status' => $statusWithCode]) }}"
                     class="border border-black/10 px-3 py-1 text-sm dark:border-white/20">
@@ -59,13 +80,19 @@
                     class="border border-black/10 px-3 py-1 text-sm dark:border-white/20">
                     {{ $statusLabel }}
                 </x-badge>
-                @if (!$entry['read'])
-                    <x-primary-button class="mark-as-read-button text-xs"
-                        @click="markAsRead(event, '{{ $entry['notification_id'] }}', '{{ route('notifications.markAsRead', $entry['notification_id']) }}', 'status_change')">{{ __('notifications.mark_as_read') }}</x-primary-button>
+                @if (! $isRead)
+                    <x-primary-button class="mark-as-read-button !bg-emerald-600 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400"
+                        aria-label="{{ __('notifications.mark_as_read') }}"
+                        @click="markAsRead(event, '{{ $entry['notification_id'] }}', '{{ route('notifications.markAsRead', $entry['notification_id']) }}', 'status_change')">
+                        <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
+                        </svg>
+                        {{ __('notifications.mark_as_read') }}
+                    </x-primary-button>
                 @endif
             </div>
         </div>
     </x-container>
 @empty
-    <p>{{ __('notifications.no_notifications_of_this_type') }}</p>
+    <p class="rounded-lg border border-dashed border-slate-300 bg-white/70 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-400">{{ __('notifications.no_notifications_of_this_type') }}</p>
 @endforelse

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -49,7 +49,7 @@ class NotificationPageDesignTest extends TestCase
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
 
-        $notification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::SSL_EXPIRY,
             'message' => 'SSL_EXPIRING',
@@ -68,7 +68,7 @@ class NotificationPageDesignTest extends TestCase
         $this->assertStringContainsString('data-notification-card="ssl_expiry"', $html);
         $this->assertStringContainsString('notification-card-accent', $html);
         $this->assertStringContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $html);
-        $this->assertStringContainsString('id="' . $notification->id . '"', $html);
+        $this->assertStringContainsString('id="' . $monitoringNotification->id . '"', $html);
         $this->assertStringContainsString('Checkout API', $html);
     }
 
@@ -90,7 +90,7 @@ class NotificationPageDesignTest extends TestCase
             'response_time' => 1200.0,
         ]);
 
-        $statusNotification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'DOWN',
@@ -98,9 +98,9 @@ class NotificationPageDesignTest extends TestCase
             'sent' => false,
         ]);
 
-        $delivery = NotificationChannelDelivery::query()->forceCreate([
+        $notificationChannelDelivery = NotificationChannelDelivery::query()->forceCreate([
             'user_id' => $user->id,
-            'monitoring_notification_id' => $statusNotification->id,
+            'monitoring_notification_id' => $monitoringNotification->id,
             'channel' => 'slack',
             'event_type' => NotificationEventType::INCIDENT->value,
             'status' => NotificationDeliveryStatus::FAILED->value,
@@ -113,7 +113,7 @@ class NotificationPageDesignTest extends TestCase
             'error_message' => 'Webhook responded with HTTP 500.',
         ]);
 
-        $statusResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+        $testResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
             'type' => NotificationType::STATUS_CHANGE->value,
             'offset' => 0,
         ]);
@@ -122,19 +122,19 @@ class NotificationPageDesignTest extends TestCase
             'offset' => 0,
         ]);
 
-        $statusResponse->assertOk();
+        $testResponse->assertOk();
         $deliveryResponse->assertOk();
 
-        $statusHtml = (string) $statusResponse->json('html');
+        $statusHtml = (string) $testResponse->json('html');
         $deliveryHtml = (string) $deliveryResponse->json('html');
 
         $this->assertStringContainsString('data-notification-card="status_change"', $statusHtml);
         $this->assertStringContainsString('notification-card-accent', $statusHtml);
-        $this->assertStringContainsString('id="' . $statusNotification->id . '"', $statusHtml);
+        $this->assertStringContainsString('id="' . $monitoringNotification->id . '"', $statusHtml);
 
         $this->assertStringContainsString('data-notification-card="delivery_history"', $deliveryHtml);
         $this->assertStringContainsString('notification-card-accent', $deliveryHtml);
-        $this->assertStringContainsString('id="' . $delivery->id . '"', $deliveryHtml);
+        $this->assertStringContainsString('id="' . $notificationChannelDelivery->id . '"', $deliveryHtml);
         $this->assertStringContainsString('Webhook responded with HTTP 500.', $deliveryHtml);
     }
 }

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Enums\MonitoringStatus;
+use App\Enums\NotificationDeliveryStatus;
+use App\Enums\NotificationEventType;
+use App\Enums\NotificationType;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringResponse;
+use App\Models\NotificationChannelDelivery;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class NotificationPageDesignTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notifications_index_renders_professional_command_center_shell(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $testResponse = $this->actingAs($user)->get(route('notifications.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('id="notification-command-center"');
+        $testResponse->assertSeeText(__('notifications.overview.eyebrow'));
+        $testResponse->assertSeeText(__('notifications.overview.description'));
+        $testResponse->assertSeeText(__('notifications.loading.title'));
+        $testResponse->assertSeeText(__('notifications.empty_state.description'));
+        $testResponse->assertSeeHtml('data-notification-section="ssl_expiry"');
+        $testResponse->assertSeeHtml('data-notification-section="domain_expiry"');
+        $testResponse->assertSeeHtml('data-notification-section="status_change"');
+        $testResponse->assertSeeHtml('data-notification-section="delivery_history"');
+    }
+
+    public function test_async_notification_cards_use_redesigned_card_markup(): void
+    {
+        Date::setTestNow('2026-05-22 10:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+
+        $notification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'SSL_EXPIRING',
+            'read' => false,
+            'sent' => false,
+        ]);
+
+        $testResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::SSL_EXPIRY->value,
+            'offset' => 0,
+        ]);
+
+        $testResponse->assertOk();
+        $html = (string) $testResponse->json('html');
+
+        $this->assertStringContainsString('data-notification-card="ssl_expiry"', $html);
+        $this->assertStringContainsString('notification-card-accent', $html);
+        $this->assertStringContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $html);
+        $this->assertStringContainsString('id="' . $notification->id . '"', $html);
+        $this->assertStringContainsString('Checkout API', $html);
+    }
+
+    public function test_status_board_and_delivery_history_cards_use_redesigned_card_markup(): void
+    {
+        Date::setTestNow('2026-05-22 10:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Primary API',
+            'target' => 'https://primary.example.test',
+        ]);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'http_status_code' => 503,
+            'response_time' => 1200.0,
+        ]);
+
+        $statusNotification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => false,
+        ]);
+
+        $delivery = NotificationChannelDelivery::query()->forceCreate([
+            'user_id' => $user->id,
+            'monitoring_notification_id' => $statusNotification->id,
+            'channel' => 'slack',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::FAILED->value,
+            'payload' => [
+                'monitoring' => [
+                    'name' => $monitoring->name,
+                    'target' => $monitoring->target,
+                ],
+            ],
+            'error_message' => 'Webhook responded with HTTP 500.',
+        ]);
+
+        $statusResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => NotificationType::STATUS_CHANGE->value,
+            'offset' => 0,
+        ]);
+        $deliveryResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
+            'type' => 'delivery_history',
+            'offset' => 0,
+        ]);
+
+        $statusResponse->assertOk();
+        $deliveryResponse->assertOk();
+
+        $statusHtml = (string) $statusResponse->json('html');
+        $deliveryHtml = (string) $deliveryResponse->json('html');
+
+        $this->assertStringContainsString('data-notification-card="status_change"', $statusHtml);
+        $this->assertStringContainsString('notification-card-accent', $statusHtml);
+        $this->assertStringContainsString('id="' . $statusNotification->id . '"', $statusHtml);
+
+        $this->assertStringContainsString('data-notification-card="delivery_history"', $deliveryHtml);
+        $this->assertStringContainsString('notification-card-accent', $deliveryHtml);
+        $this->assertStringContainsString('id="' . $delivery->id . '"', $deliveryHtml);
+        $this->assertStringContainsString('Webhook responded with HTTP 500.', $deliveryHtml);
+    }
+}


### PR DESCRIPTION
## Summary

Redesigns the authenticated `/notifications` page so it feels like a production operations inbox instead of a beta list view.

- Adds a command-center header with clearer controls and workflow context.
- Restyles notification, status-board, and delivery-history cards with stronger visual hierarchy and corporate emerald accents.
- Improves loading and empty states.
- Adds English and German copy for the new sections.
- Adds feature coverage for the redesigned shell and async card markup.

## Validation

- `php artisan test tests/Feature/Notifications/NotificationPageDesignTest.php`
- `php artisan test tests/Feature/Notifications`
- `bun run build`
- Local browser check of `/notifications` with seeded sample notifications