### PR TITLE
fix: harden public APIs and webhook targets

### DIFF
--- a/app/Http/Middleware/TrackApiUsage.php
+++ b/app/Http/Middleware/TrackApiUsage.php
@@ -6,7 +6,6 @@ namespace App\Http\Middleware;
 
 use App\Jobs\LogApiUsage;
 use Closure;
-use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +25,15 @@ class TrackApiUsage
             $user = auth('sanctum')->user();
 
             if ($user) {
-                RateLimiter::for('api', fn (Request $request) => Limit::perMinute(5)->by($request->user()->id));
+                $key = 'api:' . $user->getAuthIdentifier();
+
+                if (RateLimiter::tooManyAttempts($key, 5)) {
+                    return response()->json([
+                        'message' => 'Too many requests.',
+                    ], 429)->header('Retry-After', (string) RateLimiter::availableIn($key));
+                }
+
+                RateLimiter::hit($key, 60);
 
                 dispatch(new LogApiUsage((string) $user->getAuthIdentifier(), url()->current()));
 

--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -6,6 +6,7 @@ namespace App\Http\Requests;
 
 use App\Enums\NotificationChannel;
 use App\Models\User;
+use App\Rules\PubliclyRoutableUrl;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
@@ -48,12 +49,12 @@ class ProfileRequest extends FormRequest
             ],
             'theme' => ['required', 'string', Rule::in(['light', 'dark', 'system'])],
             'notification_channels' => ['nullable', 'array'],
-            'notification_channels.slack.webhook_url' => ['nullable', 'url', 'max:2048'],
+            'notification_channels.slack.webhook_url' => ['nullable', 'url', 'max:2048', new PubliclyRoutableUrl()],
             'notification_channels.telegram.bot_token' => ['nullable', 'string', 'max:255'],
             'notification_channels.telegram.chat_id' => ['nullable', 'string', 'max:255'],
-            'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048'],
-            'notification_channels.teams.webhook_url' => ['nullable', 'url', 'max:2048'],
-            'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048'],
+            'notification_channels.discord.webhook_url' => ['nullable', 'url', 'max:2048', new PubliclyRoutableUrl()],
+            'notification_channels.teams.webhook_url' => ['nullable', 'url', 'max:2048', new PubliclyRoutableUrl()],
+            'notification_channels.webhook.url' => ['nullable', 'url', 'max:2048', new PubliclyRoutableUrl()],
             'monitoring_digest_enabled' => ['nullable', 'boolean'],
             'monitoring_digest_frequency' => ['nullable', 'string', Rule::in(['daily', 'weekly', 'monthly'])],
             'unread_notifications_reminder_enabled' => ['nullable', 'boolean'],

--- a/app/Rules/PubliclyRoutableUrl.php
+++ b/app/Rules/PubliclyRoutableUrl.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Support\PubliclyRoutableUrl as PubliclyRoutableUrlPolicy;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class PubliclyRoutableUrl implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! PubliclyRoutableUrlPolicy::allows((string) $value, resolveDns: true)) {
+            $fail(__('validation.url'));
+        }
+    }
+}

--- a/app/Services/Notifications/Channels/DiscordChannelDriver.php
+++ b/app/Services/Notifications/Channels/DiscordChannelDriver.php
@@ -6,6 +6,7 @@ namespace App\Services\Notifications\Channels;
 
 use App\Enums\NotificationChannel;
 use App\Services\Notifications\NotificationPayload;
