### PR TITLE
Batch weekly digest monitoring summaries

### DIFF
--- a/app/Services/WeeklyMonitoringDigestService.php
+++ b/app/Services/WeeklyMonitoringDigestService.php
@@ -4,20 +4,19 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Data\MonitoringAvailabilityPayload;
+use App\Data\MonitoringAvailabilitySegmentPayload;
 use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringSslResult;
 use App\Models\User;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 
 class WeeklyMonitoringDigestService
 {
-    public function __construct(
-        private readonly MonitoringAvailabilityService $monitoringAvailabilityService
-    ) {}
-
     /**
      * @return array{
      *     period_start: Carbon,
@@ -41,7 +40,31 @@ class WeeklyMonitoringDigestService
 
         $monitorings = $user->monitorings()
             ->active()
-            ->with(['sslResult', 'domainResult'])
+            ->with([
+                'sslResult',
+                'domainResult',
+                'dailyResults' => fn ($query) => $query
+                    ->whereBetween('date', [$periodStart->toDateString(), $periodEnd->toDateString()])
+                    ->orderBy('date')
+                    ->select([
+                        'monitoring_id',
+                        'date',
+                        'uptime_minutes',
+                        'downtime_minutes',
+                        'unknown_minutes',
+                        'uptime_total',
+                        'downtime_total',
+                        'unknown_total',
+                        'incidents_count',
+                    ]),
+                'incidents' => fn ($query) => $query
+                    ->where('down_at', '<=', $periodEnd)
+                    ->where(function ($builder) use ($periodStart): void {
+                        $builder->where('up_at', '>=', $periodStart)
+                            ->orWhereNull('up_at');
+                    })
+                    ->select(['monitoring_id', 'down_at', 'up_at']),
+            ])
             ->orderBy('name')
             ->get();
 
@@ -59,17 +82,11 @@ class WeeklyMonitoringDigestService
             ->endOfDay();
 
         foreach ($monitorings as $monitoring) {
-            $uptimeDowntime = $this->monitoringAvailabilityService->getUptimeDowntime(
-                $monitoring,
-                $periodStart,
-                $periodEnd,
-                true,
-                false
-            );
+            $uptimeDowntime = $this->buildAvailabilityFromLoadedDailyResults($monitoring, $periodStart, $periodEnd);
             $maintenanceWindow = $this->getOverlappingMaintenanceWindow($monitoring, $periodStart, $periodEnd);
             $maintenanceMinutes = $this->getMaintenanceMinutes($maintenanceWindow);
 
-            $incidentDurations = $this->getOverlappingIncidentDurations($monitoring, $periodStart, $periodEnd, $maintenanceWindow);
+            $incidentDurations = $this->getOverlappingIncidentDurations($monitoring->incidents, $periodStart, $periodEnd, $maintenanceWindow);
             $incidentsCount = count($incidentDurations);
             $monitoringLongestDowntimeMinutes = empty($incidentDurations) ? 0 : max($incidentDurations);
 
@@ -122,22 +139,17 @@ class WeeklyMonitoringDigestService
     }
 
     /**
+     * @param  Collection<int, Incident>  $incidents
      * @param  array{from: Carbon, until: Carbon}|null  $maintenanceWindow
      * @return list<int>
      */
     private function getOverlappingIncidentDurations(
-        Monitoring $monitoring,
+        Collection $incidents,
         Carbon $periodStart,
         Carbon $periodEnd,
         ?array $maintenanceWindow = null
     ): array {
-        return $monitoring->incidents()
-            ->where('down_at', '<=', $periodEnd)
-            ->where(function ($builder) use ($periodStart): void {
-                $builder->where('up_at', '>=', $periodStart)
-                    ->orWhereNull('up_at');
-            })
-            ->get(['down_at', 'up_at'])
+        return $incidents
             ->map(function (Incident $incident) use ($periodStart, $periodEnd, $maintenanceWindow): int {
                 $downAt = $incident->down_at->copy()->max($periodStart);
                 $upAt = ($incident->up_at ?? $periodEnd)->copy()->min($periodEnd);
@@ -158,6 +170,71 @@ class WeeklyMonitoringDigestService
             ->filter(static fn (int $durationMinutes): bool => $durationMinutes > 0)
             ->values()
             ->all();
+    }
+
+    private function buildAvailabilityFromLoadedDailyResults(
+        Monitoring $monitoring,
+        Carbon $periodStart,
+        Carbon $periodEnd
+    ): MonitoringAvailabilityPayload {
+        $dailyResults = $monitoring->dailyResults;
+        $trackingStartedAt = $dailyResults->min('date')?->copy()->startOfDay();
+
+        if (! $trackingStartedAt || $trackingStartedAt->gt($periodEnd)) {
+            return $this->buildAvailability($periodStart, $periodEnd, $trackingStartedAt, 0, 0, 0, 0, 0, 0, 0);
+        }
+
+        return $this->buildAvailability(
+            $periodStart,
+            $periodEnd,
+            $trackingStartedAt,
+            (int) $dailyResults->sum('uptime_minutes'),
+            (int) $dailyResults->sum('downtime_minutes'),
+            (int) $dailyResults->sum('unknown_minutes'),
+            (int) $dailyResults->sum('uptime_total'),
+            (int) $dailyResults->sum('downtime_total'),
+            (int) $dailyResults->sum('unknown_total'),
+            (int) $dailyResults->sum('incidents_count')
+        );
+    }
+
+    private function buildAvailability(
+        Carbon $periodStart,
+        Carbon $periodEnd,
+        ?Carbon $trackingStartedAt,
+        int $uptimeMinutes,
+        int $downtimeMinutes,
+        int $unknownMinutes,
+        int $uptimeTotal,
+        int $downtimeTotal,
+        int $unknownTotal,
+        int $incidentsCount
+    ): MonitoringAvailabilityPayload {
+        $totalTrackedMinutes = $uptimeMinutes + $downtimeMinutes + $unknownMinutes;
+        $hasData = $totalTrackedMinutes > 0;
+
+        return new MonitoringAvailabilityPayload(
+            from: $periodStart,
+            to: $periodEnd,
+            hasData: $hasData,
+            trackingStartedAt: $trackingStartedAt?->toIso8601String(),
+            uptime: new MonitoringAvailabilitySegmentPayload(
+                minutes: $uptimeMinutes,
+                percentage: $hasData ? ($uptimeMinutes / $totalTrackedMinutes) * 100 : null,
+                total: $uptimeTotal
+            ),
+            downtime: new MonitoringAvailabilitySegmentPayload(
+                minutes: $downtimeMinutes,
+                percentage: $hasData ? ($downtimeMinutes / $totalTrackedMinutes) * 100 : null,
+                total: $downtimeTotal,
+                incidentsCount: $incidentsCount
+            ),
+            unknown: new MonitoringAvailabilitySegmentPayload(
+                minutes: $unknownMinutes,
+                percentage: $hasData ? ($unknownMinutes / $totalTrackedMinutes) * 100 : null,
+                total: $unknownTotal
+            )
+        );
     }
 
     /**

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -19,6 +19,7 @@ use App\Services\WeeklyMonitoringDigestService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
@@ -163,6 +164,67 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         $this->assertStringContainsString('.digest-monitorings-table thead', $rendered);
         $this->assertStringContainsString('display: block !important;', $rendered);
         $this->assertStringContainsString('overflow-wrap: anywhere;', $rendered);
+    }
+
+    public function test_weekly_digest_builds_monitoring_summaries_with_constant_query_count(): void
+    {
+        Date::setTestNow('2026-04-20 09:00:00');
+        Package::factory()->create();
+
+        $user = User::factory()->create([
+            'monitoring_digest_enabled' => true,
+            'monitoring_digest_frequency' => 'weekly',
+        ]);
+
+        for ($monitoringIndex = 1; $monitoringIndex <= 8; $monitoringIndex++) {
+            $monitoring = Monitoring::factory()->for($user)->create([
+                'name' => sprintf('Storefront %02d', $monitoringIndex),
+                'type' => MonitoringType::HTTP,
+            ]);
+
+            for ($day = 13; $day <= 19; $day++) {
+                MonitoringDailyResult::query()->create([
+                    'monitoring_id' => $monitoring->id,
+                    'date' => '2026-04-' . $day,
+                    'uptime_total' => 286,
+                    'downtime_total' => 2,
+                    'unknown_total' => 0,
+                    'uptime_percentage' => 99.31,
+                    'downtime_percentage' => 0.69,
+                    'unknown_percentage' => 0,
+                    'uptime_minutes' => 1430,
+                    'downtime_minutes' => 10,
+                    'unknown_minutes' => 0,
+                    'avg_response_time' => 120,
+                    'min_response_time' => 80,
+                    'max_response_time' => 250,
+                    'incidents_count' => 1,
+                ]);
+            }
+
+            Incident::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'down_at' => '2026-04-15 10:00:00',
+                'up_at' => '2026-04-15 10:30:00',
+            ]);
+        }
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $digest = resolve(WeeklyMonitoringDigestService::class)->buildForUser(
+            $user,
+            Date::parse('2026-04-19'),
+            'weekly'
+        );
+
+        $selectQueries = collect(DB::getQueryLog())
+            ->filter(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'))
+            ->values();
+
+        $this->assertSame(8, $digest['overview']['monitorings_count']);
+        $this->assertSame(8, $digest['overview']['incidents_count']);
+        $this->assertLessThanOrEqual(5, $selectQueries->count(), (string) $selectQueries->pluck('query')->implode(PHP_EOL));
     }
 
     public function test_sends_weekly_digest_to_demo_users_when_profile_setting_is_enabled(): void


### PR DESCRIPTION
## Summary
- batch-load weekly digest daily results and incidents for all active monitorings
- compute digest availability and incident summaries from the loaded relations
- add a query-count regression test for multi-monitoring digest generation

## Why
Weekly digest generation previously called availability and incident queries inside the monitoring loop. That made query volume grow with the number of active monitorings. The new path keeps the digest summary query count constant for the measured multi-monitoring case.

## Validation
- `php artisan test tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`
- `vendor/bin/pint app/Services/WeeklyMonitoringDigestService.php tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php`

Note: local dependency installation required `composer install --ignore-platform-req=ext-redis` because the local PHP CLI does not have the Redis extension enabled.