### PR TITLE
fix: remove duplicate public indexing helpers

### DIFF
--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -271,41 +271,6 @@ class PublicIndexingTest extends TestCase
     /**
      * @return list<string>
      */
-    private function representativeIndexablePublicUrls(): array
-    {
-        return [
-            route('welcome'),
-            route('public-features.show', 'api'),
-            route('sitemap'),
-        ];
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function representativeMarketingPageRouteNames(): array
-    {
-        return [
-            'welcome',
-            'monitoring-locations',
-            'imprint',
-        ];
-    }
-
-    private function assertPublicCacheHeaders(TestResponse $testResponse): void
-    {
-        $cacheControl = (string) $testResponse->headers->get('Cache-Control');
-
-        $this->assertStringContainsString('public', $cacheControl);
-        $this->assertStringContainsString('max-age=300', $cacheControl);
-        $this->assertStringContainsString('s-maxage=3600', $cacheControl);
-        $this->assertStringNotContainsString('private', $cacheControl);
-        $this->assertStringNotContainsString('no-cache', $cacheControl);
-    }
-
-    /**
-     * @return list<string>
-     */
     private function expectedIndexablePageUrls(): array
     {
         $urls = SitemapPages::urls();


### PR DESCRIPTION
## What changed
- Removed the duplicated helper method block from `tests/Feature/PublicIndexingTest.php`.
- Kept a single definition for the public URL, marketing route, and cache-header helpers.

## Why
`composer test:coverage` failed in CI with a fatal redeclare error after PR #333 was merged. The duplicate helper declarations prevented PHPUnit/Pest from loading the test suite.

## Testing
- `docker compose run --rm -e AUTORUN_ENABLED=false php php artisan test tests/Feature/PublicIndexingTest.php`
- `docker compose run --rm -e AUTORUN_ENABLED=false php composer test`
- `docker compose run --rm -e AUTORUN_ENABLED=false php composer test:coverage` was attempted locally; it now gets past the redeclare failure but this local PHP image does not include a coverage driver.

## Risks / follow-up
- Low risk: this only removes duplicate private helper declarations from a test file.