### PR TITLE
Align notification action colors

### DIFF
--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -48,24 +48,16 @@
 
     <x-slot name="header">
         <div id="notification-command-center" class="grid w-full gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,30rem)] lg:items-center">
-            <div class="flex min-w-0 items-start gap-4">
-                <span class="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20">
-                    <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2a2 2 0 0 1-.6 1.4L4 17h5" />
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 17a3 3 0 1 1-6 0" />
-                    </svg>
-                </span>
-                <div class="min-w-0">
-                    <x-paragraph class="text-sm font-semibold uppercase tracking-[0.08em] text-emerald-700 dark:text-emerald-300">
-                        {{ __('notifications.overview.eyebrow') }}
-                    </x-paragraph>
-                    <x-heading type="h1" class="mt-1 text-slate-950 dark:text-white">
-                        {{ __('notifications.title') }}
-                    </x-heading>
-                    <x-paragraph class="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base">
-                        {{ __('notifications.overview.description') }}
-                    </x-paragraph>
-                </div>
+            <div class="min-w-0">
+                <x-paragraph class="text-sm font-semibold uppercase tracking-[0.08em] text-emerald-700 dark:text-emerald-300">
+                    {{ __('notifications.overview.eyebrow') }}
+                </x-paragraph>
+                <x-heading type="h1" class="mt-1 text-slate-950 dark:text-white">
+                    {{ __('notifications.title') }}
+                </x-heading>
+                <x-paragraph class="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base">
+                    {{ __('notifications.overview.description') }}
+                </x-paragraph>
             </div>
 
             <div id="notification-action-panel" class="rounded-xl border border-slate-200 bg-white/90 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
@@ -160,14 +152,6 @@
                 this.sslExpiryOffset = offset;
             }
         },
-        syncLimitWithUrl(limit) {
-            const parsedLimit = Number.parseInt(limit, 10);
-            const nextLimit = Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : 5;
-            const url = new URL(window.location.href);
-            url.searchParams.set('limit', String(nextLimit));
-            const query = url.searchParams.toString();
-            window.history.replaceState({}, '', query ? `${url.pathname}?${query}` : url.pathname);
-        },
         updateEmptyState() {
             this.isEmpty = this.$root.querySelectorAll('.notification-entry').length === 0;
         },
@@ -216,11 +200,6 @@
                     sectionElement.style.display = response.data.count > 0 ? '' : 'none';
                     loadMoreContainer.style.display = response.data.hasMore ? '' : 'none';
 
-                    if (!initial) {
-                        this.currentLimit = Math.max(this.currentLimit, nextOffset);
-                        this.syncLimitWithUrl(this.currentLimit);
-                    }
-
                     this.updateEmptyState();
                 });
         },
@@ -246,7 +225,7 @@
                     }
                 });
         }
-    }" x-init="syncLimitWithUrl(currentLimit); loadInitialNotifications()" class="space-y-6">
+    }" x-init="loadInitialNotifications()" class="space-y-6">
         <div class="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3" aria-label="{{ __('notifications.overview.workflow_label') }}">
             @foreach (['triage', 'expiry', 'audit'] as $workflowItem)
                 <div class="rounded-lg border border-slate-200 bg-white/75 p-3 shadow-sm dark:border-slate-800 dark:bg-slate-900/50 sm:p-4">

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -76,11 +76,11 @@
                         </x-paragraph>
                         <nav class="mt-2 grid grid-cols-2 rounded-lg bg-slate-100 p-1 text-sm font-semibold dark:bg-slate-800" aria-label="{{ __('notifications.filters.heading') }}">
                             <a href="{{ route('notifications.index', $showReadDisabledQuery) }}"
-                                class="{{ ! $showRead ? 'bg-white text-emerald-700 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950 dark:text-emerald-300 dark:ring-slate-700' : 'text-slate-600 hover:text-slate-950 dark:text-slate-300 dark:hover:text-white' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
+                                class="{{ ! $showRead ? 'bg-emerald-500 text-white shadow-sm ring-1 ring-emerald-600/20 dark:bg-emerald-400 dark:text-slate-950 dark:ring-emerald-300/30' : 'text-slate-600 hover:bg-white/70 hover:text-emerald-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-emerald-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
                                 {{ __('notifications.filters.unread') }}
                             </a>
                             <a href="{{ route('notifications.index', $showReadEnabledQuery) }}"
