### PR TITLE
test(monitoring): cover heartbeat failure threshold

### DIFF
--- a/tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php
+++ b/tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php
@@ -18,6 +18,13 @@ use Tests\TestCase;
 
 class EvaluateHeartbeatMonitoringsJobTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
     public function test_it_suppresses_same_minute_duplicate_down_results_before_confirming_incident(): void
     {
         Date::setTestNow('2026-04-18 12:00:00');
@@ -145,6 +152,13 @@ class EvaluateHeartbeatMonitoringsJobTest extends TestCase
         $this->assertSame(1, Incident::query()
             ->where('monitoring_id', $monitoring->id)
             ->whereNull('up_at')
+            ->count());
+
+        Date::setTestNow(Date::now()->addMinute());
+        (new EvaluateHeartbeatMonitoringsJob)->handle();
+        $this->assertSame(3, MonitoringResponse::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->where('status', MonitoringStatus::DOWN)
             ->count());
     }
 }


### PR DESCRIPTION
## Summary
- Rebase the heartbeat coverage branch onto current `main` and resolve the job-test conflict.
- Keep the upstream same-minute duplicate and custom-threshold heartbeat tests.
- Add the remaining post-incident assertion: once threshold 3 opens an incident, another missed-heartbeat evaluation must not create an extra DOWN response.

## Validation
- `./vendor/bin/pint tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php`
- `./vendor/bin/pest tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php`
- `./vendor/bin/pest tests/Feature/Jobs/EvaluateHeartbeatMonitoringsJobTest.php tests/Feature/MonitoringFailureConfirmationThresholdTest.php tests/Feature/HeartbeatMonitoringTest.php`

## Coverage note
- Previous Docker coverage attempt failed because the Docker daemon was unreachable in this environment.
- Previous local `composer test:coverage` attempt failed because no PHP coverage driver was available.