### PR TITLE
fix(monitoring): confirm heartbeat failures before incident

### DIFF
--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -255,7 +255,7 @@ class MonitoringRequest extends FormRequest
             'public_label_enabled' => $this->boolean('public_label_enabled'),
             'notification_on_failure' => $this->boolean('notification_on_failure'),
             'notification_channels' => $this->normalizeNotificationChannels(),
-            'failure_confirmation_threshold' => $this->input('failure_confirmation_threshold', 1),
+            'failure_confirmation_threshold' => $this->input('failure_confirmation_threshold', 2),
             'ssl_expiry_warning_days' => $this->input('ssl_expiry_warning_days', 7),
             'heartbeat_grace_minutes' => $this->input('heartbeat_grace_minutes', 5),
         ];

--- a/app/Jobs/EvaluateHeartbeatMonitoringsJob.php
+++ b/app/Jobs/EvaluateHeartbeatMonitoringsJob.php
@@ -59,7 +59,7 @@ class EvaluateHeartbeatMonitoringsJob implements ShouldBeUnique, ShouldQueue
                         continue;
                     }
 
-                    if ($monitoring->latestResponseResult?->status === MonitoringStatus::DOWN) {
+                    if (! $this->shouldRecordMissedHeartbeat($monitoring)) {
                         continue;
                     }
 
@@ -71,5 +71,26 @@ class EvaluateHeartbeatMonitoringsJob implements ShouldBeUnique, ShouldQueue
                     ]);
                 }
             });
+    }
+
+    private function shouldRecordMissedHeartbeat(Monitoring $monitoring): bool
+    {
+        if ($monitoring->latestResponseResult?->status !== MonitoringStatus::DOWN) {
+            return true;
+        }
+
+        if ($monitoring->incidents()->whereNull('up_at')->exists()) {
+            return false;
+        }
+
+        $threshold = max(1, (int) ($monitoring->failure_confirmation_threshold ?? 1));
+        $responses = $monitoring->responseResults()
+            ->latest()
+            ->orderByDesc('id')
+            ->take($threshold)
+            ->get();
+
+        return $responses->count() < $threshold
+            || $responses->contains(static fn (MonitoringResponse $monitoringResponse): bool => $monitoringResponse->status !== MonitoringStatus::DOWN);
     }
 }

--- a/app/Jobs/EvaluateHeartbeatMonitoringsJob.php
+++ b/app/Jobs/EvaluateHeartbeatMonitoringsJob.php
@@ -89,8 +89,10 @@ class EvaluateHeartbeatMonitoringsJob implements ShouldBeUnique, ShouldQueue
             ->orderByDesc('id')
             ->take($threshold)
             ->get();
+        if ($responses->count() < $threshold) {
+            return true;
+        }
 
-        return $responses->count() < $threshold
-            || $responses->contains(static fn (MonitoringResponse $monitoringResponse): bool => $monitoringResponse->status !== MonitoringStatus::DOWN);
+        return $responses->contains(static fn (MonitoringResponse $monitoringResponse): bool => $monitoringResponse->status !== MonitoringStatus::DOWN);
     }
 }

--- a/tests/Feature/HeartbeatMonitoringTest.php
+++ b/tests/Feature/HeartbeatMonitoringTest.php
@@ -105,6 +105,10 @@ class HeartbeatMonitoringTest extends TestCase
         ]);
 
         (new EvaluateHeartbeatMonitoringsJob)->handle();
+        $this->assertSame(0, Incident::query()->where('monitoring_id', $monitoring->id)->count());
+
+        Date::setTestNow('2026-04-18 12:01:00');
+        (new EvaluateHeartbeatMonitoringsJob)->handle();
 
         $incident = Incident::query()->where('monitoring_id', $monitoring->id)->firstOrFail();
         $this->assertNull($incident->up_at);
@@ -122,6 +126,9 @@ class HeartbeatMonitoringTest extends TestCase
             'status' => MonitoringStatus::DOWN->value,
             'http_status_code' => 503,
         ]);
+        $this->assertSame(2, $monitoring->responseResults()
+            ->where('status', MonitoringStatus::DOWN)
+            ->count());
         $this->assertDatabaseHas('monitoring_response_results', [
             'monitoring_id' => $monitoring->id,
             'status' => MonitoringStatus::UP->value,

--- a/tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php
+++ b/tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php
@@ -56,9 +56,21 @@ class EvaluateHeartbeatMonitoringsJobTest extends TestCase
         ]);
 
         (new EvaluateHeartbeatMonitoringsJob)->handle();
+
+        $this->assertSame(0, Incident::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->count());
+
+        Date::setTestNow('2026-04-18 12:01:00');
+        (new EvaluateHeartbeatMonitoringsJob)->handle();
         (new EvaluateHeartbeatMonitoringsJob)->handle();
 
         $this->assertSame(1, MonitoringResponse::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->where('status', MonitoringStatus::DOWN)
+            ->where('created_at', Date::now())
+            ->count());
+        $this->assertSame(2, MonitoringResponse::query()
             ->where('monitoring_id', $monitoring->id)
             ->where('status', MonitoringStatus::DOWN)
             ->count());

--- a/tests/Feature/MonitoringFailureConfirmationThresholdTest.php
+++ b/tests/Feature/MonitoringFailureConfirmationThresholdTest.php
@@ -45,14 +45,16 @@ class MonitoringFailureConfirmationThresholdTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_default_threshold_opens_incident_on_first_failure(): void
+    public function test_default_threshold_requires_two_consecutive_failures(): void
     {
         Date::setTestNow('2026-05-24 09:00:00');
 
-        $monitoring = Monitoring::factory()->for($this->user)->create([
-            'failure_confirmation_threshold' => 1,
-        ]);
+        $monitoring = Monitoring::factory()->for($this->user)->create();
 
+        $this->recordResponse($monitoring, MonitoringStatus::DOWN);
+        $this->assertSame(0, Incident::query()->where('monitoring_id', $monitoring->id)->count());
+
+        Date::setTestNow(Date::now()->addMinute());
         $this->recordResponse($monitoring, MonitoringStatus::DOWN);
 
         $incident = Incident::query()->where('monitoring_id', $monitoring->id)->firstOrFail();
@@ -171,6 +173,27 @@ class MonitoringFailureConfirmationThresholdTest extends TestCase
             'user_id' => $this->user->id,
             'name' => 'Noisy API',
             'failure_confirmation_threshold' => 3,
+        ]);
+    }
+
+    public function test_monitoring_form_defaults_failure_confirmation_threshold_to_two(): void
+    {
+        $testResponse = $this->actingAs($this->user)->post(route('monitorings.store'), [
+            'name' => 'Default API',
+            'type' => MonitoringType::HTTP->value,
+            'target' => 'https://example.com/health',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'timeout' => 5,
+            'expected_http_statuses' => '200-299',
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $testResponse->assertRedirect(route('monitorings.index'));
+
+        $this->assertDatabaseHas('monitorings', [
+            'user_id' => $this->user->id,
+            'name' => 'Default API',
+            'failure_confirmation_threshold' => 2,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- align missing monitoring form threshold input with the new default of two confirmed failures
- let overdue heartbeat evaluation record enough down responses to satisfy the configured confirmation threshold before suppressing duplicates
- add focused coverage for default threshold behavior and missed-heartbeat incident confirmation

## Validation
- Docker: focused Pest tests for threshold and heartbeat coverage
- Docker: `composer test:coverage` with `pcov` enabled in the throwaway PHP container
- Docker: `./vendor/bin/pint --dirty`
