### PR TITLE
Alert admins about server instance health

### DIFF
--- a/app/Console/Commands/Notifications/SendServerInstanceHealthAlertsCommand.php
+++ b/app/Console/Commands/Notifications/SendServerInstanceHealthAlertsCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Notifications;
+
+use App\Enums\UserRole;
+use App\Mail\ServerInstanceHealthAlertMail;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Throwable;
+
+#[Description('Sends admin alerts when scanner server instances become stale, remain unseen, or recover.')]
+#[Signature('notifications:send-server-instance-health-alerts')]
+class SendServerInstanceHealthAlertsCommand extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $admins = $this->verifiedAdmins();
+
+        if ($admins->isEmpty()) {
+            return Command::SUCCESS;
+        }
+
+        ServerInstance::query()
+            ->where('is_active', true)
+            ->orderBy('code')
+            ->each(function (ServerInstance $serverInstance) use ($admins): void {
+                $healthStatus = $serverInstance->healthStatus();
+
+                if (! $this->shouldAlert($serverInstance, $healthStatus)) {
+                    return;
+                }
+
+                $this->notifyAdmins($admins, $serverInstance, $healthStatus);
+
+                $serverInstance->forceFill([
+                    'last_health_alert_status' => $healthStatus,
+                    'last_health_alerted_at' => Date::now(),
+                ])->saveQuietly();
+            });
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    private function verifiedAdmins(): Collection
+    {
+        return User::query()
+            ->where('role', UserRole::ADMIN)
+            ->whereNotNull('email_verified_at')
+            ->whereNotNull('email')
+            ->orderBy('email')
+            ->get();
+    }
+
+    private function shouldAlert(ServerInstance $serverInstance, string $healthStatus): bool
+    {
+        if ($healthStatus === 'healthy') {
+            return in_array($serverInstance->last_health_alert_status, ['stale', 'never_seen'], true);
+        }
+
+        if ($healthStatus === 'stale') {
+            return $serverInstance->last_health_alert_status !== 'stale';
+        }
+
+        if ($healthStatus === 'never_seen') {
+            if ($serverInstance->last_health_alert_status === 'never_seen') {
+                return false;
+            }
+
+            $alertAfterMinutes = max(1, (int) config('monitoring.instance_never_seen_alert_after_minutes', 15));
+
+            return $serverInstance->created_at?->lessThanOrEqualTo(Date::now()->subMinutes($alertAfterMinutes)) ?? false;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  Collection<int, User>  $admins
+     */
+    private function notifyAdmins(Collection $admins, ServerInstance $serverInstance, string $healthStatus): void
+    {
+        foreach ($admins as $admin) {
+            if (blank($admin->email)) {
+                continue;
+            }
+
+            try {
+                Mail::to($admin->email)->send(
+                    (new ServerInstanceHealthAlertMail($serverInstance, $healthStatus, $admin))
+                        ->locale($admin->locale ?? config('app.locale'))
+                );
+            } catch (Throwable $throwable) {
+                Log::error('Failed to send server instance health alert.', [
+                    'server_instance_id' => $serverInstance->id,
+                    'server_instance_code' => $serverInstance->code,
+                    'health_status' => $healthStatus,
+                    'admin_id' => $admin->id,
+                    'exception' => $throwable->getMessage(),
+                ]);
+            }
+        }
+    }
+}

--- a/app/Mail/ServerInstanceHealthAlertMail.php
+++ b/app/Mail/ServerInstanceHealthAlertMail.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ServerInstanceHealthAlertMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public ServerInstance $serverInstance,
+        public string $healthStatus,
+        public User $admin
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('mail.server_instance_health_alert.subject', [
+                'instanceCode' => $this->serverInstance->code,
+                'status' => mb_strtoupper($this->healthStatus),
+            ]),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.server-instance-health-alert',
+            with: [
+                'admin' => $this->admin,
+                'serverInstance' => $this->serverInstance,
+                'healthStatus' => $this->healthStatus,
+                'healthStatusLabel' => __('admin.server_instances.health.' . $this->healthStatus),
+                'isRecovery' => $this->healthStatus === 'healthy',
+                'staleAfterMinutes' => max(1, (int) config('monitoring.instance_stale_after_minutes', 10)),
+            ],
+        );
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/ServerInstance.php
+++ b/app/Models/ServerInstance.php
@@ -24,6 +24,8 @@ use Illuminate\Support\Facades\Hash;
     'api_key_hash',
     'is_active',
     'last_seen_at',