+use App\Support\PubliclyRoutableUrl;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
@@ -30,6 +31,11 @@ class DiscordChannelDriver implements NotificationChannelDriver
     public function send(NotificationPayload $notificationPayload, array $config): void
     {
         $webhookUrl = (string) ($config['webhook_url'] ?? '');
+
+        if (! PubliclyRoutableUrl::allows($webhookUrl)) {
+            throw new RuntimeException('Discord notification webhook URL is not publicly routable.');
+        }
+
         $response = Http::timeout(10)->post($webhookUrl, [
             'content' => $notificationPayload->title . "\n" . $notificationPayload->message,
             'embeds' => [[

--- a/app/Services/Notifications/Channels/DiscordChannelDriver.php
+++ b/app/Services/Notifications/Channels/DiscordChannelDriver.php
@@ -32,9 +32,7 @@ class DiscordChannelDriver implements NotificationChannelDriver
     {
         $webhookUrl = (string) ($config['webhook_url'] ?? '');
 
-        if (! PubliclyRoutableUrl::allows($webhookUrl)) {
-            throw new RuntimeException('Discord notification webhook URL is not publicly routable.');
-        }
+        throw_unless(PubliclyRoutableUrl::allows($webhookUrl), RuntimeException::class, 'Discord notification webhook URL is not publicly routable.');
 
         $response = Http::timeout(10)->post($webhookUrl, [
             'content' => $notificationPayload->title . "\n" . $notificationPayload->message,

--- a/app/Services/Notifications/Channels/SlackChannelDriver.php
+++ b/app/Services/Notifications/Channels/SlackChannelDriver.php
@@ -6,6 +6,7 @@ namespace App\Services\Notifications\Channels;
 
 use App\Enums\NotificationChannel;
 use App\Services\Notifications\NotificationPayload;
+use App\Support\PubliclyRoutableUrl;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
@@ -30,6 +31,11 @@ class SlackChannelDriver implements NotificationChannelDriver
     public function send(NotificationPayload $notificationPayload, array $config): void
     {
         $webhookUrl = (string) ($config['webhook_url'] ?? '');
+
+        if (! PubliclyRoutableUrl::allows($webhookUrl)) {
+            throw new RuntimeException('Slack notification webhook URL is not publicly routable.');
+        }
+
         $response = Http::timeout(10)->post($webhookUrl, [
             'text' => $notificationPayload->title . "\n" . $notificationPayload->message,
             'payload' => $notificationPayload->toArray(),

--- a/app/Services/Notifications/Channels/SlackChannelDriver.php
+++ b/app/Services/Notifications/Channels/SlackChannelDriver.php
@@ -32,9 +32,7 @@ class SlackChannelDriver implements NotificationChannelDriver
     {
         $webhookUrl = (string) ($config['webhook_url'] ?? '');
 
-        if (! PubliclyRoutableUrl::allows($webhookUrl)) {
-            throw new RuntimeException('Slack notification webhook URL is not publicly routable.');
-        }
+        throw_unless(PubliclyRoutableUrl::allows($webhookUrl), RuntimeException::class, 'Slack notification webhook URL is not publicly routable.');
 
         $response = Http::timeout(10)->post($webhookUrl, [
             'text' => $notificationPayload->title . "\n" . $notificationPayload->message,

--- a/app/Services/Notifications/Channels/TeamsChannelDriver.php
+++ b/app/Services/Notifications/Channels/TeamsChannelDriver.php
@@ -6,6 +6,7 @@ namespace App\Services\Notifications\Channels;
 
 use App\Enums\NotificationChannel;
 use App\Services\Notifications\NotificationPayload;
+use App\Support\PubliclyRoutableUrl;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
@@ -30,6 +31,11 @@ class TeamsChannelDriver implements NotificationChannelDriver
     public function send(NotificationPayload $notificationPayload, array $config): void
     {
         $webhookUrl = (string) ($config['webhook_url'] ?? '');
+
+        if (! PubliclyRoutableUrl::allows($webhookUrl)) {
+            throw new RuntimeException('Microsoft Teams notification webhook URL is not publicly routable.');
+        }
+
         $response = Http::timeout(10)->post($webhookUrl, $this->payload($notificationPayload));
 
         if (! $response->successful()) {

--- a/app/Services/Notifications/Channels/TeamsChannelDriver.php
+++ b/app/Services/Notifications/Channels/TeamsChannelDriver.php
@@ -32,9 +32,7 @@ class TeamsChannelDriver implements NotificationChannelDriver
     {
         $webhookUrl = (string) ($config['webhook_url'] ?? '');
 
-        if (! PubliclyRoutableUrl::allows($webhookUrl)) {
-            throw new RuntimeException('Microsoft Teams notification webhook URL is not publicly routable.');
-        }
+        throw_unless(PubliclyRoutableUrl::allows($webhookUrl), RuntimeException::class, 'Microsoft Teams notification webhook URL is not publicly routable.');
 
         $response = Http::timeout(10)->post($webhookUrl, $this->payload($notificationPayload));
 

--- a/app/Services/Notifications/Channels/WebhookChannelDriver.php
+++ b/app/Services/Notifications/Channels/WebhookChannelDriver.php
@@ -6,6 +6,7 @@ namespace App\Services\Notifications\Channels;
 
 use App\Enums\NotificationChannel;
 use App\Services\Notifications\NotificationPayload;
+use App\Support\PubliclyRoutableUrl;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
@@ -30,6 +31,11 @@ class WebhookChannelDriver implements NotificationChannelDriver
     public function send(NotificationPayload $notificationPayload, array $config): void
     {
         $url = (string) ($config['url'] ?? '');
+
+        if (! PubliclyRoutableUrl::allows($url)) {
+            throw new RuntimeException('Notification webhook URL is not publicly routable.');
+        }
+
         $response = Http::timeout(10)->post($url, $notificationPayload->toArray());
 
         if (! $response->successful()) {

--- a/app/Services/Notifications/Channels/WebhookChannelDriver.php
+++ b/app/Services/Notifications/Channels/WebhookChannelDriver.php
@@ -32,9 +32,7 @@ class WebhookChannelDriver implements NotificationChannelDriver
     {
         $url = (string) ($config['url'] ?? '');
 
-        if (! PubliclyRoutableUrl::allows($url)) {
-            throw new RuntimeException('Notification webhook URL is not publicly routable.');
-        }
+        throw_unless(PubliclyRoutableUrl::allows($url), RuntimeException::class, 'Notification webhook URL is not publicly routable.');
 
         $response = Http::timeout(10)->post($url, $notificationPayload->toArray());
 

--- a/app/Support/PubliclyRoutableUrl.php
+++ b/app/Support/PubliclyRoutableUrl.php
@@ -24,7 +24,7 @@ class PubliclyRoutableUrl
 
     private static function isPublicHost(string $host, bool $resolveDns): bool
     {
-        $host = mb_strtolower(trim($host, "[] \t\n\r\0\x0B."));
+        $host = mb_strtolower(mb_trim($host, "[] \t\n\r\0\x0B."));
 
         if ($host === '' || $host === 'localhost') {
             return false;

--- a/app/Support/PubliclyRoutableUrl.php
+++ b/app/Support/PubliclyRoutableUrl.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class PubliclyRoutableUrl
+{
+    public static function allows(string $url, bool $resolveDns = false): bool
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if (! is_string($host) || ! is_string($scheme)) {
+            return false;
+        }
+
+        if (! in_array(mb_strtolower($scheme), ['http', 'https'], true)) {
+            return false;
+        }
+
+        return self::isPublicHost($host, $resolveDns);
+    }
+
+    private static function isPublicHost(string $host, bool $resolveDns): bool
+    {
+        $host = mb_strtolower(trim($host, "[] \t\n\r\0\x0B."));
+
+        if ($host === '' || $host === 'localhost') {
+            return false;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return self::isPublicIp($host);
+        }
+
+        if (
+            ! str_contains($host, '.')
+            || str_ends_with($host, '.localhost')
+            || str_ends_with($host, '.local')
+        ) {
+            return false;
+        }
+
+        if (! $resolveDns) {
+            return true;
+        }
+
+        $addresses = self::resolveHost($host);
+
+        if ($addresses === []) {
+            return true;
+        }
+
+        foreach ($addresses as $address) {
+            if (! self::isPublicIp($address)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function isPublicIp(string $address): bool
+    {
+        return filter_var(
+            $address,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) !== false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function resolveHost(string $host): array
+    {
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+
+        if ($records === false) {
+            return [];
+        }
+
+        $addresses = [];
+
+        foreach ($records as $record) {
+            foreach (['ip', 'ipv6'] as $key) {
+                if (isset($record[$key]) && is_string($record[$key])) {
+                    $addresses[] = $record[$key];
+                }
+            }
+        }
+
+        return array_values(array_unique($addresses));
+    }
+}

--- a/public/js/widget.js
+++ b/public/js/widget.js
@@ -129,6 +129,20 @@ if (!window.webguardWidgetInitialized) {
         `;
         document.head.appendChild(style);
 
+        const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, character => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;',
+        }[character]));
+
+        const cssClassToken = (value) => {
+            const token = String(value ?? 'unknown').toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+
+            return token === '' ? 'unknown' : token;
+        };
+
         const fetchAndRenderWidget = () => {
             widgetContainer.innerHTML = '<p class="wg-info-line">Loading WebGuard Widget...</p>';
 
@@ -144,12 +158,13 @@ if (!window.webguardWidgetInitialized) {
                     const statusLabel = typeof data.status_label === 'string' ? data.status_label : status.toUpperCase();
                     const lastChecked = data.checked_at_human ?? 'No checks yet';
                     const formatUptime = (value) => typeof value === 'number' ? `${value.toFixed(2)}%` : 'N/A';
+                    const monitoringName = typeof data.name === 'string' ? data.name : 'WebGuard Monitor';
 
                     widgetContainer.innerHTML = `
                         <div class="wg-widget-container">
-                            <h3 class="wg-heading">${data.name}</h3>
-                            <p class="wg-status-line"><span class="wg-label">Status:</span> <span class="wg-status-text wg-status-${status}">${statusLabel}</span></p>
-                            <p class="wg-info-line"><span class="wg-label">Last Checked:</span> ${lastChecked}</p>
+                            <h3 class="wg-heading">${escapeHtml(monitoringName)}</h3>
+                            <p class="wg-status-line"><span class="wg-label">Status:</span> <span class="wg-status-text wg-status-${cssClassToken(status)}">${escapeHtml(statusLabel)}</span></p>
+                            <p class="wg-info-line"><span class="wg-label">Last Checked:</span> ${escapeHtml(lastChecked)}</p>
                             <div class="wg-uptime-grid">
                                 <p class="wg-uptime-item"><span class="wg-label">Uptime (7 Days):</span> ${formatUptime(data.uptime?.['7_days'])}</p>
                                 <p class="wg-uptime-item"><span class="wg-label">Uptime (30 Days):</span> ${formatUptime(data.uptime?.['30_days'])}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -155,7 +155,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
 });
 
 Route::group(
-    ['prefix' => 'api', 'as' => 'api.'],
+    ['prefix' => 'api', 'as' => 'api.', 'middleware' => 'auth'],
     function () {
         require __DIR__ . '/api/internal.php';
     }

--- a/tests/Feature/Api/ApiControllerTest.php
+++ b/tests/Feature/Api/ApiControllerTest.php
@@ -56,6 +56,22 @@ class ApiControllerTest extends TestCase
         $testResponse->assertJsonPath('monitoring.target', $monitoring->target);
     }
 
+    public function test_token_api_requests_are_rate_limited(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        foreach (range(1, 5) as $_) {
+            $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')->assertOk();
+        }
+
+        $testResponse = $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/status');
+
+        $testResponse->assertTooManyRequests();
+        $this->assertSame('60', $testResponse->headers->get('Retry-After'));
+    }
+
     public function test_all_endpoint_returns_combined_monitoring_payload_without_nested_controller_responses(): void
     {
         Date::setTestNow('2026-04-12 12:00:00');

--- a/tests/Feature/Api/Internal/MonitoringResponseHttpStatusCodeTest.php
+++ b/tests/Feature/Api/Internal/MonitoringResponseHttpStatusCodeTest.php
@@ -81,4 +81,34 @@ class MonitoringResponseHttpStatusCodeTest extends TestCase
         $testResponse->assertUnprocessable();
         $testResponse->assertJsonValidationErrors(['http_status_code']);
     }
+
+    public function test_internal_instance_monitoring_responses_are_not_api_usage_rate_limited(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $serverInstance->update([
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+        ]);
+
+        foreach (range(1, 6) as $attempt) {
+            $this->withHeaders([
+                'X-INSTANCE-CODE' => $serverInstance->code,
+                'X-API-KEY' => 'test-token-1234567890',
+            ])->postJson(route('v1.internal.monitoring-responses.store'), [
+                'monitoring_id' => $monitoring->id,
+                'status' => MonitoringStatus::UP->value,
+                'http_status_code' => 200,
+                'response_time' => 100 + $attempt,
+            ])->assertOk();
+        }
+    }
 }

--- a/tests/Feature/Api/MonitoringDataAccessTest.php
+++ b/tests/Feature/Api/MonitoringDataAccessTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 
 class MonitoringDataAccessTest extends TestCase
 {
-    public function test_shared_monitoring_data_endpoint_blocks_private_monitoring_without_authentication(): void
+    public function test_shared_monitoring_data_endpoint_requires_authentication_for_private_monitoring(): void
     {
         Package::factory()->create();
         $user = User::factory()->create();
@@ -21,10 +21,10 @@ class MonitoringDataAccessTest extends TestCase
 
         $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/status');
 
-        $testResponse->assertNotFound();
+        $testResponse->assertUnauthorized();
     }
 
-    public function test_shared_monitoring_data_endpoint_allows_public_monitoring_without_authentication(): void
+    public function test_shared_monitoring_data_endpoint_requires_authentication_for_public_monitoring(): void
     {
         Package::factory()->create();
         $user = User::factory()->create();
@@ -35,8 +35,7 @@ class MonitoringDataAccessTest extends TestCase
 
         $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/status');
 
-        $testResponse->assertOk()
-            ->assertJsonPath('monitoring.name', 'Public Monitoring');
+        $testResponse->assertUnauthorized();
     }
 
     public function test_shared_monitoring_data_endpoint_allows_private_monitoring_for_owner(): void
@@ -78,6 +77,6 @@ class MonitoringDataAccessTest extends TestCase
 
         $testResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/uptime-calendar');
 
-        $testResponse->assertNotFound();
+        $testResponse->assertUnauthorized();
     }
 }

--- a/tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php
+++ b/tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php
@@ -97,7 +97,7 @@ class InternalRoutesAvailableDuringMaintenanceTest extends TestCase
 
             $internalV1Response->assertOk();
 
-            $legacyInternalResponse = $this->getJson('/api/monitorings/' . $monitoring->id . '/status');
+            $legacyInternalResponse = $this->actingAs($user)->getJson('/api/monitorings/' . $monitoring->id . '/status');
             $legacyInternalResponse->assertOk();
 
             $gdprResponse = $this->get(route('gdpr'));

--- a/tests/Feature/Notifications/NotificationRouterTest.php
+++ b/tests/Feature/Notifications/NotificationRouterTest.php
@@ -25,18 +25,18 @@ class NotificationRouterTest extends TestCase
             'notification_channels' => [
                 'slack' => [
                     'enabled' => true,
-                    'webhook_url' => 'https://hooks.slack.test/services/test',
+                    'webhook_url' => 'https://hooks.slack.com/services/test',
                 ],
                 'discord' => [
                     'enabled' => true,
-                    'webhook_url' => 'https://discord.test/api/webhooks/test',
+                    'webhook_url' => 'https://discord.com/api/webhooks/test',
                 ],
             ],
         ]);
 
         Http::fake([
-            'https://hooks.slack.test/*' => Http::response(['ok' => false], 500),
-            'https://discord.test/*' => Http::response(['ok' => true], 204),
+            'https://hooks.slack.com/*' => Http::response(['ok' => false], 500),
+            'https://discord.com/*' => Http::response(['ok' => true], 204),
         ]);
 
         $notificationPayload = new NotificationPayload(
@@ -75,7 +75,7 @@ class NotificationRouterTest extends TestCase
             'notification_channels' => [
                 'slack' => [
                     'enabled' => true,
-                    'webhook_url' => 'https://hooks.slack.test/services/test',
+                    'webhook_url' => 'https://hooks.slack.com/services/test',
                 ],
             ],
         ]);
@@ -143,13 +143,13 @@ class NotificationRouterTest extends TestCase
             'notification_channels' => [
                 'teams' => [
                     'enabled' => true,
-                    'webhook_url' => 'https://teams.test/webhook/123',
+                    'webhook_url' => 'https://example.com/teams/webhook/123',
                 ],
             ],
         ]);
 
         Http::fake([
-            'https://teams.test/*' => Http::response([], 200),
+            'https://example.com/*' => Http::response([], 200),
         ]);
 
         $notificationPayload = new NotificationPayload(
@@ -166,7 +166,7 @@ class NotificationRouterTest extends TestCase
         $wasDelivered = resolve(NotificationRouter::class)->dispatch($user, $notificationPayload, ['teams']);
 
         $this->assertTrue($wasDelivered);
-        Http::assertSent(fn ($request): bool => $request->url() === 'https://teams.test/webhook/123'
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://example.com/teams/webhook/123'
             && data_get($request->data(), 'type') === 'message'
             && data_get($request->data(), 'attachments.0.contentType') === 'application/vnd.microsoft.card.adaptive'
             && str_contains(json_encode($request->data(), JSON_THROW_ON_ERROR), 'Monitoring incident'));
@@ -175,6 +175,43 @@ class NotificationRouterTest extends TestCase
             'channel' => 'teams',
             'event_type' => NotificationEventType::INCIDENT->value,
             'status' => NotificationDeliveryStatus::SENT->value,
+        ]);
+    }
+
+    public function test_router_blocks_private_webhook_destinations_before_sending(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'webhook' => [
+                    'enabled' => true,
+                    'url' => 'http://127.0.0.1:8080/webhook',
+                ],
+            ],
+        ]);
+
+        Http::fake();
+
+        $notificationPayload = new NotificationPayload(
+            eventType: NotificationEventType::INCIDENT,
+            title: 'Monitoring incident',
+            message: 'Service is down.',
+            severity: 'critical',
+            monitoringId: '01TEST',
+            monitoringName: 'API',
+            monitoringTarget: 'https://example.test',
+            occurredAt: now(),
+        );
+
+        $wasDelivered = resolve(NotificationRouter::class)->dispatch($user, $notificationPayload, ['webhook']);
+
+        $this->assertFalse($wasDelivered);
+        Http::assertNothingSent();
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'channel' => 'webhook',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::FAILED->value,
         ]);
     }
 }

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -27,10 +27,10 @@ class ProfileNotificationSettingsTest extends TestCase
                 'notificationChannels' => [
                     'slack' => [
                         'enabled' => false,
-                        'webhook_url' => 'https://hooks.slack.test/services/T000/B000/XXX',
+                        'webhook_url' => 'https://hooks.slack.com/services/T000/B000/XXX',
                     ],
                 ],
-                'expectedUrl' => 'https://hooks.slack.test/services/T000/B000/XXX',
+                'expectedUrl' => 'https://hooks.slack.com/services/T000/B000/XXX',
             ],
             'telegram' => [
                 'notificationChannels' => [
@@ -46,28 +46,28 @@ class ProfileNotificationSettingsTest extends TestCase
                 'notificationChannels' => [
                     'discord' => [
                         'enabled' => false,
-                        'webhook_url' => 'https://discord.test/api/webhooks/123/token',
+                        'webhook_url' => 'https://discord.com/api/webhooks/123/token',
                     ],
                 ],
-                'expectedUrl' => 'https://discord.test/api/webhooks/123/token',
+                'expectedUrl' => 'https://discord.com/api/webhooks/123/token',
             ],
             'teams' => [
                 'notificationChannels' => [
                     'teams' => [
                         'enabled' => false,
-                        'webhook_url' => 'https://teams.test/webhook/123',
+                        'webhook_url' => 'https://example.com/teams/webhook/123',
                     ],
                 ],
-                'expectedUrl' => 'https://teams.test/webhook/123',
+                'expectedUrl' => 'https://example.com/teams/webhook/123',
             ],
             'webhook' => [
                 'notificationChannels' => [
                     'webhook' => [
                         'enabled' => false,
-                        'url' => 'https://example.test/webhooks/webguard',
+                        'url' => 'https://example.com/webhooks/webguard',
                     ],
                 ],
-                'expectedUrl' => 'https://example.test/webhooks/webguard',
+                'expectedUrl' => 'https://example.com/webhooks/webguard',
             ],
         ];
 
@@ -135,7 +135,7 @@ class ProfileNotificationSettingsTest extends TestCase
             'notification_channels' => [
                 'slack' => [
                     'enabled' => '1',
-                    'webhook_url' => 'https://hooks.slack.test/services/T000/B000/XXX',
+                    'webhook_url' => 'https://hooks.slack.com/services/T000/B000/XXX',
                 ],
                 'telegram' => [
                     'enabled' => '1',
@@ -153,11 +153,11 @@ class ProfileNotificationSettingsTest extends TestCase
                 ],
                 'teams' => [
                     'enabled' => '1',
-                    'webhook_url' => 'https://teams.test/webhook/123',
+                    'webhook_url' => 'https://example.com/teams/webhook/123',
                 ],
                 'webhook' => [
                     'enabled' => '1',
-                    'url' => 'https://example.test/webhooks/webguard',
+                    'url' => 'https://example.com/webhooks/webguard',
                 ],
             ],
         ]);
@@ -173,7 +173,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertTrue($user->unread_notifications_reminder_enabled);
         $this->assertSame('monthly', $user->unread_notifications_reminder_frequency);
         $this->assertTrue((bool) data_get($user->notification_channels, 'slack.enabled'));
-        $this->assertSame('https://hooks.slack.test/services/T000/B000/XXX', data_get($user->notification_channels, 'slack.webhook_url'));
+        $this->assertSame('https://hooks.slack.com/services/T000/B000/XXX', data_get($user->notification_channels, 'slack.webhook_url'));
         $this->assertNull(data_get($user->notification_channels, 'slack.events'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'telegram.enabled'));
         $this->assertSame('12345:ABCDEF', data_get($user->notification_channels, 'telegram.bot_token'));
@@ -181,10 +181,57 @@ class ProfileNotificationSettingsTest extends TestCase
         $this->assertNull(data_get($user->notification_channels, 'telegram.events'));
         $this->assertFalse((bool) data_get($user->notification_channels, 'discord.enabled'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'teams.enabled'));
-        $this->assertSame('https://teams.test/webhook/123', data_get($user->notification_channels, 'teams.webhook_url'));
+        $this->assertSame('https://example.com/teams/webhook/123', data_get($user->notification_channels, 'teams.webhook_url'));
         $this->assertTrue((bool) data_get($user->notification_channels, 'webhook.enabled'));
-        $this->assertSame('https://example.test/webhooks/webguard', data_get($user->notification_channels, 'webhook.url'));
+        $this->assertSame('https://example.com/webhooks/webguard', data_get($user->notification_channels, 'webhook.url'));
         $this->assertNull(data_get($user->notification_channels, 'webhook.events'));
+    }
+
+    public function test_profile_update_rejects_private_notification_webhook_urls(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'theme' => 'system',
+        ]);
+
+        foreach ([
+            'slack' => ['notification_channels.slack.webhook_url', ['slack' => ['enabled' => '1', 'webhook_url' => 'http://127.0.0.1:8080/slack']]],
+            'discord' => ['notification_channels.discord.webhook_url', ['discord' => ['enabled' => '1', 'webhook_url' => 'http://10.0.0.5/discord']]],
+            'teams' => ['notification_channels.teams.webhook_url', ['teams' => ['enabled' => '1', 'webhook_url' => 'http://localhost/teams']]],
+            'webhook' => ['notification_channels.webhook.url', ['webhook' => ['enabled' => '1', 'url' => 'http://[::1]/webhook']]],
+        ] as [$field, $notificationChannels]) {
+            $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+                'name' => $user->name,
+                'email' => $user->email,
+                'theme' => 'system',
+                'notification_channels' => $notificationChannels,
+            ]);
+
+            $testResponse->assertSessionHasErrors([$field]);
+        }
+    }
+
+    public function test_profile_update_allows_public_notification_webhook_urls(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'theme' => 'system',
+        ]);
+
+        $testResponse = $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'theme' => 'system',
+            'notification_channels' => [
+                'webhook' => [
+                    'enabled' => '1',
+                    'url' => 'https://example.com/webhooks/webguard',
+                ],
+            ],
+        ]);
+
+        $testResponse->assertRedirect(route('profile.edit'));
+        $testResponse->assertSessionHasNoErrors();
     }
 
     public function test_profile_update_defaults_optional_notification_settings_when_omitted(): void
