### PR TITLE
Fix canonical www redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       - traefik.enable=true
       - traefik.docker.network=${WEBGUARD_NETWORK:-webguard-network}
       - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-redirect.redirectscheme.scheme=https
+      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.regex=^https?://www\.(.*)
+      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.replacement=https://$${1}
+      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.permanent=true
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.rule=Host(`${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.entrypoints=http
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-redirect
@@ -96,6 +99,16 @@ services:
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.tls=true
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.tls.certresolver=letsencrypt
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.entrypoints=http
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.entrypoints=https
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls=true
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls.certresolver=letsencrypt
+      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
       - traefik.http.services.webguard-${COOLIFY_RESOURCE_UUID:-local}.loadbalancer.server.port=8080
 
   schedule:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://webguard.m-breuer.dev/sitemap.xml
+Sitemap: https://webguard.marcel-breuer.dev/sitemap.xml

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -67,7 +67,9 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
 
         foreach ($matches[1] as $interpolatedVariable) {
             $this->assertTrue(
-                str_contains($interpolatedVariable, ':-') || str_contains($interpolatedVariable, ':?'),
+                ctype_digit($interpolatedVariable)
+                    || str_contains($interpolatedVariable, ':-')
+                    || str_contains($interpolatedVariable, ':?'),
                 sprintf('Compose variable "%s" must define a default value or be explicitly required.', $interpolatedVariable)
             );
         }
@@ -311,5 +313,36 @@ PHP
         $this->assertStringContainsString('entrypoints=https', $composeConfiguration);
         $this->assertStringContainsString('tls.certresolver=letsencrypt', $composeConfiguration);
         $this->assertStringContainsString('loadbalancer.server.port=8080', $composeConfiguration);
+    }
+
+    public function test_production_php_container_redirects_www_host_to_non_www(): void
+    {
+        $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
+
+        $this->assertIsString($composeConfiguration);
+        $this->assertStringContainsString(
+            'traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.regex=^https?://www\.(.*)',
+            $composeConfiguration
+        );
+        $this->assertStringContainsString(
+            'traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.replacement=https://$${1}',
+            $composeConfiguration
+        );
+        $this->assertStringContainsString(
+            'traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.permanent=true',
+            $composeConfiguration
+        );
+        $this->assertStringContainsString(
+            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)',
+            $composeConfiguration
+        );
+        $this->assertStringContainsString(
+            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)',
+            $composeConfiguration
+        );
+        $this->assertStringContainsString(
+            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect',
+            $composeConfiguration
+        );
     }
 }

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -199,7 +199,9 @@ class PublicIndexingTest extends TestCase
         $this->assertIsString($robotsContent);
         $this->assertStringContainsString('User-agent: *', $robotsContent);
         $this->assertStringContainsString('Allow: /', $robotsContent);
-        $this->assertStringContainsString('Sitemap: https://webguard.m-breuer.dev/sitemap.xml', $robotsContent);
+        $this->assertStringContainsString('Sitemap: https://webguard.marcel-breuer.dev/sitemap.xml', $robotsContent);
+        $this->assertStringNotContainsString('webguard.m-breuer.dev', $robotsContent);
+        $this->assertStringNotContainsString('www.webguard.marcel-breuer.dev', $robotsContent);
         $this->assertStringNotContainsString('Disallow:', $robotsContent);
     }
 


### PR DESCRIPTION
## Summary
- add Traefik routers for `www.${SERVICE_FQDN_PHP}` on HTTP and HTTPS
- permanently redirect www traffic to the non-www canonical host while preserving the path
- update `robots.txt` to point at `https://webguard.marcel-breuer.dev/sitemap.xml`
- cover the deploy labels and robots sitemap host in feature tests

## Validation
- `php artisan test tests/Feature/PublicIndexingTest.php tests/Feature/HeartbeatQueueDeploymentConfigTest.php`
- `APP_KEY=base64:test IMPRINT_OPERATOR_NAME=Example IMPRINT_ADDRESS_STREET=Example IMPRINT_ADDRESS_POSTAL_CODE=00000 IMPRINT_ADDRESS_CITY=Example IMPRINT_ADDRESS_COUNTRY=DE IMPRINT_CONTACT_EMAIL=test@example.com IMPRINT_CONTACT_PHONE=000 docker compose config --quiet`

Note: local dependency installation required `composer install --ignore-platform-req=ext-redis` because the PHP Redis extension is not installed locally.