### PR TITLE
docs: add test concept and agent instructions

### DIFF
--- a/.cursor/rules/webguard-core.mdc
+++ b/.cursor/rules/webguard-core.mdc
@@ -1,0 +1,8 @@
+---
+alwaysApply: true
+---
+
+# Cursor Instructions
+
+Follow the canonical repository instructions in `AGENTS.md`.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# GitHub Copilot Instructions
+
+Follow the canonical repository instructions in `AGENTS.md`.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# Agent Context
+
+These instructions apply to all coding agents working in this repository.
+
+## Project Scope
+
+WebGuard Core is the Laravel Management Core & API for WebGuard. It owns the
+dashboard, admin panel, public status pages, REST API, monitoring orchestration,
+notification workflows, package administration, and legal/public content.
+
+Distributed scanning nodes are maintained in the separate `webguard-instance`
+repository. Do not implement instance-node behavior in this repository unless
+the core API contract or integration surface explicitly requires it.
+
+## Technology Context
+
+- Backend: Laravel 13 on PHP 8.5+.
+- Tests: Pest, PHPUnit configuration in `phpunit.xml`, Pest Browser Plugin.
+- Frontend: Vite, Tailwind CSS, Alpine.js, TypeScript, Chart.js.
+- Runtime services: MySQL-compatible database, Redis cache and queues, SMTP mail.
+- Local Docker: `docker-compose.yml` plus `docker-compose.override.yml`.
+- Local helper: `./start-dev.sh` starts the development stack and opens a PHP container shell.
+
+## Required Workflow
+
+1. Inspect the current worktree before editing.
+2. Read the relevant application, test, and documentation files before making changes.
+3. Keep changes focused on the requested behavior.
+4. Preserve unrelated user changes; do not revert files you did not intentionally change.
+5. Prefer existing Laravel, Pest, Blade, service, DTO, enum, factory, and route patterns.
+6. Add or update tests for new behavior and regressions.
+7. Update documentation when user-facing behavior, setup, deployment, or testing expectations change.
+8. Do not commit secrets, generated local artifacts, dependency directories, logs, or machine-specific files.
+
+## Docker-First Commands
+
+Work inside Docker whenever technically possible. Prefer project-defined Docker
+configuration over host-global tools.
+
+Use this compose command shape:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml ...
+```
+
+Common commands:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer test
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer analyse
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php php artisan migrate
+docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun install
+docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun run build
+```
+
+Use host commands only when Docker is unavailable or a task explicitly requires
+host execution. Record that exception in the handoff.
+
+## Testing Instructions
+
+Follow `docs/test-concept.md`.
+
+Use:
+
+- `tests/Unit` for services, support classes, DTO-style payload logic, enum helpers,
+  and deterministic calculations.
+- `tests/Feature` for routes, controllers, requests, middleware, commands, jobs,
+  mail, notifications, database behavior, API contracts, and authorization.
+- `tests/Browser` for rendered UI, responsive layout, JavaScript interactions,
+  and behavior that cannot be validated through feature tests.
+
+The default suite uses SQLite in-memory, array mail/cache/session drivers, and
+sync queues. Tests that require MySQL, Redis, Docker, or queue workers must make
+that dependency explicit.
+
+For targeted validation, run the smallest relevant Pest file or filter first.
+For cross-cutting changes, run the full Pest suite, PHPStan, and the frontend build.
+
+## Code Standards
+
+- Keep PHP files strict typed where the surrounding code uses `declare(strict_types=1);`.
+- Use Laravel conventions for validation, authorization, routing, queues, mail,
+  notifications, factories, casts, and configuration.
+- Keep controllers thin; put reusable business logic in services or support classes.
+- Prefer named route generation over hard-coded application URLs.
+- Prefer factories and Laravel test fakes over broad fixtures or live integrations.
+- Avoid external network access in tests.
+- Keep Blade markup accessible, localized where appropriate, and consistent with existing components.
+- Keep TypeScript behavior small, typed, and tied to existing component patterns.
+
+## Quality Gates
+
+Before handing off a change, run the relevant checks inside Docker when possible:
+
+- Targeted Pest tests for changed behavior.
+- `composer test` for broad backend changes.
+- `composer analyse` for PHP type/static-analysis risk.
+- `bun run build` for frontend or asset changes.
+
+If a check cannot be run, state why and identify the remaining risk.
+
+## Documentation Standards
+
+- Keep root `README.md` concise and link expanded documentation from `docs/`.
+- Put testing strategy in `docs/test-concept.md`.
+- Put setup and Docker operations in `docs/installation.md`.
+- Put contribution workflow in `docs/contributing.md`.
+- Keep documentation language factual and repository-specific.
+- Keep agent-specific adapter files minimal and point them back to this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Claude Instructions
+
+Follow the canonical repository instructions in `AGENTS.md`.
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ php artisan test
 - [Features](docs/features.md)
 - [Architecture and technology stack](docs/architecture.md)
 - [Installation, Docker, and operations](docs/installation.md)
