### PR TITLE
Fix 90-day SLA badge uptime

### DIFF
--- a/app/Data/MonitoringWidgetUptimePayload.php
+++ b/app/Data/MonitoringWidgetUptimePayload.php
@@ -11,23 +11,25 @@ final readonly class MonitoringWidgetUptimePayload implements JsonSerializable
     public function __construct(
         public float|int|null $sevenDays,
         public float|int|null $thirtyDays,
+        public float|int|null $ninetyDays,
         public float|int|null $year
     ) {}
 
     /**
-     * @return array{7_days: float|int|null, 30_days: float|int|null, 365_days: float|int|null}
+     * @return array{7_days: float|int|null, 30_days: float|int|null, 90_days: float|int|null, 365_days: float|int|null}
      */
     public function toArray(): array
     {
         return [
             '7_days' => $this->sevenDays,
             '30_days' => $this->thirtyDays,
+            '90_days' => $this->ninetyDays,
             '365_days' => $this->year,
         ];
     }
 
     /**
-     * @return array{7_days: float|int|null, 30_days: float|int|null, 365_days: float|int|null}
+     * @return array{7_days: float|int|null, 30_days: float|int|null, 90_days: float|int|null, 365_days: float|int|null}
      */
     public function jsonSerialize(): array
     {

--- a/app/Services/MonitoringWidgetPayloadService.php
+++ b/app/Services/MonitoringWidgetPayloadService.php
@@ -25,7 +25,7 @@ class MonitoringWidgetPayloadService
         $latestStatusCode = $monitoring->latestResponseResult?->http_status_code;
         $status = (string) ($statusSince['status'] ?? 'unknown');
         $checkedAt = $statusNow['checked_at'] ?? null;
-        $uptimePercentages = $this->resolveUptimePercentages($monitoring, [7, 30, 365]);
+        $uptimePercentages = $this->resolveUptimePercentages($monitoring, [7, 30, 90, 365]);
         $incidentCounts = $this->resolveIncidentCounts($monitoring, [30, 90, 365]);
 
         return new MonitoringWidgetPayload(
@@ -40,6 +40,7 @@ class MonitoringWidgetPayloadService
             uptime: new MonitoringWidgetUptimePayload(
                 sevenDays: $uptimePercentages[7] ?? null,
                 thirtyDays: $uptimePercentages[30] ?? null,
+                ninetyDays: $uptimePercentages[90] ?? null,
                 year: $uptimePercentages[365] ?? null
             ),
             publicUrl: route('public-label', $monitoring),

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -107,6 +107,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('maintenance.active', false);
         $this->assertIsNumeric($testResponse->json('uptime.7_days'));
         $this->assertIsNumeric($testResponse->json('uptime.30_days'));
+        $this->assertIsNumeric($testResponse->json('uptime.90_days'));
         $this->assertIsNumeric($testResponse->json('uptime.365_days'));
     }
 
@@ -124,7 +125,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
             'created_at' => Date::now()->subDays(400),
         ]);
 
-        foreach ([7, 30, 365] as $days) {
+        foreach ([7, 30, 90, 365] as $days) {
             MonitoringDailyResult::query()->create([
                 'monitoring_id' => $monitoring->id,
                 'date' => Date::now()->subDays($days)->toDateString(),
@@ -162,6 +163,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertJsonPath('uptime.7_days', 100);
         $testResponse->assertJsonPath('uptime.30_days', 100);
+        $testResponse->assertJsonPath('uptime.90_days', 100);
         $testResponse->assertJsonPath('uptime.365_days', 100);
 
         $selectCount = collect(DB::getQueryLog())
@@ -204,6 +206,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('status', MonitoringStatus::UP->value);
         $testResponse->assertJsonPath('uptime.7_days', 100);
         $testResponse->assertJsonPath('uptime.30_days', 100);
+        $testResponse->assertJsonPath('uptime.90_days', 100);
         $testResponse->assertJsonPath('uptime.365_days', 100);
     }
 
@@ -247,6 +250,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('checked_at_human', null);
         $testResponse->assertJsonPath('uptime.7_days', null);
         $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.90_days', null);
         $testResponse->assertJsonPath('uptime.365_days', null);
     }
 
@@ -314,6 +318,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('checked_at_human', null);
         $testResponse->assertJsonPath('uptime.7_days', null);
         $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.90_days', null);
         $testResponse->assertJsonPath('uptime.365_days', null);
     }
 
@@ -346,6 +351,7 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('checked_at_human', null);
         $testResponse->assertJsonPath('uptime.7_days', null);
         $testResponse->assertJsonPath('uptime.30_days', null);
+        $testResponse->assertJsonPath('uptime.90_days', null);
         $testResponse->assertJsonPath('uptime.365_days', null);
     }
 }


### PR DESCRIPTION
## Summary
- Add uptime.90_days to the public monitoring widget payload.
- Keep the default SLA badge range aligned with the API response.
- Extend widget API tests to cover 90-day populated and empty states.

## Root cause
The SLA badge snippet and badge script default to data-range="90", but the widget endpoint only returned 7, 30, and 365 day uptime values. That made the default badge render "No uptime data" even when uptime was available.

## Validation
- php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php tests/Feature/WidgetScriptRouteTest.php tests/Feature/MonitoringSlaBadgeEmbedTest.php
- ./vendor/bin/pint --dirty
