### PR TITLE
perf: speed up Docker builds and deploy shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,23 @@
 # https://serversideup.net/open-source/docker-php/
 FROM serversideup/php:8.5-fpm-nginx AS base
 
-# Additional PHP extensions
+# Additional production PHP extensions
 USER root
-RUN install-php-extensions bcmath gd intl pdo_mysql sockets zip redis
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    set -eux; \
+    rm -f /etc/apt/apt.conf.d/docker-clean; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-install -j"$(nproc)" gd; \
+    apt-mark manual libfreetype6 libjpeg62-turbo; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev; \
+    php -m | grep -qx gd
 
 ############################################
 # Development Image
@@ -25,7 +39,8 @@ ARG GROUP_ID
 
 # Switch to root so we can set the user ID and group ID
 USER root
-RUN docker-php-serversideup-set-id www-data $USER_ID:$GROUP_ID && \
+RUN install-php-extensions sockets && \
+    docker-php-serversideup-set-id www-data $USER_ID:$GROUP_ID && \
     docker-php-serversideup-set-file-permissions --owner $USER_ID:$GROUP_ID
 USER www-data
 
@@ -36,6 +51,7 @@ FROM base AS ci
 
 # Sometimes CI images need to run as root
 USER root
+RUN install-php-extensions sockets
 
 ############################################
 # Production Image
@@ -51,7 +67,7 @@ USER www-data
 ENV COMPOSER_CACHE_DIR=/tmp/composer-cache
 COPY --link --chown=33:33 composer.json composer.lock ./
 RUN --mount=type=cache,target=/tmp/composer-cache,sharing=locked,uid=33,gid=33 \
