### PR TITLE
test(monitoring): cover custom heartbeat threshold

### DIFF
--- a/tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php
+++ b/tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php
@@ -78,4 +78,62 @@ class EvaluateHeartbeatMonitoringsJobTest extends TestCase
             ->where('monitoring_id', $monitoring->id)
             ->count());
     }
+
+    public function test_it_honors_custom_failure_confirmation_thresholds_for_missed_heartbeats(): void
+    {
+        Date::setTestNow('2026-04-18 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $serverInstance->update([
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+
+        $monitoring = Monitoring::factory()
+            ->heartbeat()
+            ->for($user)
+            ->create([
+                'preferred_location' => $serverInstance->code,
+                'status' => MonitoringLifecycleStatus::ACTIVE,
+                'heartbeat_token' => 'custom-threshold-heartbeat-token',
+                'target' => route('monitorings.heartbeat.ping', ['token' => 'custom-threshold-heartbeat-token']),
+                'heartbeat_interval_minutes' => 30,
+                'heartbeat_grace_minutes' => 5,
+                'heartbeat_last_ping_at' => Date::now()->subHours(2),
+                'failure_confirmation_threshold' => 3,
+            ]);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => null,
+            'created_at' => Date::now()->subHours(2),
+            'updated_at' => Date::now()->subHours(2),
+        ]);
+
+        (new EvaluateHeartbeatMonitoringsJob)->handle();
+        $this->assertSame(0, Incident::query()->where('monitoring_id', $monitoring->id)->count());
+
+        Date::setTestNow('2026-04-18 12:01:00');
+        (new EvaluateHeartbeatMonitoringsJob)->handle();
+        $this->assertSame(0, Incident::query()->where('monitoring_id', $monitoring->id)->count());
+
+        Date::setTestNow('2026-04-18 12:02:00');
+        (new EvaluateHeartbeatMonitoringsJob)->handle();
+
+        $this->assertSame(3, MonitoringResponse::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->where('status', MonitoringStatus::DOWN)
+            ->count());
+        $this->assertSame(1, Incident::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->whereNull('up_at')
+            ->count());
+    }
 }


### PR DESCRIPTION
## Summary

- adds a focused heartbeat job test for custom failure confirmation thresholds
- verifies missed heartbeat responses keep accumulating until the configured threshold opens an incident

## Validation

- Docker: `./vendor/bin/pest tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php`
- Docker: `composer test:coverage -- --coverage-html storage/coverage` with Xdebug installed in a disposable container, total coverage 87.8%
- Docker: `./vendor/bin/pint tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php`