@@ -420,7 +467,7 @@ class ProfileNotificationSettingsTest extends TestCase
             'notification_channels' => [
                 'slack' => [
                     'enabled' => false,
-                    'webhook_url' => 'https://hooks.slack.test/services/T000/B000/XXX',
+                    'webhook_url' => 'https://hooks.slack.com/services/T000/B000/XXX',
                 ],
             ],
         ]);

--- a/tests/Feature/WidgetScriptRouteTest.php
+++ b/tests/Feature/WidgetScriptRouteTest.php
@@ -14,6 +14,9 @@ class WidgetScriptRouteTest extends TestCase
 
         $testResponse->assertOk();
         $this->assertStringContainsString('/api/public/monitorings/', $testResponse->getContent());
+        $this->assertStringContainsString('const escapeHtml =', $testResponse->getContent());
+        $this->assertStringContainsString('${escapeHtml(monitoringName)}', $testResponse->getContent());
+        $this->assertStringNotContainsString('${data.name}', $testResponse->getContent());
         $this->assertStringNotContainsString('webguard.m-breuer.dev', $testResponse->getContent());
     }
 


### PR DESCRIPTION
## What changed

- Escaped public widget API values before inserting them into widget HTML and sanitized the status CSS token.
- Required authentication for the legacy `/api/monitorings/*` web route group so raw monitoring history and server health data are not publicly exposed.
- Added reusable public URL validation and outbound notification sink checks to block localhost, private, reserved, and internal-style webhook destinations.
- Enforced the external token API usage limit in `TrackApiUsage` while keeping `/api/v1/internal/*` webguard-instance routes on `auth.instance` without the API usage limiter.
- Added regression coverage for widget escaping, public API authentication, webhook URL blocking, outbound sink blocking, external API throttling, and unrestricted internal instance submissions.