-                                class="{{ $showRead ? 'bg-white text-emerald-700 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950 dark:text-emerald-300 dark:ring-slate-700' : 'text-slate-600 hover:text-slate-950 dark:text-slate-300 dark:hover:text-white' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
+                                class="{{ $showRead ? 'bg-emerald-500 text-white shadow-sm ring-1 ring-emerald-600/20 dark:bg-emerald-400 dark:text-slate-950 dark:ring-emerald-300/30' : 'text-slate-600 hover:bg-white/70 hover:text-emerald-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-emerald-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
                                 {{ __('notifications.filters.all') }}
                             </a>
                         </nav>
@@ -88,7 +88,7 @@
 
                     <form method="POST" action="{{ route('notifications.markAllAsRead') }}" class="sm:pb-1">
                         @csrf
-                        <x-secondary-button type="submit" class="!w-full justify-center !border-slate-300 px-3 py-2 text-sm !normal-case !tracking-normal !text-slate-700 hover:!border-emerald-500 hover:!bg-emerald-50 hover:!text-emerald-700 dark:!border-slate-600 dark:!bg-slate-800 dark:!text-slate-100 dark:hover:!border-emerald-400 dark:hover:!bg-emerald-300/10 dark:hover:!text-emerald-300 sm:!w-auto">
+                        <x-secondary-button type="submit" class="!w-full justify-center !border-emerald-500 !bg-emerald-500 px-3 py-2 text-sm !normal-case !tracking-normal !text-white hover:!border-emerald-600 hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!border-emerald-400 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!border-emerald-300 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto">
                             <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
                             </svg>
@@ -339,7 +339,7 @@
                     <div id="{{ $section['containerId'] }}" class="space-y-3"></div>
 
                     <div class="mt-4 text-center" id="{{ $section['loadMoreContainerId'] }}" style="display: none;">
-                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!w-full justify-center !bg-emerald-600 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400 sm:!w-auto">
+                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!w-full justify-center !bg-emerald-500 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto">
                             {{ __('notifications.load_more') }}
                         </x-primary-button>
                     </div>

--- a/resources/views/notifications/partials/notification_list.blade.php
+++ b/resources/views/notifications/partials/notification_list.blade.php
@@ -6,11 +6,8 @@
             'status_change' => 'bg-emerald-500',
             default => 'bg-amber-500',
         };
-        $iconClasses = match ($type) {
-            'domain_expiry' => 'bg-sky-100 text-sky-700 ring-sky-200 dark:bg-sky-300/10 dark:text-sky-300 dark:ring-sky-300/20',
-            'status_change' => 'bg-emerald-100 text-emerald-700 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20',
-            default => 'bg-amber-100 text-amber-700 ring-amber-200 dark:bg-amber-300/10 dark:text-amber-300 dark:ring-amber-300/20',
-        };
+        $showCardIcon = $type === 'domain_expiry';
+        $iconClasses = 'bg-sky-100 text-sky-700 ring-sky-200 dark:bg-sky-300/10 dark:text-sky-300 dark:ring-sky-300/20';
     @endphp
 
     <x-container space="true"
@@ -20,20 +17,15 @@
         <span class="{{ $accentClasses }} notification-card-accent absolute inset-y-0 left-0 w-1" aria-hidden="true"></span>
 
         <div class="flex flex-col gap-4 pl-2 sm:flex-row sm:items-center sm:justify-between">
-            <div class="flex min-w-0 items-start gap-4">
-                <span class="{{ $iconClasses }} inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ring-1">
-                    @if ($type === 'domain_expiry')
+            <div class="flex min-w-0 items-start {{ $showCardIcon ? 'gap-4' : '' }}">
+                @if ($showCardIcon)
+                    <span class="{{ $iconClasses }} inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ring-1">
                         <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z" />
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3 12h18M12 3c2.5 2.4 2.5 15.6 0 18" />
                         </svg>
