### PR TITLE
Fix notification filter limit persistence

### DIFF
--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -67,11 +67,11 @@
                             {{ __('notifications.filters.heading') }}
                         </x-paragraph>
                         <nav class="mt-2 grid grid-cols-2 rounded-lg bg-slate-100 p-1 text-sm font-semibold dark:bg-slate-800" aria-label="{{ __('notifications.filters.heading') }}">
-                            <a href="{{ route('notifications.index', $showReadDisabledQuery) }}"
+                            <a href="{{ route('notifications.index', $showReadDisabledQuery) }}" data-notification-filter-link
                                 class="{{ ! $showRead ? 'bg-emerald-500 text-white shadow-sm ring-1 ring-emerald-600/20 dark:bg-emerald-400 dark:text-slate-950 dark:ring-emerald-300/30' : 'text-slate-600 hover:bg-white/70 hover:text-emerald-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-emerald-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
                                 {{ __('notifications.filters.unread') }}
                             </a>
-                            <a href="{{ route('notifications.index', $showReadEnabledQuery) }}"
+                            <a href="{{ route('notifications.index', $showReadEnabledQuery) }}" data-notification-filter-link
                                 class="{{ $showRead ? 'bg-emerald-500 text-white shadow-sm ring-1 ring-emerald-600/20 dark:bg-emerald-400 dark:text-slate-950 dark:ring-emerald-300/30' : 'text-slate-600 hover:bg-white/70 hover:text-emerald-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-emerald-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
                                 {{ __('notifications.filters.all') }}
                             </a>
@@ -159,6 +159,11 @@
             url.searchParams.set('limit', String(nextLimit));
             const query = url.searchParams.toString();
             window.history.replaceState({}, '', query ? `${url.pathname}?${query}` : url.pathname);
+            document.querySelectorAll('[data-notification-filter-link]').forEach((link) => {
+                const linkUrl = new URL(link.href);
+                linkUrl.searchParams.set('limit', String(nextLimit));
+                link.href = linkUrl.toString();
+            });
         },
         updateEmptyState() {
             this.isEmpty = this.$root.querySelectorAll('.notification-entry').length === 0;

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -152,6 +152,14 @@
                 this.sslExpiryOffset = offset;
             }
         },
+        syncLimitWithUrl(limit) {
+            const parsedLimit = Number.parseInt(limit, 10);
+            const nextLimit = Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : 5;
+            const url = new URL(window.location.href);
+            url.searchParams.set('limit', String(nextLimit));
+            const query = url.searchParams.toString();
+            window.history.replaceState({}, '', query ? `${url.pathname}?${query}` : url.pathname);
+        },
         updateEmptyState() {
             this.isEmpty = this.$root.querySelectorAll('.notification-entry').length === 0;
         },
@@ -200,6 +208,11 @@
                     sectionElement.style.display = response.data.count > 0 ? '' : 'none';
                     loadMoreContainer.style.display = response.data.hasMore ? '' : 'none';
 
+                    if (!initial) {
+                        this.currentLimit = Math.max(this.currentLimit, nextOffset);
+                        this.syncLimitWithUrl(this.currentLimit);
+                    }
+
                     this.updateEmptyState();
                 });
         },
@@ -225,7 +238,7 @@
                     }
                 });
         }
-    }" x-init="loadInitialNotifications()" class="space-y-6">
+    }" x-init="syncLimitWithUrl(currentLimit); loadInitialNotifications()" class="space-y-6">
         <div class="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3" aria-label="{{ __('notifications.overview.workflow_label') }}">
             @foreach (['triage', 'expiry', 'audit'] as $workflowItem)
                 <div class="rounded-lg border border-slate-200 bg-white/75 p-3 shadow-sm dark:border-slate-800 dark:bg-slate-900/50 sm:p-4">

--- a/tests/Feature/Notifications/NotificationPaginationStateTest.php
+++ b/tests/Feature/Notifications/NotificationPaginationStateTest.php
@@ -65,8 +65,8 @@ class NotificationPaginationStateTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSee('currentLimit: 6');
         $testResponse->assertSee('payload.limit = this.currentLimit');
-        $testResponse->assertDontSeeHtml('window.history.replaceState');
-        $testResponse->assertDontSeeHtml('syncLimitWithUrl');
+        $testResponse->assertSeeHtml('window.history.replaceState');
+        $testResponse->assertSeeHtml('syncLimitWithUrl(currentLimit)');
 
         $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
             'type' => NotificationType::SSL_EXPIRY->value,

--- a/tests/Feature/Notifications/NotificationPaginationStateTest.php
+++ b/tests/Feature/Notifications/NotificationPaginationStateTest.php
@@ -67,6 +67,8 @@ class NotificationPaginationStateTest extends TestCase
         $testResponse->assertSee('payload.limit = this.currentLimit');
         $testResponse->assertSeeHtml('window.history.replaceState');
         $testResponse->assertSeeHtml('syncLimitWithUrl(currentLimit)');
+        $testResponse->assertSeeHtml('data-notification-filter-link');
+        $testResponse->assertSeeHtml("document.querySelectorAll('[data-notification-filter-link]')");
 
         $sectionResponse = $this->actingAs($user)->postJson(route('notifications.loadMore'), [
             'type' => NotificationType::SSL_EXPIRY->value,


### PR DESCRIPTION
## Summary
- keep notification filter links in sync when the loaded notification limit changes
- cover the filter link sync hooks in the pagination state test

## Tests
- php artisan test tests/Feature/Notifications/NotificationPaginationStateTest.php
- php artisan test tests/Feature/Notifications/NotificationPageDesignTest.php

Note: local Composer dependency install required --ignore-platform-req=ext-redis because PHP lacks ext-redis.