### PR TITLE
feat: add centralized maintenance scheduling

### DIFF
--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -75,16 +75,16 @@ class MaintenanceController extends Controller
             ->with('success', __('maintenance.messages.cleared'));
     }
 
-    private function targetMonitorings(MaintenanceRequest $request): Builder
+    private function targetMonitorings(MaintenanceRequest $maintenanceRequest): Builder
     {
         $query = Monitoring::query();
 
-        if ($request->string('scope')->toString() === 'group') {
-            return $query->whereHas('groups', function ($builder) use ($request): void {
-                $builder->where('monitoring_groups.id', $request->string('monitoring_group_id')->toString());
+        if ($maintenanceRequest->string('scope')->toString() === 'group') {
+            return $query->whereHas('groups', function ($builder) use ($maintenanceRequest): void {
+                $builder->where('monitoring_groups.id', $maintenanceRequest->string('monitoring_group_id')->toString());
             });
         }
 
-        return $query->whereKey($request->string('monitoring_id')->toString());
+        return $query->whereKey($maintenanceRequest->string('monitoring_id')->toString());
     }
 }

--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\MaintenanceRequest;
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class MaintenanceController extends Controller
+{
+    public function index(): View
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return view('maintenance.index', [
+            'monitorings' => $user->monitorings()
+                ->with('groups:id,name')
+                ->orderBy('name')
+                ->get(),
+            'monitoringGroups' => $user->monitoringGroups()
+                ->withCount('monitorings')
+                ->orderBy('name')
+                ->get(['id', 'name']),
+        ]);
+    }
+
+    public function store(MaintenanceRequest $maintenanceRequest): RedirectResponse
+    {
+        abort_if($maintenanceRequest->user()?->isDemo(), 403);
+
+        $validated = $maintenanceRequest->validated();
+
+        $updatedCount = $this->targetMonitorings($maintenanceRequest)
+            ->update([
+                'maintenance_from' => Date::parse($validated['maintenance_from']),
+                'maintenance_until' => isset($validated['maintenance_until'])
+                    ? Date::parse($validated['maintenance_until'])
+                    : null,
+            ]);
+
+        return to_route('maintenance.index')
+            ->with('success', trans_choice('maintenance.messages.scheduled', $updatedCount, ['count' => $updatedCount]));
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        abort_if($request->user()?->isDemo(), 403);
+
+        $validated = $request->validate([
+            'monitoring_id' => [
+                'required',
+                'string',
+                Rule::exists('monitorings', 'id')->where('user_id', $request->user()?->id),
+            ],
+        ]);
+
+        Monitoring::query()
+            ->whereKey($validated['monitoring_id'])
+            ->update([
+                'maintenance_from' => null,
+                'maintenance_until' => null,
+            ]);
+
+        return to_route('maintenance.index')
+            ->with('success', __('maintenance.messages.cleared'));
+    }
+
+    private function targetMonitorings(MaintenanceRequest $request): Builder
+    {
+        $query = Monitoring::query();
+
+        if ($request->string('scope')->toString() === 'group') {
+            return $query->whereHas('groups', function ($builder) use ($request): void {
+                $builder->where('monitoring_groups.id', $request->string('monitoring_group_id')->toString());
+            });
+        }
+
+        return $query->whereKey($request->string('monitoring_id')->toString());
+    }
+}

--- a/app/Http/Requests/MaintenanceRequest.php
+++ b/app/Http/Requests/MaintenanceRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MaintenanceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'scope' => ['required', 'string', Rule::in(['monitoring', 'group'])],
+            'monitoring_id' => [
+                'nullable',
+                'required_if:scope,monitoring',
+                'string',
+                Rule::exists('monitorings', 'id')->where('user_id', $this->user()?->id),
+            ],
+            'monitoring_group_id' => [
+                'nullable',
+                'required_if:scope,group',
+                'string',
+                Rule::exists('monitoring_groups', 'id')->where('user_id', $this->user()?->id),
+            ],
+            'maintenance_from' => ['required', 'date'],
+            'maintenance_until' => ['nullable', 'date', 'after:maintenance_from'],
+        ];
+    }
+}

