### PR TITLE
fix: clarify optional monitoring group assignments

### DIFF
--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -211,7 +211,7 @@ return [
         'select_type' => 'Überwachungstyp auswählen',
         'name' => 'Name',
         'groups' => 'Gruppen',
-        'groups_help' => 'Ordnen Sie diese Überwachung einer oder mehreren bestehenden Gruppen zu. Gruppen werden separat verwaltet.',
+        'groups_help' => 'Optional: Ordnen Sie diese Überwachung bestehenden Gruppen zu. Monitoring und Gruppen können auch ohne Zuordnung bestehen. Gruppen werden separat verwaltet.',
         'target' => 'Ziel',
         'target_immutable_help' => 'Die Ziel-URL kann nach der Erstellung nicht mehr geändert werden.',
         'heartbeat_target_generated' => 'Die Heartbeat-Ping-URL wird nach dem Speichern automatisch erzeugt.',

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -211,6 +211,7 @@ return [
         'select_type' => 'Überwachungstyp auswählen',
         'name' => 'Name',
         'groups' => 'Gruppen',
+        'no_group' => 'Keine Gruppe',
         'groups_help' => 'Optional: Ordnen Sie diese Überwachung bestehenden Gruppen zu. Monitoring und Gruppen können auch ohne Zuordnung bestehen. Gruppen werden separat verwaltet.',
         'target' => 'Ziel',
         'target_immutable_help' => 'Die Ziel-URL kann nach der Erstellung nicht mehr geändert werden.',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -211,7 +211,7 @@ return [
         'select_type' => 'Select Monitoring Type',
         'name' => 'Name',
         'groups' => 'Groups',
-        'groups_help' => 'Assign this monitoring to one or more existing groups. Groups are managed separately.',
+        'groups_help' => 'Optionally assign this monitoring to existing groups. Monitorings and groups can also exist without assignments. Groups are managed separately.',
         'target' => 'Target',
         'target_immutable_help' => 'Target URL cannot be changed after creation.',
         'heartbeat_target_generated' => 'The heartbeat ping URL will be generated automatically after saving.',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -211,6 +211,7 @@ return [
         'select_type' => 'Select Monitoring Type',
         'name' => 'Name',
         'groups' => 'Groups',
+        'no_group' => 'No group',
         'groups_help' => 'Optionally assign this monitoring to existing groups. Monitorings and groups can also exist without assignments. Groups are managed separately.',
         'target' => 'Target',
         'target_immutable_help' => 'Target URL cannot be changed after creation.',

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -28,6 +28,10 @@
         isset($monitoring) ? $monitoring->groups->pluck('id')->all() : []
     );
     $selectedGroupIds = is_array($selectedGroupIds) ? $selectedGroupIds : [];
+    $selectedGroupIds = array_values(array_filter(
+        array_map(static fn (mixed $groupId): string => (string) $groupId, $selectedGroupIds),
+        static fn (string $groupId): bool => $groupId !== ''
+    ));
 @endphp
 
 @csrf
@@ -41,6 +45,7 @@
     timeoutValue: {{ old('timeout', $monitoring->timeout ?? 5) }},
     publicLabelEnabled: @js(old('public_label_enabled', $monitoring->public_label_enabled ?? false)),
     notificationOnFailure: @js(old('notification_on_failure', $monitoring->notification_on_failure ?? true)),
+    groupIds: @js($selectedGroupIds === [] ? [''] : $selectedGroupIds),
     init() {
         if (!@js(isset($monitoring))) {
             if ((this.type === '{{ MonitoringType::HTTP->value }}' || this.type === '{{ MonitoringType::KEYWORD->value }}') && (!this.target || !this.target.startsWith('http'))) {
@@ -51,6 +56,35 @@
                 this.target = '';
             }
         }
+    },
+    syncGroupSelection(event) {
+        const options = Array.from(event.target.options);
+        const emptyOption = options.find(option => option.value === '');
+        const selectedValues = options.filter(option => option.selected).map(option => option.value);
+        const selectedGroupIds = selectedValues.filter(value => value !== '');
+
+        if (!emptyOption) {
+            this.groupIds = selectedGroupIds;
+
+            return;
+        }
+
+        if (emptyOption.selected && !this.groupIds.includes('')) {
+            options.forEach(option => option.selected = option.value === '');
+            this.groupIds = [''];
+
+            return;
+        }
+
+        if (selectedGroupIds.length > 0) {
+            emptyOption.selected = false;
+            this.groupIds = selectedGroupIds;
+
+            return;
+        }
+
+        emptyOption.selected = true;
+        this.groupIds = [''];
     }
 }" x-init="$watch('type', value => {
     if ((value === '{{ MonitoringType::HTTP->value }}' || value === '{{ MonitoringType::KEYWORD->value }}') && (!target || !target.startsWith('http'))) {
@@ -91,7 +125,8 @@
 
     <div class="mt-4">
         <x-input-label for="group_ids" :value="__('monitoring.form.groups')" />
-        <x-select-input id="group_ids" class="mt-1 block min-h-32 w-full" name="group_ids[]" multiple>
+        <x-select-input id="group_ids" class="mt-1 block min-h-32 w-full" name="group_ids[]" multiple x-on:change="syncGroupSelection($event)">
+            <option value="" @selected($selectedGroupIds === [])>{{ __('monitoring.form.no_group') }}</option>
             @foreach ($monitoringGroups ?? [] as $monitoringGroup)
                 <option value="{{ $monitoringGroup->id }}" @selected(in_array($monitoringGroup->id, $selectedGroupIds, true))>
                     {{ $monitoringGroup->name }}

--- a/tests/Feature/MonitoringGroupTest.php
+++ b/tests/Feature/MonitoringGroupTest.php
@@ -116,6 +116,25 @@ class MonitoringGroupTest extends TestCase
         $testResponse->assertSeeHtml('value="' . $production->id . '" selected');
     }
 
+    public function test_monitorings_and_groups_can_exist_without_assignments(): void
+    {
+        $monitoringGroup = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Unassigned Group']);
+
+        $createResponse = $this->actingAs($this->user)->post(route('monitorings.store'), $this->httpPayload([
+            'name' => 'Standalone HTTP Monitoring',
+        ]));
+
+        $createResponse->assertRedirect(route('monitorings.index'));
+
+        $monitoring = Monitoring::query()->where('name', 'Standalone HTTP Monitoring')->firstOrFail();
+
+        $this->assertSame(0, $monitoring->groups()->count());
+        $this->assertSame(0, $monitoringGroup->monitorings()->count());
+        $this->assertDatabaseMissing('monitoring_group_monitoring', [
+            'monitoring_id' => $monitoring->id,
+        ]);
+    }
+
     public function test_foreign_groups_are_not_visible_or_assignable(): void
     {
         $ownGroup = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Own Group']);

--- a/tests/Feature/MonitoringGroupTest.php
+++ b/tests/Feature/MonitoringGroupTest.php
@@ -135,6 +135,42 @@ class MonitoringGroupTest extends TestCase
         ]);
     }
 
+    public function test_create_and_edit_forms_offer_explicit_no_group_selection(): void
+    {
+        MonitoringGroup::factory()->for($this->user)->create(['name' => 'Production']);
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $createResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
+        $editResponse = $this->actingAs($this->user)->get(route('monitorings.edit', $monitoring));
+
+        $createResponse->assertOk();
+        $createResponse->assertSeeText('No group');
+        $createResponse->assertSeeHtml('<option value="" selected>No group</option>');
+
+        $editResponse->assertOk();
+        $editResponse->assertSeeText('No group');
+        $editResponse->assertSeeHtml('<option value="" selected>No group</option>');
+    }
+
+    public function test_selecting_no_group_detaches_existing_group_assignments(): void
+    {
+        $monitoringGroup = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Production']);
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+        $monitoring->groups()->attach($monitoringGroup);
+
+        $updateResponse = $this->actingAs($this->user)->patch(route('monitorings.update', $monitoring), $this->httpPayload([
+            'name' => 'Standalone HTTP Monitoring',
+            'group_ids' => [''],
+        ]));
+
+        $updateResponse->assertRedirect(route('monitorings.show', $monitoring));
+        $this->assertSame(0, $monitoring->refresh()->groups()->count());
+    }
+
     public function test_foreign_groups_are_not_visible_or_assignable(): void
     {
         $ownGroup = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Own Group']);

--- a/tests/Feature/MonitoringGroupTest.php
+++ b/tests/Feature/MonitoringGroupTest.php
@@ -120,11 +120,11 @@ class MonitoringGroupTest extends TestCase
     {
         $monitoringGroup = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Unassigned Group']);
 
-        $createResponse = $this->actingAs($this->user)->post(route('monitorings.store'), $this->httpPayload([
+        $testResponse = $this->actingAs($this->user)->post(route('monitorings.store'), $this->httpPayload([
             'name' => 'Standalone HTTP Monitoring',
         ]));
 
-        $createResponse->assertRedirect(route('monitorings.index'));
+        $testResponse->assertRedirect(route('monitorings.index'));
 
         $monitoring = Monitoring::query()->where('name', 'Standalone HTTP Monitoring')->firstOrFail();
 

--- a/tests/Feature/MonitoringGroupTest.php
+++ b/tests/Feature/MonitoringGroupTest.php
@@ -142,12 +142,12 @@ class MonitoringGroupTest extends TestCase
             'preferred_location' => $this->serverInstance->code,
         ]);
 
-        $createResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
+        $testResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
         $editResponse = $this->actingAs($this->user)->get(route('monitorings.edit', $monitoring));
 
-        $createResponse->assertOk();
-        $createResponse->assertSeeText('No group');
-        $createResponse->assertSeeHtml('<option value="" selected>No group</option>');
+        $testResponse->assertOk();
+        $testResponse->assertSeeText('No group');
+        $testResponse->assertSeeHtml('<option value="" selected>No group</option>');
 
         $editResponse->assertOk();
         $editResponse->assertSeeText('No group');
@@ -162,12 +162,12 @@ class MonitoringGroupTest extends TestCase
         ]);
         $monitoring->groups()->attach($monitoringGroup);
 
-        $updateResponse = $this->actingAs($this->user)->patch(route('monitorings.update', $monitoring), $this->httpPayload([
+        $testResponse = $this->actingAs($this->user)->patch(route('monitorings.update', $monitoring), $this->httpPayload([
             'name' => 'Standalone HTTP Monitoring',
             'group_ids' => [''],
         ]));
 
-        $updateResponse->assertRedirect(route('monitorings.show', $monitoring));
+        $testResponse->assertRedirect(route('monitorings.show', $monitoring));
         $this->assertSame(0, $monitoring->refresh()->groups()->count());
     }
 


### PR DESCRIPTION
## What changed
- Updated the monitoring form help text in German and English to make group assignment explicitly optional.
- Added an explicit "No group" / "Keine Gruppe" option to the create and edit group selection so users can save monitorings without group assignments.
- Added feature regression tests covering monitorings without groups, groups without monitor assignments, the form option, and detaching existing groups through the empty selection.

## Why
The UI copy and selection experience implied that every monitoring should be assigned to at least one group. The data model already supports optional many-to-many assignments, so the wording, form behavior, and coverage now match the intended 0:n behavior.

## Testing
- `composer test -- tests/Feature/MonitoringGroupTest.php` inside Docker: passed, with existing missing `.env` warnings.
- `./vendor/bin/pint --dirty` inside Docker: passed.

## Risks / follow-up
- No migration was needed because the pivot-table relationship already allows both sides to exist without assignments.