### PR TITLE
Move canonical redirect into app

### DIFF
--- a/app/Http/Middleware/RedirectWwwToNonWww.php
+++ b/app/Http/Middleware/RedirectWwwToNonWww.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectWwwToNonWww
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $canonicalUrl = (string) config('app.url');
+        $canonicalHost = parse_url($canonicalUrl, PHP_URL_HOST);
+
+        if (! is_string($canonicalHost) || $canonicalHost === '') {
+            return $next($request);
+        }
+
+        if ($request->getHost() !== 'www.' . $canonicalHost) {
+            return $next($request);
+        }
+
+        $canonicalScheme = parse_url($canonicalUrl, PHP_URL_SCHEME) ?: $request->getScheme();
+        $canonicalPort = parse_url($canonicalUrl, PHP_URL_PORT);
+        $redirectUrl = $canonicalScheme . '://' . $canonicalHost;
+
+        if (is_int($canonicalPort)) {
+            $redirectUrl .= ':' . $canonicalPort;
+        }
+
+        return redirect()->away($redirectUrl . $request->getRequestUri(), 301);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Http\Middleware\RedirectWwwToNonWww;
 use App\Http\View\Composers\NotificationComposer;
 use App\Models\Incident;
 use App\Models\MonitoringResponse;
@@ -14,6 +15,7 @@ use App\Observers\UserObserver;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -31,11 +33,13 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
+    public function boot(Router $router): void
     {
         if (env('APP_ENV') === 'production') {
             URL::forceScheme('https');
         }
+
+        $router->pushMiddlewareToGroup('web', RedirectWwwToNonWww::class);
 
         VerifyEmail::createUrlUsing(function (object $notifiable): string {
             $temporarySignedPath = URL::temporarySignedRoute(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,9 +87,6 @@ services:
       - traefik.enable=true
       - traefik.docker.network=${WEBGUARD_NETWORK:-webguard-network}
       - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-redirect.redirectscheme.scheme=https
-      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.regex=^https?://www\.(.*)
-      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.replacement=https://$${1}
-      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.permanent=true
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.rule=Host(`${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.entrypoints=http
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-redirect
@@ -99,16 +96,6 @@ services:
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.tls=true
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.tls.certresolver=letsencrypt
       - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.entrypoints=http
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.entrypoints=https
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls=true
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls.certresolver=letsencrypt
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
       - traefik.http.services.webguard-${COOLIFY_RESOURCE_UUID:-local}.loadbalancer.server.port=8080
 
   schedule:

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -67,9 +67,7 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
 
         foreach ($matches[1] as $interpolatedVariable) {
             $this->assertTrue(
-                ctype_digit($interpolatedVariable)
-                    || str_contains($interpolatedVariable, ':-')
-                    || str_contains($interpolatedVariable, ':?'),
+                str_contains($interpolatedVariable, ':-') || str_contains($interpolatedVariable, ':?'),
                 sprintf('Compose variable "%s" must define a default value or be explicitly required.', $interpolatedVariable)
             );
         }
@@ -313,36 +311,5 @@ PHP
         $this->assertStringContainsString('entrypoints=https', $composeConfiguration);
         $this->assertStringContainsString('tls.certresolver=letsencrypt', $composeConfiguration);
         $this->assertStringContainsString('loadbalancer.server.port=8080', $composeConfiguration);
-    }
-
-    public function test_production_php_container_redirects_www_host_to_non_www(): void
-    {
-        $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
-
-        $this->assertIsString($composeConfiguration);
-        $this->assertStringContainsString(
-            'traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.regex=^https?://www\.(.*)',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.replacement=https://$${1}',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect.redirectregex.permanent=true',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-www-redirect',
-            $composeConfiguration
-        );
     }
 }

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -205,6 +205,16 @@ class PublicIndexingTest extends TestCase
         $this->assertStringNotContainsString('Disallow:', $robotsContent);
     }
 
+    public function test_www_host_redirects_to_non_www_canonical_host(): void
+    {
+        config(['app.url' => 'https://webguard.marcel-breuer.dev']);
+
+        $testResponse = $this->get('https://www.webguard.marcel-breuer.dev/features?source=www');
+
+        $this->assertSame(301, $testResponse->getStatusCode());
+        $testResponse->assertRedirect('https://webguard.marcel-breuer.dev/features?source=www');
+    }
+
     public function test_generated_sitemap_lists_exactly_the_indexable_public_pages(): void
     {
         $sitemapPath = public_path('sitemap.xml');


### PR DESCRIPTION
## Summary
- remove the www-to-non-www forwarding from production Docker/Traefik labels
- register the canonical host redirect from `AppServiceProvider`
- add app-level middleware that redirects `www.<APP_URL host>` to the canonical non-www host while preserving path and query string
- replace the deployment-label assertion with an HTTP redirect test

## Validation
- `./vendor/bin/pint app/Http/Middleware/RedirectWwwToNonWww.php app/Providers/AppServiceProvider.php tests/Feature/HeartbeatQueueDeploymentConfigTest.php tests/Feature/PublicIndexingTest.php`
- `php artisan test tests/Feature/PublicIndexingTest.php tests/Feature/HeartbeatQueueDeploymentConfigTest.php`
- `APP_KEY=base64:test IMPRINT_OPERATOR_NAME=Example IMPRINT_ADDRESS_STREET=Example IMPRINT_ADDRESS_POSTAL_CODE=00000 IMPRINT_ADDRESS_CITY=Example IMPRINT_ADDRESS_COUNTRY=DE IMPRINT_CONTACT_EMAIL=test@example.com IMPRINT_CONTACT_PHONE=000 docker compose config --quiet`