### PR TITLE
ci: run Pint in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: ./vendor/bin/rector process --ansi --debug
 
     - name: Run Pint
-      run: ./vendor/bin/pint
+      run: ./vendor/bin/pint --parallel
 
     - name: Ensure local PR branch exists
       run: git checkout -B "${{ github.head_ref }}"


### PR DESCRIPTION
## What changed

- Updated the CI auto-fix job to run Laravel Pint with `--parallel`.

## Why

- Pint can use multiple processes in parallel mode, reducing formatter runtime on CI runners with more than one core.

## Testing

- Ran `git diff --check`.
- Parsed `.github/workflows/ci.yml` as YAML inside Docker with `ruby:3.3-alpine`.

## Risks and follow-up

- Pint parallel mode is marked experimental by Laravel, so formatter behavior should be watched on the first CI run.