--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -224,8 +224,6 @@ class MonitoringRequest extends FormRequest
             ],
             'failure_confirmation_threshold' => ['required', 'integer', 'min:1', 'max:10'],
             'ssl_expiry_warning_days' => ['required', 'integer', 'min:1', 'max:365'],
-            'maintenance_from' => ['nullable', 'date'],
-            'maintenance_until' => ['nullable', 'date', 'after:maintenance_from'],
         ];
 
         if ($this->isMethod('post')) {

--- a/resources/lang/de/maintenance.php
+++ b/resources/lang/de/maintenance.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Wartung',
+    'schedule' => [
+        'heading' => 'Wartung planen',
+        'description' => 'Planen Sie ein Wartungsfenster für eine einzelne Überwachung oder wenden Sie dasselbe Fenster auf alle Überwachungen einer Gruppe an.',
+    ],
+    'form' => [
+        'scope' => 'Anwenden auf',
+        'scopes' => [
+            'monitoring' => 'Einzelne Überwachung',
+            'group' => 'Überwachungsgruppe',
+        ],
+        'monitoring' => 'Überwachung',
+        'group' => 'Gruppe',
+        'select_monitoring' => 'Überwachung auswählen',
+        'select_group' => 'Gruppe auswählen',
+        'from' => 'Wartung von',
+        'until' => 'Wartung bis',
+        'help' => 'Während des Wartungsfensters werden Prüfungen übersprungen und der Status als UNBEKANNT gemeldet. Lassen Sie das Ende leer, wenn das Fenster offen bleiben soll.',
+    ],
+    'windows' => [
+        'heading' => 'Geplante Fenster',
+        'description' => 'Aktuelle und kommende Fenster über alle Ihre Überwachungen hinweg.',
+    ],
+    'status' => [
+        'active' => 'Aktiv',
+        'upcoming' => 'Geplant',
+        'expired' => 'Abgelaufen',
+        'none' => 'Keine',
+        'open_ended' => 'Ohne Endzeit',
+    ],
+    'actions' => [
+        'schedule' => 'Wartung planen',
+        'clear' => 'Wartung entfernen',
+        'clear_confirmation' => 'Dieses Wartungsfenster entfernen?',
+    ],
+    'messages' => [
+        'scheduled' => 'Wartung wurde für :count Überwachung geplant.|Wartung wurde für :count Überwachungen geplant.',
+        'cleared' => 'Wartungsfenster wurde entfernt.',
+    ],
+    'empty' => [
+        'title' => 'Noch keine Überwachungen',
+        'text' => 'Erstellen Sie eine Überwachung, bevor Sie Wartung planen.',
+    ],
+];

--- a/resources/lang/en/maintenance.php
+++ b/resources/lang/en/maintenance.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Maintenance',
+    'schedule' => [
+        'heading' => 'Schedule maintenance',
+        'description' => 'Plan a maintenance window for one monitoring or apply the same window to every monitoring in a group.',
+    ],
+    'form' => [
+        'scope' => 'Apply to',
+        'scopes' => [
+            'monitoring' => 'Single monitoring',
+            'group' => 'Monitoring group',
+        ],
+        'monitoring' => 'Monitoring',
+        'group' => 'Group',
+        'select_monitoring' => 'Select monitoring',
+        'select_group' => 'Select group',
+        'from' => 'Maintenance from',
+        'until' => 'Maintenance until',
+        'help' => 'During the maintenance window, checks are skipped and the status is reported as UNKNOWN. Leave the end empty for an open-ended window.',
+    ],
+    'windows' => [
+        'heading' => 'Planned windows',
+        'description' => 'Current and upcoming windows across your monitorings.',
+    ],
+    'status' => [
+        'active' => 'Active',
+        'upcoming' => 'Upcoming',
+        'expired' => 'Expired',
+        'none' => 'None',
+        'open_ended' => 'Open-ended',
+    ],
+    'actions' => [
+        'schedule' => 'Schedule maintenance',
+        'clear' => 'Clear maintenance',
+        'clear_confirmation' => 'Clear this maintenance window?',
+    ],
+    'messages' => [
+        'scheduled' => 'Maintenance was scheduled for :count monitoring.|Maintenance was scheduled for :count monitorings.',
+        'cleared' => 'Maintenance window was cleared.',
+    ],
+    'empty' => [
+        'title' => 'No monitorings yet',
+        'text' => 'Create a monitoring before planning maintenance.',
+    ],
+];

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -16,6 +16,10 @@
                         {{ __('monitoring.title') }}
                     </x-nav-link>
 
