### PR TITLE
Refine notifications header and mobile layout

### DIFF
--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -56,6 +56,11 @@ return [
     'empty_state' => [
         'description' => 'Ungelesene Meldungen, Ablaufwarnungen und Zustellereignisse erscheinen hier, sobald sie Aufmerksamkeit benötigen.',
     ],
+    'filters' => [
+        'heading' => 'Ansicht',
+        'unread' => 'Offen',
+        'all' => 'Alle',
+    ],
     'load_more' => 'Mehr laden',
     'mark_as_read' => 'Als gelesen markieren',
     'mark_all_as_read' => 'Alle als gelesen markieren',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -56,6 +56,11 @@ return [
     'empty_state' => [
         'description' => 'Unread alerts, expiry warnings, and delivery events will appear here as soon as they need attention.',
     ],
+    'filters' => [
+        'heading' => 'View',
+        'unread' => 'Open',
+        'all' => 'All',
+    ],
     'load_more' => 'Load More',
     'mark_as_read' => 'Mark as Read',
     'mark_all_as_read' => 'Mark all as read',

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -47,7 +47,7 @@
     @endphp
 
     <x-slot name="header">
-        <div id="notification-command-center" class="flex w-full flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+        <div id="notification-command-center" class="grid w-full gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,30rem)] lg:items-center">
             <div class="flex min-w-0 items-start gap-4">
                 <span class="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20">
                     <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
@@ -68,24 +68,34 @@
                 </div>
             </div>
 
-            <div class="flex w-full flex-col gap-3 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 sm:w-[30rem]">
-                <form method="POST" action="{{ route('notifications.markAllAsRead') }}" class="flex justify-end">
-                    @csrf
-                    <x-secondary-button type="submit" class="justify-center !border-slate-300 px-3 py-2 text-xs !normal-case !tracking-normal !text-slate-700 hover:!border-emerald-500 hover:!bg-emerald-50 hover:!text-emerald-700 dark:!border-slate-600 dark:!bg-slate-800 dark:!text-slate-100 dark:hover:!border-emerald-400 dark:hover:!bg-emerald-300/10 dark:hover:!text-emerald-300">
-                        <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
-                        </svg>
-                        {{ __('notifications.mark_all_as_read') }}
-                    </x-secondary-button>
-                </form>
+            <div id="notification-action-panel" class="rounded-xl border border-slate-200 bg-white/90 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                <div class="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+                    <div>
+                        <x-paragraph class="px-1 text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
+                            {{ __('notifications.filters.heading') }}
+                        </x-paragraph>
+                        <nav class="mt-2 grid grid-cols-2 rounded-lg bg-slate-100 p-1 text-sm font-semibold dark:bg-slate-800" aria-label="{{ __('notifications.filters.heading') }}">
+                            <a href="{{ route('notifications.index', $showReadDisabledQuery) }}"
+                                class="{{ ! $showRead ? 'bg-white text-emerald-700 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950 dark:text-emerald-300 dark:ring-slate-700' : 'text-slate-600 hover:text-slate-950 dark:text-slate-300 dark:hover:text-white' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
+                                {{ __('notifications.filters.unread') }}
+                            </a>
+                            <a href="{{ route('notifications.index', $showReadEnabledQuery) }}"
+                                class="{{ $showRead ? 'bg-white text-emerald-700 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950 dark:text-emerald-300 dark:ring-slate-700' : 'text-slate-600 hover:text-slate-950 dark:text-slate-300 dark:hover:text-white' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
+                                {{ __('notifications.filters.all') }}
+                            </a>
+                        </nav>
+                    </div>
 
