### PR TITLE
fix: preserve old audit log values

### DIFF
--- a/app/Support/ActivityLog/RedactActivityLogChanges.php
+++ b/app/Support/ActivityLog/RedactActivityLogChanges.php
@@ -53,11 +53,11 @@ class RedactActivityLogChanges extends LogActivityAction
      * @param  Collection<string, mixed>|array<string, mixed>  $values
      * @return array<string, mixed>
      */
-    private function withMissingOldAttributes(Collection|array $values, Model $activity): array
+    private function withMissingOldAttributes(Collection|array $values, Model $model): array
     {
         $changes = $values instanceof Collection ? $values->toArray() : $values;
 
-        if (($activity->event ?? null) !== 'updated' || ! $activity->subject instanceof Model) {
+        if (($model->event ?? null) !== 'updated' || ! $model->subject instanceof Model) {
             return $changes;
         }
 
@@ -66,16 +66,21 @@ class RedactActivityLogChanges extends LogActivityAction
         }
 
         $old = is_array($changes['old'] ?? null) ? $changes['old'] : [];
-        $previous = method_exists($activity->subject, 'getPrevious')
-            ? $activity->subject->getPrevious()
+        $previous = method_exists($model->subject, 'getPrevious')
+            ? $model->subject->getPrevious()
             : [];
 
         foreach (array_keys($changes['attributes']) as $attribute) {
-            if (! is_string($attribute) || array_key_exists($attribute, $old) || ! array_key_exists($attribute, $previous)) {
+            if (! is_string($attribute)) {
                 continue;
             }
-
-            $old[$attribute] = $this->formatPreviousAttributeValue($activity->subject, $attribute, $previous[$attribute]);
+            if (array_key_exists($attribute, $old)) {
+                continue;
+            }
+            if (! array_key_exists($attribute, $previous)) {
+                continue;
+            }
+            $old[$attribute] = $this->formatPreviousAttributeValue($model->subject, $attribute, $previous[$attribute]);
         }
 
         if ($old !== []) {

--- a/app/Support/ActivityLog/RedactActivityLogChanges.php
+++ b/app/Support/ActivityLog/RedactActivityLogChanges.php
@@ -6,6 +6,8 @@ namespace App\Support\ActivityLog;
 
 use App\Enums\MonitoringType;
 use App\Models\Monitoring;
+use BackedEnum;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\Actions\LogActivityAction;
@@ -40,8 +42,64 @@ class RedactActivityLogChanges extends LogActivityAction
 
     protected function transformChanges(Model $activity): void
     {
-        $activity->attribute_changes = $this->redactCollection($activity->attribute_changes ?? collect(), $activity);
+        $activity->attribute_changes = $this->redactCollection(
+            $this->withMissingOldAttributes($activity->attribute_changes ?? collect(), $activity),
+            $activity
+        );
         $activity->properties = $this->redactCollection($activity->properties ?? collect(), $activity);
+    }
+
+    /**
+     * @param  Collection<string, mixed>|array<string, mixed>  $values
+     * @return array<string, mixed>
+     */
+    private function withMissingOldAttributes(Collection|array $values, Model $activity): array
+    {
+        $changes = $values instanceof Collection ? $values->toArray() : $values;
+
+        if (($activity->event ?? null) !== 'updated' || ! $activity->subject instanceof Model) {
+            return $changes;
+        }
+
+        if (! is_array($changes['attributes'] ?? null)) {
+            return $changes;
+        }
+
+        $old = is_array($changes['old'] ?? null) ? $changes['old'] : [];
+        $previous = method_exists($activity->subject, 'getPrevious')
+            ? $activity->subject->getPrevious()
+            : [];
+
+        foreach (array_keys($changes['attributes']) as $attribute) {
+            if (! is_string($attribute) || array_key_exists($attribute, $old) || ! array_key_exists($attribute, $previous)) {
+                continue;
+            }
+
+            $old[$attribute] = $this->formatPreviousAttributeValue($activity->subject, $attribute, $previous[$attribute]);
+        }
+
+        if ($old !== []) {
+            $changes['old'] = $old;
+        }
+
+        return $changes;
+    }
+
+    private function formatPreviousAttributeValue(Model $subject, string $attribute, mixed $value): mixed
+    {
+        $model = $subject->newInstance([], true);
+        $model->setRawAttributes([$attribute => $value], true);
+        $formatted = $model->getAttribute($attribute);
+
+        if ($formatted instanceof BackedEnum) {
+            return $formatted->value;
+        }
+
+        if ($formatted instanceof DateTimeInterface) {
+            return $formatted->format(DateTimeInterface::ATOM);
+        }
+
+        return $formatted;
     }
 
     /**

--- a/tests/Unit/Support/ActivityLog/RedactActivityLogChangesTest.php
+++ b/tests/Unit/Support/ActivityLog/RedactActivityLogChangesTest.php
@@ -21,9 +21,9 @@ class RedactActivityLogChangesTest extends TestCase
             'auth_password' => 'fresh-basic-password',
         ], true);
 
-        $reflection = new ReflectionClass($monitoring);
-        $previous = $reflection->getProperty('previous');
-        $previous->setValue($monitoring, [
+        $reflectionClass = new ReflectionClass($monitoring);
+        $reflectionProperty = $reflectionClass->getProperty('previous');
+        $reflectionProperty->setValue($monitoring, [
             'name' => 'Sensitive HTTP Monitor',
             'auth_password' => 'raw-basic-password',
         ]);
@@ -38,11 +38,11 @@ class RedactActivityLogChangesTest extends TestCase
             ],
         ]);
 
-        $action = new RedactActivityLogChanges();
-        $method = new ReflectionMethod($action, 'transformChanges');
-        $method->invoke($action, $activity);
+        $redactActivityLogChanges = new RedactActivityLogChanges();
+        $reflectionMethod = new ReflectionMethod($redactActivityLogChanges, 'transformChanges');
+        $reflectionMethod->invoke($redactActivityLogChanges, $activity);
 
-        $changes = $activity->attribute_changes->toArray();
+        $changes = $activity->attribute_changes->all();
 
         $this->assertSame('Sensitive HTTP Monitor', data_get($changes, 'old.name'));
         $this->assertSame('[redacted]', data_get($changes, 'old.auth_password'));

--- a/tests/Unit/Support/ActivityLog/RedactActivityLogChangesTest.php
+++ b/tests/Unit/Support/ActivityLog/RedactActivityLogChangesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\ActivityLog;
+
+use App\Models\Monitoring;
+use App\Support\ActivityLog\RedactActivityLogChanges;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use Spatie\Activitylog\Models\Activity;
+
+class RedactActivityLogChangesTest extends TestCase
+{
+    public function test_updated_activity_backfills_missing_old_attributes_before_redaction(): void
+    {
+        $monitoring = new Monitoring();
+        $monitoring->setRawAttributes([
+            'name' => 'Renamed Sensitive HTTP Monitor',
+            'auth_password' => 'fresh-basic-password',
+        ], true);
+
+        $reflection = new ReflectionClass($monitoring);
+        $previous = $reflection->getProperty('previous');
+        $previous->setValue($monitoring, [
+            'name' => 'Sensitive HTTP Monitor',
+            'auth_password' => 'raw-basic-password',
+        ]);
+
+        $activity = new Activity();
+        $activity->event = 'updated';
+        $activity->setRelation('subject', $monitoring);
+        $activity->attribute_changes = collect([
+            'attributes' => [
+                'name' => 'Renamed Sensitive HTTP Monitor',
+                'auth_password' => 'fresh-basic-password',
+            ],
+        ]);
+
+        $action = new RedactActivityLogChanges();
+        $method = new ReflectionMethod($action, 'transformChanges');
+        $method->invoke($action, $activity);
+
+        $changes = $activity->attribute_changes->toArray();
+
+        $this->assertSame('Sensitive HTTP Monitor', data_get($changes, 'old.name'));
+        $this->assertSame('[redacted]', data_get($changes, 'old.auth_password'));
+        $this->assertSame('[redacted]', data_get($changes, 'attributes.auth_password'));
+    }
+}


### PR DESCRIPTION
## What changed
- Backfill missing `old` attribute values for updated activity log entries from Laravel's previous model state before redaction runs.
- Preserve redaction for sensitive old and new values.
- Added a focused unit regression test for update activities that arrive without an `old` payload.

## Why
The monitoring audit log test expected `attribute_changes.old.name` to contain the previous monitor name, but the saved update activity could contain only the new attributes. This made the audit trail incomplete and caused the CI assertion to fail.

## Testing
- `./vendor/bin/pest tests/Unit/Support/ActivityLog/RedactActivityLogChangesTest.php`
- `./vendor/bin/pest tests/Feature/AuditLogTest.php --parallel --processes=4`
- `./vendor/bin/pest --parallel --processes=4`
- `composer analyse`

## Notes
- Local Docker image did not include a coverage driver, so `composer test:coverage` could not be run locally.