+    'last_health_alert_status',
+    'last_health_alerted_at',
 ])]
 #[Hidden([
     'api_key_hash',
@@ -109,6 +111,7 @@ class ServerInstance extends Model
             'ip_address' => 'string',
             'is_active' => 'boolean',
             'last_seen_at' => 'datetime',
+            'last_health_alerted_at' => 'datetime',
         ];
     }
 }

--- a/config/monitoring.php
+++ b/config/monitoring.php
@@ -40,6 +40,7 @@ return [
     */
     'instance_seen_write_throttle_seconds' => (int) env('MONITORING_INSTANCE_SEEN_WRITE_THROTTLE_SECONDS', 60),
     'instance_stale_after_minutes' => (int) env('MONITORING_INSTANCE_STALE_AFTER_MINUTES', 10),
+    'instance_never_seen_alert_after_minutes' => (int) env('MONITORING_INSTANCE_NEVER_SEEN_ALERT_AFTER_MINUTES', 15),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2026_06_11_120000_add_health_alert_state_to_server_instances_table.php
+++ b/database/migrations/2026_06_11_120000_add_health_alert_state_to_server_instances_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('server_instances', function (Blueprint $table): void {
+            $table->string('last_health_alert_status')->nullable()->after('last_seen_at');
+            $table->timestamp('last_health_alerted_at')->nullable()->after('last_health_alert_status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('server_instances', function (Blueprint $table): void {
+            $table->dropColumn(['last_health_alert_status', 'last_health_alerted_at']);
+        });
+    }
+};

--- a/resources/lang/de/mail.php
+++ b/resources/lang/de/mail.php
@@ -40,6 +40,17 @@ return [
         'unsubscribe_text' => 'Diese Statusupdates abbestellen',
         'salutation' => 'Vielen Dank,',
     ],
