### PR TITLE
Add embeddable SLA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WebGuard is an open-source monitoring core built with Laravel 13. It provides th
 - Tracks uptime, response times, expected HTTP status ranges, expected DNS records, SSL expiry, and domain expiry.
 - Monitors heartbeats and cron jobs through private ping URLs.
 - Sends in-app, configurable, expiry, status-change, and weekly digest notifications.
-- Provides dashboards, public status pages, an embeddable widget, and a REST API.
+- Provides dashboards, public status pages, embeddable widgets, SLA badges, and a REST API.
 - Supports a global language switch across public and authenticated navigation.
 
 ## Quick Start

--- a/app/Data/MonitoringWidgetPayload.php
+++ b/app/Data/MonitoringWidgetPayload.php
@@ -18,7 +18,15 @@ final readonly class MonitoringWidgetPayload implements JsonSerializable
         public ?string $checkedAt,
         public ?string $checkedAtHuman,
         public MonitoringWidgetUptimePayload $uptime,
-        public string $publicUrl
+        public string $publicUrl,
+        /** @var array{30_days: int, 90_days: int, 365_days: int} */
+        public array $incidents,
+        /** @var array{valid: bool|null, expires_at: string|null} */
+        public array $ssl,
+        /** @var array{valid: bool|null, expires_at: string|null} */
+        public array $domain,
+        /** @var array{active: bool, starts_at: string|null, ends_at: string|null} */
+        public array $maintenance
     ) {}
 
     /**
@@ -37,6 +45,10 @@ final readonly class MonitoringWidgetPayload implements JsonSerializable
             'checked_at_human' => $this->checkedAtHuman,
             'uptime' => $this->uptime->toArray(),
             'public_url' => $this->publicUrl,
+            'incidents' => $this->incidents,
+            'ssl' => $this->ssl,
+            'domain' => $this->domain,
+            'maintenance' => $this->maintenance,
         ];
     }
 

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -358,7 +358,25 @@ class ApiController extends Controller
      *     "30_days": 99.9,
      *     "365_days": 99.1
      *   },
-     *   "public_url": "https://example.com/label/01H..."
+     *   "public_url": "https://example.com/label/01H...",
+     *   "incidents": {
+     *     "30_days": 0,
+     *     "90_days": 1,
+     *     "365_days": 2
+     *   },
+     *   "ssl": {
+     *     "valid": true,
+     *     "expires_at": "2026-08-01T00:00:00+00:00"
+     *   },
+     *   "domain": {
+     *     "valid": true,
+     *     "expires_at": "2027-02-01T00:00:00+00:00"
+     *   },
+     *   "maintenance": {
+     *     "active": false,
+     *     "starts_at": null,
+     *     "ends_at": null
+     *   }
      * }
      */
     public function widget(

--- a/app/Services/MonitoringWidgetPayloadService.php
+++ b/app/Services/MonitoringWidgetPayloadService.php
@@ -26,6 +26,7 @@ class MonitoringWidgetPayloadService
         $status = (string) ($statusSince['status'] ?? 'unknown');
         $checkedAt = $statusNow['checked_at'] ?? null;
         $uptimePercentages = $this->resolveUptimePercentages($monitoring, [7, 30, 365]);
+        $incidentCounts = $this->resolveIncidentCounts($monitoring, [30, 90, 365]);
 
         return new MonitoringWidgetPayload(
             name: $monitoring->name,
@@ -41,7 +42,25 @@ class MonitoringWidgetPayloadService
                 thirtyDays: $uptimePercentages[30] ?? null,
                 year: $uptimePercentages[365] ?? null
             ),
-            publicUrl: route('public-label', $monitoring)
+            publicUrl: route('public-label', $monitoring),
+            incidents: [
+                '30_days' => $incidentCounts[30] ?? 0,
+                '90_days' => $incidentCounts[90] ?? 0,
+                '365_days' => $incidentCounts[365] ?? 0,
+            ],
+            ssl: [
+                'valid' => $monitoring->sslResult?->is_valid,
+                'expires_at' => $monitoring->sslResult?->expires_at?->toIso8601String(),
+            ],
+            domain: [
+                'valid' => $monitoring->domainResult?->is_valid,
+                'expires_at' => $monitoring->domainResult?->expires_at?->toIso8601String(),
+            ],
+            maintenance: [
+                'active' => $monitoring->isUnderMaintenance(),
+                'starts_at' => $monitoring->maintenance_from?->toIso8601String(),
+                'ends_at' => $monitoring->maintenance_until?->toIso8601String(),
+            ]
         );
     }
 
