### PR TITLE
test: cover public uptime calendar endpoint injection

### DIFF
--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -18,6 +18,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Js;
 use Tests\TestCase;
 
 class PublicStatusPageTest extends TestCase
@@ -102,7 +103,10 @@ class PublicStatusPageTest extends TestCase
 
         $this->createDailyResult($monitoring, '2026-04-10');
 
-        $this->get(route('public-label', $monitoring))->assertOk()->assertSeeHtml('uptimeCalendar');
+        $this->get(route('public-label', $monitoring))
+            ->assertOk()
+            ->assertSeeHtml('uptimeCalendar')
+            ->assertSee(Js::from(route('public.monitorings.uptime-calendar', $monitoring))->toHtml(), false);
 
         $testResponse = $this->getJson(route('public.monitorings.uptime-calendar', $monitoring) . '?' . http_build_query([
             'start_date' => '2026-04-01',

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -104,9 +104,7 @@ class PublicStatusPageTest extends TestCase
         $this->createDailyResult($monitoring, '2026-04-10');
 
         $this->get(route('public-label', $monitoring))
-            ->assertOk()
-            ->assertSeeHtml('uptimeCalendar')
-            ->assertSee(Js::from(route('public.monitorings.uptime-calendar', $monitoring))->toHtml(), false);
+            ->assertOk()->assertSeeHtml('uptimeCalendar')->assertSeeHtml(Js::from(route('public.monitorings.uptime-calendar', $monitoring))->toHtml());
 
         $testResponse = $this->getJson(route('public.monitorings.uptime-calendar', $monitoring) . '?' . http_build_query([
             'start_date' => '2026-04-01',


### PR DESCRIPTION
## Summary
- Strengthens the public status page calendar test to assert the rendered Alpine component receives the public uptime-calendar API endpoint.
- Keeps coverage scoped to the recent public-label uptime calendar fix.

## Validation
- composer test:coverage -- --coverage-html coverage (blocked: Docker daemon unavailable; host PHP has no coverage driver)
- ./vendor/bin/pest tests/Feature/PublicStatusPageTest.php --filter=public_status_page_loads_uptime_calendar_without_authentication
- ./vendor/bin/pest tests/Feature/PublicStatusPageTest.php
- ./vendor/bin/pint --test tests/Feature/PublicStatusPageTest.php