+                    <x-nav-link :href="route('maintenance.index')" :active="request()->routeIs('maintenance.*')">
+                        {{ __('maintenance.title') }}
+                    </x-nav-link>
+
                     <x-nav-link :href="route('monitoring-groups.index')" :active="request()->routeIs('monitoring-groups.*')">
                         {{ __('monitoring_group.title') }}
                     </x-nav-link>
@@ -129,6 +133,10 @@
         <div class="space-y-1 pb-3 pt-2">
             <x-responsive-nav-link :href="route('monitorings.index')" :active="request()->routeIs('monitorings.*')">
                 {{ __('monitoring.title') }}
+            </x-responsive-nav-link>
+
+            <x-responsive-nav-link :href="route('maintenance.index')" :active="request()->routeIs('maintenance.*')">
+                {{ __('maintenance.title') }}
             </x-responsive-nav-link>
 
             <x-responsive-nav-link :href="route('monitoring-groups.index')" :active="request()->routeIs('monitoring-groups.*')">

--- a/resources/views/maintenance/index.blade.php
+++ b/resources/views/maintenance/index.blade.php
@@ -1,0 +1,149 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('maintenance.title') }}</x-heading>
+    </x-slot>
+
+    <x-main>
+        <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)]">
+            <x-container>
+                <x-heading type="h2">{{ __('maintenance.schedule.heading') }}</x-heading>
+                <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                    {{ __('maintenance.schedule.description') }}
+                </x-paragraph>
+
+                <form method="POST" action="{{ route('maintenance.store') }}" class="mt-6 space-y-4" x-data="{ scope: @js(old('scope', 'monitoring')) }">
+                    @csrf
+
+                    <div>
+                        <x-input-label for="scope" :value="__('maintenance.form.scope')" />
+                        <x-select-input id="scope" class="mt-1 block w-full" name="scope" x-model="scope">
+                            <option value="monitoring">{{ __('maintenance.form.scopes.monitoring') }}</option>
+                            <option value="group">{{ __('maintenance.form.scopes.group') }}</option>
+                        </x-select-input>
+                        <x-input-error :messages="$errors->get('scope')" />
+                    </div>
+
+                    <div>
+                        <div x-show="scope === 'monitoring'">
+                            <x-input-label for="monitoring_id" :value="__('maintenance.form.monitoring')" />
+                            <x-select-input id="monitoring_id" class="mt-1 block w-full" name="monitoring_id">
+                                <option value="">{{ __('maintenance.form.select_monitoring') }}</option>
+                                @foreach ($monitorings as $monitoring)
+                                    <option value="{{ $monitoring->id }}" @selected(old('monitoring_id') === $monitoring->id)>
+                                        {{ $monitoring->name }}
+                                    </option>
+                                @endforeach
+                            </x-select-input>
+                            <x-input-error :messages="$errors->get('monitoring_id')" />
+                        </div>
+
+                        <div x-show="scope === 'group'">
+                            <x-input-label for="monitoring_group_id" :value="__('maintenance.form.group')" />
+                            <x-select-input id="monitoring_group_id" class="mt-1 block w-full" name="monitoring_group_id">
+                                <option value="">{{ __('maintenance.form.select_group') }}</option>
+                                @foreach ($monitoringGroups as $monitoringGroup)
+                                    <option value="{{ $monitoringGroup->id }}" @selected(old('monitoring_group_id') === $monitoringGroup->id)>
+                                        {{ $monitoringGroup->name }} ({{ $monitoringGroup->monitorings_count }})
+                                    </option>
+                                @endforeach
+                            </x-select-input>
+                            <x-input-error :messages="$errors->get('monitoring_group_id')" />
+                        </div>
+                    </div>
+
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div>
+                            <x-input-label for="maintenance_from" :value="__('maintenance.form.from')" />
+                            <x-text-input id="maintenance_from" type="datetime-local" name="maintenance_from" :value="old('maintenance_from')" required />
+                            <x-input-error :messages="$errors->get('maintenance_from')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="maintenance_until" :value="__('maintenance.form.until')" />
+                            <x-text-input id="maintenance_until" type="datetime-local" name="maintenance_until" :value="old('maintenance_until')" />
+                            <x-input-error :messages="$errors->get('maintenance_until')" />
+                        </div>
+                    </div>
+
+                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                        {{ __('maintenance.form.help') }}
+                    </p>
+
+                    <x-primary-button>{{ __('maintenance.actions.schedule') }}</x-primary-button>
+                </form>
+            </x-container>
+
+            <x-container>
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                        <x-heading type="h2">{{ __('maintenance.windows.heading') }}</x-heading>
+                        <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                            {{ __('maintenance.windows.description') }}
+                        </x-paragraph>
+                    </div>
+                </div>
+
+                <div class="mt-6 space-y-3">
+                    @forelse ($monitorings as $monitoring)
+                        <div class="rounded-md border border-gray-200 p-4 dark:border-gray-700">
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <div class="font-semibold text-gray-900 dark:text-gray-100">{{ $monitoring->name }}</div>
+                                    <div class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $monitoring->target }}</div>
+                                    @if ($monitoring->groups->isNotEmpty())
+                                        <div class="mt-2 flex flex-wrap gap-2">
+                                            @foreach ($monitoring->groups as $group)
+                                                <x-badge type="neutral">{{ $group->name }}</x-badge>
+                                            @endforeach
+                                        </div>
+                                    @endif
+                                </div>
+
+                                @if ($monitoring->isUnderMaintenance())
+                                    <x-badge type="info">{{ __('maintenance.status.active') }}</x-badge>
+                                @elseif ($monitoring->maintenance_from && $monitoring->maintenance_from->isFuture())
+                                    <x-badge type="warning">{{ __('maintenance.status.upcoming') }}</x-badge>
+                                @elseif ($monitoring->maintenance_from)
+                                    <x-badge type="neutral">{{ __('maintenance.status.expired') }}</x-badge>
+                                @else
+                                    <x-badge type="success">{{ __('maintenance.status.none') }}</x-badge>
+                                @endif
+                            </div>
+
+                            @if ($monitoring->maintenance_from)
+                                <dl class="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+                                    <div>
+                                        <dt class="text-gray-500 dark:text-gray-400">{{ __('maintenance.form.from') }}</dt>
+                                        <dd class="font-medium text-gray-900 dark:text-gray-100">{{ $monitoring->maintenance_from->toDayDateTimeString() }}</dd>
+                                    </div>
+                                    <div>
+                                        <dt class="text-gray-500 dark:text-gray-400">{{ __('maintenance.form.until') }}</dt>
+                                        <dd class="font-medium text-gray-900 dark:text-gray-100">{{ $monitoring->maintenance_until?->toDayDateTimeString() ?? __('maintenance.status.open_ended') }}</dd>
+                                    </div>
+                                </dl>
+
+                                <form method="POST" action="{{ route('maintenance.destroy') }}" class="mt-4">
+                                    @csrf
+                                    @method('DELETE')
+                                    <input type="hidden" name="monitoring_id" value="{{ $monitoring->id }}">
+                                    <x-secondary-button
+                                        x-data
+                                        x-on:click.prevent="if (confirm('{{ __('maintenance.actions.clear_confirmation') }}')) $el.closest('form').submit()">
+                                        {{ __('maintenance.actions.clear') }}
+                                    </x-secondary-button>
+                                </form>
+                            @endif
+                        </div>
+                    @empty
+                        <div class="rounded-md border border-gray-200 p-6 text-center dark:border-gray-700">
+                            <x-heading type="h3">{{ __('maintenance.empty.title') }}</x-heading>
+                            <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                {{ __('maintenance.empty.text') }}
+                            </x-paragraph>
+                        </div>
+                    @endforelse
+                </div>
+            </x-container>
+        </div>
+    </x-main>
+</x-app-layout>

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -512,21 +512,6 @@
         <x-input-error :messages="$errors->get('status')" />
     </div>
 
