### PR TITLE
Test widget uptime payload coverage

### DIFF
--- a/tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
+++ b/tests/Unit/Services/MonitoringWidgetPayloadServiceTest.php
@@ -97,6 +97,7 @@ class MonitoringWidgetPayloadServiceTest extends TestCase
         $this->assertSame(route('public-label', $monitoring), $payload['public_url']);
         $this->assertEquals(100.0, $payload['uptime']['7_days']);
         $this->assertEquals(100.0, $payload['uptime']['30_days']);
+        $this->assertEquals(100.0, $payload['uptime']['90_days']);
         $this->assertEquals(100.0, $payload['uptime']['365_days']);
         $this->assertSame(1, $payload['incidents']['30_days']);
         $this->assertSame(2, $payload['incidents']['90_days']);


### PR DESCRIPTION
## Summary
- Add service-level coverage for the public widget 90-day uptime payload value.

## Tests
- `composer test -- --filter=MonitoringWidgetPayloadServiceTest`
- `composer test -- --filter=PublicMonitoringWidgetApiTest`

Note: local dependency install required `composer install --ignore-platform-req=ext-redis` because the CLI environment is missing `ext-redis`.