### PR TITLE
Paginate notification status board in SQL

### DIFF
--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -46,7 +46,7 @@ class NotificationBoardService
             ->where('monitorings.user_id', auth()->id())
             ->whereNull('monitorings.deleted_at')
             ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
-            ->when(! $showRead, fn ($query) => $query->where('monitoring_notifications.read', false))
+            ->unless($showRead, fn ($query) => $query->where('monitoring_notifications.read', false))
             ->whereNotExists(function ($query) use ($showRead): void {
                 $query->selectRaw('1')
                     ->from('monitoring_notifications as newer_notifications')
@@ -61,7 +61,7 @@ class NotificationBoardService
                             });
                     });
             })
-            ->orderByDesc('monitoring_notifications.created_at')
+            ->latest('monitoring_notifications.created_at')
             ->orderByDesc('monitoring_notifications.id')
             ->offset($offset)
             ->limit($limit + 1)
@@ -88,24 +88,24 @@ class NotificationBoardService
             ->get()
             ->keyBy('id');
 
-        return $statusChangeNotifications->map(function (MonitoringNotification $latestStatusNotification) use ($monitorings): array {
+        return $statusChangeNotifications->map(function (MonitoringNotification $monitoringNotification) use ($monitorings): array {
             /** @var Monitoring $monitoring */
-            $monitoring = $monitorings->get($latestStatusNotification->monitoring_id);
+            $monitoring = $monitorings->get($monitoringNotification->monitoring_id);
             /** @var MonitoringResponse|null $latestResponse */
             $latestResponse = $monitoring->getRelation('latestResponseResult');
             $latestStatusCode = $latestResponse?->http_status_code;
             $maintenanceActive = $monitoring->isUnderMaintenance();
 
             $statusIdentifier = MonitoringStatusMeta::identifier($latestStatusCode !== null ? (int) $latestStatusCode : null, $maintenanceActive);
-            $statusChangeMessage = $latestStatusNotification->message;
+            $statusChangeMessage = $monitoringNotification->message;
             $latestCheckedAt = $latestResponse?->created_at;
-            $latestStatusChangeAt = $latestStatusNotification->created_at;
+            $latestStatusChangeAt = $monitoringNotification->created_at;
             $statusChangeIdentifier = $maintenanceActive
                 ? 'maintenance'
                 : MonitoringNotification::extractStatusChangeIdentifierFromMessage($statusChangeMessage);
 
             return [
-                'notification_id' => $latestStatusNotification->id,
+                'notification_id' => $monitoringNotification->id,
                 'monitoring_id' => $monitoring->id,
                 'monitor_name' => $monitoring->name,
                 'target' => $monitoring->target,
@@ -123,7 +123,7 @@ class NotificationBoardService
                 ),
                 'status_change_key' => 'notifications.status_change.' . $statusChangeIdentifier,
                 'badge_type' => MonitoringStatusMeta::badgeType($statusIdentifier),
-                'read' => $latestStatusNotification->read,
+                'read' => $monitoringNotification->read,
             ];
         });
     }

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -33,9 +33,39 @@ class NotificationBoardService
      */
     public function getStatusBoardEntries(bool $showRead, int $offset = 0, int $limit = 5): Collection
     {
-        $notificationRelation = $showRead
-            ? 'latestStatusChangeNotification'
-            : 'latestUnreadStatusChangeNotification';
+        $statusChangeNotifications = MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->select([
+                'monitoring_notifications.id',
+                'monitoring_notifications.monitoring_id',
+                'monitoring_notifications.message',
+                'monitoring_notifications.read',
+                'monitoring_notifications.created_at',
+            ])
+            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
+            ->where('monitorings.user_id', auth()->id())
+            ->whereNull('monitorings.deleted_at')
+            ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
+            ->when(! $showRead, fn ($query) => $query->where('monitoring_notifications.read', false))
+            ->whereNotExists(function ($query) use ($showRead): void {
+                $query->selectRaw('1')
+                    ->from('monitoring_notifications as newer_notifications')
+                    ->whereColumn('newer_notifications.monitoring_id', 'monitoring_notifications.monitoring_id')
+                    ->where('newer_notifications.type', NotificationType::STATUS_CHANGE->value)
+                    ->when(! $showRead, fn ($query) => $query->where('newer_notifications.read', false))
+                    ->where(function ($query): void {
+                        $query->whereColumn('newer_notifications.created_at', '>', 'monitoring_notifications.created_at')
+                            ->orWhere(function ($query): void {
+                                $query->whereColumn('newer_notifications.created_at', 'monitoring_notifications.created_at')
+                                    ->whereColumn('newer_notifications.id', '>', 'monitoring_notifications.id');
+                            });
+                    });
+            })
+            ->orderByDesc('monitoring_notifications.created_at')
+            ->orderByDesc('monitoring_notifications.id')
+            ->offset($offset)
+            ->limit($limit + 1)
+            ->get();
 
         $monitorings = Monitoring::query()
             ->select([
@@ -46,15 +76,8 @@ class NotificationBoardService
                 'maintenance_from',
                 'maintenance_until',
             ])
-            ->where('user_id', auth()->id())
+            ->whereKey($statusChangeNotifications->pluck('monitoring_id')->all())
             ->with([
-                $notificationRelation => fn ($builder) => $builder->select([
-                    'monitoring_notifications.id',
-                    'monitoring_notifications.monitoring_id',
-                    'monitoring_notifications.message',
-                    'monitoring_notifications.read',
-                    'monitoring_notifications.created_at',
-                ]),
                 'latestResponseResult' => fn ($builder) => $builder->select([
                     'monitoring_response_results.id',
                     'monitoring_response_results.monitoring_id',
@@ -63,27 +86,11 @@ class NotificationBoardService
                 ]),
             ])
             ->get()
-            ->filter(fn (Monitoring $monitoring): bool => $monitoring->getRelation($notificationRelation) !== null)
-            ->sort(function (Monitoring $left, Monitoring $right) use ($notificationRelation): int {
-                /** @var MonitoringNotification $leftNotification */
-                $leftNotification = $left->getRelation($notificationRelation);
-                /** @var MonitoringNotification $rightNotification */
-                $rightNotification = $right->getRelation($notificationRelation);
+            ->keyBy('id');
 
-                return [
-                    $rightNotification->created_at?->getTimestamp() ?? 0,
-                    $rightNotification->id,
-                ] <=> [
-                    $leftNotification->created_at?->getTimestamp() ?? 0,
-                    $leftNotification->id,
-                ];
-            })
-            ->slice($offset, $limit + 1)
-            ->values();
-
-        return $monitorings->map(function (Monitoring $monitoring) use ($notificationRelation): array {
-            /** @var MonitoringNotification $latestStatusNotification */
-            $latestStatusNotification = $monitoring->getRelation($notificationRelation);
+        return $statusChangeNotifications->map(function (MonitoringNotification $latestStatusNotification) use ($monitorings): array {
+            /** @var Monitoring $monitoring */
+            $monitoring = $monitorings->get($latestStatusNotification->monitoring_id);
             /** @var MonitoringResponse|null $latestResponse */
             $latestResponse = $monitoring->getRelation('latestResponseResult');
             $latestStatusCode = $latestResponse?->http_status_code;

--- a/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
+++ b/tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php
@@ -48,8 +48,10 @@ class NotificationStatusBoardPerformanceTest extends TestCase
             ->implode("\n");
 
         $this->assertCount(3, $selectQueries);
-        $this->assertStringContainsString('from monitorings where user_id = ?', $normalizedSql);
-        $this->assertStringContainsString('monitoring_notifications.monitoring_id in', $normalizedSql);
+        $this->assertStringContainsString('from monitoring_notifications', $normalizedSql);
+        $this->assertStringContainsString('inner join monitorings on monitoring_notifications.monitoring_id = monitorings.id', $normalizedSql);
+        $this->assertStringContainsString('not exists', $normalizedSql);
+        $this->assertStringContainsString('from monitorings where monitorings.id in', $normalizedSql);
         $this->assertStringNotContainsString('latest_status_change_timestamps', $normalizedSql);
         $this->assertStringNotContainsString('status_change_monitorings', $normalizedSql);
         $this->assertSame([$secondMonitoring->id, $firstMonitoring->id], $entries->pluck('monitoring_id')->all());
@@ -78,23 +80,79 @@ class NotificationStatusBoardPerformanceTest extends TestCase
         $selectQueries = collect(DB::getQueryLog())
             ->filter(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'))
             ->values();
-        $monitoringQuery = $selectQueries->first();
-        $notificationQuery = $selectQueries->first(
-            fn (array $query): bool => str_contains($query['query'], 'monitoring_notifications')
+        $notificationQuery = $selectQueries->first();
+        $monitoringQuery = $selectQueries->first(
+            fn (array $query): bool => str_contains($query['query'], 'from "monitorings"')
+                || str_contains($query['query'], 'from `monitorings`')
+                || str_contains($query['query'], 'from monitorings')
+        );
+        $responseQuery = $selectQueries->first(
+            fn (array $query): bool => str_contains($query['query'], 'monitoring_response_results')
         );
 
         $normalizedMonitoringSql = str_replace(['"', '`'], '', $monitoringQuery['query']);
         $normalizedNotificationSql = str_replace(['"', '`'], '', $notificationQuery['query']);
+        $normalizedResponseSql = str_replace(['"', '`'], '', $responseQuery['query']);
 
         $this->assertSame([$monitoring->id], $entries->pluck('monitoring_id')->all());
-        $this->assertStringContainsString('from monitorings where user_id = ?', $normalizedMonitoringSql);
-        $this->assertStringContainsString('monitorings.deleted_at is null', $normalizedMonitoringSql);
-        $this->assertStringContainsString('monitoring_notifications.monitoring_id in', $normalizedNotificationSql);
-        $this->assertContains($user->id, $monitoringQuery['bindings']);
-        $this->assertContains($monitoring->id, $notificationQuery['bindings']);
-        $this->assertNotContains($otherUser->id, $monitoringQuery['bindings']);
-        $this->assertNotContains($otherUserMonitoring->id, $notificationQuery['bindings']);
-        $this->assertNotContains($deletedMonitoring->id, $notificationQuery['bindings']);
+        $this->assertStringContainsString('from monitoring_notifications', $normalizedNotificationSql);
+        $this->assertStringContainsString('monitorings.user_id = ?', $normalizedNotificationSql);
+        $this->assertStringContainsString('monitorings.deleted_at is null', $normalizedNotificationSql);
+        $this->assertStringContainsString('from monitorings where monitorings.id in', $normalizedMonitoringSql);
+        $this->assertStringContainsString('monitoring_response_results.monitoring_id in', $normalizedResponseSql);
+        $this->assertContains($user->id, $notificationQuery['bindings']);
+        $this->assertContains($monitoring->id, $monitoringQuery['bindings']);
+        $this->assertContains($monitoring->id, $responseQuery['bindings']);
+        $this->assertNotContains($otherUser->id, $notificationQuery['bindings']);
+        $this->assertNotContains($otherUserMonitoring->id, $monitoringQuery['bindings']);
+        $this->assertNotContains($deletedMonitoring->id, $monitoringQuery['bindings']);
+    }
+
+    public function test_status_board_paginates_latest_notifications_before_loading_monitorings(): void
+    {
+        Date::setTestNow('2026-04-19 10:00:00');
+
+        $package = Package::factory()->create();
+        $user = User::factory()->for($package)->create();
+
+        $oldestMonitoring = $this->createStatusBoardMonitoring($user, 503, Date::now()->copy()->subMinutes(10));
+        $secondMonitoring = $this->createStatusBoardMonitoring($user, 204, Date::now()->copy()->subMinutes(8));
+        $selectedMonitoring = $this->createStatusBoardMonitoring($user, 503, Date::now()->copy()->subMinutes(6));
+        $extraMonitoring = $this->createStatusBoardMonitoring($user, 204, Date::now()->copy()->subMinutes(4));
+        $newestMonitoring = $this->createStatusBoardMonitoring($user, 503, Date::now()->copy()->subMinutes(2));
+
+        $this->actingAs($user);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $entries = resolve(NotificationBoardService::class)->getStatusBoardEntries(
+            showRead: true,
+            offset: 2,
+            limit: 1
+        );
+
+        $selectQueries = collect(DB::getQueryLog())
+            ->filter(fn (array $query): bool => str_starts_with(mb_strtolower($query['query']), 'select'))
+            ->values();
+        $notificationQuery = $selectQueries->first();
+        $monitoringQuery = $selectQueries->first(
+            fn (array $query): bool => str_contains($query['query'], 'from "monitorings"')
+                || str_contains($query['query'], 'from `monitorings`')
+                || str_contains($query['query'], 'from monitorings')
+        );
+
+        $normalizedNotificationSql = str_replace(['"', '`'], '', $notificationQuery['query']);
+
+        $this->assertSame([$selectedMonitoring->id, $secondMonitoring->id], $entries->pluck('monitoring_id')->all());
+        $this->assertStringContainsString('order by monitoring_notifications.created_at desc, monitoring_notifications.id desc', $normalizedNotificationSql);
+        $this->assertStringContainsString('limit', mb_strtolower($normalizedNotificationSql));
+        $this->assertStringContainsString('offset', mb_strtolower($normalizedNotificationSql));
+        $this->assertContains($selectedMonitoring->id, $monitoringQuery['bindings']);
+        $this->assertContains($secondMonitoring->id, $monitoringQuery['bindings']);
+        $this->assertNotContains($oldestMonitoring->id, $monitoringQuery['bindings']);
+        $this->assertNotContains($extraMonitoring->id, $monitoringQuery['bindings']);
+        $this->assertNotContains($newestMonitoring->id, $monitoringQuery['bindings']);
     }
 
     public function test_status_board_orders_entries_by_notification_id_when_status_change_timestamps_match(): void


### PR DESCRIPTION
## Summary
- Paginate notification status-board entries in SQL instead of loading every active monitoring for the user and slicing in PHP.
- Load only the selected monitorings and their latest responses after the page of latest status-change notifications is known.
- Add regression coverage for SQL pagination and page-bounded monitoring loads.

## Why
The status-board service already used three select queries, but one of them returned all active monitorings for the authenticated user before PHP filtering, sorting, and slicing. That made the endpoint scale with total monitor count rather than the requested page size.

## Validation
- `./vendor/bin/pest tests/Feature/Notifications/UnreadNotificationCountPerformanceTest.php tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php` passed: 12 tests, 55 assertions.
- `./vendor/bin/pint app/Services/NotificationBoardService.php tests/Feature/Notifications/NotificationStatusBoardPerformanceTest.php` passed.
