### PR TITLE
fix: replace browser delete confirms with modal

### DIFF
--- a/resources/lang/de/api.php
+++ b/resources/lang/de/api.php
@@ -18,6 +18,7 @@ return [
         ],
         'messages' => [
             'copied' => 'API-Schlüssel in die Zwischenablage kopiert!',
+            'confirm_revoke_token' => 'Möchten Sie Ihren API-Token wirklich widerrufen? Bestehende Integrationen mit diesem Token funktionieren danach nicht mehr.',
             'tokens_deleted' => 'Token erfolgreich gelöscht.',
             'api_key_confidential_warning' => 'Halten Sie Ihren API-Schlüssel vertraulich. Wenn Sie glauben, dass Ihr Schlüssel kompromittiert wurde, können Sie einen neuen generieren.',
         ],

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -316,6 +316,7 @@ return [
             'email_placeholder' => 'sie@example.com',
             'heading' => 'Updates abonnieren',
             'unsubscribe_button' => 'Abmelden',
+            'unsubscribe_confirmation' => 'Möchten Sie diese Statusupdates wirklich abbestellen?',
             'unsubscribe_description' => 'Keine Statusupdates für diese Überwachung mehr an :email senden.',
             'unsubscribe_heading' => 'Statusupdates abbestellen',
             'unsubscribe_title' => 'Updates für :monitoringName abbestellen',

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -18,6 +18,7 @@ return [
         ],
         'messages' => [
             'copied' => 'API Key copied to clipboard!',
+            'confirm_revoke_token' => 'Are you sure you want to revoke your API token? Existing integrations that use this token will stop working.',
             'tokens_deleted' => 'Tokens deleted successfully.',
             'api_key_confidential_warning' => 'Keep your API key confidential. If you believe your key has been compromised, you can generate a new one.',
         ],

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -316,6 +316,7 @@ return [
             'email_placeholder' => 'you@example.com',
             'heading' => 'Subscribe to updates',
             'unsubscribe_button' => 'Unsubscribe',
+            'unsubscribe_confirmation' => 'Are you sure you want to unsubscribe from these status updates?',
             'unsubscribe_description' => 'Stop sending status updates for this monitor to :email.',
             'unsubscribe_heading' => 'Unsubscribe from status updates',
             'unsubscribe_title' => 'Unsubscribe from :monitoringName updates',

--- a/resources/views/components/confirm-dialog.blade.php
+++ b/resources/views/components/confirm-dialog.blade.php
@@ -1,22 +1,37 @@
 <div x-data="confirmDialog()" x-show="open" x-cloak x-on:keydown.escape.window="cancel()"
     class="fixed inset-0 z-50 overflow-y-auto px-4 py-6 sm:px-0" role="dialog" aria-modal="true"
-    aria-labelledby="app-confirm-dialog-title">
-    <div x-show="open" class="fixed inset-0 bg-gray-500 opacity-75" x-on:click="cancel()"
+    aria-labelledby="app-confirm-dialog-title" aria-describedby="app-confirm-dialog-message">
+    <div x-show="open" class="fixed inset-0 bg-gray-950/70 backdrop-blur-sm" x-on:click="cancel()"
         x-transition:enter="ease-out duration-200" x-transition:enter-start="opacity-0"
-        x-transition:enter-end="opacity-75" x-transition:leave="ease-in duration-150"
-        x-transition:leave-start="opacity-75" x-transition:leave-end="opacity-0"></div>
+        x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-150"
+        x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"></div>
 
     <div x-show="open"
-        class="relative mx-auto mb-6 overflow-hidden rounded-lg bg-white p-6 shadow-xl transition-all dark:bg-gray-800 sm:w-full sm:max-w-md"
+        class="relative mx-auto mb-6 overflow-hidden rounded-lg border border-purple-100 bg-white shadow-2xl shadow-purple-950/20 transition-all dark:border-purple-900/50 dark:bg-gray-800 dark:shadow-black/40 sm:w-full sm:max-w-md"
         x-transition:enter="ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100" x-transition:leave="ease-in duration-150"
         x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
         x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-        <h2 id="app-confirm-dialog-title" class="text-lg font-semibold text-gray-900 dark:text-gray-100"
-            x-text="title"></h2>
-        <p class="mt-3 text-sm text-gray-600 dark:text-gray-300" x-text="message"></p>
+        <div class="border-b border-purple-100 bg-purple-50/70 px-6 py-5 dark:border-purple-900/50 dark:bg-purple-950/30">
+            <div class="flex items-start gap-4">
+                <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-red-100 text-red-600 ring-8 ring-red-50 dark:bg-red-950/60 dark:text-red-300 dark:ring-red-950/30">
+                    <svg class="h-5 w-5" aria-hidden="true" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd"
+                            d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.516-2.625L8.485 2.495ZM10 5.5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5.5Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                            clip-rule="evenodd" />
+                    </svg>
+                </div>
 
-        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                <div>
+                    <h2 id="app-confirm-dialog-title" class="text-lg font-semibold text-gray-950 dark:text-gray-50"
+                        x-text="title"></h2>
+                    <p id="app-confirm-dialog-message" class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300"
+                        x-text="message"></p>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex flex-col-reverse gap-3 px-6 py-5 sm:flex-row sm:justify-end">
             <x-secondary-button type="button" x-on:click="cancel()" class="justify-center"
                 data-confirm-cancel-button>
                 <span x-text="cancelText"></span>

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-confirm-title="{{ __('app.confirmation.title') }}"
+    data-confirm-confirm="{{ __('app.confirmation.confirm') }}" data-confirm-cancel="{{ __('button.cancel') }}">
 
 <head>
     <meta charset="utf-8">
@@ -55,6 +56,8 @@
 
     <main class="py-6">
         {{ $slot }}
+
+        <x-confirm-dialog />
     </main>
 
     @include('components.footer')

--- a/resources/views/monitoring-groups/index.blade.php
+++ b/resources/views/monitoring-groups/index.blade.php
@@ -50,12 +50,11 @@
                                     <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)">
                                         {{ __('button.edit') }}
                                     </x-secondary-button>
-                                    <form method="POST" action="{{ route('monitoring-groups.destroy', $monitoringGroup) }}">
+                                    <form method="POST" action="{{ route('monitoring-groups.destroy', $monitoringGroup) }}"
+                                        data-confirm-message="{{ __('monitoring_group.actions.delete.confirmation') }}">
                                         @csrf
                                         @method('DELETE')
-                                        <x-danger-button
-                                            x-data
-                                            x-on:click.prevent="if (confirm('{{ __('monitoring_group.actions.delete.confirmation') }}')) $el.closest('form').submit()">
+                                        <x-danger-button>
                                             {{ __('button.delete') }}
                                         </x-danger-button>
                                     </form>

--- a/resources/views/monitorings/status-page-unsubscribe.blade.php
+++ b/resources/views/monitorings/status-page-unsubscribe.blade.php
@@ -22,7 +22,8 @@
             </p>
 
             <form method="POST" action="{{ route('public-label.subscribers.destroy', ['monitoring' => $monitoring, 'token' => $token]) }}"
-                class="mt-6 space-y-4">
+                class="mt-6 space-y-4"
+                data-confirm-message="{{ __('monitoring.public_label.subscribe.unsubscribe_confirmation') }}">
                 @csrf
                 @method('DELETE')
 

--- a/resources/views/profile/partials/api-configuration.blade.php
+++ b/resources/views/profile/partials/api-configuration.blade.php
@@ -13,7 +13,8 @@
             <x-primary-button>{{ __('api.configuration.actions.generate_token') }}</x-primary-button>
         </form>
 
-        <form method="POST" action="{{ route('profile.api-revoke-token') }}" class="mt-4 md:mt-0">
+        <form method="POST" action="{{ route('profile.api-revoke-token') }}" class="mt-4 md:mt-0"
+            data-confirm-message="{{ __('api.configuration.messages.confirm_revoke_token') }}">
             @csrf
             @method('DELETE')
             <x-danger-button>{{ __('api.configuration.actions.revoke_token') }}</x-danger-button>

--- a/tests/Feature/MonitoringGroupTest.php
+++ b/tests/Feature/MonitoringGroupTest.php
@@ -106,6 +106,18 @@ class MonitoringGroupTest extends TestCase
         $testResponse->assertDontSeeText('Foreign Services');
     }
 