-                <label for="show_read" class="inline-flex items-center gap-3 border-t border-slate-200 px-2 pt-3 text-sm font-medium text-slate-700 dark:border-slate-700 dark:text-slate-200">
-                    <input type="checkbox" id="show_read" name="show_read" value="1"
-                        class="shadow-xs focus:ring-3 rounded-sm border-slate-300 text-emerald-600 focus:border-emerald-400 focus:ring-emerald-200 focus:ring-opacity-70 dark:border-slate-600 dark:bg-slate-800"
-                        onchange="window.location.href = this.checked ? '{{ route('notifications.index', $showReadEnabledQuery) }}' : '{{ route('notifications.index', $showReadDisabledQuery) }}'"
-                        {{ $showRead ? 'checked' : '' }}>
-                    <span>{{ __('notifications.show_read_notifications') }}</span>
-                </label>
+                    <form method="POST" action="{{ route('notifications.markAllAsRead') }}" class="sm:pb-1">
+                        @csrf
+                        <x-secondary-button type="submit" class="!w-full justify-center !border-slate-300 px-3 py-2 text-sm !normal-case !tracking-normal !text-slate-700 hover:!border-emerald-500 hover:!bg-emerald-50 hover:!text-emerald-700 dark:!border-slate-600 dark:!bg-slate-800 dark:!text-slate-100 dark:hover:!border-emerald-400 dark:hover:!bg-emerald-300/10 dark:hover:!text-emerald-300 sm:!w-auto">
+                            <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
+                            </svg>
+                            {{ __('notifications.mark_all_as_read') }}
+                        </x-secondary-button>
+                    </form>
+                </div>
             </div>
         </div>
     </x-slot>
@@ -237,16 +247,18 @@
                 });
         }
     }" x-init="syncLimitWithUrl(currentLimit); loadInitialNotifications()" class="space-y-6">
-        <div class="grid grid-cols-1 gap-3 md:grid-cols-3" aria-label="{{ __('notifications.overview.workflow_label') }}">
+        <div class="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3" aria-label="{{ __('notifications.overview.workflow_label') }}">
             @foreach (['triage', 'expiry', 'audit'] as $workflowItem)
-                <div class="rounded-lg border border-slate-200 bg-white/75 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/50">
-                    <x-paragraph class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
-                        {{ __('notifications.overview.workflow.' . $workflowItem . '.label') }}
-                    </x-paragraph>
-                    <x-heading type="h3" class="mt-2 text-base font-semibold text-slate-950 dark:text-white">
-                        {{ __('notifications.overview.workflow.' . $workflowItem . '.title') }}
-                    </x-heading>
-                    <x-paragraph class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                <div class="rounded-lg border border-slate-200 bg-white/75 p-3 shadow-sm dark:border-slate-800 dark:bg-slate-900/50 sm:p-4">
+                    <div class="flex items-center justify-between gap-3 sm:block">
+                        <x-paragraph class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
+                            {{ __('notifications.overview.workflow.' . $workflowItem . '.label') }}
+                        </x-paragraph>
+                        <x-heading type="h3" class="text-right text-sm font-semibold text-slate-950 dark:text-white sm:mt-2 sm:text-left sm:text-base">
+                            {{ __('notifications.overview.workflow.' . $workflowItem . '.title') }}
+                        </x-heading>
+                    </div>
+                    <x-paragraph class="mt-1 hidden text-sm leading-6 text-slate-600 dark:text-slate-300 sm:block">
                         {{ __('notifications.overview.workflow.' . $workflowItem . '.description') }}
                     </x-paragraph>
                 </div>
@@ -283,7 +295,7 @@
             </div>
         </x-container>
 
-        <div x-cloak x-show="!isLoading && !isEmpty" class="space-y-10">
+        <div x-cloak x-show="!isLoading && !isEmpty" class="space-y-8 sm:space-y-10">
             @foreach ($notificationSections as $section)
                 <section class="notification-section" id="{{ $section['sectionId'] }}" data-notification-section="{{ $section['type'] }}" style="display: none;">
                     <div class="mb-4 flex flex-col gap-3 border-b border-slate-200 pb-4 dark:border-slate-800 sm:flex-row sm:items-end sm:justify-between">
@@ -327,7 +339,7 @@
                     <div id="{{ $section['containerId'] }}" class="space-y-3"></div>
 
                     <div class="mt-4 text-center" id="{{ $section['loadMoreContainerId'] }}" style="display: none;">