-                    @else
-                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 11V8a4 4 0 1 1 8 0v3" />
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M7 11h10v9H7z" />
-                        </svg>
-                    @endif
-                </span>
+                    </span>
+                @endif
 
                 <div class="min-w-0">
                     <x-paragraph bold=true class="{{ $isRead ? 'text-slate-500 dark:text-slate-400' : 'text-slate-950 dark:text-white' }} leading-6">

--- a/resources/views/notifications/partials/notification_list.blade.php
+++ b/resources/views/notifications/partials/notification_list.blade.php
@@ -51,7 +51,7 @@
             </div>
 
             @if (! $isRead)
-                <x-primary-button class="mark-as-read-button shrink-0 !w-full justify-center !bg-emerald-600 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400 sm:!w-auto"
+                <x-primary-button class="mark-as-read-button shrink-0 !w-full justify-center !bg-emerald-500 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto"
                     aria-label="{{ __('notifications.mark_as_read') }}"
                     @click="markAsRead(event, '{{ $notification->id }}', '{{ route('notifications.markAsRead', $notification) }}', '{{ $type }}')">
                     <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/resources/views/notifications/partials/status_board_list.blade.php
+++ b/resources/views/notifications/partials/status_board_list.blade.php
@@ -21,13 +21,7 @@
         <span class="notification-card-accent absolute inset-y-0 left-0 w-1 bg-emerald-500" aria-hidden="true"></span>
 
         <div class="flex flex-col gap-5 pl-2 lg:flex-row lg:items-start lg:justify-between">
-            <div class="flex min-w-0 items-start gap-4">
-                <span class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-300/10 dark:text-emerald-300 dark:ring-emerald-300/20">
-                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 12h4l3-6 4 12 2-6h3" />
-                    </svg>
-                </span>
-
+            <div class="flex min-w-0 items-start">
                 <div class="min-w-0">
                     <div class="flex flex-wrap items-center gap-2">
                         <x-heading type="h3" class="{{ $isRead ? 'text-slate-500 dark:text-slate-400' : 'text-slate-950 dark:text-white' }} truncate text-lg font-semibold">

--- a/resources/views/notifications/partials/status_board_list.blade.php
+++ b/resources/views/notifications/partials/status_board_list.blade.php
@@ -81,7 +81,7 @@
                     {{ $statusLabel }}
                 </x-badge>
                 @if (! $isRead)
-                    <x-primary-button class="mark-as-read-button !w-full justify-center !bg-emerald-600 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-emerald-700 focus:!bg-emerald-700 focus:!ring-emerald-500 dark:!bg-emerald-500 dark:hover:!bg-emerald-400 sm:!w-auto"
+                    <x-primary-button class="mark-as-read-button !w-full justify-center !bg-emerald-500 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto"
                         aria-label="{{ __('notifications.mark_as_read') }}"
                         @click="markAsRead(event, '{{ $entry['notification_id'] }}', '{{ route('notifications.markAsRead', $entry['notification_id']) }}', 'status_change')">
                         <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -32,6 +32,7 @@ class NotificationPageDesignTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('id="notification-command-center"');
         $testResponse->assertSeeHtml('id="notification-action-panel"');
+        $testResponse->assertDontSeeHtml('M15 17h5');
         $testResponse->assertSeeText(__('notifications.overview.eyebrow'));
         $testResponse->assertSeeText(__('notifications.overview.description'));
         $testResponse->assertSeeText(__('notifications.filters.heading'));
@@ -77,6 +78,7 @@ class NotificationPageDesignTest extends TestCase
 
         $this->assertStringContainsString('data-notification-card="ssl_expiry"', $html);
         $this->assertStringContainsString('notification-card-accent', $html);
+        $this->assertStringNotContainsString('inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ring-1', $html);
         $this->assertStringContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $html);
         $this->assertStringContainsString('!bg-emerald-500', $html);
         $this->assertStringContainsString('dark:!text-slate-950', $html);
