### PR TITLE
Optimize uptime range aggregation

### DIFF
--- a/app/Services/MonitoringAvailabilityService.php
+++ b/app/Services/MonitoringAvailabilityService.php
@@ -8,7 +8,6 @@ use App\Data\MonitoringAvailabilityPayload;
 use App\Data\MonitoringAvailabilitySegmentPayload;
 use App\Enums\MonitoringStatus;
 use App\Models\Monitoring;
-use App\Models\MonitoringDailyResult;
 use App\Support\MonitoringResponseHistory;
 use Carbon\Carbon;
 use Illuminate\Contracts\Database\Query\Builder;
@@ -117,6 +116,7 @@ class MonitoringAvailabilityService
 
         $dailyResults = $monitoring->dailyResults()
             ->whereBetween('date', [$globalStartDate->toDateString(), $endDate->toDateString()])
+            ->orderByDesc('date')
             ->get([
                 'date',
                 'uptime_minutes',
@@ -128,29 +128,54 @@ class MonitoringAvailabilityService
                 'incidents_count',
             ]);
 
+        $rollingTotals = [
+            'uptime_minutes' => 0,
+            'downtime_minutes' => 0,
+            'unknown_minutes' => 0,
+            'uptime_total' => 0,
+            'downtime_total' => 0,
+            'unknown_total' => 0,
+            'incidents_count' => 0,
+        ];
+        $dailyResultIndex = 0;
+        $dailyResultCount = $dailyResults->count();
+
         return $normalizedDays
-            ->mapWithKeys(function (int $day) use ($dailyResults, $endDate, $now, $trackingStartedAt): array {
+            ->mapWithKeys(function (int $day) use ($dailyResults, $dailyResultCount, &$dailyResultIndex, &$rollingTotals, $endDate, $now, $trackingStartedAt): array {
                 $startDate = $now->copy()->subDays($day)->startOfDay();
                 $startDateString = $startDate->toDateString();
-                $endDateString = $endDate->toDateString();
 
-                $rangeRows = $dailyResults->filter(
-                    static fn (MonitoringDailyResult $monitoringDailyResult): bool => $monitoringDailyResult->date >= $startDateString
-                        && $monitoringDailyResult->date <= $endDateString
-                );
+                while ($dailyResultIndex < $dailyResultCount) {
+                    $dailyResult = $dailyResults[$dailyResultIndex];
+                    $dailyResultDate = $dailyResult->date->toDateString();
+
+                    if ($dailyResultDate < $startDateString) {
+                        break;
+                    }
+
+                    $rollingTotals['uptime_minutes'] += (int) $dailyResult->uptime_minutes;
+                    $rollingTotals['downtime_minutes'] += (int) $dailyResult->downtime_minutes;
+                    $rollingTotals['unknown_minutes'] += (int) $dailyResult->unknown_minutes;
+                    $rollingTotals['uptime_total'] += (int) $dailyResult->uptime_total;
+                    $rollingTotals['downtime_total'] += (int) $dailyResult->downtime_total;
+                    $rollingTotals['unknown_total'] += (int) $dailyResult->unknown_total;
+                    $rollingTotals['incidents_count'] += (int) $dailyResult->incidents_count;
+
+                    $dailyResultIndex++;
+                }
 
                 return [
                     (string) $day => $this->buildStats(
                         $startDate,
                         $endDate,
                         $trackingStartedAt,
-                        (int) $rangeRows->sum('uptime_minutes'),
-                        (int) $rangeRows->sum('downtime_minutes'),
-                        (int) $rangeRows->sum('unknown_minutes'),
-                        (int) $rangeRows->sum('uptime_total'),
-                        (int) $rangeRows->sum('downtime_total'),
-                        (int) $rangeRows->sum('unknown_total'),
-                        (int) $rangeRows->sum('incidents_count')
+                        $rollingTotals['uptime_minutes'],
+                        $rollingTotals['downtime_minutes'],
+                        $rollingTotals['unknown_minutes'],
+                        $rollingTotals['uptime_total'],
+                        $rollingTotals['downtime_total'],
+                        $rollingTotals['unknown_total'],
+                        $rollingTotals['incidents_count']
                     ),
                 ];
             })

--- a/tests/Unit/Services/MonitoringAvailabilityServiceTest.php
+++ b/tests/Unit/Services/MonitoringAvailabilityServiceTest.php
@@ -14,6 +14,7 @@ use App\Models\Package;
 use App\Models\User;
 use App\Services\MonitoringAvailabilityService;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class MonitoringAvailabilityServiceTest extends TestCase
@@ -71,20 +72,27 @@ class MonitoringAvailabilityServiceTest extends TestCase
             'created_at' => Date::now()->subDays(30),
         ]);
 
-        foreach (range(1, 10) as $daysAgo) {
+        foreach (range(1, 30) as $daysAgo) {
             $this->createDailyResult($monitoring, Date::now()->subDays($daysAgo)->toDateString());
         }
 
-        $statsByRange = resolve(MonitoringAvailabilityService::class)->getUptimeDowntimesForRanges($monitoring, [7, 10]);
+        DB::enableQueryLog();
+
+        $statsByRange = resolve(MonitoringAvailabilityService::class)->getUptimeDowntimesForRanges($monitoring, [7, 10, 30]);
 
         $this->assertInstanceOf(MonitoringAvailabilityPayload::class, $statsByRange['7']);
         $this->assertInstanceOf(MonitoringAvailabilityPayload::class, $statsByRange['10']);
+        $this->assertInstanceOf(MonitoringAvailabilityPayload::class, $statsByRange['30']);
         $this->assertSame(700, $statsByRange['7']->uptime->minutes);
         $this->assertSame(70, $statsByRange['7']->downtime->minutes);
         $this->assertSame(7, $statsByRange['7']->downtime->incidentsCount);
         $this->assertSame(1_000, $statsByRange['10']->uptime->minutes);
         $this->assertSame(100, $statsByRange['10']->downtime->minutes);
         $this->assertSame(10, $statsByRange['10']->downtime->incidentsCount);
+        $this->assertSame(3_000, $statsByRange['30']->uptime->minutes);
+        $this->assertSame(300, $statsByRange['30']->downtime->minutes);
+        $this->assertSame(30, $statsByRange['30']->downtime->incidentsCount);
+        $this->assertCount(2, DB::getQueryLog());
     }
 
     private function createResponse(Monitoring $monitoring, MonitoringStatus $monitoringStatus, string $checkedAt): void


### PR DESCRIPTION
## Summary
- optimize multi-range uptime aggregation by ordering daily rows once and accumulating rolling totals
- expand service coverage for 7/10/30-day aggregate totals
- assert the aggregate summary path remains at 2 database queries

## Verification
- vendor/bin/pint app/Services/MonitoringAvailabilityService.php tests/Unit/Services/MonitoringAvailabilityServiceTest.php
- php artisan test tests/Unit/Services/MonitoringAvailabilityServiceTest.php