-    <div class="mt-4">
-        <x-input-label for="maintenance_from" :value="__('monitoring.form.maintenance_from')" />
-        <x-text-input id="maintenance_from" type="datetime-local" name="maintenance_from" :value="old('maintenance_from', isset($monitoring) ? $monitoring->maintenance_from?->format('Y-m-d\TH:i') : '')" />
-        <x-input-error :messages="$errors->get('maintenance_from')" />
-        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            {{ __('monitoring.form.maintenance_help') }}
-        </p>
-    </div>
-
-    <div class="mt-4">
-        <x-input-label for="maintenance_until" :value="__('monitoring.form.maintenance_until')" />
-        <x-text-input id="maintenance_until" type="datetime-local" name="maintenance_until" :value="old('maintenance_until', isset($monitoring) ? $monitoring->maintenance_until?->format('Y-m-d\TH:i') : '')" />
-        <x-input-error :messages="$errors->get('maintenance_until')" />
-    </div>
-
         </section>
 
         <x-primary-button>{{ isset($monitoring) ? __('button.update') : __('button.create') }}</x-primary-button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Auth\SocialiteController;
 use App\Http\Controllers\HeartbeatPingController;
 use App\Http\Controllers\LegalController;
 use App\Http\Controllers\LocaleController;
+use App\Http\Controllers\MaintenanceController;
 use App\Http\Controllers\MonitoringController;
 use App\Http\Controllers\MonitoringGroupController;
 use App\Http\Controllers\MonitoringLocationsController;
