### PR TITLE
fix: load public label uptime calendar

### DIFF
--- a/resources/js/components/uptime-calendar.ts
+++ b/resources/js/components/uptime-calendar.ts
@@ -18,14 +18,16 @@ interface UptimeCalendarComponent {
     isLoading: boolean;
     calendarData: CalendarData | null;
     monitoringId: string;
+    endpoint: string | null;
     currentLocale: string;
     fetchUptimeCalendar(this: UptimeCalendarComponent): Promise<void>;
 }
 
-export default (monitoringId: string): UptimeCalendarComponent => ({
+export default (monitoringId: string, endpoint: string | null = null): UptimeCalendarComponent => ({
     isLoading: true,
     calendarData: null,
     monitoringId: monitoringId,
+    endpoint: endpoint,
     currentLocale: getCurrentDayjsLocale(),
 
     async fetchUptimeCalendar() {
@@ -38,7 +40,11 @@ export default (monitoringId: string): UptimeCalendarComponent => ({
         const formatDateForApi = (date: Date) => date.toISOString().split('T')[0];
 
         try {
-            const response = await fetch(`/api/monitorings/${this.monitoringId}/uptime-calendar?start_date=${formatDateForApi(startDate)}&end_date=${formatDateForApi(endDate)}`);
+            const url = new URL(this.endpoint ?? `/api/monitorings/${this.monitoringId}/uptime-calendar`, window.location.origin);
+            url.searchParams.set('start_date', formatDateForApi(startDate));
+            url.searchParams.set('end_date', formatDateForApi(endDate));
+
+            const response = await fetch(url.toString());
             if (!response.ok) {
                 throw new Error('Network response was not ok');
             }

--- a/resources/views/monitorings/public-label.blade.php
+++ b/resources/views/monitorings/public-label.blade.php
@@ -181,7 +181,7 @@
                 <div class="mb-4">
                     <x-heading type="h2">{{ __('monitoring.detail.calendar.heading') }}</x-heading>
                 </div>
-                <div x-data="uptimeCalendar('{{ $monitoring->id }}')" x-init="fetchUptimeCalendar">
+                <div x-data="uptimeCalendar('{{ $monitoring->id }}', @js(route('public.monitorings.uptime-calendar', $monitoring)))" x-init="fetchUptimeCalendar">
                     <template x-if="isLoading">
                         <x-container>
                             <p>{{ __('calendar.loading') }}</p>

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/public/monitorings/{monitoring}/badge', [ApiController::class, 'badge'])
     ->name('public.monitorings.badge');
+Route::get('/public/monitorings/{monitoring}/uptime-calendar', [ApiController::class, 'uptimeCalendar'])
+    ->name('public.monitorings.uptime-calendar');
 
 Route::post('/v1/server-health/{token}', ServerHealthReportController::class)
     ->middleware('throttle:60,1')

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -88,6 +88,35 @@ class PublicStatusPageTest extends TestCase
         $testResponse->assertSeeText(__('monitoring.public_label.subscribe.heading'));
     }
 
+    public function test_public_status_page_loads_uptime_calendar_without_authentication(): void
+    {
+        Date::setTestNow('2026-05-03 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Public Calendar API',
+            'public_label_enabled' => true,
+            'created_at' => Date::parse('2026-04-01 00:00:00'),
+        ]);
+
+        $this->createDailyResult($monitoring, '2026-04-10');
+
+        $this->get(route('public-label', $monitoring))
+            ->assertOk()
+            ->assertSee('uptimeCalendar', false);
+
+        $testResponse = $this->getJson(route('public.monitorings.uptime-calendar', $monitoring) . '?' . http_build_query([
+            'start_date' => '2026-04-01',
+            'end_date' => '2026-04-30',
+        ]));
+
+        $testResponse->assertOk()
+            ->assertJsonCount(30, '2026-04.days')
+            ->assertJsonPath('2026-04.days.9.uptime_percentage', 100)
+            ->assertJsonPath('2026-04.monthly_average_uptime', 100);
+    }
+
     public function test_public_status_page_accepts_email_subscriptions_and_sends_confirmation(): void
     {
         Mail::fake();

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -102,9 +102,7 @@ class PublicStatusPageTest extends TestCase
 
         $this->createDailyResult($monitoring, '2026-04-10');
 
-        $this->get(route('public-label', $monitoring))
-            ->assertOk()
-            ->assertSee('uptimeCalendar', false);
+        $this->get(route('public-label', $monitoring))->assertOk()->assertSeeHtml('uptimeCalendar');
 
         $testResponse = $this->getJson(route('public.monitorings.uptime-calendar', $monitoring) . '?' . http_build_query([
             'start_date' => '2026-04-01',


### PR DESCRIPTION
## What changed
- Added a public uptime-calendar API route for monitorings with public labels enabled.
- Updated the public label page to pass that public endpoint into the Alpine uptime calendar component.
- Kept the monitoring detail page on the existing authenticated internal endpoint.
- Added regression coverage for anonymous public-label calendar loading.

## Why
The public label page rendered the calendar component, but the browser fetched the authenticated internal `/api/monitorings/{id}/uptime-calendar` route. Anonymous visitors could therefore see the page but could not load the calendar data.

## Testing
- `docker compose run --rm --no-deps --entrypoint php php artisan test tests/Feature/PublicStatusPageTest.php tests/Feature/Api/MonitoringDataAccessTest.php`
- `docker run --rm -v "$PWD":/app -w /app oven/bun:latest bun run build`

## Risks
The new public route reuses the existing controller authorization, so it only returns data when `public_label_enabled` is true.