@@ -142,6 +144,7 @@ class NotificationPageDesignTest extends TestCase
 
         $this->assertStringContainsString('data-notification-card="status_change"', $statusHtml);
         $this->assertStringContainsString('notification-card-accent', $statusHtml);
+        $this->assertStringNotContainsString('inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg', $statusHtml);
         $this->assertStringContainsString('id="' . $monitoringNotification->id . '"', $statusHtml);
 
         $this->assertStringContainsString('data-notification-card="delivery_history"', $deliveryHtml);

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -38,6 +38,9 @@ class NotificationPageDesignTest extends TestCase
         $testResponse->assertSeeText(__('notifications.filters.unread'));
         $testResponse->assertSeeText(__('notifications.filters.all'));
         $testResponse->assertSeeText(__('notifications.mark_all_as_read'));
+        $testResponse->assertSeeHtml('bg-emerald-500 text-white');
+        $testResponse->assertSeeHtml('dark:bg-emerald-400 dark:text-slate-950');
+        $testResponse->assertSeeHtml('dark:!bg-emerald-400 dark:!text-slate-950');
         $testResponse->assertSeeHtml('sm:grid-cols-[1fr_auto]');
         $testResponse->assertSeeHtml('sm:grid-cols-3');
         $testResponse->assertSeeText(__('notifications.loading.title'));
@@ -75,6 +78,8 @@ class NotificationPageDesignTest extends TestCase
         $this->assertStringContainsString('data-notification-card="ssl_expiry"', $html);
         $this->assertStringContainsString('notification-card-accent', $html);
         $this->assertStringContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $html);
+        $this->assertStringContainsString('!bg-emerald-500', $html);
+        $this->assertStringContainsString('dark:!text-slate-950', $html);
         $this->assertStringContainsString('id="' . $monitoringNotification->id . '"', $html);
         $this->assertStringContainsString('Checkout API', $html);
     }

--- a/tests/Feature/Notifications/NotificationPaginationStateTest.php
+++ b/tests/Feature/Notifications/NotificationPaginationStateTest.php
@@ -65,6 +65,8 @@ class NotificationPaginationStateTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSee('currentLimit: 6');
         $testResponse->assertSee('payload.limit = this.currentLimit');
+        $testResponse->assertDontSee('window.history.replaceState', false);
+        $testResponse->assertDontSee('syncLimitWithUrl', false);
 
         $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
             'type' => NotificationType::SSL_EXPIRY->value,

--- a/tests/Feature/Notifications/NotificationPaginationStateTest.php
+++ b/tests/Feature/Notifications/NotificationPaginationStateTest.php
@@ -65,8 +65,8 @@ class NotificationPaginationStateTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSee('currentLimit: 6');
         $testResponse->assertSee('payload.limit = this.currentLimit');
-        $testResponse->assertDontSee('window.history.replaceState', false);
-        $testResponse->assertDontSee('syncLimitWithUrl', false);
+        $testResponse->assertDontSeeHtml('window.history.replaceState');
+        $testResponse->assertDontSeeHtml('syncLimitWithUrl');
 
         $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
             'type' => NotificationType::SSL_EXPIRY->value,


### PR DESCRIPTION
## Summary
- align notification filter tabs and action buttons with the corporate emerald button palette
- remove the decorative header icon and the leading SSL/status-change card icons
- keep Load more fully async by no longer writing the derived `limit` value back into the URL
- add regression coverage for the icon removal and URL-stable async loading

## Validation
- `php artisan test tests/Feature/Notifications/NotificationPageDesignTest.php tests/Feature/Notifications/NotificationPaginationStateTest.php`
- `php artisan test tests/Feature/Notifications`
- `bun run build`
- `git diff --check`

## Browser QA
- Local `/notifications?limit=5` server was opened, but automated login in the in-app browser was blocked by the browser input/URL safety policy. The requested URL behavior is covered by the rendered markup regression asserting that the History API URL sync code is absent.
