### PR TITLE
feat(docker): add php healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ FROM serversideup/php:8.5-fpm-nginx AS base
 
 # Additional production PHP extensions
 USER root
+COPY docker/php/healthcheck.sh /usr/local/bin/webguard-healthcheck
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     set -eux; \
+    chmod +x /usr/local/bin/webguard-healthcheck; \
     rm -f /etc/apt/apt.conf.d/docker-clean; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
@@ -88,6 +90,7 @@ COPY --link --from=app_build --chown=33:33 /app /var/www/html
 COPY --link --from=frontend_build --chown=33:33 /app/public/build /var/www/html/public/build
 COPY --link docker/php/entrypoint.d/ /etc/entrypoint.d/
 RUN chmod +x /etc/entrypoint.d/*.sh
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=6 CMD ["webguard-healthcheck"]
 USER www-data
 WORKDIR /var/www/html
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,12 @@ services:
     expose:
       - "8080"
       - "8443"
+    healthcheck:
+      test: ["CMD", "webguard-healthcheck"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 6
     volumes:
       - config:/config
       - data:/data

--- a/docker/php/healthcheck.sh
+++ b/docker/php/healthcheck.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+healthcheck_url="${HEALTHCHECK_URL:-http://127.0.0.1:${DOCKER_PHP_INTERNAL_PORT:-8080}/status}"
+healthcheck_timeout="${HEALTHCHECK_TIMEOUT_SECONDS:-3}"
+
+HEALTHCHECK_URL="$healthcheck_url" php -d "default_socket_timeout=${healthcheck_timeout}" -r '
+$url = getenv("HEALTHCHECK_URL") ?: "http://127.0.0.1:8080/status";
+$headers = @get_headers($url);
+
+if ($headers === false || ! isset($headers[0]) || preg_match("/^HTTP\/\S+\s+2\d\d\b/", (string) $headers[0]) !== 1) {
+    exit(1);
+}
+'


### PR DESCRIPTION
## What changed

- Added a `webguard-healthcheck` command to the PHP image.
- Configured the production PHP image with a Docker `HEALTHCHECK` that probes Laravel's existing `/status` route.
- Added the same healthcheck to the Compose `php` service so deployment platforms such as Coolify can detect healthy and unhealthy containers.

## Why

Coolify needs a container health signal to know whether the PHP web service is running correctly or failing after startup. The check uses the app's internal HTTP listener on port `8080` and avoids adding a `curl` or `wget` dependency by using PHP itself.

## Testing

- `sh -n docker/php/healthcheck.sh`
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml config`
- `docker build --target base --progress=plain .`
- `docker build --target base -t webguard-core-healthcheck-test --progress=plain .`
- Verified `webguard-healthcheck` exits successfully against a temporary local 2xx `/status` endpoint inside the built image.
- Verified `webguard-healthcheck` exits unhealthy when the endpoint is unreachable.

## Risks and follow-up

- The check depends on Laravel's existing `/status` route remaining available and returning a 2xx response when the web server is healthy.