+    'server_instance_health_alert' => [
+        'subject' => 'Server-Instanz :instanceCode ist :status',
+        'title' => 'Server-Instanz :status',
+        'greeting' => 'Hallo :userName,',
+        'alert_intro' => 'Die Scanner-Instanz ":instanceCode" ist aktuell als :status markiert.',
+        'recovery_intro' => 'Die Scanner-Instanz ":instanceCode" meldet sich wieder und ist jetzt fehlerfrei.',
+        'details' => 'IP-Adresse: :ipAddress. Zuletzt gesehen: :lastSeenAt. Instanzen gelten nach :staleAfterMinutes Minuten ohne erfolgreichen Bericht als veraltet.',
+        'action_text' => 'Prüfen Sie die Instanz-Zuweisung und den Scanner-Prozess, damit die Monitoring-Abdeckung intakt bleibt.',
+        'button_text' => 'Server-Instanzen anzeigen',
+        'salutation' => 'Vielen Dank,',
+    ],
     'unread_notifications_reminder' => [
         'subject' => 'Aktion auf der Plattform erforderlich',
         'greeting' => 'Hallo :userName,',

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -40,6 +40,17 @@ return [
         'unsubscribe_text' => 'Unsubscribe from these status updates',
         'salutation' => 'Thank you,',
     ],
+    'server_instance_health_alert' => [
+        'subject' => 'Server instance :instanceCode is :status',
+        'title' => 'Server instance :status',
+        'greeting' => 'Hello :userName,',
+        'alert_intro' => 'The scanner instance ":instanceCode" is currently marked as :status.',
+        'recovery_intro' => 'The scanner instance ":instanceCode" is reporting again and is now healthy.',
+        'details' => 'IP address: :ipAddress. Last seen: :lastSeenAt. Instances are considered stale after :staleAfterMinutes minutes without a successful report.',
+        'action_text' => 'Review the instance assignment and scanner process to make sure monitoring coverage is intact.',
+        'button_text' => 'View Server Instances',
+        'salutation' => 'Thank you,',
+    ],
     'unread_notifications_reminder' => [
         'subject' => 'Action required on the platform',
         'greeting' => 'Hello :userName,',

--- a/resources/views/mail/server-instance-health-alert.blade.php
+++ b/resources/views/mail/server-instance-health-alert.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.mail')
+
+@section('title', __('mail.server_instance_health_alert.title', ['status' => $healthStatusLabel]))
+@section('eyebrow', __('mail.general.notification_eyebrow'))
+
+@section('content')
+    <p>{{ __('mail.server_instance_health_alert.greeting', ['userName' => $admin->name]) }}</p>
+
+    @if ($isRecovery)
+        <p>{{ __('mail.server_instance_health_alert.recovery_intro', ['instanceCode' => $serverInstance->code]) }}</p>
+    @else
+        <p>{{ __('mail.server_instance_health_alert.alert_intro', ['instanceCode' => $serverInstance->code, 'status' => $healthStatusLabel]) }}</p>
+    @endif
+
+    <p>
+        {{ __('mail.server_instance_health_alert.details', [
+            'ipAddress' => $serverInstance->ip_address ?: __('admin.server_instances.fields.none'),
+            'lastSeenAt' => $serverInstance->last_seen_at?->toDayDateTimeString() ?: __('admin.server_instances.health.never_seen'),
+            'staleAfterMinutes' => $staleAfterMinutes,
+        ]) }}
+    </p>
+
+    <p>{{ __('mail.server_instance_health_alert.action_text') }}</p>
+
+    <p>
+        <a href="{{ route('admin.server-instances.index') }}" class="mail-button">{{ __('mail.server_instance_health_alert.button_text') }}</a>
+    </p>
+
+    <p>{{ __('mail.server_instance_health_alert.salutation') }}<br>
+    {{ __('mail.general.team_name') }}</p>
+@endsection

--- a/routes/console.php
+++ b/routes/console.php
@@ -26,6 +26,9 @@ Schedule::command('notifications:remind-unread-weekly')->dailyAt('08:00')->witho
 // Send customers their configured monitoring performance digest.
 Schedule::command('notifications:send-weekly-monitoring-digest')->dailyAt('08:30')->withoutOverlapping();
 
+// Alert admins when scanner instances stop reporting or recover.
+Schedule::command('notifications:send-server-instance-health-alerts')->everyFiveMinutes()->withoutOverlapping();
+
 // Prune old read notifications daily.
 Schedule::command('notifications:prune-read')->dailyAt('01:00');
 

--- a/tests/Feature/Console/ConsoleCommandRegistrationTest.php
+++ b/tests/Feature/Console/ConsoleCommandRegistrationTest.php
@@ -51,6 +51,10 @@ class ConsoleCommandRegistrationTest extends TestCase
                 'notifications:remind-unread-weekly',
                 'Sends email reminders to users with unread board notifications according to their profile settings.',
             ],
+            'send server instance health alerts' => [
+                'notifications:send-server-instance-health-alerts',
+                'Sends admin alerts when scanner server instances become stale, remain unseen, or recover.',
+            ],
             'send weekly monitoring digest' => [
                 'notifications:send-weekly-monitoring-digest',
                 'Sends weekly email summaries with uptime, incidents, downtime, and expiry warnings.',

--- a/tests/Feature/Console/NotificationsScheduleTest.php
+++ b/tests/Feature/Console/NotificationsScheduleTest.php
@@ -43,6 +43,17 @@ class NotificationsScheduleTest extends TestCase
         $this->assertTrue($event->withoutOverlapping);
     }
 
+    public function test_server_instance_health_alerts_are_scheduled_every_five_minutes_without_overlap(): void
+    {
+        /** @var Event|null $event */
+        $event = collect(resolve(Schedule::class)->events())
+            ->first(fn (Event $event): bool => str_contains((string) $event->command, 'notifications:send-server-instance-health-alerts'));
+
+        $this->assertNotNull($event);
+        $this->assertSame('*/5 * * * *', $event->expression);
+        $this->assertTrue($event->withoutOverlapping);
+    }
+
     public function test_expiry_warnings_are_scheduled_daily_without_overlap(): void
     {
         /** @var Event|null $event */

--- a/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
+++ b/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Enums\UserRole;
+use App\Mail\ServerInstanceHealthAlertMail;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class SendServerInstanceHealthAlertsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_sends_stale_alerts_to_verified_admins(): void
+    {
+        config(['monitoring.instance_stale_after_minutes' => 10]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $unverifiedAdmin = User::factory()->unverified()->create(['role' => UserRole::ADMIN]);
+        $member = User::factory()->create(['role' => UserRole::REGULAR]);
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'scanner-de-1',
+            'ip_address' => '192.0.2.40',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subMinutes(11),
+        ]);
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $mail) use ($admin, $serverInstance): bool {
+            return $mail->hasTo($admin->email)
+                && $mail->serverInstance->is($serverInstance)
+                && $mail->healthStatus === 'stale';
+        });
+        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $mail): bool => $mail->hasTo($unverifiedAdmin->email));
+        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $mail): bool => $mail->hasTo($member->email));
+
+        $serverInstance->refresh();
+        $this->assertSame('stale', $serverInstance->last_health_alert_status);
+        $this->assertSame(Date::now()->toDateTimeString(), $serverInstance->last_health_alerted_at?->toDateTimeString());
+    }
+
+    public function test_does_not_repeat_same_stale_alert(): void
+    {
+        config(['monitoring.instance_stale_after_minutes' => 10]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        User::factory()->create(['role' => UserRole::ADMIN]);
+        ServerInstance::query()->create([
+            'code' => 'scanner-us-1',
+            'ip_address' => '192.0.2.41',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subMinutes(15),
+            'last_health_alert_status' => 'stale',
+            'last_health_alerted_at' => Date::now()->subMinutes(4),
+        ]);
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_never_seen_alert_respects_grace_period(): void
+    {
+        config(['monitoring.instance_never_seen_alert_after_minutes' => 15]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $newInstance = ServerInstance::query()->create([
+            'code' => 'scanner-new-1',
+            'ip_address' => '192.0.2.42',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => null,
+        ]);
+        $newInstance->forceFill([
+            'created_at' => Date::now()->subMinutes(5),
+            'updated_at' => Date::now()->subMinutes(5),
+        ])->saveQuietly();
+        $lateInstance = ServerInstance::query()->create([
+            'code' => 'scanner-late-1',
+            'ip_address' => '192.0.2.43',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => null,
+        ]);
+        $lateInstance->forceFill([
+            'created_at' => Date::now()->subMinutes(16),
+            'updated_at' => Date::now()->subMinutes(16),
+        ])->saveQuietly();
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $mail) use ($admin, $lateInstance): bool {
+            return $mail->hasTo($admin->email)
+                && $mail->serverInstance->is($lateInstance)
+                && $mail->healthStatus === 'never_seen';
+        });
+        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $mail): bool => $mail->serverInstance->is($newInstance));
+
+        $this->assertNull($newInstance->fresh()->last_health_alert_status);
+        $this->assertSame('never_seen', $lateInstance->fresh()->last_health_alert_status);
+    }
+
+    public function test_sends_recovery_after_reported_instance_becomes_healthy(): void
+    {
+        config(['monitoring.instance_stale_after_minutes' => 10]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'scanner-recovered-1',
+            'ip_address' => '192.0.2.44',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subMinutes(2),
+            'last_health_alert_status' => 'stale',
+            'last_health_alerted_at' => Date::now()->subHour(),
+        ]);
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $mail) use ($admin, $serverInstance): bool {
+            return $mail->hasTo($admin->email)
+                && $mail->serverInstance->is($serverInstance)
+                && $mail->healthStatus === 'healthy';
+        });
+
+        $serverInstance->refresh();
+        $this->assertSame('healthy', $serverInstance->last_health_alert_status);
+        $this->assertSame(Date::now()->toDateTimeString(), $serverInstance->last_health_alerted_at?->toDateTimeString());
+    }
+
+    public function test_inactive_instances_do_not_alert(): void
+    {
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        User::factory()->create(['role' => UserRole::ADMIN]);
+        ServerInstance::query()->create([
+            'code' => 'scanner-disabled-1',
+            'ip_address' => '192.0.2.45',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => false,
+            'last_seen_at' => null,
+        ]);
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertNothingSent();
+    }
+}

