### PR TITLE
Improve public widget payload performance

### DIFF
--- a/app/Services/MonitoringWidgetPayloadService.php
+++ b/app/Services/MonitoringWidgetPayloadService.php
@@ -71,20 +71,17 @@ class MonitoringWidgetPayloadService
     private function resolveUptimePercentages(Monitoring $monitoring, array $days): array
     {
         if ($monitoring->created_at->diffInDays(Date::now()) < 1) {
-            return collect($days)
-                ->mapWithKeys(function (int $day) use ($monitoring): array {
-                    $monitoringDateRange = MonitoringDateRange::pastDays($day);
+            $monitoringDateRange = MonitoringDateRange::pastDays(max($days));
+            $uptimePercentage = data_get($this->monitoringAvailabilityService->getUptimeDowntime(
+                $monitoring,
+                $monitoringDateRange->startDate,
+                $monitoringDateRange->endDate,
+                false,
+                false
+            ), 'uptime.percentage');
 
-                    return [
-                        $day => data_get($this->monitoringAvailabilityService->getUptimeDowntime(
-                            $monitoring,
-                            $monitoringDateRange->startDate,
-                            $monitoringDateRange->endDate,
-                            false,
-                            false
-                        ), 'uptime.percentage'),
-                    ];
-                })
+            return collect($days)
+                ->mapWithKeys(fn (int $day): array => [$day => $uptimePercentage])
                 ->all();
         }
 
@@ -104,15 +101,26 @@ class MonitoringWidgetPayloadService
     private function resolveIncidentCounts(Monitoring $monitoring, array $days): array
     {
         $oldestRange = max($days);
-        $incidents = $monitoring->incidents()
-            ->where('down_at', '>=', Date::now()->subDays($oldestRange))
-            ->get(['down_at']);
+        $now = Date::now();
+        $bindings = collect($days)
+            ->map(fn (int $day): string => $now->copy()->subDays($day)->toDateTimeString())
+            ->all();
+
+        $select = collect($days)
+            ->map(fn (int $day): string => sprintf(
+                'SUM(CASE WHEN down_at >= ? THEN 1 ELSE 0 END) as incidents_%d_days',
+                $day
+            ))
+            ->implode(', ');
+
+        $counts = $monitoring->incidents()
+            ->where('down_at', '>=', $now->copy()->subDays($oldestRange))
+            ->selectRaw($select, $bindings)
+            ->first();
 
         return collect($days)
             ->mapWithKeys(fn (int $day): array => [
-                $day => $incidents
-                    ->filter(fn ($incident): bool => $incident->down_at->greaterThanOrEqualTo(Date::now()->subDays($day)))
-                    ->count(),
+                $day => (int) ($counts->{'incidents_' . $day . '_days'} ?? 0),
             ])
             ->all();
     }

--- a/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
+++ b/tests/Feature/Api/PublicMonitoringWidgetApiTest.php
@@ -198,6 +198,9 @@ class PublicMonitoringWidgetApiTest extends TestCase
             'updated_at' => $checkedAt,
         ]);
 
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
         $testResponse = $this->getJson('/api/public/monitorings/' . $monitoring->id . '/widget');
 
         $testResponse->assertOk();
@@ -205,6 +208,12 @@ class PublicMonitoringWidgetApiTest extends TestCase
         $testResponse->assertJsonPath('uptime.7_days', 100);
         $testResponse->assertJsonPath('uptime.30_days', 100);
         $testResponse->assertJsonPath('uptime.365_days', 100);
+
+        $selectCount = collect(DB::getQueryLog())
+            ->filter(static fn (array $entry): bool => str_starts_with(mb_strtolower($entry['query']), 'select'))
+            ->count();
+
+        $this->assertLessThanOrEqual(12, $selectCount, (string) collect(DB::getQueryLog())->pluck('query')->implode(PHP_EOL));
     }
 
     public function test_public_widget_endpoint_returns_not_found_when_public_label_is_disabled(): void

--- a/tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
+++ b/tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
@@ -18,6 +18,7 @@ use App\Models\Package;
 use App\Models\User;
 use App\Services\MonitoringWidgetPayloadService;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class MonitoringWidgetPayloadServiceTest extends TestCase
@@ -81,6 +82,9 @@ class MonitoringWidgetPayloadServiceTest extends TestCase
         ]);
         $this->createDailyResult($monitoring, Date::now()->subDays(2)->toDateString());
 
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
         $monitoringWidgetPayload = resolve(MonitoringWidgetPayloadService::class)->getPayload($monitoring->fresh());
         $payload = $monitoringWidgetPayload->toArray();
 
@@ -102,6 +106,13 @@ class MonitoringWidgetPayloadServiceTest extends TestCase
         $this->assertTrue($payload['domain']['valid']);
         $this->assertSame(Date::parse('2027-02-01 00:00:00')->toIso8601String(), $payload['domain']['expires_at']);
         $this->assertFalse($payload['maintenance']['active']);
+
+        $incidentCountQuery = collect(DB::getQueryLog())->first(
+            static fn (array $entry): bool => str_contains($entry['query'], 'incidents_30_days')
+        );
+
+        $this->assertNotNull($incidentCountQuery);
+        $this->assertStringContainsString('SUM(CASE WHEN down_at >= ?', $incidentCountQuery['query']);
     }
 
     public function test_widget_payload_returns_unknown_without_results(): void


### PR DESCRIPTION
## Summary
- reuse one fresh-monitoring uptime calculation across widget ranges
- aggregate widget incident buckets in SQL instead of hydrating incidents
- add query-count and SQL-shape coverage for the public widget payload

## Tests
- php artisan test tests/Feature/Api/PublicMonitoringWidgetApiTest.php tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
- ./vendor/bin/pint --dirty
- git diff --check