### PR TITLE
Update WebGuard Instance repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 WebGuard is an open-source monitoring core built with Laravel 13. It provides the management UI, REST API, public status pages, notification workflows, and package administration for monitoring websites, DNS records, domains, SSL certificates, and background jobs.
 
-> **System architecture note:** this repository contains the Management Core & API. Distributed scanning nodes live in the [WebGuard Instance Repository](https://github.com/m-breuer/webguard-instance-v2).
+> **System architecture note:** this repository contains the Management Core & API. Distributed scanning nodes live in the [WebGuard Instance Repository](https://github.com/marcel-breuer/webguard-instance).
 
 ## What It Does
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This repository contains the WebGuard Management Core & API. It owns the user-facing dashboard, admin panel, status pages, notification workflows, API surface, and orchestration logic.
 
-Distributed scanning nodes and workers are maintained separately in the [WebGuard Instance Repository](https://github.com/m-breuer/webguard-instance-v2).
+Distributed scanning nodes and workers are maintained separately in the [WebGuard Instance Repository](https://github.com/marcel-breuer/webguard-instance).
 
 ## Backend
 

--- a/tests/Feature/DocumentationStructureTest.php
+++ b/tests/Feature/DocumentationStructureTest.php
@@ -65,6 +65,19 @@ class DocumentationStructureTest extends TestCase
         }
     }
 
+    public function test_docs_reference_current_webguard_instance_repository(): void
+    {
+        $expectedRepositoryUrl = 'https://github.com/marcel-breuer/webguard-instance';
+
+        foreach (['README.md', 'docs/architecture.md'] as $document) {
+            $contents = file_get_contents(base_path($document));
+
+            $this->assertIsString($contents);
+            $this->assertStringContainsString($expectedRepositoryUrl, $contents);
+            $this->assertStringNotContainsString('https://github.com/m-breuer/webguard-instance-v2', $contents);
+        }
+    }
+
     public function test_public_widget_api_docs_include_all_uptime_ranges(): void
     {
         $apiController = file_get_contents(app_path('Http/Controllers/ApiController.php'));


### PR DESCRIPTION
## Summary

Updates the WebGuard Instance repository references after the GitHub rename.

## Changes

- Point README and architecture docs to `marcel-breuer/webguard-instance`.
- Add a documentation structure test that requires the current Instance repository URL and rejects the old `m-breuer/webguard-instance-v2` URL.

## Validation

- `php artisan test tests/Feature/DocumentationStructureTest.php`