--- a/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
+++ b/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
@@ -46,13 +46,13 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
 
         Artisan::call('notifications:send-server-instance-health-alerts');
 
-        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $mail) use ($admin, $serverInstance): bool {
-            return $mail->hasTo($admin->email)
-                && $mail->serverInstance->is($serverInstance)
-                && $mail->healthStatus === 'stale';
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail) use ($admin, $serverInstance): bool {
+            return $serverInstanceHealthAlertMail->hasTo($admin->email)
+                && $serverInstanceHealthAlertMail->serverInstance->is($serverInstance)
+                && $serverInstanceHealthAlertMail->healthStatus === 'stale';
         });
-        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $mail): bool => $mail->hasTo($unverifiedAdmin->email));
-        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $mail): bool => $mail->hasTo($member->email));
+        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail): bool => $serverInstanceHealthAlertMail->hasTo($unverifiedAdmin->email));
+        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail): bool => $serverInstanceHealthAlertMail->hasTo($member->email));
 
         $serverInstance->refresh();
         $this->assertSame('stale', $serverInstance->last_health_alert_status);
@@ -90,14 +90,14 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
 
         Package::factory()->create();
         $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-        $newInstance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'scanner-new-1',
             'ip_address' => '192.0.2.42',
             'api_key_hash' => 'valid-instance-key',
             'is_active' => true,
             'last_seen_at' => null,
         ]);