+- [Test concept](docs/test-concept.md)
 - [Contributing](docs/contributing.md)
 
 ## License

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ Contributions are welcome. Please keep changes focused, tested, and easy to revi
    ```
 
 3. Make the change and add tests for the behavior.
-4. Run the relevant test suite.
+4. Follow the [test concept](test-concept.md) and run the relevant test suite.
 
    ```bash
    php artisan test

--- a/docs/test-concept.md
+++ b/docs/test-concept.md
@@ -1,0 +1,184 @@
+# Test Concept
+
+This document defines the testing strategy for the WebGuard Management Core & API.
+It complements the contribution workflow and should guide feature work, bug fixes,
+reviews, and release validation.
+
+## Goals
+
+- Protect monitoring, notification, status page, admin, and API behavior from regressions.
+- Keep tests fast enough for local development while still covering production-critical paths.
+- Prefer deterministic tests with isolated mail, queue, cache, session, and database state.
+- Validate Docker-based development and production assumptions when infrastructure behavior changes.
+- Make every user-facing behavior change reviewable through a focused test.
+
+## Test Layers
+
+### Unit Tests
+
+Use unit tests for pure or mostly pure logic in `app/Services`, `app/Support`,
+DTO-style payload classes, enum helpers, and small model-related helpers.
+
+Unit tests should:
+
+- Avoid HTTP requests and full browser flows.
+- Use explicit input data and assert concrete output values.
+- Cover edge cases such as empty histories, unknown statuses, threshold boundaries,
+  locale-sensitive labels, and time range boundaries.
+- Stay independent from external services.
+
+Relevant location: `tests/Unit`.
+
+### Feature Tests
+
+Use feature tests for Laravel behavior that crosses framework boundaries:
+controllers, requests, routes, middleware, policies, database state, jobs,
+commands, mail, notifications, API authentication, and public pages.
+
+Feature tests should:
+
+- Assert authorization and data isolation, especially for user-owned monitorings,
+  API tokens, admin routes, notification settings, and status pages.
+- Cover validation failures as well as successful paths.
+- Use factories instead of large fixture files unless a fixture captures a stable protocol contract.
+- Assert queued, mailed, notified, logged, and cached behavior with Laravel test fakes.
+- Use route names when possible so tests remain stable through URL changes.
+
+Relevant location: `tests/Feature`.
+
+### Browser Tests
+
+Use browser tests only when server-rendered markup, responsive behavior, JavaScript,
+or real user interaction is the risk being tested.
+
+Browser tests should cover:
+
+- Navigation and language switching.
+- Responsive public and authenticated layouts.
+- Interactive monitoring cards, calendars, async tables, dialogs, and theme behavior.
+- Critical regressions that cannot be seen through feature tests alone.
+
+Relevant location: `tests/Browser`.
+
+## Test Environment
+
+The default PHP test environment is configured in `phpunit.xml` and `.env.testing`:
+
+- `APP_ENV=testing`
+- SQLite in-memory database
+- array cache and session drivers
+- sync queue driver
+- array mail driver
+
+This keeps the standard Pest suite fast and deterministic. Tests that specifically
+verify MySQL, Redis, queue worker, or Docker integration behavior must make that
+dependency explicit in the test name and setup.
+
+## Docker-First Execution
+
+Run validation inside the project Docker environment whenever technically possible.
+Use the local compose stack from `docker-compose.yml` plus `docker-compose.override.yml`.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer test
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer analyse
+docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun run build
+```
+
+For targeted backend tests:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php ./vendor/bin/pest tests/Feature/MonitoringExpectedHttpStatusesTest.php
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php ./vendor/bin/pest --filter "expected http statuses"
+```
+
+For frontend dependency or build checks:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun install
+docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun run build
+```
+
+Host execution is acceptable only when Docker is unavailable or the repository
+explicitly requires a host-specific check. Document that limitation in the final
+handoff or pull request.
+
+## Coverage Expectations
+
+Every change should include the narrowest useful validation:
+
+- Service or support logic: unit tests for normal, boundary, and empty-state cases.
+- HTTP routes and Blade output: feature tests for status code, authorization,
+  visible text, redirects, validation, and persisted state.
+- API changes: feature tests for authentication, authorization, request validation,
+  response schema, pagination, and backward compatibility.
+- Jobs and commands: feature tests for scheduling, dispatch behavior, idempotency,
+  retries where applicable, and observable side effects.
+- Notifications and mail: feature tests with fakes plus rendering assertions for
+  important templates.
+- Database migrations: migration compatibility tests when columns, indexes, enums,
+  or production database behavior change.
+- Frontend scripts and responsive UI: browser tests when behavior depends on
+  JavaScript, viewport size, or user interaction.
+
+Bug fixes should include a regression test that fails before the fix and passes
+after it.
+
+## Risk Areas
+
+Prioritize tests around these project-specific risks:
+
+- Monitoring state transitions, failure confirmation thresholds, and lifecycle status.
+- Response time, uptime, SLA, heatmap, and calendar aggregation calculations.
+- Status pages, incident updates, subscribers, and public indexing behavior.
+- Notification routing, channel delivery history, digest commands, expiry warnings,
+  and unread reminders.
+- Heartbeat monitoring and dedicated heartbeat queue behavior.
+- API token access, internal instance API compatibility, and public badge/card APIs.
+- Admin table filtering, user deletion, package administration, and audit logging.
+- Locale, theme, and public legal page rendering.
+- Docker deployment settings, Redis extension availability, MySQL compatibility,
+  and generated Vite manifest assumptions.
+
+## Test Data Guidelines
+
+- Prefer factories for users, packages, monitorings, responses, incidents, and status pages.
+- Freeze time with Laravel helpers when testing date ranges, expiry windows,
+  digest periods, and aggregation windows.
+- Keep test data minimal but semantically meaningful.
+- Avoid external network calls; fake HTTP, mail, notification, queue, and event boundaries.
+- Do not depend on test order or previously persisted state.
+- Use named constants or helper methods when repeated values represent a business rule.
+
+## Pull Request Validation Matrix
+
+Use this matrix to decide the minimum validation before a change is ready:
+
+| Change type | Minimum validation |
+| --- | --- |
+| Documentation only | Relevant documentation structure test if links or required topics change |
+| Pure service/support logic | Targeted unit tests |
+| Route, controller, middleware, request, or Blade change | Targeted feature tests |
+| API contract change | Targeted API feature tests plus backward compatibility checks |
+| Job, command, scheduler, queue, or notification change | Targeted feature tests for side effects and scheduling |
+| Migration, index, or database behavior change | Migration or compatibility test; use MySQL when SQLite cannot model the risk |
+| Frontend asset or TypeScript change | `bun run build`; browser test for interaction or responsive behavior |
+| Cross-cutting behavior | Targeted tests plus full Pest suite, PHPStan, and frontend build |
+
+## Release Validation
+
+Before a release or broad deployment change, run:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer test
+docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer analyse
+docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun run build
+```
+
+Also verify:
+
+- The Docker stack starts successfully with the intended compose profile.
+- Migrations run cleanly against the target database engine.
+- Queue workers can process the `default` and `heartbeat` queues.
+- Mail configuration is validated through Mailpit locally or the configured SMTP provider in staging.
+- Public pages, status pages, badges, and API documentation remain reachable.