+    public function test_delete_action_uses_app_confirm_dialog(): void
+    {
+        MonitoringGroup::factory()->for($this->user)->create();
+
+        $testResponse = $this->actingAs($this->user)->get(route('monitoring-groups.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('data-confirm-message="' . __('monitoring_group.actions.delete.confirmation') . '"');
+        $testResponse->assertDontSeeHtml('if (confirm(');
+        $testResponse->assertDontSeeHtml('x-on:click.prevent');
+    }
+
     public function test_user_can_view_create_and_edit_monitoring_group_forms(): void
     {
         $monitoringGroup = MonitoringGroup::factory()->for($this->user)->create([

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -111,6 +111,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse->assertSeeText(__('profile.notification_settings.unread_reminder.heading'));
         $testResponse->assertDontSeeText(__('profile.notification_settings.expiry_warning_days.heading'));
         $testResponse->assertSeeText(__('profile.notification_settings.hint_banner'));
+        $testResponse->assertSeeHtml('data-confirm-message="' . __('api.configuration.messages.confirm_revoke_token') . '"');
 
         $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit'));
         $secondResponse->assertOk();

--- a/tests/Feature/PublicStatusPageTest.php
+++ b/tests/Feature/PublicStatusPageTest.php
@@ -233,10 +233,14 @@ class PublicStatusPageTest extends TestCase
             'verified_at' => Date::now(),
         ]);
 
-        $this->get(route('public-label.subscribers.unsubscribe', [
+        $unsubscribeResponse = $this->get(route('public-label.subscribers.unsubscribe', [
             'monitoring' => $monitoring,
             'token' => $statusPageSubscriber->unsubscribe_token,
-        ]))->assertOk();
+        ]));
+
+        $unsubscribeResponse->assertOk();
+        $unsubscribeResponse->assertSeeHtml('x-data="confirmDialog()"');
+        $unsubscribeResponse->assertSeeHtml('data-confirm-message="' . __('monitoring.public_label.subscribe.unsubscribe_confirmation') . '"');
 
         $testResponse = $this->delete(route('public-label.subscribers.destroy', [
             'monitoring' => $monitoring,


### PR DESCRIPTION
## What changed
- Restyled the shared confirmation dialog to match the WebGuard UI with branded purple framing, a destructive-action icon, improved overlay, and accessible description wiring.
- Replaced native browser confirmations and simple delete-style form submissions with the shared app confirmation modal, covering monitorings, monitoring groups, admin delete actions, status pages, API token revocation, and public status update unsubscribe.
- Added the confirmation modal to the public layout so public unsubscribe actions use the same component with localized labels.
- Added feature regression coverage for monitoring group delete, API token revocation, and public unsubscribe confirmation markup.

## Why
Delete actions should use the app's branded confirmation experience instead of native browser alerts, keeping destructive workflows consistent across the dashboard and public unsubscribe flow.

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps -e AUTORUN_ENABLED=false php ./vendor/bin/pest tests/Feature/ConfirmDialogTest.php tests/Feature/MonitoringGroupTest.php tests/Feature/ProfileNotificationSettingsTest.php tests/Feature/PublicStatusPageTest.php`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps node bun run build`

The targeted Pest run exited successfully. It emitted Dotenv warnings because this local worktree has no `.env` file; phpunit-provided testing env values were still applied.

## Risks / follow-up
- No data migrations or API contracts changed.
- Account deletion keeps its existing password-confirmation modal because it requires credential input rather than a simple confirmation.