-                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!bg-emerald-600 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400">
+                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!w-full justify-center !bg-emerald-600 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400 sm:!w-auto">
                             {{ __('notifications.load_more') }}
                         </x-primary-button>
                     </div>

--- a/resources/views/notifications/partials/notification_list.blade.php
+++ b/resources/views/notifications/partials/notification_list.blade.php
@@ -51,7 +51,7 @@
             </div>
 
             @if (! $isRead)
-                <x-primary-button class="mark-as-read-button shrink-0 !bg-emerald-600 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400"
+                <x-primary-button class="mark-as-read-button shrink-0 !w-full justify-center !bg-emerald-600 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400 sm:!w-auto"
                     aria-label="{{ __('notifications.mark_as_read') }}"
                     @click="markAsRead(event, '{{ $notification->id }}', '{{ route('notifications.markAsRead', $notification) }}', '{{ $type }}')">
                     <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/resources/views/notifications/partials/status_board_list.blade.php
+++ b/resources/views/notifications/partials/status_board_list.blade.php
@@ -65,7 +65,7 @@
                 </div>
             </div>
 
-            <div class="flex shrink-0 flex-wrap items-center gap-2 lg:flex-col lg:items-end">
+            <div class="flex w-full shrink-0 flex-wrap items-center gap-2 lg:w-auto lg:flex-col lg:items-end">
                 <x-badge type="{{ $entry['badge_type'] }}"
                     title="{{ __('notifications.tooltips.latest_status', ['status' => $statusWithCode]) }}"
                     class="border border-black/10 px-3 py-1 text-sm dark:border-white/20">
@@ -81,7 +81,7 @@
                     {{ $statusLabel }}
                 </x-badge>
                 @if (! $isRead)
-                    <x-primary-button class="mark-as-read-button !bg-emerald-600 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400"
+                    <x-primary-button class="mark-as-read-button !w-full justify-center !bg-emerald-600 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400 sm:!w-auto"
                         aria-label="{{ __('notifications.mark_as_read') }}"
                         @click="markAsRead(event, '{{ $entry['notification_id'] }}', '{{ route('notifications.markAsRead', $entry['notification_id']) }}', 'status_change')">
                         <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -31,12 +31,15 @@ class NotificationPageDesignTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('id="notification-command-center"');
+        $testResponse->assertSeeHtml('id="notification-action-panel"');
         $testResponse->assertSeeText(__('notifications.overview.eyebrow'));
         $testResponse->assertSeeText(__('notifications.overview.description'));
-        $testResponse->assertSeeTextInOrder([
-            __('notifications.mark_all_as_read'),
-            __('notifications.show_read_notifications'),
-        ]);
+        $testResponse->assertSeeText(__('notifications.filters.heading'));
+        $testResponse->assertSeeText(__('notifications.filters.unread'));
+        $testResponse->assertSeeText(__('notifications.filters.all'));
+        $testResponse->assertSeeText(__('notifications.mark_all_as_read'));
+        $testResponse->assertSeeHtml('sm:grid-cols-[1fr_auto]');
+        $testResponse->assertSeeHtml('sm:grid-cols-3');
         $testResponse->assertSeeText(__('notifications.loading.title'));
         $testResponse->assertSeeText(__('notifications.empty_state.description'));
         $testResponse->assertSeeHtml('data-notification-section="ssl_expiry"');


### PR DESCRIPTION
## Summary

Refines the notifications page header and mobile experience after the initial redesign.

- Replaces the checkbox-style read filter with a clearer segmented view control for open vs. all notifications.
- Groups filters and the mark-all action into a responsive action panel that stays compact on desktop and full-width/tappable on mobile.
- Tightens the mobile workflow summary so it no longer pushes notifications far down the page.
- Makes notification and status-board action buttons full-width on small screens.
- Adds localized filter labels and updates the design test coverage.

## Validation

- `php artisan test tests/Feature/Notifications/NotificationPageDesignTest.php`
- `php artisan test tests/Feature/Notifications`
- `bun run build`
- Local browser QA at desktop width and 390px mobile viewport, including overflow and tap-target checks