### PR TITLE
fix: backfill outage daily monitoring results

### DIFF
--- a/database/migrations/2026_06_17_200000_backfill_missing_monitoring_daily_results_for_outage_days.php
+++ b/database/migrations/2026_06_17_200000_backfill_missing_monitoring_daily_results_for_outage_days.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $targetDates = $this->targetDates();
+        $timestamp = now()->toDateTimeString();
+
+        DB::table('monitoring_daily_results')->insertUsing(
+            [
+                'monitoring_id',
+                'date',
+                'uptime_total',
+                'downtime_total',
+                'unknown_total',
+                'uptime_percentage',
+                'downtime_percentage',
+                'unknown_percentage',
+                'uptime_minutes',
+                'downtime_minutes',
+                'unknown_minutes',
+                'avg_response_time',
+                'min_response_time',
+                'max_response_time',
+                'incidents_count',
+                'created_at',
+                'updated_at',
+            ],
+            DB::query()
+                ->fromSub($targetDates, 'target_dates')
+                ->join('monitoring_daily_results as source', 'source.date', '=', 'target_dates.source_date')
+                ->leftJoin('monitoring_daily_results as existing', function (JoinClause $join): void {
+                    $join
+                        ->on('existing.monitoring_id', '=', 'source.monitoring_id')
+                        ->on('existing.date', '=', 'target_dates.missing_date');
+                })
+                ->whereNull('existing.id')
+                ->select([
+                    'source.monitoring_id',
+                    'target_dates.missing_date',
+                    'source.uptime_total',
+                    'source.downtime_total',
+                    'source.unknown_total',
+                    'source.uptime_percentage',
+                    'source.downtime_percentage',
+                    'source.unknown_percentage',
+                    'source.uptime_minutes',
+                    'source.downtime_minutes',
+                    'source.unknown_minutes',
+                    'source.avg_response_time',
+                    'source.min_response_time',
+                    'source.max_response_time',
+                    'source.incidents_count',
+                ])
+                ->selectRaw('? as created_at, ? as updated_at', [$timestamp, $timestamp])
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+
+    private function targetDates(): Builder
+    {
+        $datePairs = [
+            ['2025-10-19', '2025-10-18'],
+            ['2025-12-16', '2025-12-15'],
+            ['2026-01-07', '2026-01-06'],
+            ['2026-04-28', '2026-04-27'],
+            ['2026-06-05', '2026-06-04'],
+            ['2026-06-16', '2026-06-15'],
+        ];
+
+        $targetDates = null;
+
+        foreach ($datePairs as [$missingDate, $sourceDate]) {
+            $query = DB::query()->selectRaw('? as missing_date, ? as source_date', [$missingDate, $sourceDate]);
+
+            $targetDates = $targetDates instanceof Builder
+                ? $targetDates->unionAll($query)
+                : $query;
+        }
+
+        return $targetDates;
+    }
+};


### PR DESCRIPTION
## What changed

Added a data migration that backfills missing `monitoring_daily_results` rows for the known outage dates by duplicating each monitor's previous-day aggregate result when the target day is absent.

The affected dates are:

- 2025-10-19 from 2025-10-18
- 2025-12-16 from 2025-12-15
- 2026-01-07 from 2026-01-06
- 2026-04-28 from 2026-04-27
- 2026-06-05 from 2026-06-04
- 2026-06-16 from 2026-06-15

## Why

The deployed service was down on those dates, leaving gaps in daily monitoring aggregates. This migration fills only missing monitor/date pairs and leaves existing target-day data untouched.

## Testing

- Ran a Docker-based PHP syntax check:
  `docker run --rm -v "$PWD":/var/www/html -w /var/www/html serversideup/php:8.5-cli php -l database/migrations/2026_06_17_200000_backfill_missing_monitoring_daily_results_for_outage_days.php`

No full test suite was run because dependencies are not installed in this worktree.

## Risks and follow-up

`down()` is intentionally a no-op so rollback does not delete historical monitoring rows that may be valid after the migration runs.