### PR TITLE
test: cover read notification card states

### DIFF
--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -208,14 +208,18 @@ class NotificationPageDesignTest extends TestCase
         $domainHtml = (string) $testResponse->json('html');
         $statusHtml = (string) $statusResponse->json('html');
 
+        $this->assertStringContainsString('data-notification-card="domain_expiry"', $domainHtml);
         $this->assertStringContainsString('id="' . $monitoringNotification->id . '"', $domainHtml);
         $this->assertStringContainsString('opacity-70', $domainHtml);
         $this->assertStringContainsString(__('notifications.read'), $domainHtml);
         $this->assertStringNotContainsString('mark-as-read-button', $domainHtml);
+        $this->assertStringNotContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $domainHtml);
 
+        $this->assertStringContainsString('data-notification-card="status_change"', $statusHtml);
         $this->assertStringContainsString('id="' . $statusNotification->id . '"', $statusHtml);
         $this->assertStringContainsString('opacity-70', $statusHtml);
         $this->assertStringContainsString(__('notifications.read'), $statusHtml);
         $this->assertStringNotContainsString('mark-as-read-button', $statusHtml);
+        $this->assertStringNotContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $statusHtml);
     }
 }


### PR DESCRIPTION
## Summary
- add focused coverage for read regular notification cards
- add focused coverage for read status-board notification cards
- assert muted markup and absence of mark-as-read actions

## Tests
- php artisan test tests/Feature/Notifications/NotificationPageDesignTest.php
- ./vendor/bin/pint tests/Feature/Notifications/NotificationPageDesignTest.php

Note: composer install required --ignore-platform-req=ext-redis locally because the PHP Redis extension is not installed in this shell.