@@ -126,6 +127,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     });
 
     Route::resource('monitorings', MonitoringController::class)->names('monitorings');
+    Route::get('/maintenance', [MaintenanceController::class, 'index'])->name('maintenance.index');
+    Route::post('/maintenance', [MaintenanceController::class, 'store'])->name('maintenance.store');
+    Route::delete('/maintenance', [MaintenanceController::class, 'destroy'])->name('maintenance.destroy');
     Route::resource('monitoring-groups', MonitoringGroupController::class)
         ->except(['show'])
         ->parameters(['monitoring-groups' => 'monitoringGroup'])

--- a/tests/Feature/MaintenanceManagementTest.php
+++ b/tests/Feature/MaintenanceManagementTest.php
@@ -160,12 +160,12 @@ class MaintenanceManagementTest extends TestCase
             'preferred_location' => $this->serverInstance->code,
         ]);
 
-        $createResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
+        $testResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
         $editResponse = $this->actingAs($this->user)->get(route('monitorings.edit', $monitoring));
 
-        $createResponse->assertOk();
-        $createResponse->assertDontSeeHtml('name="maintenance_from"');
-        $createResponse->assertDontSeeHtml('name="maintenance_until"');
+        $testResponse->assertOk();
+        $testResponse->assertDontSeeHtml('name="maintenance_from"');
+        $testResponse->assertDontSeeHtml('name="maintenance_until"');
 
         $editResponse->assertOk();
         $editResponse->assertDontSeeHtml('name="maintenance_from"');

