### PR TITLE
ci: add PHPStan and Pest coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,13 @@ jobs:
     - name: Build frontend assets
       run: bun run build
 
-    - name: Run tests
+    - name: Run PHPStan
+      run: composer analyse
+
+    - name: Run tests with coverage
       env:
         DB_CONNECTION: sqlite
         DB_DATABASE: ':memory:'
+        XDEBUG_MODE: coverage
       run: |
-        php artisan test
+        composer test:coverage

--- a/app/Http/Middleware/TrackApiUsage.php
+++ b/app/Http/Middleware/TrackApiUsage.php
@@ -28,7 +28,7 @@ class TrackApiUsage
             if ($user) {
                 RateLimiter::for('api', fn (Request $request) => Limit::perMinute(5)->by($request->user()->id));
 
-                dispatch(new LogApiUsage($user->id, url()->current()));
+                dispatch(new LogApiUsage((string) $user->getAuthIdentifier(), url()->current()));
 
                 return $next($request);
             }

--- a/app/Jobs/LogApiUsage.php
+++ b/app/Jobs/LogApiUsage.php
@@ -35,6 +35,12 @@ class LogApiUsage implements ShouldQueue
      */
     protected ?string $route = null;
 
+    public function __construct(string $userId, ?string $route = null)
+    {
+        $this->userId = $userId;
+        $this->route = $route;
+    }
+
     /**
      * Execute the job.
      */

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -35,7 +35,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(Router $router): void
     {
-        if (env('APP_ENV') === 'production') {
+        if (app()->isProduction()) {
             URL::forceScheme('https');
         }
 

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,15 @@
     "require-dev": {
         "driftingly/rector-laravel": "^2.1",
         "fakerphp/faker": "^1.23",
+        "larastan/larastan": "^3.9",
         "laravel/breeze": "^2.2",
         "laravel/pail": "^1.2",
         "laravel/pint": "^1.24",
         "mockery/mockery": "^1.6",
         "pestphp/pest": "^4.1",
         "pestphp/pest-plugin-browser": "^4.1",
-        "pestphp/pest-plugin-laravel": "^4.0"
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "phpstan/phpstan": "^2.2"
     },
     "autoload": {
         "psr-4": {
@@ -64,8 +66,14 @@
             "Composer\\Config::disableProcessTimeout",
             "bunx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#facc15\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan queue:listen redis --queue=heartbeat --tries=1\" \"php artisan pail --timeout=0\" \"bun run dev\" --names=server,queue,heartbeat,logs,vite"
         ],
+        "analyse": [
+            "./vendor/bin/phpstan analyse --ansi --memory-limit=1G"
+        ],
         "test": [
-            "@php artisan test"
+            "./vendor/bin/pest"
+        ],
+        "test:coverage": [
+            "./vendor/bin/pest --coverage --min=0"
         ]
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c9e122608d0a47803a1723221afed03",
+    "content-hash": "6cb3121b67958bd410dd357d735ea3fa",
     "packages": [
         {
             "name": "brick/math",
@@ -9591,6 +9591,47 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "iamcal/sql-parser",
+            "version": "v0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/610392f38de49a44dab08dc1659960a29874c4b8",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
+            },
+            "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -9707,6 +9748,96 @@
                 "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
             },
             "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.7.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.2.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+                "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T08:00:58+00:00"
         },
         {
             "name": "laravel/breeze",

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -20,12 +20,11 @@ return [
     |
     */
 
-    'stateful' => explode(',', (string) env('SANCTUM_STATEFUL_DOMAINS', sprintf(
-        '%s%s',
+    'stateful' => explode(',', (string) env('SANCTUM_STATEFUL_DOMAINS', implode(',', array_filter([
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),
         Sanctum::currentRequestHost(),
-    ))),
+    ])))),
 
     /*
     |--------------------------------------------------------------------------

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    level: 0
+    paths:
+        - app
+        - config
+        - routes
+    tmpDir: storage/framework/cache/phpstan

--- a/tests/Feature/CiWorkflowRedisExtensionTest.php
+++ b/tests/Feature/CiWorkflowRedisExtensionTest.php
@@ -38,6 +38,31 @@ class CiWorkflowRedisExtensionTest extends TestCase
         }
     }
 
+    public function test_ci_runs_phpstan_and_pest_coverage(): void
+    {
+        $composerConfig = json_decode((string) file_get_contents(base_path('composer.json')), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('^3.9', $composerConfig['require-dev']['larastan/larastan'] ?? null);
+        $this->assertSame('^2.2', $composerConfig['require-dev']['phpstan/phpstan'] ?? null);
+        $this->assertSame(['./vendor/bin/phpstan analyse --ansi --memory-limit=1G'], $composerConfig['scripts']['analyse'] ?? null);
+        $this->assertSame(['./vendor/bin/pest --coverage --min=0'], $composerConfig['scripts']['test:coverage'] ?? null);
+        $this->assertFileExists(base_path('phpstan.neon'));
+
+        $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
+        $testJobSteps = collect($workflowConfig['jobs']['test']['steps'] ?? []);
+        $phpstanStep = $testJobSteps->firstWhere('name', 'Run PHPStan');
+        $coverageStep = $testJobSteps->firstWhere('name', 'Run tests with coverage');
+
+        $this->assertIsArray($phpstanStep);
+        $this->assertSame('composer analyse', $phpstanStep['run'] ?? null);
+
+        $this->assertIsArray($coverageStep);
+        $this->assertStringContainsString('composer test:coverage', $coverageStep['run'] ?? '');
+        $this->assertSame('sqlite', $coverageStep['env']['DB_CONNECTION'] ?? null);
+        $this->assertSame(':memory:', $coverageStep['env']['DB_DATABASE'] ?? null);
+        $this->assertSame('coverage', $coverageStep['env']['XDEBUG_MODE'] ?? null);
+    }
+
     public function test_captcha_uses_intervention_image_three_until_package_supports_v4(): void
     {
         $composerConfig = json_decode((string) file_get_contents(base_path('composer.json')), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Summary
- add Larastan/PHPStan configuration and Composer analysis script
- run PHPStan and Pest coverage in CI
- fix issues surfaced by the new static analysis gate
- add a workflow regression test covering the CI commands

## Validation
- composer analyse
- ./vendor/bin/pest tests/Feature/CiWorkflowRedisExtensionTest.php
- composer test
- composer validate --strict
- git diff --check

Note: local `composer test:coverage` requires a loaded coverage driver; CI installs Xdebug and sets `XDEBUG_MODE=coverage`.