### PR TITLE
test: cover canonical redirect edge cases

### DIFF
--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -215,6 +215,25 @@ class PublicIndexingTest extends TestCase
         $testResponse->assertRedirect('https://webguard.marcel-breuer.dev/features?source=www');
     }
 
+    public function test_www_host_redirect_preserves_configured_canonical_port(): void
+    {
+        config(['app.url' => 'https://webguard.marcel-breuer.dev:8443']);
+
+        $testResponse = $this->get('https://www.webguard.marcel-breuer.dev/features?source=www');
+
+        $this->assertSame(301, $testResponse->getStatusCode());
+        $testResponse->assertRedirect('https://webguard.marcel-breuer.dev:8443/features?source=www');
+    }
+
+    public function test_www_host_redirect_is_skipped_without_configured_canonical_host(): void
+    {
+        config(['app.url' => '/']);
+
+        $testResponse = $this->get('https://www.webguard.marcel-breuer.dev/features');
+
+        $testResponse->assertOk();
+    }
+
     public function test_generated_sitemap_lists_exactly_the_indexable_public_pages(): void
     {
         $sitemapPath = public_path('sitemap.xml');


### PR DESCRIPTION
## Summary
- add coverage for canonical www redirects when APP_URL includes a port
- add coverage that redirects are skipped when APP_URL has no canonical host

## Validation
- php artisan test tests/Feature/PublicIndexingTest.php

## Notes
- composer install required --ignore-platform-req=ext-redis locally because the PHP Redis extension is not enabled in this environment