-    composer install --no-dev --optimize-autoloader --no-scripts --no-interaction --no-progress --prefer-dist --ignore-platform-req=ext-redis
+    composer install --no-dev --no-autoloader --no-scripts --no-interaction --no-progress --prefer-dist --ignore-platform-req=ext-redis
 COPY --link --chown=33:33 . .
 RUN rm -f bootstrap/cache/*.php && \
     composer dump-autoload --no-dev --optimize --classmap-authoritative --no-scripts
@@ -79,8 +95,6 @@ WORKDIR /var/www/html
 # Production Worker Image
 ############################################
 FROM serversideup/php:8.5-cli AS worker
-USER root
-RUN install-php-extensions redis
 # Copy application code from the build stage
 COPY --link --from=app_build --chown=33:33 /app /var/www/html
 USER www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       target: production
     image: webguard-core-php:latest
     restart: unless-stopped
+    stop_signal: SIGTERM
     environment:
       <<: *app-environment
       SSL_MODE: "${DOCKER_SSL_MODE:-off}"
@@ -117,7 +118,15 @@ services:
       PHP_MAX_EXECUTION_TIME: "3600"
       PHP_OPCACHE_ENABLE: "1"
       AUTORUN_ENABLED: "false"
-    command: php artisan schedule:work --verbose --no-interaction
+    command:
+      - sh
+      - -lc
+      - |
+        trap "exit 0" TERM INT QUIT
+        while true; do
+          php artisan schedule:run --verbose --no-interaction
+          sleep 60 & wait %1
+        done
     stop_signal: SIGTERM
     depends_on:
       mysql:

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -21,6 +21,16 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
         );
     }
 
+    public function test_scheduler_container_uses_signal_aware_schedule_loop(): void
+    {
+        $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
+
+        $this->assertIsString($composeConfiguration);
+        $this->assertStringContainsString('php artisan schedule:run --verbose --no-interaction', $composeConfiguration);
+        $this->assertStringContainsString('sleep 60 & wait %1', $composeConfiguration);
+        $this->assertStringNotContainsString('php artisan schedule:work --verbose --no-interaction', $composeConfiguration);
+    }
+
     public function test_internal_database_and_redis_services_are_optional_for_external_deployments(): void
     {
         $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
@@ -188,6 +198,7 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
         $this->assertStringContainsString('COPY --link --from=app_build', $workerStage);
         $this->assertStringNotContainsString('frontend_build', $workerStage);
         $this->assertStringNotContainsString('bun install', $workerStage);
+        $this->assertStringNotContainsString('install-php-extensions redis', $workerStage);
     }
 
     public function test_production_dockerfile_uses_dependency_cache_mounts(): void
@@ -198,9 +209,27 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
         $this->assertStringContainsString('# syntax=docker/dockerfile:1.7', $dockerfile);
         $this->assertStringContainsString('COPY --from=composer:2', $dockerfile);
         $this->assertStringContainsString('--mount=type=cache,target=/tmp/composer-cache', $dockerfile);
+        $this->assertStringContainsString('composer install --no-dev --no-autoloader', $dockerfile);
         $this->assertStringContainsString('FROM oven/bun:1 AS frontend_build', $dockerfile);
         $this->assertStringContainsString('--mount=type=cache,target=/tmp/bun-cache', $dockerfile);
         $this->assertStringContainsString('COPY --link resources resources', $dockerfile);
+    }
+
+    public function test_production_dockerfile_only_compiles_required_missing_php_extensions(): void
+    {
+        $dockerfile = file_get_contents(base_path('Dockerfile'));
+
+        $this->assertIsString($dockerfile);
+        $this->assertStringContainsString('--mount=type=cache,target=/var/cache/apt', $dockerfile);
+        $this->assertStringContainsString('apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev', $dockerfile);
+        $this->assertStringContainsString('docker-php-ext-configure gd --with-freetype --with-jpeg', $dockerfile);
+        $this->assertStringContainsString('docker-php-ext-install -j"$(nproc)" gd', $dockerfile);
+        $this->assertStringNotContainsString('install-php-extensions gd', $dockerfile);
+        $this->assertStringNotContainsString('install-php-extensions bcmath gd intl pdo_mysql sockets zip redis', $dockerfile);
+        $this->assertStringNotContainsString('install-php-extensions redis', $dockerfile);
+        $this->assertStringContainsString('FROM base AS development', $dockerfile);
+        $this->assertStringContainsString('FROM base AS ci', $dockerfile);
+        $this->assertStringContainsString('install-php-extensions sockets', $dockerfile);
     }
 
     public function test_production_php_container_defaults_to_proxy_terminated_ssl(): void
@@ -209,6 +238,7 @@ class HeartbeatQueueDeploymentConfigTest extends TestCase
 
         $this->assertIsString($composeConfiguration);
         $this->assertStringContainsString('SSL_MODE: "${DOCKER_SSL_MODE:-off}"', $composeConfiguration);
+        $this->assertStringContainsString('stop_signal: SIGTERM', $composeConfiguration);
         $this->assertStringContainsString('- "8080"', $composeConfiguration);
         $this->assertStringContainsString('- "8443"', $composeConfiguration);
     }


### PR DESCRIPTION
## What changed

- Narrowed the production PHP extension build to the required GD support and removed redundant production extension installs.
- Built GD with only JPEG, PNG, and FreeType support plus BuildKit apt cache mounts.
- Changed Composer's production install to skip the first autoloader generation and keep the final optimized dump after app code is copied.
- Removed redundant worker Redis extension installation.
- Made the PHP service stop with SIGTERM and replaced `schedule:work` with a signal-aware `schedule:run` loop so deploy shutdown does not wait for the full Docker timeout.
- Added deployment config coverage for the Dockerfile and scheduler behavior.

## Why

The deployment log showed most remaining time in PHP extension compilation and old-container shutdown: the extension step took about 66 seconds, and both `schedule` and `php` waited about 30 seconds during stop. These changes reduce unnecessary build work and make the runtime services exit promptly during deploy replacement.

## Testing

- `docker compose -f docker-compose.yml config`
- `docker build --target production --no-cache --progress=plain -t webguard-core-production-optimized .`
- `docker build --target worker --progress=plain -t webguard-core-worker-optimized .`
- Verified the production image has GD, JPEG, PNG, and FreeType support enabled.
- Verified PHP container stop time locally improved from about 30.2s to about 3.2s with SIGTERM.
- Verified scheduler stop time locally improved from about 30.1s to about 0.14s with the signal-aware loop.
- `docker run --rm --user root -v "$PWD":/var/www/html -v webguard_ci_vendor:/var/www/html/vendor -w /var/www/html webguard-core-ci-optimized sh -lc './vendor/bin/pest tests/Feature/HeartbeatQueueDeploymentConfigTest.php tests/Feature/AuthEntryPointsTest.php'`
- `git diff --check`

## Risks and follow-up

- The production GD build intentionally omits AVIF/WebP/XPM support because the app currently needs JPEG, PNG, and FreeType for captcha/image handling. If future features process AVIF or WebP server-side, GD support should be expanded deliberately.
- Coolify still appears to have a stale `MAIL_USERNAME=${MAIL_FROM_ADDRESS}` style value in environment settings; that should be replaced with a literal value in Coolify.