### PR TITLE
fix: raise PHP container memory limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     environment:
       <<: *app-environment
       SSL_MODE: "${DOCKER_SSL_MODE:-off}"
-      PHP_MEMORY_LIMIT: "512M"
+      PHP_MEMORY_LIMIT: "2048M"
       PHP_UPLOAD_MAX_FILE_SIZE: "100M"
       PHP_MAX_EXECUTION_TIME: "300"
       PHP_OPCACHE_ENABLE: "1"


### PR DESCRIPTION
## What changed
- Increased the main PHP container `PHP_MEMORY_LIMIT` from `512M` to `2048M` in `docker-compose.yml`.

## Why
- Aligns the web PHP container with the existing scheduler and queue worker memory limit, giving the application more headroom for memory-intensive requests.

## Testing
- Ran `docker compose config` with required environment placeholders and confirmed the rendered PHP service environment resolves `PHP_MEMORY_LIMIT: 2048M`.
- Ran `git diff --check`.

## Risks and follow-up
- This only changes the PHP runtime memory limit; container-level memory constraints, if configured externally, are unchanged.