@@ -74,6 +93,26 @@ class MonitoringWidgetPayloadService
         return collect($days)
             ->mapWithKeys(fn (int $day): array => [
                 $day => data_get($statsByRange, $day . '.uptime.percentage'),
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  array<int, int>  $days
+     * @return array<int, int>
+     */
+    private function resolveIncidentCounts(Monitoring $monitoring, array $days): array
+    {
+        $oldestRange = max($days);
+        $incidents = $monitoring->incidents()
+            ->where('down_at', '>=', Date::now()->subDays($oldestRange))
+            ->get(['down_at']);
+
+        return collect($days)
+            ->mapWithKeys(fn (int $day): array => [
+                $day => $incidents
+                    ->filter(fn ($incident): bool => $incident->down_at->greaterThanOrEqualTo(Date::now()->subDays($day)))
+                    ->count(),
             ])
             ->all();
     }

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,7 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 - **Real-time dashboard:** visualize monitoring data with statistics and charts.
 - **Admin panel:** manage users, subscription packages, and API usage logs.
 - **REST API:** access monitoring data programmatically and integrate WebGuard with external systems.
-- **Embeddable widget:** display website monitoring status on external sites with a JavaScript widget.
+- **Embeddable widget and SLA badge:** display website monitoring status on external sites with a JavaScript widget or compact SLA badge that shows live status, uptime proof, and public trust context.
 - **Public status pages:** publish monitoring status, uptime, recent incidents, and active or upcoming maintenance windows for users and customers.
 - **Global language switch:** switch between supported languages from both public and authenticated top navigation.
 - **Landing navigation anchors:** landing-page menu links resolve correctly to homepage sections, even when clicked from other routes.

--- a/public/js/badge.js
+++ b/public/js/badge.js
@@ -1,0 +1,261 @@
+(() => {
+    const containers = Array.from(new Set([
+        ...document.querySelectorAll('[data-webguard-sla-badge]'),
+        ...document.querySelectorAll('#webguard-sla-badge'),
+    ]));
+
+    if (containers.length === 0) {
+        console.error('WebGuard SLA Badge: No badge container found.');
+        return;
+    }
+
+    const scriptSource = document.currentScript?.src;
+
+    if (!scriptSource) {
+        console.error('WebGuard SLA Badge: Unable to determine the badge script source.');
+        return;
+    }
+
+    const appBaseUrl = new URL(scriptSource);
+
+    if (!document.getElementById('webguard-sla-badge-styles')) {
+        const style = document.createElement('style');
+        style.id = 'webguard-sla-badge-styles';
+        style.textContent = `
+            .wg-sla-badge {
+                box-sizing: border-box;
+                display: inline-flex;
+                align-items: center;
+                gap: 10px;
+                max-width: 100%;
+                border: 1px solid #d7dde8;
+                border-radius: 999px;
+                background: #ffffff;
+                color: #172033;
+                font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+                font-size: 13px;
+                line-height: 1.25;
+                padding: 8px 12px;
+                text-decoration: none;
+                box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+            }
+            .wg-sla-badge:hover {
+                border-color: #aeb8c9;
+            }
+            .wg-sla-regular {
+                border-radius: 12px;
+                align-items: flex-start;
+                flex-direction: column;
+                min-width: 240px;
+                padding: 12px;
+            }
+            .wg-sla-dark {
+                border-color: #334155;
+                background: #111827;
+                color: #f8fafc;
+                box-shadow: 0 6px 18px rgba(15, 23, 42, 0.24);
+            }
+            @media (prefers-color-scheme: dark) {
+                .wg-sla-auto {
+                    border-color: #334155;
+                    background: #111827;
+                    color: #f8fafc;
+                    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.24);
+                }
+            }
+            .wg-sla-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                min-width: 0;
+            }
+            .wg-sla-main {
+                font-weight: 700;
+                white-space: nowrap;
+            }
+            .wg-sla-meta {
+                color: #64748b;
+                white-space: nowrap;
+            }
+            .wg-sla-dark .wg-sla-meta {
+                color: #cbd5e1;
+            }
+            @media (prefers-color-scheme: dark) {
+                .wg-sla-auto .wg-sla-meta {
+                    color: #cbd5e1;
+                }
+            }
+            .wg-sla-dot {
+                width: 9px;
+                height: 9px;
+                border-radius: 999px;
+                flex: 0 0 auto;
+                background: #94a3b8;
+            }
+            .wg-sla-status-up .wg-sla-dot,
+            .wg-sla-status-success .wg-sla-dot {
+                background: #10b981;
+            }
+            .wg-sla-status-down .wg-sla-dot,
+            .wg-sla-status-danger .wg-sla-dot {
+                background: #ef4444;
+            }
+            .wg-sla-status-maintenance .wg-sla-dot,
+            .wg-sla-status-warning .wg-sla-dot {
+                background: #f59e0b;
+            }
+            .wg-sla-brand {
+                color: #475569;
+                font-size: 11px;
+                font-weight: 600;
+                white-space: nowrap;
+            }
+            .wg-sla-dark .wg-sla-brand {
+                color: #e2e8f0;
+            }
+            @media (prefers-color-scheme: dark) {
+                .wg-sla-auto .wg-sla-brand {
+                    color: #e2e8f0;
+                }
+            }
+            .wg-sla-details {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 6px 10px;
+                color: #64748b;
+                font-size: 12px;
+            }
+            .wg-sla-dark .wg-sla-details {
+                color: #cbd5e1;
+            }
+            @media (prefers-color-scheme: dark) {
+                .wg-sla-auto .wg-sla-details {
+                    color: #cbd5e1;
+                }
+            }
+            .wg-sla-error {
+                color: #b91c1c;
+                font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+                font-size: 13px;
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    const allowedRanges = new Set(['30', '90', '365']);
+    const formatUptime = (value) => typeof value === 'number' ? `${value.toFixed(2)}% uptime` : 'No uptime data';
+    const normalizeStatusTone = (data) => {
+        if (data.status_identifier === 'status.maintenance' || data.maintenance?.active) {
+            return 'maintenance';
+        }
+
+        return typeof data.status === 'string' ? data.status : 'unknown';
+    };
+    const statusLabel = (data) => {
+        if (data.status_identifier === 'status.maintenance' || data.maintenance?.active) {
+            return 'Maintenance';
+        }
+
+        return typeof data.status_label === 'string' ? data.status_label : 'UNKNOWN';
+    };
+
+    const appendText = (parent, className, text) => {
+        const element = document.createElement('span');
+        element.className = className;
+        element.textContent = text;
+        parent.appendChild(element);
+
+        return element;
+    };
+
+    const renderBadge = (container, data) => {
+        const range = allowedRanges.has(container.dataset.range) ? container.dataset.range : '90';
+        const theme = ['light', 'dark', 'auto'].includes(container.dataset.theme) ? container.dataset.theme : 'auto';
+        const size = container.dataset.size === 'regular' ? 'regular' : 'compact';
+        const layout = container.dataset.layout === 'rich' ? 'rich' : 'badge';
+        const uptimeKey = `${range}_days`;
+        const uptime = data.uptime?.[uptimeKey];
+        const incidentsCount = data.incidents?.[uptimeKey];
+        const checkedAt = data.checked_at_human ?? 'No checks yet';
+
+        const badge = document.createElement('a');
+        badge.className = [
+            'wg-sla-badge',
+            `wg-sla-${theme}`,
+            `wg-sla-${size}`,
+            `wg-sla-status-${normalizeStatusTone(data)}`,
+        ].join(' ');
+        badge.href = data.public_url ?? appBaseUrl.origin;
+        badge.target = '_blank';
+        badge.rel = 'noopener noreferrer';
+        badge.setAttribute('aria-label', `${data.name ?? 'WebGuard monitor'} SLA status`);
+
+        const row = document.createElement('span');
+        row.className = 'wg-sla-row';
+        appendText(row, 'wg-sla-dot', '');
+        appendText(row, 'wg-sla-main', `${statusLabel(data)} · ${formatUptime(uptime)}`);
+        appendText(row, 'wg-sla-meta', `${range} days`);
+        badge.appendChild(row);
+
+        if (layout === 'rich' || size === 'regular') {
+            const details = document.createElement('span');
+            details.className = 'wg-sla-details';
+            appendText(details, '', `Last checked ${checkedAt}`);
+
+            if (typeof incidentsCount === 'number') {
+                appendText(details, '', incidentsCount === 0 ? `0 incidents in ${range} days` : `${incidentsCount} incidents in ${range} days`);
+            }
+
+            if (data.ssl?.expires_at) {
+                appendText(details, '', `SSL valid until ${new Date(data.ssl.expires_at).toLocaleDateString()}`);
+            }
+
+            if (data.domain?.expires_at) {
+                appendText(details, '', `Domain valid until ${new Date(data.domain.expires_at).toLocaleDateString()}`);
+            }
+
+            badge.appendChild(details);
+        }
+
+        appendText(badge, 'wg-sla-brand', 'Verified by WebGuard');
+        container.replaceChildren(badge);
+    };
+
+    const renderError = (container) => {
+        const error = document.createElement('span');
+        error.className = 'wg-sla-error';
+        error.textContent = 'WebGuard SLA Badge unavailable.';
+        container.replaceChildren(error);
+    };
+
+    const fetchAndRender = (container) => {
+        const monitoringId = container.dataset.monitoring;
+
+        if (!monitoringId) {
+            console.error("WebGuard SLA Badge: 'data-monitoring' attribute is missing.");
+            renderError(container);
+            return;
+        }
+
+        const apiUrl = new URL(`/api/public/monitorings/${encodeURIComponent(monitoringId)}/widget`, appBaseUrl).toString();
+
+        fetch(apiUrl)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                return response.json();
+            })
+            .then(data => renderBadge(container, data))
+            .catch(error => {
+                console.error('WebGuard SLA Badge: Error fetching data:', error);
+                renderError(container);
+            });
+    };
+
+    containers.forEach(container => {
+        fetchAndRender(container);
+        setInterval(() => fetchAndRender(container), 300000);
+    });
+})();

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -156,6 +156,11 @@ return [
             'description' => 'Betten Sie ein Live-Überwachungs-Widget auf Ihrer Website oder Ihrem Dashboard ein.',
             'copy_button' => 'Snippet kopieren',
         ],
+        'sla_badge' => [
+            'heading' => 'SLA-Badge einbetten',
+            'description' => 'Zeigen Sie ein kompaktes öffentliches Vertrauens-Badge mit Live-Status, Uptime, Incident-Anzahl und Link zum öffentlichen Monitoring-Label.',
+            'snippet_help' => 'Platzieren Sie dieses Snippet auf Ihrer Website, im Footer, im Kundenportal oder in einer Statusübersicht. Das Badge ist nur öffentlich, solange das Public Label aktiviert ist.',
+        ],
         'heartbeat' => [
             'heading' => 'Heartbeat-Konfiguration',
             'ping_url' => 'Ping-URL',

--- a/resources/lang/de/welcome.php
+++ b/resources/lang/de/welcome.php
@@ -127,8 +127,8 @@ return [
         ],
         'embeddable_widget' => [
             'badge' => 'Embed',
-            'title' => 'Einbettbares Status-Widget',
-            'text' => 'Binden Sie ein schlankes JavaScript-Widget in externe Websites oder Dashboards ein, damit Besucher den Live-Status dort sehen, wo sie arbeiten.',
+            'title' => 'Einbettbares Status-Widget und SLA-Badge',
+            'text' => 'Binden Sie ein schlankes JavaScript-Widget oder kompaktes SLA-Badge in externe Websites, Dashboards, Footer und Kundenportale ein, damit Besucher Live-Status und Uptime-Nachweis dort sehen, wo sie arbeiten.',
         ],
         'rest_api' => [
             'badge' => 'API',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -156,6 +156,11 @@ return [
             'description' => 'Embed a live monitoring widget on your website or dashboard.',
             'copy_button' => 'Copy Snippet',
         ],
+        'sla_badge' => [
+            'heading' => 'Embed SLA Badge',
+            'description' => 'Show a compact public trust badge with live status, uptime, incident count, and a link to the public monitoring label.',
+            'snippet_help' => 'Place this snippet on your website, footer, customer portal, or status overview. The badge is public only while the public label is enabled.',
+        ],
         'heartbeat' => [
             'heading' => 'Heartbeat Configuration',
             'ping_url' => 'Ping URL',

--- a/resources/lang/en/welcome.php
+++ b/resources/lang/en/welcome.php
@@ -127,8 +127,8 @@ return [
         ],
         'embeddable_widget' => [
             'badge' => 'Embed',
-            'title' => 'Embeddable Status Widget',
-            'text' => 'Add a lightweight JavaScript widget to external sites or dashboards so visitors can see live monitoring status where they already work.',
+            'title' => 'Embeddable Status Widget and SLA Badge',
+            'text' => 'Add a lightweight JavaScript widget or compact SLA badge to external sites, dashboards, footers, and customer portals so visitors can see live status and uptime proof where they already work.',
         ],
         'rest_api' => [
             'badge' => 'API',

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -338,6 +338,19 @@
 &lt;script src="{{ route('widget.js') }}"&gt;&lt;/script&gt;</code></pre>
                     </div>
                 </div>
+
+                <div class="mt-4">
+                    <x-input-label for="sla-badge-snippet" :value="__('monitoring.detail.sla_badge.heading')" />
+                    <x-paragraph
+                        class="text-sm text-gray-600 dark:text-gray-400">{{ __('monitoring.detail.sla_badge.description') }}</x-paragraph>
+                    <x-paragraph
+                        class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('monitoring.detail.sla_badge.snippet_help') }}</x-paragraph>
+                    <div class="mt-2 flex items-center space-x-2">
+                        <pre id="sla-badge-snippet"
+                            class="flex-grow overflow-auto rounded-md border-gray-300 bg-gray-100 p-2 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-500 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"><code>&lt;div data-webguard-sla-badge data-monitoring="{{ $monitoring->id }}" data-range="90" data-theme="auto" data-size="compact"&gt;&lt;/div&gt;
+&lt;script src="{{ route('badge.js') }}"&gt;&lt;/script&gt;</code></pre>
+                    </div>
+                </div>
             </div>
         @endif
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,10 @@ Route::get('/widget.js', function () {
     return response(file_get_contents(public_path('js/widget.js')))->header('Content-Type', 'application/javascript');
 })->name('widget.js');
 
+Route::get('/badge.js', function () {
+    return response(file_get_contents(public_path('js/badge.js')))->header('Content-Type', 'application/javascript');
+})->name('badge.js');
+
 Route::middleware(['auth', 'role:member,admin'])
     ->prefix('profile')
     ->as('profile.')

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -7,9 +7,12 @@ namespace Tests\Feature\Api;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringStatus;
 use App\Enums\MonitoringType;
+use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringResponse;
+use App\Models\MonitoringSslResult;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -62,6 +65,30 @@ class PublicMonitoringWidgetApiTest extends TestCase
             'max_response_time' => 123.4,
             'incidents_count' => 0,
         ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDays(20),
+            'up_at' => Date::now()->subDays(20)->addMinutes(10),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDays(80),
+            'up_at' => Date::now()->subDays(80)->addMinutes(10),
+        ]);
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'issuer' => 'Example CA',
+            'issued_at' => Date::now()->subDays(30),
+            'expires_at' => Date::parse('2026-08-01 00:00:00'),
+        ]);
+        MonitoringDomainResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'registrar' => 'Example Registrar',
+            'checked_at' => Date::now(),
+            'expires_at' => Date::parse('2027-02-01 00:00:00'),
+        ]);
 
         $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
 
@@ -72,6 +99,12 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('status_code', 200);
         $testResponse->assertJsonPath('status_identifier', 'status.success');
         $testResponse->assertJsonPath('public_url', route('public-label', $monitoring));
+        $testResponse->assertJsonPath('incidents.30_days', 1);
+        $testResponse->assertJsonPath('incidents.90_days', 2);
+        $testResponse->assertJsonPath('incidents.365_days', 2);
+        $testResponse->assertJsonPath('ssl.valid', true);
+        $testResponse->assertJsonPath('domain.valid', true);
+        $testResponse->assertJsonPath('maintenance.active', false);
         $this->assertIsNumeric($testResponse->json('uptime.7_days'));
         $this->assertIsNumeric($testResponse->json('uptime.30_days'));
         $this->assertIsNumeric($testResponse->json('uptime.365_days'));
@@ -135,7 +168,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
             ->filter(static fn (array $entry): bool => str_starts_with(mb_strtolower($entry['query']), 'select'))
             ->count();
 
-        $this->assertLessThanOrEqual(5, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
+        $this->assertLessThanOrEqual(8, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
     }
 
     public function test_public_widget_endpoint_uses_live_uptime_for_fresh_monitoring_without_daily_results(): void

--- a/tests/Feature/MonitoringSlaBadgeEmbedTest.php
+++ b/tests/Feature/MonitoringSlaBadgeEmbedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Tests\TestCase;
+
+class MonitoringSlaBadgeEmbedTest extends TestCase
+{
+    public function test_edit_page_explains_and_shows_sla_badge_embed_snippet_when_public_label_is_enabled(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['name' => 'Germany 1', 'api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'public_label_enabled' => true,
+        ]);
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.edit', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('monitoring.detail.sla_badge.heading'));
+        $testResponse->assertSeeText(__('monitoring.detail.sla_badge.description'));
+        $testResponse->assertSeeText(__('monitoring.detail.sla_badge.snippet_help'));
+        $testResponse->assertSeeHtml('id="sla-badge-snippet"');
+        $testResponse->assertSeeHtml('data-webguard-sla-badge');
+        $testResponse->assertSeeHtml('data-range="90"');
+        $testResponse->assertSeeHtml(route('badge.js'));
+    }
+}

--- a/tests/Feature/WelcomeLatestFeatureCopyTest.php
+++ b/tests/Feature/WelcomeLatestFeatureCopyTest.php
@@ -57,6 +57,7 @@ class WelcomeLatestFeatureCopyTest extends TestCase
                     'component-based status pages with recent incidents, manual incident updates, subscriber emails',
                     'Embeddable Status Widget',
                     'lightweight JavaScript widget',
+                    'compact SLA badge',
                     'REST API and Integrations',
                     'token-based API access and the API reference',
                     'method, header, body, auth, and status-code validation',
@@ -73,6 +74,7 @@ class WelcomeLatestFeatureCopyTest extends TestCase
                     'komponentenbasierte Statusseiten mit aktuellen Incidents, manuellen Updates, E-Mail-Abos',
                     'Einbettbares Status-Widget',
                     'schlankes JavaScript-Widget',
+                    'kompaktes SLA-Badge',
                     'REST API und Integrationen',
                     'tokenbasierten API-Zugriff und die API-Referenz',
                     'Methode, Headern, Body, Authentifizierung und Statuscode-Prüfung',
@@ -123,6 +125,8 @@ class WelcomeLatestFeatureCopyTest extends TestCase
         $this->assertStringContainsString('status changes, SSL expiry, and domain expiry', $features);
         $this->assertStringContainsString('Server health monitoring', $features);
         $this->assertStringContainsString('configurable per-monitor usage thresholds', $features);
+        $this->assertStringContainsString('SLA badge', $features);
+        $this->assertStringContainsString('live status, uptime proof, and public trust context', $features);
     }
 
     #[DataProvider('featureTeaserCoverageProvider')]

--- a/tests/Feature/WidgetScriptRouteTest.php
+++ b/tests/Feature/WidgetScriptRouteTest.php
@@ -16,4 +16,15 @@ class WidgetScriptRouteTest extends TestCase
         $this->assertStringContainsString('/api/public/monitorings/', $testResponse->getContent());
         $this->assertStringNotContainsString('webguard.m-breuer.dev', $testResponse->getContent());
     }
+
+    public function test_sla_badge_script_uses_public_widget_endpoint_without_hard_coded_environment_domain(): void
+    {
+        $testResponse = $this->get(route('badge.js'));
+
+        $testResponse->assertOk();
+        $this->assertStringContainsString('[data-webguard-sla-badge]', $testResponse->getContent());
+        $this->assertStringContainsString('/api/public/monitorings/', $testResponse->getContent());
+        $this->assertStringContainsString('Verified by WebGuard', $testResponse->getContent());
+        $this->assertStringNotContainsString('webguard.m-breuer.dev', $testResponse->getContent());
+    }
 }

--- a/tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
+++ b/tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
@@ -8,9 +8,12 @@ use App\Data\MonitoringWidgetPayload;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringStatus;
 use App\Enums\MonitoringType;
+use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringResponse;
+use App\Models\MonitoringSslResult;
 use App\Models\Package;
 use App\Models\User;
 use App\Services\MonitoringWidgetPayloadService;
@@ -47,6 +50,35 @@ class MonitoringWidgetPayloadServiceTest extends TestCase
             'updated_at' => Date::now()->subMinutes(5),
         ]);
 
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDays(20),
+            'up_at' => Date::now()->subDays(20)->addMinutes(12),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDays(80),
+            'up_at' => Date::now()->subDays(80)->addMinutes(12),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDays(200),
+            'up_at' => Date::now()->subDays(200)->addMinutes(12),
+        ]);
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'issuer' => 'Example CA',
+            'issued_at' => Date::now()->subDays(30),
+            'expires_at' => Date::parse('2026-08-01 00:00:00'),
+        ]);
+        MonitoringDomainResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'registrar' => 'Example Registrar',
+            'checked_at' => Date::now(),
+            'expires_at' => Date::parse('2027-02-01 00:00:00'),
+        ]);
         $this->createDailyResult($monitoring, Date::now()->subDays(2)->toDateString());
 
         $monitoringWidgetPayload = resolve(MonitoringWidgetPayloadService::class)->getPayload($monitoring->fresh());
@@ -62,6 +94,14 @@ class MonitoringWidgetPayloadServiceTest extends TestCase
         $this->assertEquals(100.0, $payload['uptime']['7_days']);
         $this->assertEquals(100.0, $payload['uptime']['30_days']);
         $this->assertEquals(100.0, $payload['uptime']['365_days']);
+        $this->assertSame(1, $payload['incidents']['30_days']);
+        $this->assertSame(2, $payload['incidents']['90_days']);
+        $this->assertSame(3, $payload['incidents']['365_days']);
+        $this->assertTrue($payload['ssl']['valid']);
+        $this->assertSame(Date::parse('2026-08-01 00:00:00')->toIso8601String(), $payload['ssl']['expires_at']);
+        $this->assertTrue($payload['domain']['valid']);
+        $this->assertSame(Date::parse('2027-02-01 00:00:00')->toIso8601String(), $payload['domain']['expires_at']);
+        $this->assertFalse($payload['maintenance']['active']);
     }
 
     public function test_widget_payload_returns_unknown_without_results(): void


### PR DESCRIPTION
## Summary

Adds an embeddable SLA badge for public monitorings so users can display live trust signals on websites, footers, dashboards, and customer portals.

## Changes

- Adds `/badge.js` for rendering compact and rich SLA badges from the existing public widget API.
- Extends the public widget payload with incident counts, SSL/domain expiry metadata, and maintenance state.
- Shows an SLA badge embed snippet and explanation on the monitoring edit page when the public label is enabled.
- Updates landing copy, docs, README, and EN/DE translations so users know the badge exists and how to embed it.
- Adds tests for the badge script route, embed snippet, payload metadata, and marketing/docs coverage.

## Validation

- `node --check public/js/badge.js`
- `php artisan test tests/Feature tests/Unit`