## Why

These changes address security scan findings around widget XSS, unauthenticated raw monitoring API exposure, notification webhook SSRF, and a defined-but-unused external API rate limit. The internal webguard-instance API remains separate and is not rate limited by the external API usage middleware.

## Tested

- `docker compose --profile internal-services up -d mysql redis php`
- Verified `mysql`, `redis`, and `php` containers are healthy.
- Verified app responds with HTTP 200 on `/status` from inside the PHP container.
- Verified route split with `php artisan route:list --path=api/v1/internal` and `php artisan route:list --path=api/v1/monitorings`.
- `./vendor/bin/pest tests/Feature/WidgetScriptRouteTest.php tests/Feature/Api/MonitoringDataAccessTest.php tests/Feature/Api/ApiControllerTest.php tests/Feature/Api/Internal/MonitoringResponseHttpStatusCodeTest.php tests/Feature/ProfileNotificationSettingsTest.php tests/Feature/Notifications/NotificationRouterTest.php tests/Feature/InternalRoutesAvailableDuringMaintenanceTest.php` passed: 43 tests, 309 assertions.
- `./vendor/bin/pint --dirty --test` passed.
- `./vendor/bin/phpstan analyse app/Rules app/Support app/Http/Middleware/TrackApiUsage.php app/Http/Requests/ProfileRequest.php app/Services/Notifications/Channels --memory-limit=1G` passed.
- `git diff --check` passed.

## Risks and follow-up

- The legacy `/api/monitorings/*` endpoints now require an authenticated web session. Browser-side monitoring detail usage still works for signed-in users, while public embeds continue to use `/api/public/monitorings/{monitoring}/widget`.
- The webhook URL policy intentionally rejects private and internal destinations. Existing stored private webhook URLs will fail delivery until changed to public endpoints.