-        $newInstance->forceFill([
+        $serverInstance->forceFill([
             'created_at' => Date::now()->subMinutes(5),
             'updated_at' => Date::now()->subMinutes(5),
         ])->saveQuietly();
@@ -115,14 +115,14 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
 
         Artisan::call('notifications:send-server-instance-health-alerts');
 
-        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $mail) use ($admin, $lateInstance): bool {
-            return $mail->hasTo($admin->email)
-                && $mail->serverInstance->is($lateInstance)
-                && $mail->healthStatus === 'never_seen';
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail) use ($admin, $lateInstance): bool {
+            return $serverInstanceHealthAlertMail->hasTo($admin->email)
+                && $serverInstanceHealthAlertMail->serverInstance->is($lateInstance)
+                && $serverInstanceHealthAlertMail->healthStatus === 'never_seen';
         });
-        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $mail): bool => $mail->serverInstance->is($newInstance));
+        Mail::assertNotSent(ServerInstanceHealthAlertMail::class, fn (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail): bool => $serverInstanceHealthAlertMail->serverInstance->is($serverInstance));
 
-        $this->assertNull($newInstance->fresh()->last_health_alert_status);
+        $this->assertNull($serverInstance->fresh()->last_health_alert_status);
         $this->assertSame('never_seen', $lateInstance->fresh()->last_health_alert_status);
     }
 
@@ -146,10 +146,10 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
 
         Artisan::call('notifications:send-server-instance-health-alerts');
 
-        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $mail) use ($admin, $serverInstance): bool {
-            return $mail->hasTo($admin->email)
-                && $mail->serverInstance->is($serverInstance)
-                && $mail->healthStatus === 'healthy';
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail) use ($admin, $serverInstance): bool {
+            return $serverInstanceHealthAlertMail->hasTo($admin->email)
+                && $serverInstanceHealthAlertMail->serverInstance->is($serverInstance)
+                && $serverInstanceHealthAlertMail->healthStatus === 'healthy';
         });
 
         $serverInstance->refresh();


### PR DESCRIPTION
## Summary
- add scheduled admin alerts for stale and never-seen scanner server instances
- store the last alerted health status on each server instance to avoid duplicate notifications
- send recovery emails when a previously alerted instance becomes healthy again

## Motivation
Distributed scanner instances already expose health states in the admin UI, but admins had to notice stale or never-seen instances manually. This change turns those states into proactive email alerts while preserving deduplication.

## Testing
- Docker: `./vendor/bin/phpunit tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php tests/Feature/Console/ConsoleCommandRegistrationTest.php tests/Feature/Console/NotificationsScheduleTest.php --display-warnings --display-deprecations --display-notices`
- Docker: `./vendor/bin/pint --dirty`
- Docker: `composer analyse`

## Rollout Notes
Run migrations so `server_instances` has the new alert-state columns. The `MONITORING_INSTANCE_NEVER_SEEN_ALERT_AFTER_MINUTES` env var can tune the default 15-minute grace period.
