### PR TITLE
fix(monitoring): set failure confirmation threshold to two

### DIFF
--- a/database/migrations/2026_06_01_120000_set_failure_confirmation_threshold_to_two.php
+++ b/database/migrations/2026_06_01_120000_set_failure_confirmation_threshold_to_two.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('failure_confirmation_threshold')
+                ->default(2)
+                ->change();
+        });
+
+        DB::table('monitorings')->update([
+            'failure_confirmation_threshold' => 2,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('failure_confirmation_threshold')
+                ->default(1)
+                ->change();
+        });
+    }
+};


### PR DESCRIPTION
## What changed
- Added a migration that changes the `monitorings.failure_confirmation_threshold` default from `1` to `2`.
- Backfilled all existing monitorings so their consecutive failure threshold is set to `2`.

## Why
This makes every monitoring require two consecutive failures before opening an incident, reducing noise from transient one-off failures.

## Testing
- Ran Docker-based PHP syntax validation for the new migration:
  `php -l /var/www/html/database/migrations/2026_06_01_120000_set_failure_confirmation_threshold_to_two.php`

## Risks and limitations
- Existing monitorings with intentionally customized thresholds will be overwritten to `2` by this migration.
- The full Laravel test suite was not run because dependencies are not installed in the workspace (`vendor/autoload.php` is missing).