--- a/tests/Feature/MaintenanceManagementTest.php
+++ b/tests/Feature/MaintenanceManagementTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Tests\TestCase;
+
+class MaintenanceManagementTest extends TestCase
+{
+    private User $user;
+
+    private ServerInstance $serverInstance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $this->user = User::factory()->create(['package_id' => $package->id]);
+
+        $this->serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+    }
+
+    public function test_user_can_view_central_maintenance_page(): void
+    {
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'name' => 'Checkout API',
+            'target' => 'https://checkout.example.com',
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+        $group = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Production']);
+        $monitoring->groups()->attach($group);
+
+        $testResponse = $this->actingAs($this->user)->get(route('maintenance.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('maintenance.title'));
+        $testResponse->assertSeeText('Checkout API');
+        $testResponse->assertSeeText('Production');
+        $testResponse->assertSeeHtml('action="' . route('maintenance.store') . '"');
+    }
+
+    public function test_user_can_schedule_maintenance_for_single_monitoring(): void
+    {
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $testResponse = $this->actingAs($this->user)->post(route('maintenance.store'), [
+            'scope' => 'monitoring',
+            'monitoring_id' => $monitoring->id,
+            'maintenance_from' => '2026-07-01T10:00',
+            'maintenance_until' => '2026-07-01T11:00',
+        ]);
+
+        $testResponse->assertRedirect(route('maintenance.index'));
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+    }
+
+    public function test_user_can_schedule_maintenance_for_monitoring_group(): void
+    {
+        $group = MonitoringGroup::factory()->for($this->user)->create();
+        $firstMonitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+        $secondMonitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+        $outsideMonitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+        $firstMonitoring->groups()->attach($group);
+        $secondMonitoring->groups()->attach($group);
+
+        $testResponse = $this->actingAs($this->user)->post(route('maintenance.store'), [
+            'scope' => 'group',
+            'monitoring_group_id' => $group->id,
+            'maintenance_from' => '2026-07-02T12:00',
+            'maintenance_until' => '',
+        ]);
+
+        $testResponse->assertRedirect(route('maintenance.index'));
+        foreach ([$firstMonitoring, $secondMonitoring] as $monitoring) {
+            $this->assertDatabaseHas('monitorings', [
+                'id' => $monitoring->id,
+                'maintenance_from' => '2026-07-02 12:00:00',
+                'maintenance_until' => null,
+            ]);
+        }
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $outsideMonitoring->id,
+            'maintenance_from' => null,
+            'maintenance_until' => null,
+        ]);
+    }
+
+    public function test_user_can_clear_monitoring_maintenance_window(): void
+    {
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+
+        $testResponse = $this->actingAs($this->user)->delete(route('maintenance.destroy'), [
+            'monitoring_id' => $monitoring->id,
+        ]);
+
+        $testResponse->assertRedirect(route('maintenance.index'));
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'maintenance_from' => null,
+            'maintenance_until' => null,
+        ]);
+    }
+
+    public function test_user_cannot_schedule_maintenance_for_foreign_monitoring_or_group(): void
+    {
+        $otherUser = User::factory()->create(['package_id' => Package::factory()->create()->id]);
+        $foreignMonitoring = Monitoring::factory()->for($otherUser)->create([
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+        $foreignGroup = MonitoringGroup::factory()->for($otherUser)->create();
+
+        $this->actingAs($this->user)->post(route('maintenance.store'), [
+            'scope' => 'monitoring',
+            'monitoring_id' => $foreignMonitoring->id,
+            'maintenance_from' => '2026-07-01T10:00',
+        ])->assertSessionHasErrors(['monitoring_id']);
+
+        $this->actingAs($this->user)->post(route('maintenance.store'), [
+            'scope' => 'group',
+            'monitoring_group_id' => $foreignGroup->id,
+            'maintenance_from' => '2026-07-01T10:00',
+        ])->assertSessionHasErrors(['monitoring_group_id']);
+    }
+
+    public function test_monitoring_create_and_edit_forms_do_not_render_maintenance_fields(): void
+    {
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'type' => MonitoringType::PING,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $createResponse = $this->actingAs($this->user)->get(route('monitorings.create'));
+        $editResponse = $this->actingAs($this->user)->get(route('monitorings.edit', $monitoring));
+
+        $createResponse->assertOk();
+        $createResponse->assertDontSeeHtml('name="maintenance_from"');
+        $createResponse->assertDontSeeHtml('name="maintenance_until"');
+
+        $editResponse->assertOk();
+        $editResponse->assertDontSeeHtml('name="maintenance_from"');
+        $editResponse->assertDontSeeHtml('name="maintenance_until"');
+    }
+}


### PR DESCRIPTION
## What changed
- Added a dedicated Maintenance page with routes, controller, request validation, and localized copy.
- Added scheduling for a single monitoring or all monitorings in a selected monitoring group.
- Added per-monitoring maintenance clearing from the centralized page.
- Removed maintenance fields from monitoring create/edit forms.
- Added feature coverage for individual scheduling, group scheduling, clearing windows, ownership validation, and form rendering.

## Why
Maintenance planning was embedded in monitoring create/edit forms. Moving it into a dedicated page gives users one central place to manage planned windows across monitorings and groups.

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --entrypoint sh php -lc './vendor/bin/pest tests/Feature/MaintenanceManagementTest.php'`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --entrypoint sh php -lc './vendor/bin/pest tests/Feature/MonitoringGroupTest.php'`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --entrypoint sh php -lc 'composer analyse'`

Pest reports existing Vite asset lookup warnings from the shared layout, but the commands completed successfully.

## Risks / follow-up
- Group scheduling writes the same maintenance window onto each current monitoring in the group; future monitorings added to that group do not inherit old planned windows automatically.