### PR TITLE
test: cover public calendar validation

### DIFF
--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -117,6 +117,20 @@ class PublicStatusPageTest extends TestCase
             ->assertJsonPath('2026-04.monthly_average_uptime', 100);
     }
 
+    public function test_public_status_page_calendar_endpoint_validates_date_range_without_authentication(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'public_label_enabled' => true,
+        ]);
+
+        $testResponse = $this->getJson(route('public.monitorings.uptime-calendar', $monitoring));
+
+        $testResponse->assertUnprocessable();
+        $testResponse->assertJsonValidationErrors(['start_date', 'end_date']);
+    }
+
     public function test_public_status_page_accepts_email_subscriptions_and_sends_confirmation(): void
     {
         Mail::fake();


### PR DESCRIPTION
## Summary

- Add a focused feature test for the public uptime calendar endpoint validation path.
- Cover the unauthenticated public route returning request validation errors for missing date range parameters.

## Validation

- Docker Pest coverage command completed with Xdebug installed in the disposable PHP container: `composer test:coverage -- --coverage-html storage/coverage`
- `./vendor/bin/pest tests/Feature/PublicStatusPageTest.php`
- `./vendor/bin/pint --dirty`