### PR TITLE
Update robots sitemap URL

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://webguard.m-breuer.dev/sitemap.xml
+Sitemap: https://webguard.marcel-breuer.dev/sitemap.xml

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -199,7 +199,7 @@ class PublicIndexingTest extends TestCase
         $this->assertIsString($robotsContent);
         $this->assertStringContainsString('User-agent: *', $robotsContent);
         $this->assertStringContainsString('Allow: /', $robotsContent);
-        $this->assertStringContainsString('Sitemap: https://webguard.m-breuer.dev/sitemap.xml', $robotsContent);
+        $this->assertStringContainsString('Sitemap: https://webguard.marcel-breuer.dev/sitemap.xml', $robotsContent);
         $this->assertStringNotContainsString('Disallow:', $robotsContent);
     }
 


### PR DESCRIPTION
## Summary
- Update `public/robots.txt` to point to the new sitemap URL at `https://webguard.marcel-breuer.dev/sitemap.xml`.
- Adjust the indexing feature test expectation for the new sitemap location.

## Validation
- `php artisan test tests/Feature/PublicIndexingTest.php`