--- a/tests/Feature/DocumentationStructureTest.php
+++ b/tests/Feature/DocumentationStructureTest.php
@@ -47,6 +47,12 @@ class DocumentationStructureTest extends TestCase
                 'queue:work redis',
                 'webguard-instance Integration With Local Docker',
             ],
+            'docs/test-concept.md' => [
+                'Docker-First Execution',
+                'Pest',
+                'Browser Tests',
+                'Release Validation',
+            ],
             'docs/contributing.md' => [
                 'Conventional Commits',
                 'Write tests',
@@ -98,6 +104,7 @@ class DocumentationStructureTest extends TestCase
             'docs/features.md',
             'docs/architecture.md',
             'docs/installation.md',
+            'docs/test-concept.md',
             'docs/contributing.md',
         ];
     }


### PR DESCRIPTION
## What changed

- Added a project-specific test concept covering test layers, Docker-first execution, risk areas, and release validation.
- Added a canonical `AGENTS.md` context for coding agents working in this repository.
- Added minimal adapter instruction files for Claude, GitHub Copilot, and Cursor that point back to `AGENTS.md`.
- Linked the test concept from the README and contributing docs.
- Updated the documentation structure test to include the new test concept.

## Why

This gives contributors and coding agents a single source of truth for testing expectations, Docker-based validation, and repository-specific workflow rules.

## Testing

- `git diff --check`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps -e AUTORUN_ENABLED=false php ./vendor/bin/pest tests/Feature/DocumentationStructureTest.php`

The targeted Pest run completed with exit code 0 and 53 assertions. It reported existing PHP stream warnings from the documentation structure test output.

## Risks and follow-up

- Documentation-only change; runtime risk is low.
- The full test suite was not run because the requested change only affects documentation and documentation structure coverage.