### PR TITLE
feat: add team-based monitorings

### DIFF
--- a/app/Console/Commands/Notifications/DispatchStatusChangeNotificationsCommand.php
+++ b/app/Console/Commands/Notifications/DispatchStatusChangeNotificationsCommand.php
@@ -8,6 +8,8 @@ use App\Enums\NotificationEventType;
 use App\Mail\StatusPageStatusUpdateMail;
 use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
+use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
+use App\Services\Notifications\MonitoringNotificationStateService;
 use App\Services\Notifications\NotificationPayload;
 use App\Services\Notifications\NotificationRouter;
 use Illuminate\Console\Attributes\Description;
@@ -19,8 +21,11 @@ use Illuminate\Support\Facades\Mail;
 #[Signature('notifications:dispatch-status-changes')]
 class DispatchStatusChangeNotificationsCommand extends Command
 {
-    public function __construct(private readonly NotificationRouter $notificationRouter)
-    {
+    public function __construct(
+        private readonly NotificationRouter $notificationRouter,
+        private readonly MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver,
+        private readonly MonitoringNotificationStateService $monitoringNotificationStateService
+    ) {
         parent::__construct();
     }
 
@@ -32,14 +37,13 @@ class DispatchStatusChangeNotificationsCommand extends Command
         $notifications = MonitoringNotification::query()
             ->statusChange()
             ->where('sent', false)
-            ->with(['monitoring.user'])
+            ->with(['monitoring.user', 'monitoring.team.users'])
             ->get();
 
         foreach ($notifications as $notification) {
             $monitoring = $notification->monitoring;
-            $user = $monitoring?->user;
 
-            if (! $monitoring || ! $user) {
+            if (! $monitoring) {
                 $notification->update(['sent' => true]);
 
                 continue;
@@ -51,12 +55,6 @@ class DispatchStatusChangeNotificationsCommand extends Command
                 : NotificationEventType::RECOVERY;
 
             $this->dispatchStatusPageSubscriberEmails($monitoring, $notification, $identifier);
-
-            if (! $monitoring->notification_on_failure) {
-                $notification->update(['sent' => true]);
-
-                continue;
-            }
 
             $payload = new NotificationPayload(
                 eventType: $eventType,
@@ -79,7 +77,22 @@ class DispatchStatusChangeNotificationsCommand extends Command
                 ],
             );
 
-            $this->notificationRouter->dispatch($user, $payload, $monitoring->notification_channels);
+            $this->monitoringNotificationPreferenceResolver
+                ->recipientsFor($monitoring)
+                ->each(function (array $recipient) use ($notification, $payload): void {
+                    $user = $recipient['user'];
+                    $preference = $recipient['preference'];
+
+                    $this->monitoringNotificationStateService->ensureState($notification, $user);
+
+                    if (! $preference->notification_on_failure) {
+                        return;
+                    }
+
+                    $this->notificationRouter->dispatch($user, $payload, $preference->notification_channels);
+                    $this->monitoringNotificationStateService->markSent($notification, $user);
+                });
+
             $notification->update(['sent' => true]);
         }
 

--- a/app/Console/Commands/Notifications/PruneReadNotificationsCommand.php
+++ b/app/Console/Commands/Notifications/PruneReadNotificationsCommand.php
@@ -21,11 +21,23 @@ class PruneReadNotificationsCommand extends Command
         $this->info('Deleting old read notifications...');
 
         $deletedCount = 0;
-        MonitoringNotification::query()->read()
+        MonitoringNotification::query()
+            ->withoutGlobalScopes()
             ->where('created_at', '<', now()->subMonth())
+            ->whereExists(function ($query): void {
+                $query->selectRaw('1')
+                    ->from('monitoring_notification_states')
+                    ->whereColumn('monitoring_notification_states.monitoring_notification_id', 'monitoring_notifications.id');
+            })
+            ->whereNotExists(function ($query): void {
+                $query->selectRaw('1')
+                    ->from('monitoring_notification_states')
+                    ->whereColumn('monitoring_notification_states.monitoring_notification_id', 'monitoring_notifications.id')
+                    ->whereNull('monitoring_notification_states.read_at');
+            })
             ->chunkById(250, function ($notifications) use (&$deletedCount) {
                 $deletedCount += $notifications->count();
-                MonitoringNotification::query()->whereIn('id', $notifications->pluck('id'))->delete();
+                MonitoringNotification::query()->withoutGlobalScopes()->whereIn('id', $notifications->pluck('id'))->delete();
             });
 
         $this->info("Deleted {$deletedCount} old read notifications.");

--- a/app/Console/Commands/Notifications/SendSslExpiryWarningsCommand.php
+++ b/app/Console/Commands/Notifications/SendSslExpiryWarningsCommand.php
@@ -9,6 +9,8 @@ use App\Enums\NotificationType;
 use App\Models\MonitoringDomainResult;
 use App\Models\MonitoringNotification;
 use App\Models\MonitoringSslResult;
+use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
+use App\Services\Notifications\MonitoringNotificationStateService;
 use App\Services\Notifications\NotificationPayload;
 use App\Services\Notifications\NotificationRouter;
 use Carbon\CarbonInterface;
@@ -21,8 +23,11 @@ use Illuminate\Support\Facades\Cache;
 #[Signature('notifications:send-ssl-expiry-warnings')]
 class SendSslExpiryWarningsCommand extends Command
 {
-    public function __construct(private readonly NotificationRouter $notificationRouter)
-    {
+    public function __construct(
+        private readonly NotificationRouter $notificationRouter,
+        private readonly MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver,
+        private readonly MonitoringNotificationStateService $monitoringNotificationStateService
+    ) {
         parent::__construct();
     }
 
@@ -47,7 +52,7 @@ class SendSslExpiryWarningsCommand extends Command
                 })
                     ->orWhere('is_valid', false);
             })
-            ->with(['monitoring.user'])
+            ->with(['monitoring.user', 'monitoring.team.users'])
             ->get();
 
         foreach ($sslResults as $sslResult) {
@@ -77,7 +82,7 @@ class SendSslExpiryWarningsCommand extends Command
                 })
                     ->orWhere('is_valid', false);
             })
-            ->with(['monitoring.user'])
+            ->with(['monitoring.user', 'monitoring.team.users'])
             ->get();
 
         foreach ($domainResults as $domainResult) {
@@ -115,20 +120,24 @@ class SendSslExpiryWarningsCommand extends Command
             return;
         }
 
-        $user = $monitoring->user;
-        if (! $user) {
-            return;
-        }
-
-        if (! $monitoring->notification_on_failure) {
-            return;
-        }
-
         $expiresAt = $result->expires_at;
         $isExpired = ! $result->is_valid || ($expiresAt !== null && $expiresAt->lte(now()));
         $daysUntilExpiry = $expiresAt !== null ? $this->daysUntilExpiry($expiresAt) : null;
 
-        if (! $isExpired && ! $this->shouldWarn($daysUntilExpiry, $warningWindowDays)) {
+        $recipients = $this->monitoringNotificationPreferenceResolver
+            ->recipientsFor($monitoring)
+            ->filter(function (array $recipient) use ($daysUntilExpiry, $isExpired): bool {
+                $preference = $recipient['preference'];
+
+                if (! $preference->notification_on_failure) {
+                    return false;
+                }
+
+                return $isExpired || $this->shouldWarn($daysUntilExpiry, $preference->ssl_expiry_warning_days);
+            })
+            ->values();
+
+        if ($recipients->isEmpty()) {
             return;
         }
 
@@ -170,7 +179,15 @@ class SendSslExpiryWarningsCommand extends Command
             ],
         );
 
-        $this->notificationRouter->dispatch($user, $notificationPayload, $monitoring->notification_channels);
+        $recipients->each(function (array $recipient) use ($monitoringNotification, $notificationPayload): void {
+            $user = $recipient['user'];
+            $preference = $recipient['preference'];
+
+            $this->monitoringNotificationStateService->ensureState($monitoringNotification, $user);
+            $this->notificationRouter->dispatch($user, $notificationPayload, $preference->notification_channels);
+            $this->monitoringNotificationStateService->markSent($monitoringNotification, $user);
+        });
+
         $monitoringNotification->update(['sent' => true]);
         Cache::put($cacheKey, true, now()->addHours(23));
     }

--- a/app/Console/Commands/Notifications/SendWeeklyMonitoringDigestCommand.php
+++ b/app/Console/Commands/Notifications/SendWeeklyMonitoringDigestCommand.php
@@ -36,7 +36,6 @@ class SendWeeklyMonitoringDigestCommand extends Command
             ->where('email', '!=', '')
             ->whereNotNull('email_verified_at')
             ->where('monitoring_digest_enabled', true)
-            ->whereHas('monitorings', fn ($builder) => $builder->active())
             ->chunkById(100, function ($users) use ($periodEnd): void {
                 foreach ($users as $user) {
                     $frequency = $user->monitoring_digest_frequency ?: 'weekly';

--- a/app/Enums/TeamRole.php
+++ b/app/Enums/TeamRole.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum TeamRole: string
+{
+    case ADMIN = 'admin';
+    case MEMBER = 'member';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -41,6 +41,7 @@ class MonitoringCardDataController extends Controller
             ->select([
                 'id',
                 'user_id',
+                'team_id',
                 'name',
                 'target',
                 'type',
@@ -48,7 +49,7 @@ class MonitoringCardDataController extends Controller
                 'maintenance_from',
                 'maintenance_until',
             ])
-            ->where('user_id', $request->user()->id)
+            ->visibleTo($request->user())
             ->whereIn('id', $requestedIds)
             ->with([
                 'latestIncident',

--- a/app/Http/Controllers/Api/MonitoringManagementController.php
+++ b/app/Http/Controllers/Api/MonitoringManagementController.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\MonitoringRequest;
+use App\Models\Monitoring;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Monitorings\MonitoringOwnershipService;
+use App\Support\MonitoringPayload;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * @group Monitoring Management
+ *
+ * Create, update, delete, and move private or team-owned monitorings.
+ */
+class MonitoringManagementController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $monitorings = Monitoring::query()
+            ->visibleTo($user)
+            ->orderBy('name')
+            ->paginate(min(max((int) $request->integer('per_page', 25), 1), 100));
+
+        return response()->json($monitorings);
+    }
+
+    public function store(MonitoringRequest $monitoringRequest): JsonResponse
+    {
+        /** @var User $user */
+        $user = $monitoringRequest->user();
+        abort_if($user->isDemo(), 403);
+
+        if ($user->monitorings()->whereNull('team_id')->count() >= $user->package->monitoring_limit
+            && blank($monitoringRequest->input('team_id'))) {
+            return response()->json(['message' => __('monitoring.messages.limit_reached')], 422);
+        }
+
+        $validated = $monitoringRequest->validated();
+        $teamId = $validated['team_id'] ?? null;
+        unset($validated['group_ids'], $validated['team_id']);
+
+        $payload = MonitoringPayload::prepareStore($validated);
+
+        if ($teamId) {
+            $payload['user_id'] = null;
+            $payload['team_id'] = $teamId;
+            $payload['created_by_user_id'] = $user->id;
+
+            $monitoring = Monitoring::query()->create($payload);
+        } else {
+            $monitoring = $user->monitorings()->create($payload);
+        }
+
+        return response()->json(['data' => $monitoring], 201);
+    }
+
+    public function update(MonitoringRequest $monitoringRequest, Monitoring $monitoring): JsonResponse
+    {
+        /** @var User $user */
+        $user = $monitoringRequest->user();
+        abort_if($user->isDemo(), 403);
+        abort_unless($monitoring->isManageableBy($user), 403);
+
+        $validated = $monitoringRequest->validated();
+        unset($validated['group_ids'], $validated['team_id']);
+
+        $payload = MonitoringPayload::prepareUpdate($validated, $monitoring);
+        if (! isset($payload['public_label_enabled']) || ! $payload['public_label_enabled']) {
+            $payload['public_label_enabled'] = false;
+        }
+
+        $monitoring->update($payload);
+
+        return response()->json(['data' => $monitoring->refresh()]);
+    }
+
+    public function destroy(Request $request, Monitoring $monitoring): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        abort_unless($monitoring->isManageableBy($user), 403);
+
+        $monitoring->delete();
+
+        return response()->json(status: 204);
+    }
+
+    public function moveToTeam(
+        Request $request,
+        Monitoring $monitoring,
+        MonitoringOwnershipService $monitoringOwnershipService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+
+        $validated = $request->validate([
+            'team_id' => [
+                'required',
+                'string',
+                Rule::exists('teams', 'id'),
+                function ($attribute, $value, $fail) use ($user): void {
+                    if (! Team::query()->administeredBy($user)->whereKey((string) $value)->exists()) {
+                        $fail(__('team.validation.not_admin'));
+                    }
+                },
+            ],
+        ]);
+
+        $team = Team::query()->findOrFail($validated['team_id']);
+
+        return response()->json([
+            'data' => $monitoringOwnershipService->moveToTeam($monitoring, $team, $user),
+        ]);
+    }
+
+    public function moveToPrivate(
+        Request $request,
+        Monitoring $monitoring,
+        MonitoringOwnershipService $monitoringOwnershipService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+
+        return response()->json([
+            'data' => $monitoringOwnershipService->moveToPrivate($monitoring, $user),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/TeamController.php
+++ b/app/Http/Controllers/Api/TeamController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @group Teams
+ *
+ * Manage teams and team ownership.
+ */
+class TeamController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $teams = Team::query()
+            ->visibleTo($user)
+            ->withCount(['memberships', 'monitorings'])
+            ->orderBy('name')
+            ->get();
+
+        return response()->json(['data' => $teams]);
+    }
+
+    public function store(Request $request, TeamMembershipService $teamMembershipService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:120'],
+            'description' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $team = $teamMembershipService->createTeam($user, $validated);
+
+        return response()->json(['data' => $team->load('memberships.user')], 201);
+    }
+
+    public function show(Request $request, Team $team, TeamMembershipService $teamMembershipService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $teamMembershipService->assertMember($team, $user);
+
+        return response()->json([
+            'data' => $team->load(['memberships.user', 'invitations' => fn ($builder) => $builder->whereNull('accepted_at')])
+                ->loadCount('monitorings'),
+        ]);
+    }
+
+    public function update(Request $request, Team $team, TeamMembershipService $teamMembershipService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $teamMembershipService->assertAdmin($team, $user);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:120'],
+            'description' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $team->update($validated);
+
+        return response()->json(['data' => $team->refresh()]);
+    }
+
+    public function destroy(Request $request, Team $team, TeamMembershipService $teamMembershipService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $teamMembershipService->assertAdmin($team, $user);
+
+        $team->delete();
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/Api/TeamInvitationController.php
+++ b/app/Http/Controllers/Api/TeamInvitationController.php
@@ -49,29 +49,29 @@ class TeamInvitationController extends Controller
             'role' => ['required', Rule::enum(TeamRole::class)],
         ]);
 
-        $invitation = $teamInvitationService->invite(
+        $teamInvitation = $teamInvitationService->invite(
             $team,
             $user,
             (string) $validated['email'],
             TeamRole::from((string) $validated['role'])
         );
 
-        return response()->json(['data' => $invitation], 201);
+        return response()->json(['data' => $teamInvitation], 201);
     }
 
     public function destroy(
         Request $request,
         Team $team,
-        TeamInvitation $invitation,
+        TeamInvitation $teamInvitation,
         TeamMembershipService $teamMembershipService
     ): JsonResponse {
         /** @var User $user */
         $user = $request->user();
         abort_if($user->isDemo(), 403);
         $teamMembershipService->assertAdmin($team, $user);
-        abort_unless($invitation->team_id === $team->id, 404);
+        abort_unless($teamInvitation->team_id === $team->id, 404);
 
-        $invitation->delete();
+        $teamInvitation->delete();
 
         return response()->json(status: 204);
     }

--- a/app/Http/Controllers/Api/TeamInvitationController.php
+++ b/app/Http/Controllers/Api/TeamInvitationController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Enums\TeamRole;
+use App\Http\Controllers\Controller;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Services\Teams\TeamInvitationService;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * @group Teams
+ *
+ * Manage and accept team invitations.
+ */
+class TeamInvitationController extends Controller
+{
+    public function index(Request $request, Team $team, TeamMembershipService $teamMembershipService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $teamMembershipService->assertAdmin($team, $user);
+
+        return response()->json([
+            'data' => $team->invitations()->whereNull('accepted_at')->latest()->get(),
+        ]);
+    }
+
+    public function store(
+        Request $request,
+        Team $team,
+        TeamMembershipService $teamMembershipService,
+        TeamInvitationService $teamInvitationService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $teamMembershipService->assertAdmin($team, $user);
+
+        $validated = $request->validate([
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255'],
+            'role' => ['required', Rule::enum(TeamRole::class)],
+        ]);
+
+        $invitation = $teamInvitationService->invite(
+            $team,
+            $user,
+            (string) $validated['email'],
+            TeamRole::from((string) $validated['role'])
+        );
+
+        return response()->json(['data' => $invitation], 201);
+    }
+
+    public function destroy(
+        Request $request,
+        Team $team,
+        TeamInvitation $invitation,
+        TeamMembershipService $teamMembershipService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $teamMembershipService->assertAdmin($team, $user);
+        abort_unless($invitation->team_id === $team->id, 404);
+
+        $invitation->delete();
+
+        return response()->json(status: 204);
+    }
+
+    public function accept(Request $request, string $token, TeamInvitationService $teamInvitationService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $team = $teamInvitationService->accept($token, $user);
+
+        return response()->json(['data' => $team]);
+    }
+}

--- a/app/Http/Controllers/Api/TeamMemberController.php
+++ b/app/Http/Controllers/Api/TeamMemberController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Enums\TeamRole;
+use App\Http\Controllers\Controller;
+use App\Models\Team;
+use App\Models\TeamMembership;
+use App\Models\User;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * @group Teams
+ *
+ * Manage team members and roles.
+ */
+class TeamMemberController extends Controller
+{
+    public function index(Request $request, Team $team, TeamMembershipService $teamMembershipService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $teamMembershipService->assertMember($team, $user);
+
+        return response()->json([
+            'data' => $team->memberships()->with('user:id,name,email')->orderBy('created_at')->get(),
+        ]);
+    }
+
+    public function update(
+        Request $request,
+        Team $team,
+        TeamMembership $membership,
+        TeamMembershipService $teamMembershipService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $teamMembershipService->assertAdmin($team, $user);
+        abort_unless($membership->team_id === $team->id, 404);
+
+        $validated = $request->validate([
+            'role' => ['required', Rule::enum(TeamRole::class)],
+        ]);
+
+        $teamMembershipService->changeRole($membership, TeamRole::from((string) $validated['role']));
+
+        return response()->json(['data' => $membership->refresh()->load('user:id,name,email')]);
+    }
+
+    public function destroy(
+        Request $request,
+        Team $team,
+        TeamMembership $membership,
+        TeamMembershipService $teamMembershipService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $teamMembershipService->assertAdmin($team, $user);
+        abort_unless($membership->team_id === $team->id, 404);
+
+        $teamMembershipService->remove($membership);
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/Api/TeamMemberController.php
+++ b/app/Http/Controllers/Api/TeamMemberController.php
@@ -28,44 +28,44 @@ class TeamMemberController extends Controller
         $teamMembershipService->assertMember($team, $user);
 
         return response()->json([
-            'data' => $team->memberships()->with('user:id,name,email')->orderBy('created_at')->get(),
+            'data' => $team->memberships()->with('user:id,name,email')->oldest()->get(),
         ]);
     }
 
     public function update(
         Request $request,
         Team $team,
-        TeamMembership $membership,
+        TeamMembership $teamMembership,
         TeamMembershipService $teamMembershipService
     ): JsonResponse {
         /** @var User $user */
         $user = $request->user();
         abort_if($user->isDemo(), 403);
         $teamMembershipService->assertAdmin($team, $user);
-        abort_unless($membership->team_id === $team->id, 404);
+        abort_unless($teamMembership->team_id === $team->id, 404);
 
         $validated = $request->validate([
             'role' => ['required', Rule::enum(TeamRole::class)],
         ]);
 
-        $teamMembershipService->changeRole($membership, TeamRole::from((string) $validated['role']));
+        $teamMembershipService->changeRole($teamMembership, TeamRole::from((string) $validated['role']));
 
-        return response()->json(['data' => $membership->refresh()->load('user:id,name,email')]);
+        return response()->json(['data' => $teamMembership->refresh()->load('user:id,name,email')]);
     }
 
     public function destroy(
         Request $request,
         Team $team,
-        TeamMembership $membership,
+        TeamMembership $teamMembership,
         TeamMembershipService $teamMembershipService
     ): JsonResponse {
         /** @var User $user */
         $user = $request->user();
         abort_if($user->isDemo(), 403);
         $teamMembershipService->assertAdmin($team, $user);
-        abort_unless($membership->team_id === $team->id, 404);
+        abort_unless($teamMembership->team_id === $team->id, 404);
 
-        $teamMembershipService->remove($membership);
+        $teamMembershipService->remove($teamMembership);
 
         return response()->json(status: 204);
     }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -492,7 +492,7 @@ class ApiController extends Controller
     {
         $user = request()->user();
 
-        if ($user && $monitoring->user_id === $user->id) {
+        if ($user && $monitoring->isVisibleTo($user)) {
             return;
         }
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -69,6 +69,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($model);
 
-        return redirect(route('dashboard', absolute: false));
+        return redirect()->intended(route('dashboard', absolute: false));
     }
 }

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -10,7 +10,9 @@ use App\Http\Requests\MonitoringRequest;
 use App\Jobs\DeleteMonitoringResults;
 use App\Models\Monitoring;
 use App\Models\ServerInstance;
+use App\Models\Team;
 use App\Models\User;
+use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
 use App\Support\MonitoringPayload;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Contracts\Database\Query\Builder;
@@ -55,6 +57,20 @@ class MonitoringController extends Controller
                 'string',
                 Rule::exists('monitoring_groups', 'id')->where('user_id', $currentUser->id),
             ],
+            'team_id' => [
+                'nullable',
+                'string',
+                function ($attribute, $value, $fail) use ($currentUser): void {
+                    if (blank($value)) {
+                        return;
+                    }
+
+                    if (! Team::query()->visibleTo($currentUser)->whereKey((string) $value)->exists()) {
+                        $fail(__('team.validation.not_member'));
+                    }
+                },
+            ],
+            'ownership' => ['nullable', 'string', Rule::in(['all', 'private', 'team'])],
         ]);
 
         $query = Monitoring::query();
@@ -84,6 +100,16 @@ class MonitoringController extends Controller
             });
         }
 
+        if ($request->filled('team_id')) {
+            $query->where('team_id', $request->string('team_id')->toString());
+        }
+
+        if ($request->input('ownership') === 'private') {
+            $query->whereNull('team_id');
+        } elseif ($request->input('ownership') === 'team') {
+            $query->whereNotNull('team_id');
+        }
+
         $query->orderBy('status');
 
         match ($request->input('sort')) {
@@ -97,12 +123,16 @@ class MonitoringController extends Controller
         $hasActiveFilters = $request->filled('search')
             || $request->filled('types')
             || $request->filled('lifecycle')
-            || $request->filled('group_id');
+            || $request->filled('group_id')
+            || $request->filled('team_id')
+            || $request->filled('ownership');
+        $privateMonitoringsTotal = $currentUser->monitorings()->whereNull('team_id')->count();
         $monitoringsTotal = $hasActiveFilters
-            ? $currentUser->monitorings()->count()
+            ? Monitoring::query()->count()
             : $lengthAwarePaginator->total();
         $monitoringLimit = (int) $currentUser->package->monitoring_limit;
-        $canCreateMonitoring = ! $currentUser->isDemo() && $monitoringsTotal < $monitoringLimit;
+        $canCreateMonitoring = ! $currentUser->isDemo()
+            && ($privateMonitoringsTotal < $monitoringLimit || $currentUser->administeredTeams()->exists());
 
         if (! $hasActiveFilters && $monitoringsTotal === 0) {
             $request->attributes->set('unread_notifications_count', 0);
@@ -117,9 +147,11 @@ class MonitoringController extends Controller
             'monitorings' => $lengthAwarePaginator,
             'monitoringsTotal' => $monitoringsTotal,
             'monitoringLimit' => $monitoringLimit,
+            'privateMonitoringsTotal' => $privateMonitoringsTotal,
             'canCreateMonitoring' => $canCreateMonitoring,
             'maintenanceStatusMap' => $maintenanceStatusMap,
             'monitoringGroups' => $currentUser->monitoringGroups()->orderBy('name')->get(['id', 'name']),
+            'teams' => Team::query()->visibleTo($currentUser)->orderBy('name')->get(['id', 'name']),
         ]);
     }
 
@@ -132,7 +164,10 @@ class MonitoringController extends Controller
     {
         abort_if(Auth::user()->isDemo(), 403);
 
-        if (Auth::user()->monitorings()->count() >= Auth::user()->package->monitoring_limit) {
+        $adminTeams = Auth::user()->administeredTeams()->orderBy('name')->get(['teams.id', 'teams.name']);
+
+        if (Auth::user()->monitorings()->whereNull('team_id')->count() >= Auth::user()->package->monitoring_limit
+            && $adminTeams->isEmpty()) {
             return to_route('monitorings.index')
                 ->withErrors(['limit' => __('monitoring.messages.limit_reached')]);
         }
@@ -150,6 +185,7 @@ class MonitoringController extends Controller
             'serverInstances' => $serverInstances,
             'enabledNotificationChannels' => Auth::user()->enabledNotificationChannelKeys(),
             'monitoringGroups' => Auth::user()->monitoringGroups()->orderBy('name')->get(['id', 'name']),
+            'adminTeams' => $adminTeams,
         ]);
     }
 
@@ -163,19 +199,30 @@ class MonitoringController extends Controller
     {
         abort_if(Auth::user()->isDemo(), 403);
 
-        if (Auth::user()->monitorings()->count() >= Auth::user()->package->monitoring_limit) {
+        if (Auth::user()->monitorings()->whereNull('team_id')->count() >= Auth::user()->package->monitoring_limit
+            && blank($monitoringRequest->input('team_id'))) {
             return to_route('monitorings.index')
                 ->withErrors(['limit' => __('monitoring.messages.limit_reached')]);
         }
 
         $validated = $monitoringRequest->validated();
         $groupIds = $validated['group_ids'] ?? [];
+        $teamId = $validated['team_id'] ?? null;
         unset($validated['group_ids']);
+        unset($validated['team_id']);
 
         $validated = MonitoringPayload::prepareStore($validated);
 
-        $monitoring = Auth::user()->monitorings()->create($validated);
-        $monitoring->groups()->sync($groupIds);
+        if ($teamId) {
+            $validated['user_id'] = null;
+            $validated['team_id'] = $teamId;
+            $validated['created_by_user_id'] = Auth::id();
+
+            $monitoring = Monitoring::query()->create($validated);
+        } else {
+            $monitoring = Auth::user()->monitorings()->create($validated);
+            $monitoring->groups()->sync($groupIds);
+        }
 
         return to_route('monitorings.index')->with('success', __('monitoring.messages.created'));
     }
@@ -186,12 +233,19 @@ class MonitoringController extends Controller
      * @param  Monitoring  $monitoring  The monitoring instance to display.
      * @return View The view displaying the monitoring details.
      */
-    public function show(Monitoring $monitoring): View
-    {
-        $monitoring->loadMissing('domainResult');
+    public function show(
+        Monitoring $monitoring,
+        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver
+    ): View {
+        /** @var User $user */
+        $user = Auth::user();
+        $monitoring->loadMissing('domainResult', 'team');
 
         return view('monitorings.show', [
             'monitoring' => $monitoring,
+            'canManageMonitoring' => $monitoring->isManageableBy($user) && ! $user->isDemo(),
+            'adminTeams' => Team::query()->administeredBy($user)->orderBy('name')->get(['teams.id', 'teams.name']),
+            'notificationPreference' => $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user),
         ]);
     }
 
@@ -204,8 +258,9 @@ class MonitoringController extends Controller
     public function edit(Monitoring $monitoring): View
     {
         abort_if(Auth::user()->isDemo(), 403);
+        abort_unless($monitoring->isManageableBy(Auth::user()), 403);
 
-        $monitoring->loadMissing('groups');
+        $monitoring->loadMissing('groups', 'team');
         $types = MonitoringType::cases();
         $serverInstances = ServerInstance::query()
             ->where(function ($query) use ($monitoring): void {
@@ -220,7 +275,10 @@ class MonitoringController extends Controller
             'types' => $types,
             'serverInstances' => $serverInstances,
             'enabledNotificationChannels' => Auth::user()->enabledNotificationChannelKeys(),
-            'monitoringGroups' => Auth::user()->monitoringGroups()->orderBy('name')->get(['id', 'name']),
+            'monitoringGroups' => $monitoring->isPrivateOwned()
+                ? Auth::user()->monitoringGroups()->orderBy('name')->get(['id', 'name'])
+                : collect(),
+            'adminTeams' => Auth::user()->administeredTeams()->orderBy('name')->get(['teams.id', 'teams.name']),
         ]);
     }
 
@@ -234,10 +292,12 @@ class MonitoringController extends Controller
     public function update(MonitoringRequest $monitoringRequest, Monitoring $monitoring): RedirectResponse
     {
         abort_if(Auth::user()->isDemo(), 403);
+        abort_unless($monitoring->isManageableBy(Auth::user()), 403);
 
         $validated = $monitoringRequest->validated();
         $groupIds = $validated['group_ids'] ?? [];
         unset($validated['group_ids']);
+        unset($validated['team_id']);
 
         $validated = MonitoringPayload::prepareUpdate($validated, $monitoring);
 
@@ -246,7 +306,9 @@ class MonitoringController extends Controller
         }
 
         $monitoring->update($validated);
-        $monitoring->groups()->sync($groupIds);
+        if ($monitoring->isPrivateOwned()) {
+            $monitoring->groups()->sync($groupIds);
+        }
 
         return to_route('monitorings.show', $monitoring)->with('success', __('monitoring.messages.updated'));
     }
@@ -260,6 +322,7 @@ class MonitoringController extends Controller
     public function destroy(Monitoring $monitoring): RedirectResponse
     {
         abort_if(Auth::user()->isDemo(), 403);
+        abort_unless($monitoring->isManageableBy(Auth::user()), 403);
 
         $monitoring->delete();
 
@@ -275,6 +338,7 @@ class MonitoringController extends Controller
     public function destroyResults(Monitoring $monitoring): RedirectResponse
     {
         abort_if(Auth::user()->isDemo(), 403);
+        abort_unless($monitoring->isManageableBy(Auth::user()), 403);
 
         if (cache()->getStore() instanceof TaggableStore) {
             cache()->tags(['monitoring:' . $monitoring->id])->flush();

--- a/app/Http/Controllers/MonitoringNotificationPreferenceController.php
+++ b/app/Http/Controllers/MonitoringNotificationPreferenceController.php
@@ -33,8 +33,8 @@ class MonitoringNotificationPreferenceController extends Controller
             'ssl_expiry_warning_days' => ['required', 'integer', 'min:1', 'max:365'],
         ]);
 
-        $preference = $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user);
-        $preference->update([
+        $monitoringNotificationPreference = $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user);
+        $monitoringNotificationPreference->update([
             'notification_on_failure' => $request->boolean('notification_on_failure'),
             'notification_channels' => array_values(array_unique($validated['notification_channels'] ?? [])),
             'ssl_expiry_warning_days' => (int) $validated['ssl_expiry_warning_days'],
@@ -42,9 +42,9 @@ class MonitoringNotificationPreferenceController extends Controller
 
         if ($monitoring->user_id === $user->id && $monitoring->team_id === null) {
             $monitoring->update([
-                'notification_on_failure' => $preference->notification_on_failure,
-                'notification_channels' => $preference->notification_channels,
-                'ssl_expiry_warning_days' => $preference->ssl_expiry_warning_days,
+                'notification_on_failure' => $monitoringNotificationPreference->notification_on_failure,
+                'notification_channels' => $monitoringNotificationPreference->notification_channels,
+                'ssl_expiry_warning_days' => $monitoringNotificationPreference->ssl_expiry_warning_days,
             ]);
         }
 

--- a/app/Http/Controllers/MonitoringNotificationPreferenceController.php
+++ b/app/Http/Controllers/MonitoringNotificationPreferenceController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Monitoring;
+use App\Models\User;
+use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class MonitoringNotificationPreferenceController extends Controller
+{
+    public function update(
+        Request $request,
+        Monitoring $monitoring,
+        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        abort_unless($monitoring->isVisibleTo($user), 404);
+
+        $validated = $request->validate([
+            'notification_on_failure' => ['nullable', 'boolean'],
+            'notification_channels' => ['nullable', 'array'],
+            'notification_channels.*' => [
+                'string',
+                Rule::in($user->enabledNotificationChannelKeys()),
+            ],
+            'ssl_expiry_warning_days' => ['required', 'integer', 'min:1', 'max:365'],
+        ]);
+
+        $preference = $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user);
+        $preference->update([
+            'notification_on_failure' => $request->boolean('notification_on_failure'),
+            'notification_channels' => array_values(array_unique($validated['notification_channels'] ?? [])),
+            'ssl_expiry_warning_days' => (int) $validated['ssl_expiry_warning_days'],
+        ]);
+
+        if ($monitoring->user_id === $user->id && $monitoring->team_id === null) {
+            $monitoring->update([
+                'notification_on_failure' => $preference->notification_on_failure,
+                'notification_channels' => $preference->notification_channels,
+                'ssl_expiry_warning_days' => $preference->ssl_expiry_warning_days,
+            ]);
+        }
+
+        return back()->with('success', __('monitoring.messages.notification_preferences_updated'));
+    }
+}

--- a/app/Http/Controllers/MonitoringOwnershipController.php
+++ b/app/Http/Controllers/MonitoringOwnershipController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Monitoring;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Monitorings\MonitoringOwnershipService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class MonitoringOwnershipController extends Controller
+{
+    public function moveToTeam(
+        Request $request,
+        Monitoring $monitoring,
+        MonitoringOwnershipService $monitoringOwnershipService
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+
+        $validated = $request->validate([
+            'team_id' => [
+                'required',
+                'string',
+                Rule::exists('teams', 'id'),
+                function ($attribute, $value, $fail) use ($user): void {
+                    if (! Team::query()->administeredBy($user)->whereKey((string) $value)->exists()) {
+                        $fail(__('team.validation.not_admin'));
+                    }
+                },
+            ],
+        ]);
+
+        $team = Team::query()->findOrFail($validated['team_id']);
+        $monitoringOwnershipService->moveToTeam($monitoring, $team, $user);
+
+        return to_route('monitorings.show', $monitoring)
+            ->with('success', __('team.ownership.moved_to_team'));
+    }
+
+    public function moveToPrivate(
+        Request $request,
+        Monitoring $monitoring,
+        MonitoringOwnershipService $monitoringOwnershipService
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+
+        $monitoringOwnershipService->moveToPrivate($monitoring, $user);
+
+        return to_route('monitorings.show', $monitoring)
+            ->with('success', __('team.ownership.moved_to_private'));
+    }
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -252,8 +252,8 @@ class NotificationController extends Controller
             ->limit($limit + 1)
             ->get();
 
-        $notifications->each(function (MonitoringNotification $notification): void {
-            $notification->setAttribute('read', $notification->user_read_at !== null);
+        $notifications->each(function (MonitoringNotification $monitoringNotification): void {
+            $monitoringNotification->setAttribute('read', $monitoringNotification->user_read_at !== null);
         });
 
         $hasMore = $notifications->count() > $limit;

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\NotificationType;
 use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationState;
 use App\Models\NotificationChannelDelivery;
 use App\Services\NotificationBoardService;
 use Illuminate\Database\Eloquent\Builder;
@@ -38,10 +39,9 @@ class NotificationController extends Controller
         $monitoringNotification = MonitoringNotification::query()->findOrFail($notificationId);
 
         if ($monitoringNotification->type === NotificationType::STATUS_CHANGE) {
-            MonitoringNotification::query()
+            $notificationIds = MonitoringNotification::query()
                 ->where('monitoring_id', $monitoringNotification->monitoring_id)
                 ->statusChange()
-                ->unread()
                 ->where(function (Builder $builder) use ($monitoringNotification): void {
                     $builder->where('created_at', '<', $monitoringNotification->created_at)
                         ->orWhere(function (Builder $builder) use ($monitoringNotification): void {
@@ -49,10 +49,24 @@ class NotificationController extends Controller
                                 ->where('id', '<=', $monitoringNotification->id);
                         });
                 })
+                ->pluck('id');
+
+            MonitoringNotificationState::query()
+                ->where('user_id', auth()->id())
+                ->whereIn('monitoring_notification_id', $notificationIds)
+                ->update(['read_at' => now()]);
+
+            MonitoringNotification::query()
+                ->whereIn('id', $notificationIds)
                 ->update(['read' => true]);
         } else {
-            $monitoringNotification->read = true;
-            $monitoringNotification->save();
+            MonitoringNotificationState::query()
+                ->firstOrCreate([
+                    'monitoring_notification_id' => $monitoringNotification->id,
+                    'user_id' => auth()->id(),
+                ])
+                ->update(['read_at' => now()]);
+            $monitoringNotification->update(['read' => true]);
         }
 
         return back()->with('success', __('notifications.messages.notification_marked_as_read'));
@@ -60,7 +74,20 @@ class NotificationController extends Controller
 
     public function markAllAsRead(): RedirectResponse
     {
-        MonitoringNotification::query()->unread()->update(['read' => true]);
+        $notificationIds = MonitoringNotificationState::query()
+            ->where('user_id', auth()->id())
+            ->whereNull('read_at')
+            ->pluck('monitoring_notification_id');
+
+        MonitoringNotificationState::query()
+            ->where('user_id', auth()->id())
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->whereIn('id', $notificationIds)
+            ->update(['read' => true]);
 
         return back()->with('success', __('notifications.messages.all_notifications_marked_as_read'));
     }
@@ -196,19 +223,38 @@ class NotificationController extends Controller
         int $offset,
         int $limit
     ): array {
-        $builder = MonitoringNotification::query()->ofType($notificationType);
+        $builder = MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->select('monitoring_notifications.*', 'monitoring_notification_states.read_at as user_read_at')
+            ->join('monitoring_notification_states', 'monitoring_notification_states.monitoring_notification_id', '=', 'monitoring_notifications.id')
+            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
+            ->where('monitoring_notification_states.user_id', auth()->id())
+            ->where(function ($query): void {
+                $query->where('monitorings.user_id', auth()->id())
+                    ->orWhereExists(function ($query): void {
+                        $query->selectRaw('1')
+                            ->from('team_memberships')
+                            ->whereColumn('team_memberships.team_id', 'monitorings.team_id')
+                            ->where('team_memberships.user_id', auth()->id());
+                    });
+            })
+            ->ofType($notificationType);
         if (! $showRead) {
-            $builder->unread();
+            $builder->whereNull('monitoring_notification_states.read_at');
         }
 
         $notifications = $builder
             ->with(['monitoring:id,name'])
-            ->orderBy('read')
-            ->latest('created_at')
-            ->latest('id')
+            ->orderByRaw('monitoring_notification_states.read_at is not null')
+            ->latest('monitoring_notifications.created_at')
+            ->latest('monitoring_notifications.id')
             ->offset($offset)
             ->limit($limit + 1)
             ->get();
+
+        $notifications->each(function (MonitoringNotification $notification): void {
+            $notification->setAttribute('read', $notification->user_read_at !== null);
+        });
 
         $hasMore = $notifications->count() > $limit;
         if ($hasMore) {

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Teams\TeamRequest;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class TeamController extends Controller
+{
+    public function index(Request $request): View
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return view('teams.index', [
+            'teams' => Team::query()
+                ->visibleTo($user)
+                ->withCount(['memberships', 'monitorings'])
+                ->orderBy('name')
+                ->paginate(10),
+        ]);
+    }
+
+    public function create(): View
+    {
+        abort_if(auth()->user()->isDemo(), 403);
+
+        return view('teams.create');
+    }
+
+    public function store(TeamRequest $teamRequest, TeamMembershipService $teamMembershipService): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $teamRequest->user();
+        $team = $teamMembershipService->createTeam($user, $teamRequest->validated());
+
+        return to_route('teams.show', $team)
+            ->with('success', __('team.messages.created'));
+    }
+
+    public function show(Team $team, TeamMembershipService $teamMembershipService): View
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamMembershipService->assertMember($team, $user);
+
+        return view('teams.show', [
+            'team' => $team->load([
+                'memberships.user',
+                'invitations' => fn ($builder) => $builder->whereNull('accepted_at')->latest(),
+            ])->loadCount('monitorings'),
+            'isTeamAdmin' => $team->isAdmin($user),
+        ]);
+    }
+
+    public function edit(Team $team, TeamMembershipService $teamMembershipService): View
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamMembershipService->assertAdmin($team, $user);
+
+        return view('teams.edit', ['team' => $team]);
+    }
+
+    public function update(TeamRequest $teamRequest, Team $team, TeamMembershipService $teamMembershipService): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $teamRequest->user();
+        $teamMembershipService->assertAdmin($team, $user);
+
+        $team->update($teamRequest->validated());
+
+        return to_route('teams.show', $team)
+            ->with('success', __('team.messages.updated'));
+    }
+
+    public function destroy(Team $team, TeamMembershipService $teamMembershipService): RedirectResponse
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamMembershipService->assertAdmin($team, $user);
+
+        $team->delete();
+
+        return to_route('teams.index')
+            ->with('success', __('team.messages.deleted'));
+    }
+}

--- a/app/Http/Controllers/TeamInvitationAcceptController.php
+++ b/app/Http/Controllers/TeamInvitationAcceptController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Services\Teams\TeamInvitationService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class TeamInvitationAcceptController extends Controller
+{
+    public function __invoke(
+        string $token,
+        Request $request,
+        TeamInvitationService $teamInvitationService
+    ): RedirectResponse {
+        $invitation = $teamInvitationService->findPendingByToken($token);
+
+        if (! $request->user()) {
+            $targetRoute = User::query()->where('email', $invitation->email)->exists()
+                ? route('login')
+                : route('register', ['mode' => 'register', 'email' => $invitation->email]);
+
+            return redirect()->guest($targetRoute)
+                ->with('status', __('team.messages.login_to_accept'));
+        }
+
+        /** @var User $user */
+        $user = $request->user();
+        $team = $teamInvitationService->accept($token, $user);
+
+        return to_route('teams.show', $team)
+            ->with('success', __('team.messages.invitation_accepted'));
+    }
+}

--- a/app/Http/Controllers/TeamInvitationAcceptController.php
+++ b/app/Http/Controllers/TeamInvitationAcceptController.php
@@ -16,12 +16,12 @@ class TeamInvitationAcceptController extends Controller
         Request $request,
         TeamInvitationService $teamInvitationService
     ): RedirectResponse {
-        $invitation = $teamInvitationService->findPendingByToken($token);
+        $teamInvitation = $teamInvitationService->findPendingByToken($token);
 
         if (! $request->user()) {
-            $targetRoute = User::query()->where('email', $invitation->email)->exists()
+            $targetRoute = User::query()->where('email', $teamInvitation->email)->exists()
                 ? route('login')
-                : route('register', ['mode' => 'register', 'email' => $invitation->email]);
+                : route('register', ['mode' => 'register', 'email' => $teamInvitation->email]);
 
             return redirect()->guest($targetRoute)
                 ->with('status', __('team.messages.login_to_accept'));

--- a/app/Http/Controllers/TeamInvitationController.php
+++ b/app/Http/Controllers/TeamInvitationController.php
@@ -38,15 +38,15 @@ class TeamInvitationController extends Controller
 
     public function destroy(
         Team $team,
-        TeamInvitation $invitation,
+        TeamInvitation $teamInvitation,
         TeamMembershipService $teamMembershipService
     ): RedirectResponse {
         /** @var User $user */
         $user = auth()->user();
         $teamMembershipService->assertAdmin($team, $user);
-        abort_unless($invitation->team_id === $team->id, 404);
+        abort_unless($teamInvitation->team_id === $team->id, 404);
 
-        $invitation->delete();
+        $teamInvitation->delete();
 
         return back()->with('success', __('team.messages.invitation_revoked'));
     }

--- a/app/Http/Controllers/TeamInvitationController.php
+++ b/app/Http/Controllers/TeamInvitationController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\TeamRole;
+use App\Http\Requests\Teams\TeamInvitationRequest;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Services\Teams\TeamInvitationService;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Http\RedirectResponse;
+
+class TeamInvitationController extends Controller
+{
+    public function store(
+        TeamInvitationRequest $teamInvitationRequest,
+        Team $team,
+        TeamMembershipService $teamMembershipService,
+        TeamInvitationService $teamInvitationService
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $teamInvitationRequest->user();
+        $teamMembershipService->assertAdmin($team, $user);
+        $validated = $teamInvitationRequest->validated();
+
+        $teamInvitationService->invite(
+            $team,
+            $user,
+            (string) $validated['email'],
+            TeamRole::from((string) $validated['role'])
+        );
+
+        return back()->with('success', __('team.messages.invitation_sent'));
+    }
+
+    public function destroy(
+        Team $team,
+        TeamInvitation $invitation,
+        TeamMembershipService $teamMembershipService
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamMembershipService->assertAdmin($team, $user);
+        abort_unless($invitation->team_id === $team->id, 404);
+
+        $invitation->delete();
+
+        return back()->with('success', __('team.messages.invitation_revoked'));
+    }
+}

--- a/app/Http/Controllers/TeamMemberController.php
+++ b/app/Http/Controllers/TeamMemberController.php
@@ -17,31 +17,31 @@ class TeamMemberController extends Controller
     public function update(
         TeamMembershipRequest $teamMembershipRequest,
         Team $team,
-        TeamMembership $membership,
+        TeamMembership $teamMembership,
         TeamMembershipService $teamMembershipService
     ): RedirectResponse {
         /** @var User $user */
         $user = $teamMembershipRequest->user();
         $teamMembershipService->assertAdmin($team, $user);
-        abort_unless($membership->team_id === $team->id, 404);
+        abort_unless($teamMembership->team_id === $team->id, 404);
         $validated = $teamMembershipRequest->validated();
 
-        $teamMembershipService->changeRole($membership, TeamRole::from((string) $validated['role']));
+        $teamMembershipService->changeRole($teamMembership, TeamRole::from((string) $validated['role']));
 
         return back()->with('success', __('team.messages.member_updated'));
     }
 
     public function destroy(
         Team $team,
-        TeamMembership $membership,
+        TeamMembership $teamMembership,
         TeamMembershipService $teamMembershipService
     ): RedirectResponse {
         /** @var User $user */
         $user = auth()->user();
         $teamMembershipService->assertAdmin($team, $user);
-        abort_unless($membership->team_id === $team->id, 404);
+        abort_unless($teamMembership->team_id === $team->id, 404);
 
-        $teamMembershipService->remove($membership);
+        $teamMembershipService->remove($teamMembership);
 
         return back()->with('success', __('team.messages.member_removed'));
     }

--- a/app/Http/Controllers/TeamMemberController.php
+++ b/app/Http/Controllers/TeamMemberController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\TeamRole;
+use App\Http\Requests\Teams\TeamMembershipRequest;
+use App\Models\Team;
+use App\Models\TeamMembership;
+use App\Models\User;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Http\RedirectResponse;
+
+class TeamMemberController extends Controller
+{
+    public function update(
+        TeamMembershipRequest $teamMembershipRequest,
+        Team $team,
+        TeamMembership $membership,
+        TeamMembershipService $teamMembershipService
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $teamMembershipRequest->user();
+        $teamMembershipService->assertAdmin($team, $user);
+        abort_unless($membership->team_id === $team->id, 404);
+        $validated = $teamMembershipRequest->validated();
+
+        $teamMembershipService->changeRole($membership, TeamRole::from((string) $validated['role']));
+
+        return back()->with('success', __('team.messages.member_updated'));
+    }
+
+    public function destroy(
+        Team $team,
+        TeamMembership $membership,
+        TeamMembershipService $teamMembershipService
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamMembershipService->assertAdmin($team, $user);
+        abort_unless($membership->team_id === $team->id, 404);
+
+        $teamMembershipService->remove($membership);
+
+        return back()->with('success', __('team.messages.member_removed'));
+    }
+
+    public function leave(Team $team, TeamMembershipService $teamMembershipService): RedirectResponse
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamMembershipService->assertMember($team, $user);
+        $teamMembershipService->leave($team, $user);
+
+        return to_route('teams.index')->with('success', __('team.messages.left'));
+    }
+}

--- a/app/Http/Requests/Api/MonitoringApiRequest.php
+++ b/app/Http/Requests/Api/MonitoringApiRequest.php
@@ -19,7 +19,7 @@ abstract class MonitoringApiRequest extends FormRequest
 
         $user = $this->user();
 
-        if ($user && $monitoring->user_id === $user->id) {
+        if ($user && $monitoring->isVisibleTo($user)) {
             return true;
         }
 

--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -7,12 +7,12 @@ namespace App\Http\Requests;
 use App\Enums\HttpMethod;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
+use App\Models\Team;
 use App\Models\User;
 use App\Support\DnsRecordExpectation;
 use App\Support\HttpStatusCodeRanges;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use InvalidArgumentException;
 use JsonException;
@@ -36,7 +36,7 @@ class MonitoringRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return Auth::check();
+        return $this->user() !== null;
     }
 
     /**
@@ -219,6 +219,22 @@ class MonitoringRequest extends FormRequest
                 'string',
                 Rule::in($this->notificationChannelUser()?->enabledNotificationChannelKeys() ?? []),
             ],
+            'team_id' => [
+                'nullable',
+                'string',
+                Rule::exists('teams', 'id'),
+                function ($attribute, $value, $fail): void {
+                    if (blank($value)) {
+                        return;
+                    }
+
+                    $user = $this->user();
+
+                    if (! $user || ! Team::query()->administeredBy($user)->whereKey((string) $value)->exists()) {
+                        $fail(__('team.validation.not_admin'));
+                    }
+                },
+            ],
             'group_ids' => ['nullable', 'array'],
             'group_ids.*' => [
                 'string',
@@ -265,6 +281,7 @@ class MonitoringRequest extends FormRequest
             'public_label_enabled' => $this->boolean('public_label_enabled'),
             'notification_on_failure' => $this->boolean('notification_on_failure'),
             'notification_channels' => $this->normalizeNotificationChannels(),
+            'team_id' => $this->normalizeTeamId(),
             'group_ids' => $this->normalizeGroupIds(),
             'failure_confirmation_threshold' => $this->input('failure_confirmation_threshold', 2),
             'ssl_expiry_warning_days' => $this->input('ssl_expiry_warning_days', 7),
@@ -312,6 +329,19 @@ class MonitoringRequest extends FormRequest
             array_map(static fn (mixed $groupId): string => (string) $groupId, $groupIds),
             static fn (string $groupId): bool => $groupId !== ''
         )));
+    }
+
+    private function normalizeTeamId(): ?string
+    {
+        $teamId = $this->input('team_id');
+
+        if (! is_scalar($teamId)) {
+            return null;
+        }
+
+        $teamId = mb_trim((string) $teamId);
+
+        return $teamId === '' ? null : $teamId;
     }
 
     /**

--- a/app/Http/Requests/StatusPages/StatusPageRequest.php
+++ b/app/Http/Requests/StatusPages/StatusPageRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\StatusPages;
 
 use App\Enums\StatusPageComponentSource;
+use App\Models\Monitoring;
 use App\Models\StatusPage;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -48,7 +49,13 @@ class StatusPageRequest extends FormRequest
             'components.*.monitoring_ids.*' => [
                 'required',
                 'string',
-                Rule::exists('monitorings', 'id')->where('user_id', $this->user()?->id),
+                Rule::exists('monitorings', 'id'),
+                function ($attribute, $value, $fail): void {
+                    if (! $this->user()
+                        || ! Monitoring::query()->visibleTo($this->user())->whereKey((string) $value)->exists()) {
+                        $fail(__('status_page.validation.monitoring_not_accessible'));
+                    }
+                },
             ],
         ];
     }

--- a/app/Http/Requests/StatusPages/StatusPageRequest.php
+++ b/app/Http/Requests/StatusPages/StatusPageRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\StatusPages;
 use App\Enums\StatusPageComponentSource;
 use App\Models\Monitoring;
 use App\Models\StatusPage;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -60,9 +61,9 @@ class StatusPageRequest extends FormRequest
         ];
     }
 
-    public function withValidator(\Illuminate\Contracts\Validation\Validator $validator): void
+    public function withValidator(Validator $validator): void
     {
-        $validator->after(function (\Illuminate\Contracts\Validation\Validator $validator): void {
+        $validator->after(function (Validator $validator): void {
             $components = $this->input('components', []);
 
             if (! is_array($components)) {

--- a/app/Http/Requests/Teams/TeamInvitationRequest.php
+++ b/app/Http/Requests/Teams/TeamInvitationRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Teams;
+
+use App\Enums\TeamRole;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TeamInvitationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null && ! $this->user()->isDemo();
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255'],
+            'role' => ['required', Rule::enum(TeamRole::class)],
+        ];
+    }
+}

--- a/app/Http/Requests/Teams/TeamMembershipRequest.php
+++ b/app/Http/Requests/Teams/TeamMembershipRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Teams;
+
+use App\Enums\TeamRole;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TeamMembershipRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null && ! $this->user()->isDemo();
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', Rule::enum(TeamRole::class)],
+        ];
+    }
+}

--- a/app/Http/Requests/Teams/TeamRequest.php
+++ b/app/Http/Requests/Teams/TeamRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Teams;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null && ! $this->user()->isDemo();
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:120'],
+            'description' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+}

--- a/app/Mail/TeamInvitationMail.php
+++ b/app/Mail/TeamInvitationMail.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Models\TeamInvitation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class TeamInvitationMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public TeamInvitation $invitation,
+        public string $token
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('team.mail.invitation.subject', ['team' => $this->invitation->team->name]),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.team-invitation',
+            with: [
+                'acceptUrl' => route('team-invitations.accept', ['token' => $this->token]),
+            ],
+        );
+    }
+}

--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Enums\HttpMethod;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
+use App\Enums\TeamRole;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
@@ -320,7 +321,7 @@ class Monitoring extends Model
         return $this->team()
             ->whereHas('memberships', function (Builder $builder) use ($user): void {
                 $builder->where('user_id', $user->id)
-                    ->where('role', \App\Enums\TeamRole::ADMIN);
+                    ->where('role', TeamRole::ADMIN);
             })
             ->exists();
     }
@@ -419,7 +420,7 @@ class Monitoring extends Model
             })
                 ->orWhereHas('team.memberships', function (Builder $builder) use ($user): void {
                     $builder->where('user_id', $user->id)
-                        ->where('role', \App\Enums\TeamRole::ADMIN);
+                        ->where('role', TeamRole::ADMIN);
                 });
         });
     }

--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -34,6 +34,8 @@ use Spatie\Activitylog\Support\LogOptions;
  **/
 #[Fillable([
     'user_id',
+    'team_id',
+    'created_by_user_id',
     'name',
     'type',
     'target',
@@ -86,6 +88,22 @@ class Monitoring extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
     }
 
     /**
@@ -194,6 +212,14 @@ class Monitoring extends Model
     }
 
     /**
+     * @return HasMany<MonitoringNotificationPreference, $this>
+     */
+    public function notificationPreferences(): HasMany
+    {
+        return $this->hasMany(MonitoringNotificationPreference::class);
+    }
+
+    /**
      * @return HasMany<StatusPageSubscriber, $this>
      */
     public function statusPageSubscribers(): HasMany
@@ -254,6 +280,51 @@ class Monitoring extends Model
         return $this->type === MonitoringType::SERVER_HEALTH;
     }
 
+    public function isTeamOwned(): bool
+    {
+        return $this->team_id !== null;
+    }
+
+    public function isPrivateOwned(): bool
+    {
+        return $this->user_id !== null && $this->team_id === null;
+    }
+
+    public function isVisibleTo(User $user): bool
+    {
+        if ($this->user_id === $user->id) {
+            return true;
+        }
+
+        if ($this->team_id === null) {
+            return false;
+        }
+
+        return $this->team()
+            ->whereHas('memberships', function (Builder $builder) use ($user): void {
+                $builder->where('user_id', $user->id);
+            })
+            ->exists();
+    }
+
+    public function isManageableBy(User $user): bool
+    {
+        if ($this->user_id === $user->id && $this->team_id === null) {
+            return true;
+        }
+
+        if ($this->team_id === null) {
+            return false;
+        }
+
+        return $this->team()
+            ->whereHas('memberships', function (Builder $builder) use ($user): void {
+                $builder->where('user_id', $user->id)
+                    ->where('role', \App\Enums\TeamRole::ADMIN);
+            })
+            ->exists();
+    }
+
     /**
      * Determine if the monitoring is currently under maintenance.
      */
@@ -297,7 +368,14 @@ class Monitoring extends Model
 
         static::addGlobalScope('user', function (Builder $builder): void {
             if (Auth::check()) {
-                $builder->where('user_id', Auth::user()->id);
+                $user = Auth::user();
+
+                $builder->where(function (Builder $builder) use ($user): void {
+                    $builder->where('user_id', $user->id)
+                        ->orWhereHas('team.memberships', function (Builder $builder) use ($user): void {
+                            $builder->where('user_id', $user->id);
+                        });
+                });
             }
         });
     }
@@ -318,6 +396,39 @@ class Monitoring extends Model
     protected function paused(Builder $builder): Builder
     {
         return $builder->where('status', MonitoringLifecycleStatus::PAUSED);
+    }
+
+    #[Scope]
+    protected function visibleTo(Builder $builder, User $user): Builder
+    {
+        return $builder->where(function (Builder $builder) use ($user): void {
+            $builder->where('user_id', $user->id)
+                ->orWhereHas('team.memberships', function (Builder $builder) use ($user): void {
+                    $builder->where('user_id', $user->id);
+                });
+        });
+    }
+
+    #[Scope]
+    protected function manageableBy(Builder $builder, User $user): Builder
+    {
+        return $builder->where(function (Builder $builder) use ($user): void {
+            $builder->where(function (Builder $builder) use ($user): void {
+                $builder->where('user_id', $user->id)
+                    ->whereNull('team_id');
+            })
+                ->orWhereHas('team.memberships', function (Builder $builder) use ($user): void {
+                    $builder->where('user_id', $user->id)
+                        ->where('role', \App\Enums\TeamRole::ADMIN);
+                });
+        });
+    }
+
+    #[Scope]
+    protected function privateOwnedBy(Builder $builder, User $user): Builder
+    {
+        return $builder->where('user_id', $user->id)
+            ->whereNull('team_id');
     }
 
     /**

--- a/app/Models/MonitoringNotification.php
+++ b/app/Models/MonitoringNotification.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 #[Appends(['created_at_for_humans', 'translated_message'])]
 #[Fillable([
@@ -56,6 +57,14 @@ class MonitoringNotification extends Model
         return $this->belongsTo(Monitoring::class);
     }
 
+    /**
+     * @return HasMany<MonitoringNotificationState, $this>
+     */
+    public function states(): HasMany
+    {
+        return $this->hasMany(MonitoringNotificationState::class);
+    }
+
     public function statusChangeIdentifier(bool $maintenanceActive = false): string
     {
         if ($maintenanceActive) {
@@ -73,6 +82,32 @@ class MonitoringNotification extends Model
     protected static function booted(): void
     {
         static::addGlobalScope(new UserScope());
+
+        static::created(function (MonitoringNotification $monitoringNotification): void {
+            /** @var Monitoring|null $monitoring */
+            $monitoring = Monitoring::query()
+                ->withoutGlobalScopes()
+                ->with(['user', 'team.users'])
+                ->find($monitoringNotification->monitoring_id);
+
+            if (! $monitoring) {
+                return;
+            }
+
+            $users = $monitoring->team_id !== null
+                ? ($monitoring->team?->users ?? collect())
+                : collect([$monitoring->user])->filter();
+
+            foreach ($users as $user) {
+                MonitoringNotificationState::query()->firstOrCreate([
+                    'monitoring_notification_id' => $monitoringNotification->id,
+                    'user_id' => $user->id,
+                ], [
+                    'read_at' => $monitoringNotification->read ? now() : null,
+                    'sent_at' => $monitoringNotification->sent ? now() : null,
+                ]);
+            }
+        });
     }
 
     /**
@@ -83,7 +118,7 @@ class MonitoringNotification extends Model
     {
         $value = $type instanceof NotificationType ? $type->value : $type;
 
-        return $builder->where('type', $value);
+        return $builder->where($builder->getModel()->qualifyColumn('type'), $value);
     }
 
     /**
@@ -119,6 +154,13 @@ class MonitoringNotification extends Model
     #[Scope]
     protected function read(Builder $builder): Builder
     {
+        if (auth()->check()) {
+            return $builder->whereHas('states', function (Builder $builder): void {
+                $builder->where('user_id', auth()->id())
+                    ->whereNotNull('read_at');
+            });
+        }
+
         return $builder->where('read', true);
     }
 
@@ -128,6 +170,13 @@ class MonitoringNotification extends Model
     #[Scope]
     protected function unread(Builder $builder): Builder
     {
+        if (auth()->check()) {
+            return $builder->whereHas('states', function (Builder $builder): void {
+                $builder->where('user_id', auth()->id())
+                    ->whereNull('read_at');
+            });
+        }
+
         return $builder->where('read', false);
     }
 

--- a/app/Models/MonitoringNotificationPreference.php
+++ b/app/Models/MonitoringNotificationPreference.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'monitoring_id',
+    'user_id',
+    'notification_on_failure',
+    'notification_channels',
+    'ssl_expiry_warning_days',
+])]
+#[Table(name: 'monitoring_notification_preferences', key: 'id', keyType: 'string')]
+#[WithoutIncrementing]
+class MonitoringNotificationPreference extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<Monitoring, $this>
+     */
+    public function monitoring(): BelongsTo
+    {
+        return $this->belongsTo(Monitoring::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'notification_on_failure' => 'boolean',
+            'notification_channels' => 'array',
+            'ssl_expiry_warning_days' => 'integer',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/MonitoringNotificationState.php
+++ b/app/Models/MonitoringNotificationState.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'monitoring_notification_id',
+    'user_id',
+    'read_at',
+    'sent_at',
+])]
+#[Table(name: 'monitoring_notification_states', key: 'id', keyType: 'string')]
+#[WithoutIncrementing]
+class MonitoringNotificationState extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<MonitoringNotification, $this>
+     */
+    public function monitoringNotification(): BelongsTo
+    {
+        return $this->belongsTo(MonitoringNotification::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isRead(): bool
+    {
+        return $this->read_at !== null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'read_at' => 'datetime',
+            'sent_at' => 'datetime',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Scopes/UserScope.php
+++ b/app/Models/Scopes/UserScope.php
@@ -13,8 +13,13 @@ class UserScope implements Scope
     public function apply(Builder $builder, Model $model)
     {
         if (auth()->check()) {
-            $builder->whereHas('monitoring', function (\Illuminate\Contracts\Database\Query\Builder $builder) {
-                $builder->where('user_id', auth()->id());
+            $user = auth()->user();
+
+            $builder->whereHas('monitoring', function (Builder $builder) use ($user): void {
+                $builder->where('user_id', $user->id)
+                    ->orWhereHas('team.memberships', function (Builder $builder) use ($user): void {
+                        $builder->where('user_id', $user->id);
+                    });
             });
         }
     }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Enums\TeamRole;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Builder;
@@ -92,14 +93,16 @@ class Team extends Model
             ->count();
     }
 
-    public function scopeVisibleTo(Builder $builder, User $user): Builder
+    #[Scope]
+    protected function visibleTo(Builder $builder, User $user): Builder
     {
         return $builder->whereHas('memberships', function (Builder $builder) use ($user): void {
             $builder->where('user_id', $user->id);
         });
     }
 
-    public function scopeAdministeredBy(Builder $builder, User $user): Builder
+    #[Scope]
+    protected function administeredBy(Builder $builder, User $user): Builder
     {
         return $builder->whereHas('memberships', function (Builder $builder) use ($user): void {
             $builder->where('user_id', $user->id)

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\TeamRole;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'name',
+    'description',
+    'created_by_user_id',
+])]
+#[Table(name: 'teams', key: 'id', keyType: 'string')]
+#[WithoutIncrementing]
+class Team extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    /**
+     * @return HasMany<TeamMembership, $this>
+     */
+    public function memberships(): HasMany
+    {
+        return $this->hasMany(TeamMembership::class);
+    }
+
+    /**
+     * @return BelongsToMany<User, $this>
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'team_memberships')
+            ->withPivot('id', 'role')
+            ->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<TeamInvitation, $this>
+     */
+    public function invitations(): HasMany
+    {
+        return $this->hasMany(TeamInvitation::class);
+    }
+
+    /**
+     * @return HasMany<Monitoring, $this>
+     */
+    public function monitorings(): HasMany
+    {
+        return $this->hasMany(Monitoring::class);
+    }
+
+    public function isMember(User $user): bool
+    {
+        return $this->memberships()
+            ->where('user_id', $user->id)
+            ->exists();
+    }
+
+    public function isAdmin(User $user): bool
+    {
+        return $this->memberships()
+            ->where('user_id', $user->id)
+            ->where('role', TeamRole::ADMIN)
+            ->exists();
+    }
+
+    public function adminCount(): int
+    {
+        return $this->memberships()
+            ->where('role', TeamRole::ADMIN)
+            ->count();
+    }
+
+    public function scopeVisibleTo(Builder $builder, User $user): Builder
+    {
+        return $builder->whereHas('memberships', function (Builder $builder) use ($user): void {
+            $builder->where('user_id', $user->id);
+        });
+    }
+
+    public function scopeAdministeredBy(Builder $builder, User $user): Builder
+    {
+        return $builder->whereHas('memberships', function (Builder $builder) use ($user): void {
+            $builder->where('user_id', $user->id)
+                ->where('role', TeamRole::ADMIN);
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\TeamRole;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'team_id',
+    'email',
+    'role',
+    'token_hash',
+    'invited_by_user_id',
+    'accepted_at',
+    'expires_at',
+])]
+#[Table(name: 'team_invitations', key: 'id', keyType: 'string')]
+#[WithoutIncrementing]
+class TeamInvitation extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function invitedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'invited_by_user_id');
+    }
+
+    public function scopePending(Builder $builder): Builder
+    {
+        return $builder->whereNull('accepted_at')
+            ->where('expires_at', '>', now());
+    }
+
+    public function isPending(): bool
+    {
+        return $this->accepted_at === null
+            && $this->expires_at !== null
+            && $this->expires_at->isFuture();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'role' => TeamRole::class,
+            'accepted_at' => 'datetime',
+            'expires_at' => 'datetime',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Enums\TeamRole;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Builder;
@@ -46,17 +47,18 @@ class TeamInvitation extends Model
         return $this->belongsTo(User::class, 'invited_by_user_id');
     }
 
-    public function scopePending(Builder $builder): Builder
-    {
-        return $builder->whereNull('accepted_at')
-            ->where('expires_at', '>', now());
-    }
-
     public function isPending(): bool
     {
         return $this->accepted_at === null
             && $this->expires_at !== null
             && $this->expires_at->isFuture();
+    }
+
+    #[Scope]
+    protected function pending(Builder $builder): Builder
+    {
+        return $builder->whereNull('accepted_at')
+            ->where('expires_at', '>', now());
     }
 
     /**

--- a/app/Models/TeamMembership.php
+++ b/app/Models/TeamMembership.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\TeamRole;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'team_id',
+    'user_id',
+    'role',
+])]
+#[Table(name: 'team_memberships', key: 'id', keyType: 'string')]
+#[WithoutIncrementing]
+class TeamMembership extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->role === TeamRole::ADMIN;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'role' => TeamRole::class,
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\TeamRole;
 use App\Enums\UserRole;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -137,7 +138,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function administeredTeams(): BelongsToMany
     {
-        return $this->teams()->wherePivot('role', \App\Enums\TeamRole::ADMIN->value);
+        return $this->teams()->wherePivot('role', TeamRole::ADMIN->value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -111,6 +112,48 @@ class User extends Authenticatable implements MustVerifyEmail
     public function monitoringGroups(): HasMany
     {
         return $this->hasMany(MonitoringGroup::class);
+    }
+
+    /**
+     * @return HasMany<TeamMembership, $this>
+     */
+    public function teamMemberships(): HasMany
+    {
+        return $this->hasMany(TeamMembership::class);
+    }
+
+    /**
+     * @return BelongsToMany<Team, $this>
+     */
+    public function teams(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class, 'team_memberships')
+            ->withPivot('id', 'role')
+            ->withTimestamps();
+    }
+
+    /**
+     * @return BelongsToMany<Team, $this>
+     */
+    public function administeredTeams(): BelongsToMany
+    {
+        return $this->teams()->wherePivot('role', \App\Enums\TeamRole::ADMIN->value);
+    }
+
+    /**
+     * @return HasMany<MonitoringNotificationPreference, $this>
+     */
+    public function monitoringNotificationPreferences(): HasMany
+    {
+        return $this->hasMany(MonitoringNotificationPreference::class);
+    }
+
+    /**
+     * @return HasMany<MonitoringNotificationState, $this>
+     */
+    public function monitoringNotificationStates(): HasMany
+    {
+        return $this->hasMany(MonitoringNotificationState::class);
     }
 
     /**

--- a/app/Services/Monitorings/MonitoringOwnershipService.php
+++ b/app/Services/Monitorings/MonitoringOwnershipService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Monitorings;
+
+use App\Models\Monitoring;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Support\Facades\DB;
+
+class MonitoringOwnershipService
+{
+    public function moveToTeam(Monitoring $monitoring, Team $team, User $actor): Monitoring
+    {
+        abort_unless($team->isAdmin($actor), 403);
+        abort_unless($monitoring->isManageableBy($actor), 403);
+
+        return DB::transaction(function () use ($monitoring, $team, $actor): Monitoring {
+            $monitoring->groups()->detach();
+            $monitoring->update([
+                'user_id' => null,
+                'team_id' => $team->id,
+                'created_by_user_id' => $monitoring->created_by_user_id ?? $actor->id,
+            ]);
+
+            $this->flushStatsCache($monitoring);
+
+            return $monitoring->refresh();
+        });
+    }
+
+    public function moveToPrivate(Monitoring $monitoring, User $actor): Monitoring
+    {
+        abort_unless($monitoring->isTeamOwned(), 404);
+        abort_unless($monitoring->isManageableBy($actor), 403);
+
+        return DB::transaction(function () use ($monitoring, $actor): Monitoring {
+            $monitoring->update([
+                'user_id' => $actor->id,
+                'team_id' => null,
+                'created_by_user_id' => $monitoring->created_by_user_id ?? $actor->id,
+            ]);
+
+            $this->flushStatsCache($monitoring);
+
+            return $monitoring->refresh();
+        });
+    }
+
+    private function flushStatsCache(Monitoring $monitoring): void
+    {
+        if (cache()->getStore() instanceof TaggableStore) {
+            cache()->tags(['monitoring:' . $monitoring->id])->flush();
+        }
+    }
+}

--- a/app/Services/Monitorings/MonitoringOwnershipService.php
+++ b/app/Services/Monitorings/MonitoringOwnershipService.php
@@ -12,17 +12,17 @@ use Illuminate\Support\Facades\DB;
 
 class MonitoringOwnershipService
 {
-    public function moveToTeam(Monitoring $monitoring, Team $team, User $actor): Monitoring
+    public function moveToTeam(Monitoring $monitoring, Team $team, User $user): Monitoring
     {
-        abort_unless($team->isAdmin($actor), 403);
-        abort_unless($monitoring->isManageableBy($actor), 403);
+        abort_unless($team->isAdmin($user), 403);
+        abort_unless($monitoring->isManageableBy($user), 403);
 
-        return DB::transaction(function () use ($monitoring, $team, $actor): Monitoring {
+        return DB::transaction(function () use ($monitoring, $team, $user): Monitoring {
             $monitoring->groups()->detach();
             $monitoring->update([
                 'user_id' => null,
                 'team_id' => $team->id,
-                'created_by_user_id' => $monitoring->created_by_user_id ?? $actor->id,
+                'created_by_user_id' => $monitoring->created_by_user_id ?? $user->id,
             ]);
 
             $this->flushStatsCache($monitoring);
@@ -31,16 +31,16 @@ class MonitoringOwnershipService
         });
     }
 
-    public function moveToPrivate(Monitoring $monitoring, User $actor): Monitoring
+    public function moveToPrivate(Monitoring $monitoring, User $user): Monitoring
     {
         abort_unless($monitoring->isTeamOwned(), 404);
-        abort_unless($monitoring->isManageableBy($actor), 403);
+        abort_unless($monitoring->isManageableBy($user), 403);
 
-        return DB::transaction(function () use ($monitoring, $actor): Monitoring {
+        return DB::transaction(function () use ($monitoring, $user): Monitoring {
             $monitoring->update([
-                'user_id' => $actor->id,
+                'user_id' => $user->id,
                 'team_id' => null,
-                'created_by_user_id' => $monitoring->created_by_user_id ?? $actor->id,
+                'created_by_user_id' => $monitoring->created_by_user_id ?? $user->id,
             ]);
 
             $this->flushStatsCache($monitoring);

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -39,20 +39,32 @@ class NotificationBoardService
                 'monitoring_notifications.id',
                 'monitoring_notifications.monitoring_id',
                 'monitoring_notifications.message',
-                'monitoring_notifications.read',
+                'monitoring_notification_states.read_at',
                 'monitoring_notifications.created_at',
             ])
+            ->join('monitoring_notification_states', 'monitoring_notification_states.monitoring_notification_id', '=', 'monitoring_notifications.id')
             ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
-            ->where('monitorings.user_id', auth()->id())
+            ->where('monitoring_notification_states.user_id', auth()->id())
+            ->where(function ($query): void {
+                $query->where('monitorings.user_id', auth()->id())
+                    ->orWhereExists(function ($query): void {
+                        $query->selectRaw('1')
+                            ->from('team_memberships')
+                            ->whereColumn('team_memberships.team_id', 'monitorings.team_id')
+                            ->where('team_memberships.user_id', auth()->id());
+                    });
+            })
             ->whereNull('monitorings.deleted_at')
             ->where('monitoring_notifications.type', NotificationType::STATUS_CHANGE->value)
-            ->unless($showRead, fn ($query) => $query->where('monitoring_notifications.read', false))
+            ->unless($showRead, fn ($query) => $query->whereNull('monitoring_notification_states.read_at'))
             ->whereNotExists(function ($query) use ($showRead): void {
                 $query->selectRaw('1')
                     ->from('monitoring_notifications as newer_notifications')
+                    ->join('monitoring_notification_states as newer_states', 'newer_states.monitoring_notification_id', '=', 'newer_notifications.id')
                     ->whereColumn('newer_notifications.monitoring_id', 'monitoring_notifications.monitoring_id')
+                    ->whereColumn('newer_states.user_id', 'monitoring_notification_states.user_id')
                     ->where('newer_notifications.type', NotificationType::STATUS_CHANGE->value)
-                    ->when(! $showRead, fn ($query) => $query->where('newer_notifications.read', false))
+                    ->when(! $showRead, fn ($query) => $query->whereNull('newer_states.read_at'))
                     ->where(function ($query): void {
                         $query->whereColumn('newer_notifications.created_at', '>', 'monitoring_notifications.created_at')
                             ->orWhere(function ($query): void {
@@ -123,7 +135,7 @@ class NotificationBoardService
                 ),
                 'status_change_key' => 'notifications.status_change.' . $statusChangeIdentifier,
                 'badge_type' => MonitoringStatusMeta::badgeType($statusIdentifier),
-                'read' => $monitoringNotification->read,
+                'read' => $monitoringNotification->read_at !== null,
             ];
         });
     }
@@ -132,10 +144,20 @@ class NotificationBoardService
     {
         $total = MonitoringNotification::query()
             ->withoutGlobalScopes()
+            ->join('monitoring_notification_states', 'monitoring_notification_states.monitoring_notification_id', '=', 'monitoring_notifications.id')
             ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
-            ->where('monitorings.user_id', auth()->id())
+            ->where('monitoring_notification_states.user_id', auth()->id())
+            ->where(function ($query): void {
+                $query->where('monitorings.user_id', auth()->id())
+                    ->orWhereExists(function ($query): void {
+                        $query->selectRaw('1')
+                            ->from('team_memberships')
+                            ->whereColumn('team_memberships.team_id', 'monitorings.team_id')
+                            ->where('team_memberships.user_id', auth()->id());
+                    });
+            })
             ->whereNull('monitorings.deleted_at')
-            ->where('monitoring_notifications.read', false)
+            ->whereNull('monitoring_notification_states.read_at')
             ->selectRaw(
                 <<<'SQL'
                 count(distinct case
@@ -164,12 +186,22 @@ class NotificationBoardService
     {
         return MonitoringNotification::query()
             ->withoutGlobalScopes()
+            ->join('monitoring_notification_states', 'monitoring_notification_states.monitoring_notification_id', '=', 'monitoring_notifications.id')
             ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
-            ->where('monitoring_notifications.read', false)
+            ->whereNull('monitoring_notification_states.read_at')
+            ->where(function ($query): void {
+                $query->whereColumn('monitorings.user_id', 'monitoring_notification_states.user_id')
+                    ->orWhereExists(function ($query): void {
+                        $query->selectRaw('1')
+                            ->from('team_memberships')
+                            ->whereColumn('team_memberships.team_id', 'monitorings.team_id')
+                            ->whereColumn('team_memberships.user_id', 'monitoring_notification_states.user_id');
+                    });
+            })
             ->whereNull('monitorings.deleted_at')
             ->selectRaw(
                 <<<'SQL'
-                monitorings.user_id as user_id,
+                monitoring_notification_states.user_id as user_id,
                 count(distinct case
                     when monitoring_notifications.type = ?
                     then monitoring_notifications.monitoring_id
@@ -184,7 +216,7 @@ class NotificationBoardService
                     NotificationType::STATUS_CHANGE->value,
                 ]
             )
-            ->groupBy('monitorings.user_id')
+            ->groupBy('monitoring_notification_states.user_id')
             ->pluck('total', 'user_id')
             ->map(fn (int|string $total): int => (int) $total);
     }

--- a/app/Services/Notifications/MonitoringNotificationPreferenceResolver.php
+++ b/app/Services/Notifications/MonitoringNotificationPreferenceResolver.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Notifications;
+
+use App\Models\Monitoring;
+use App\Models\MonitoringNotificationPreference;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+
+class MonitoringNotificationPreferenceResolver
+{
+    public function preferenceFor(Monitoring $monitoring, User $user): MonitoringNotificationPreference
+    {
+        /** @var MonitoringNotificationPreference $preference */
+        $preference = MonitoringNotificationPreference::query()->firstOrCreate(
+            [
+                'monitoring_id' => $monitoring->id,
+                'user_id' => $user->id,
+            ],
+            [
+                'notification_on_failure' => $monitoring->notification_on_failure,
+                'notification_channels' => $monitoring->user_id === $user->id
+                    ? $monitoring->notification_channels
+                    : $user->enabledNotificationChannelKeys(),
+                'ssl_expiry_warning_days' => $monitoring->ssl_expiry_warning_days ?? 7,
+            ]
+        );
+
+        return $preference;
+    }
+
+    /**
+     * @return Collection<int, array{user: User, preference: MonitoringNotificationPreference}>
+     */
+    public function recipientsFor(Monitoring $monitoring): Collection
+    {
+        $users = $this->usersFor($monitoring);
+
+        return $users
+            ->map(fn (User $user): array => [
+                'user' => $user,
+                'preference' => $this->preferenceFor($monitoring, $user),
+            ])
+            ->values();
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function usersFor(Monitoring $monitoring): Collection
+    {
+        if ($monitoring->team_id !== null) {
+            $team = $monitoring->team()->with('users')->first();
+
+            if (! $team) {
+                return collect();
+            }
+
+            /** @var EloquentCollection<int, User> $users */
+            $users = $team->users;
+
+            return $users->toBase();
+        }
+
+        $user = $monitoring->user;
+
+        return $user ? collect([$user]) : collect();
+    }
+}

--- a/app/Services/Notifications/MonitoringNotificationPreferenceResolver.php
+++ b/app/Services/Notifications/MonitoringNotificationPreferenceResolver.php
@@ -14,8 +14,8 @@ class MonitoringNotificationPreferenceResolver
 {
     public function preferenceFor(Monitoring $monitoring, User $user): MonitoringNotificationPreference
     {
-        /** @var MonitoringNotificationPreference $preference */
-        $preference = MonitoringNotificationPreference::query()->firstOrCreate(
+        /** @var MonitoringNotificationPreference $monitoringNotificationPreference */
+        $monitoringNotificationPreference = MonitoringNotificationPreference::query()->firstOrCreate(
             [
                 'monitoring_id' => $monitoring->id,
                 'user_id' => $user->id,
@@ -29,7 +29,7 @@ class MonitoringNotificationPreferenceResolver
             ]
         );
 
-        return $preference;
+        return $monitoringNotificationPreference;
     }
 
     /**

--- a/app/Services/Notifications/MonitoringNotificationStateService.php
+++ b/app/Services/Notifications/MonitoringNotificationStateService.php
@@ -10,27 +10,27 @@ use App\Models\User;
 
 class MonitoringNotificationStateService
 {
-    public function ensureState(MonitoringNotification $notification, User $user): MonitoringNotificationState
+    public function ensureState(MonitoringNotification $monitoringNotification, User $user): MonitoringNotificationState
     {
-        /** @var MonitoringNotificationState $state */
-        $state = MonitoringNotificationState::query()->firstOrCreate([
-            'monitoring_notification_id' => $notification->id,
+        /** @var MonitoringNotificationState $monitoringNotificationState */
+        $monitoringNotificationState = MonitoringNotificationState::query()->firstOrCreate([
+            'monitoring_notification_id' => $monitoringNotification->id,
             'user_id' => $user->id,
         ]);
 
-        return $state;
+        return $monitoringNotificationState;
     }
 
-    public function markSent(MonitoringNotification $notification, User $user): void
+    public function markSent(MonitoringNotification $monitoringNotification, User $user): void
     {
-        $this->ensureState($notification, $user)->update([
+        $this->ensureState($monitoringNotification, $user)->update([
             'sent_at' => now(),
         ]);
     }
 
-    public function markRead(MonitoringNotification $notification, User $user): void
+    public function markRead(MonitoringNotification $monitoringNotification, User $user): void
     {
-        $this->ensureState($notification, $user)->update([
+        $this->ensureState($monitoringNotification, $user)->update([
             'read_at' => now(),
         ]);
     }

--- a/app/Services/Notifications/MonitoringNotificationStateService.php
+++ b/app/Services/Notifications/MonitoringNotificationStateService.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Notifications;
+
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationState;
+use App\Models\User;
+
+class MonitoringNotificationStateService
+{
+    public function ensureState(MonitoringNotification $notification, User $user): MonitoringNotificationState
+    {
+        /** @var MonitoringNotificationState $state */
+        $state = MonitoringNotificationState::query()->firstOrCreate([
+            'monitoring_notification_id' => $notification->id,
+            'user_id' => $user->id,
+        ]);
+
+        return $state;
+    }
+
+    public function markSent(MonitoringNotification $notification, User $user): void
+    {
+        $this->ensureState($notification, $user)->update([
+            'sent_at' => now(),
+        ]);
+    }
+
+    public function markRead(MonitoringNotification $notification, User $user): void
+    {
+        $this->ensureState($notification, $user)->update([
+            'read_at' => now(),
+        ]);
+    }
+}

--- a/app/Services/Teams/TeamInvitationService.php
+++ b/app/Services/Teams/TeamInvitationService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Teams;
+
+use App\Enums\TeamRole;
+use App\Mail\TeamInvitationMail;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class TeamInvitationService
+{
+    public function invite(Team $team, User $inviter, string $email, TeamRole $role): TeamInvitation
+    {
+        $normalizedEmail = Str::lower(trim($email));
+
+        if ($team->memberships()
+            ->whereHas('user', fn ($builder) => $builder->where('email', $normalizedEmail))
+            ->exists()) {
+            throw ValidationException::withMessages([
+                'email' => __('team.validation.already_member'),
+            ]);
+        }
+
+        $token = Str::random(64);
+        $invitation = DB::transaction(function () use ($team, $inviter, $normalizedEmail, $role, $token): TeamInvitation {
+            $team->invitations()
+                ->where('email', $normalizedEmail)
+                ->whereNull('accepted_at')
+                ->delete();
+
+            return $team->invitations()->create([
+                'email' => $normalizedEmail,
+                'role' => $role,
+                'token_hash' => $this->hashToken($token),
+                'invited_by_user_id' => $inviter->id,
+                'expires_at' => now()->addDays(7),
+            ]);
+        });
+
+        $invitation->load('team');
+
+        Mail::to($normalizedEmail)->send(new TeamInvitationMail($invitation, $token));
+
+        return $invitation;
+    }
+
+    public function findPendingByToken(string $token): TeamInvitation
+    {
+        /** @var TeamInvitation|null $invitation */
+        $invitation = TeamInvitation::query()
+            ->where('token_hash', $this->hashToken($token))
+            ->whereNull('accepted_at')
+            ->where('expires_at', '>', now())
+            ->with('team')
+            ->first();
+
+        if (! $invitation) {
+            abort(404);
+        }
+
+        return $invitation;
+    }
+
+    public function accept(string $token, User $user): Team
+    {
+        return DB::transaction(function () use ($token, $user): Team {
+            $invitation = $this->findPendingByToken($token);
+
+            if (Str::lower($user->email) !== Str::lower($invitation->email)) {
+                throw ValidationException::withMessages([
+                    'email' => __('team.validation.email_mismatch'),
+                ]);
+            }
+
+            $invitation->team->memberships()->firstOrCreate(
+                ['user_id' => $user->id],
+                ['role' => $invitation->role]
+            );
+
+            $invitation->update(['accepted_at' => now()]);
+
+            return $invitation->team;
+        });
+    }
+
+    private function hashToken(string $token): string
+    {
+        return hash('sha256', $token);
+    }
+}

--- a/app/Services/Teams/TeamInvitationService.php
+++ b/app/Services/Teams/TeamInvitationService.php
@@ -16,9 +16,9 @@ use Illuminate\Validation\ValidationException;
 
 class TeamInvitationService
 {
-    public function invite(Team $team, User $inviter, string $email, TeamRole $role): TeamInvitation
+    public function invite(Team $team, User $user, string $email, TeamRole $teamRole): TeamInvitation
     {
-        $normalizedEmail = Str::lower(trim($email));
+        $normalizedEmail = Str::lower(mb_trim($email));
 
         if ($team->memberships()
             ->whereHas('user', fn ($builder) => $builder->where('email', $normalizedEmail))
@@ -29,7 +29,7 @@ class TeamInvitationService
         }
 
         $token = Str::random(64);
-        $invitation = DB::transaction(function () use ($team, $inviter, $normalizedEmail, $role, $token): TeamInvitation {
+        $invitation = DB::transaction(function () use ($team, $user, $normalizedEmail, $teamRole, $token): TeamInvitation {
             $team->invitations()
                 ->where('email', $normalizedEmail)
                 ->whereNull('accepted_at')
@@ -37,9 +37,9 @@ class TeamInvitationService
 
             return $team->invitations()->create([
                 'email' => $normalizedEmail,
-                'role' => $role,
+                'role' => $teamRole,
                 'token_hash' => $this->hashToken($token),
-                'invited_by_user_id' => $inviter->id,
+                'invited_by_user_id' => $user->id,
                 'expires_at' => now()->addDays(7),
             ]);
         });
@@ -61,9 +61,7 @@ class TeamInvitationService
             ->with('team')
             ->first();
 
-        if (! $invitation) {
-            abort(404);
-        }
+        abort_unless($invitation, 404);
 
         return $invitation;
     }
@@ -71,22 +69,22 @@ class TeamInvitationService
     public function accept(string $token, User $user): Team
     {
         return DB::transaction(function () use ($token, $user): Team {
-            $invitation = $this->findPendingByToken($token);
+            $teamInvitation = $this->findPendingByToken($token);
 
-            if (Str::lower($user->email) !== Str::lower($invitation->email)) {
+            if (Str::lower($user->email) !== Str::lower($teamInvitation->email)) {
                 throw ValidationException::withMessages([
                     'email' => __('team.validation.email_mismatch'),
                 ]);
             }
 
-            $invitation->team->memberships()->firstOrCreate(
+            $teamInvitation->team->memberships()->firstOrCreate(
                 ['user_id' => $user->id],
-                ['role' => $invitation->role]
+                ['role' => $teamInvitation->role]
             );
 
-            $invitation->update(['accepted_at' => now()]);
+            $teamInvitation->update(['accepted_at' => now()]);
 
-            return $invitation->team;
+            return $teamInvitation->team;
         });
     }
 

--- a/app/Services/Teams/TeamMembershipService.php
+++ b/app/Services/Teams/TeamMembershipService.php
@@ -37,27 +37,27 @@ class TeamMembershipService
         });
     }
 
-    public function changeRole(TeamMembership $membership, TeamRole $role): void
+    public function changeRole(TeamMembership $teamMembership, TeamRole $teamRole): void
     {
-        if ($membership->role === $role) {
+        if ($teamMembership->role === $teamRole) {
             return;
         }
 
-        if ($membership->role === TeamRole::ADMIN && $role !== TeamRole::ADMIN) {
-            $this->assertNotLastAdmin($membership);
+        if ($teamMembership->role === TeamRole::ADMIN && $teamRole !== TeamRole::ADMIN) {
+            $this->assertNotLastAdmin($teamMembership);
         }
 
-        $membership->update(['role' => $role]);
+        $teamMembership->update(['role' => $teamRole]);
     }
 
-    public function remove(TeamMembership $membership): void
+    public function remove(TeamMembership $teamMembership): void
     {
-        if ($membership->role === TeamRole::ADMIN) {
-            $this->assertNotLastAdmin($membership);
+        if ($teamMembership->role === TeamRole::ADMIN) {
+            $this->assertNotLastAdmin($teamMembership);
         }
 
-        $this->deleteMemberMonitoringState($membership);
-        $membership->delete();
+        $this->deleteMemberMonitoringState($teamMembership);
+        $teamMembership->delete();
     }
 
     public function leave(Team $team, User $user): void
@@ -76,29 +76,23 @@ class TeamMembershipService
 
     public function assertAdmin(Team $team, User $user): void
     {
-        if (! $team->isMember($user)) {
-            abort(404);
-        }
+        abort_unless($team->isMember($user), 404);
 
-        if (! $team->isAdmin($user)) {
-            abort(403);
-        }
+        abort_unless($team->isAdmin($user), 403);
     }
 
     public function assertMember(Team $team, User $user): void
     {
-        if (! $team->isMember($user)) {
-            abort(404);
-        }
+        abort_unless($team->isMember($user), 404);
     }
 
-    private function assertNotLastAdmin(TeamMembership $membership): void
+    private function assertNotLastAdmin(TeamMembership $teamMembership): void
     {
-        if (! $membership->team) {
-            $membership->load('team');
+        if (! $teamMembership->team) {
+            $teamMembership->load('team');
         }
 
-        $adminCount = $membership->team->adminCount();
+        $adminCount = $teamMembership->team->adminCount();
 
         if ($adminCount <= 1) {
             throw ValidationException::withMessages([
@@ -107,11 +101,11 @@ class TeamMembershipService
         }
     }
 
-    private function deleteMemberMonitoringState(TeamMembership $membership): void
+    private function deleteMemberMonitoringState(TeamMembership $teamMembership): void
     {
         $monitoringIds = Monitoring::query()
             ->withoutGlobalScopes()
-            ->where('team_id', $membership->team_id)
+            ->where('team_id', $teamMembership->team_id)
             ->pluck('id');
 
         if ($monitoringIds->isEmpty()) {
@@ -119,12 +113,12 @@ class TeamMembershipService
         }
 
         MonitoringNotificationPreference::query()
-            ->where('user_id', $membership->user_id)
+            ->where('user_id', $teamMembership->user_id)
             ->whereIn('monitoring_id', $monitoringIds)
             ->delete();
 
         MonitoringNotificationState::query()
-            ->where('user_id', $membership->user_id)
+            ->where('user_id', $teamMembership->user_id)
             ->whereHas('monitoringNotification', function ($builder) use ($monitoringIds): void {
                 $builder->whereIn('monitoring_id', $monitoringIds);
             })

--- a/app/Services/Teams/TeamMembershipService.php
+++ b/app/Services/Teams/TeamMembershipService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Teams;
+
+use App\Enums\TeamRole;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotificationPreference;
+use App\Models\MonitoringNotificationState;
+use App\Models\Team;
+use App\Models\TeamMembership;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class TeamMembershipService
+{
+    /**
+     * @param  array{name: string, description?: string|null}  $data
+     */
+    public function createTeam(User $user, array $data): Team
+    {
+        return DB::transaction(function () use ($user, $data): Team {
+            $team = Team::query()->create([
+                'name' => $data['name'],
+                'description' => $data['description'] ?? null,
+                'created_by_user_id' => $user->id,
+            ]);
+
+            $team->memberships()->create([
+                'user_id' => $user->id,
+                'role' => TeamRole::ADMIN,
+            ]);
+
+            return $team;
+        });
+    }
+
+    public function changeRole(TeamMembership $membership, TeamRole $role): void
+    {
+        if ($membership->role === $role) {
+            return;
+        }
+
+        if ($membership->role === TeamRole::ADMIN && $role !== TeamRole::ADMIN) {
+            $this->assertNotLastAdmin($membership);
+        }
+
+        $membership->update(['role' => $role]);
+    }
+
+    public function remove(TeamMembership $membership): void
+    {
+        if ($membership->role === TeamRole::ADMIN) {
+            $this->assertNotLastAdmin($membership);
+        }
+
+        $this->deleteMemberMonitoringState($membership);
+        $membership->delete();
+    }
+
+    public function leave(Team $team, User $user): void
+    {
+        /** @var TeamMembership|null $membership */
+        $membership = $team->memberships()
+            ->where('user_id', $user->id)
+            ->first();
+
+        if (! $membership) {
+            return;
+        }
+
+        $this->remove($membership);
+    }
+
+    public function assertAdmin(Team $team, User $user): void
+    {
+        if (! $team->isMember($user)) {
+            abort(404);
+        }
+
+        if (! $team->isAdmin($user)) {
+            abort(403);
+        }
+    }
+
+    public function assertMember(Team $team, User $user): void
+    {
+        if (! $team->isMember($user)) {
+            abort(404);
+        }
+    }
+
+    private function assertNotLastAdmin(TeamMembership $membership): void
+    {
+        if (! $membership->team) {
+            $membership->load('team');
+        }
+
+        $adminCount = $membership->team->adminCount();
+
+        if ($adminCount <= 1) {
+            throw ValidationException::withMessages([
+                'role' => __('team.validation.last_admin'),
+            ]);
+        }
+    }
+
+    private function deleteMemberMonitoringState(TeamMembership $membership): void
+    {
+        $monitoringIds = Monitoring::query()
+            ->withoutGlobalScopes()
+            ->where('team_id', $membership->team_id)
+            ->pluck('id');
+
+        if ($monitoringIds->isEmpty()) {
+            return;
+        }
+
+        MonitoringNotificationPreference::query()
+            ->where('user_id', $membership->user_id)
+            ->whereIn('monitoring_id', $monitoringIds)
+            ->delete();
+
+        MonitoringNotificationState::query()
+            ->where('user_id', $membership->user_id)
+            ->whereHas('monitoringNotification', function ($builder) use ($monitoringIds): void {
+                $builder->whereIn('monitoring_id', $monitoringIds);
+            })
+            ->delete();
+    }
+}

--- a/app/Services/UserDeletionPreparationService.php
+++ b/app/Services/UserDeletionPreparationService.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Enums\TeamRole;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class UserDeletionPreparationService
 {
     public function disableLoginUntilDeletion(User $user): void
     {
+        $this->assertUserIsNotLastTeamAdmin($user);
+
         $emailBeforeDeletion = $user->email;
 
         $user->forceFill([
@@ -27,5 +31,25 @@ class UserDeletionPreparationService
 
         DB::table('sessions')->where('user_id', $user->id)->delete();
         DB::table('password_reset_tokens')->where('email', $emailBeforeDeletion)->delete();
+    }
+
+    private function assertUserIsNotLastTeamAdmin(User $user): void
+    {
+        $lastAdminTeam = $user->teamMemberships()
+            ->where('role', TeamRole::ADMIN)
+            ->whereDoesntHave('team.memberships', function ($builder) use ($user): void {
+                $builder->where('role', TeamRole::ADMIN)
+                    ->where('user_id', '!=', $user->id);
+            })
+            ->with('team:id,name')
+            ->first();
+
+        if (! $lastAdminTeam) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            'user' => __('team.validation.delete_last_admin', ['team' => $lastAdminTeam->team?->name]),
+        ]);
     }
 }

--- a/app/Services/WeeklyMonitoringDigestService.php
+++ b/app/Services/WeeklyMonitoringDigestService.php
@@ -38,7 +38,8 @@ class WeeklyMonitoringDigestService
         };
         $periodStart = $periodEnd->copy()->subDays($periodDays - 1)->startOfDay();
 
-        $monitorings = $user->monitorings()
+        $monitorings = Monitoring::query()
+            ->visibleTo($user)
             ->active()
             ->with([
                 'sslResult',

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Team>
+ */
+class TeamFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+            'description' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/TeamMembershipFactory.php
+++ b/database/factories/TeamMembershipFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\TeamRole;
+use App\Models\TeamMembership;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TeamMembership>
+ */
+class TeamMembershipFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'role' => TeamRole::MEMBER,
+        ];
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (): array => [
+            'role' => TeamRole::ADMIN,
+        ]);
+    }
+}

--- a/database/migrations/2026_06_21_000000_create_teams_table.php
+++ b/database/migrations/2026_06_21_000000_create_teams_table.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TeamRole;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->string('name', 120);
+            $table->text('description')->nullable();
+            $table->foreignUlid('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['created_by_user_id', 'created_at'], 'teams_created_by_created_at_idx');
+        });
+
+        Schema::create('team_memberships', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('team_id')->constrained('teams')->cascadeOnDelete();
+            $table->foreignUlid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->enum('role', TeamRole::values())->default(TeamRole::MEMBER->value);
+            $table->timestamps();
+
+            $table->unique(['team_id', 'user_id'], 'team_memberships_team_user_unique');
+            $table->index(['user_id', 'team_id'], 'team_memberships_user_team_idx');
+            $table->index(['team_id', 'role'], 'team_memberships_team_role_idx');
+        });
+
+        Schema::create('team_invitations', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('team_id')->constrained('teams')->cascadeOnDelete();
+            $table->string('email');
+            $table->enum('role', TeamRole::values())->default(TeamRole::MEMBER->value);
+            $table->string('token_hash', 128)->unique();
+            $table->foreignUlid('invited_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['team_id', 'email', 'accepted_at'], 'team_invitations_team_email_accepted_unique');
+            $table->index(['email', 'accepted_at'], 'team_invitations_email_accepted_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_invitations');
+        Schema::dropIfExists('team_memberships');
+        Schema::dropIfExists('teams');
+    }
+};

--- a/database/migrations/2026_06_21_000100_add_team_ownership_to_monitorings_table.php
+++ b/database/migrations/2026_06_21_000100_add_team_ownership_to_monitorings_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->dropForeign(['user_id']);
+        });
+
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->foreignUlid('team_id')->nullable()->after('user_id')->constrained('teams')->cascadeOnDelete();
+            $table->foreignUlid('created_by_user_id')->nullable()->after('team_id')->constrained('users')->nullOnDelete();
+            $table->foreignUlid('user_id')->nullable()->change();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+
+            $table->index(['team_id', 'created_at'], 'monitorings_team_created_at_idx');
+            $table->index(['created_by_user_id', 'created_at'], 'monitorings_created_by_created_at_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->dropForeign(['team_id']);
+            $table->dropForeign(['created_by_user_id']);
+            $table->dropForeign(['user_id']);
+            $table->dropIndex('monitorings_team_created_at_idx');
+            $table->dropIndex('monitorings_created_by_created_at_idx');
+            $table->dropColumn(['team_id', 'created_by_user_id']);
+        });
+
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->foreignUlid('user_id')->nullable(false)->change();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+};

--- a/database/migrations/2026_06_21_000200_create_monitoring_notification_preferences_table.php
+++ b/database/migrations/2026_06_21_000200_create_monitoring_notification_preferences_table.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('monitoring_notification_preferences', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('monitoring_id')->constrained('monitorings')->cascadeOnDelete();
+            $table->foreignUlid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->boolean('notification_on_failure')->default(true);
+            $table->json('notification_channels')->nullable();
+            $table->unsignedSmallInteger('ssl_expiry_warning_days')->default(7);
+            $table->timestamps();
+
+            $table->unique(['monitoring_id', 'user_id'], 'monitoring_notification_preferences_monitoring_user_unique');
+            $table->index(['user_id', 'monitoring_id'], 'monitoring_notification_preferences_user_monitoring_idx');
+        });
+
+        DB::table('monitorings')
+            ->whereNotNull('user_id')
+            ->orderBy('id')
+            ->select(['id', 'user_id', 'notification_on_failure', 'notification_channels', 'ssl_expiry_warning_days', 'created_at', 'updated_at'])
+            ->chunk(500, function ($monitorings): void {
+                $rows = [];
+
+                foreach ($monitorings as $monitoring) {
+                    $rows[] = [
+                        'id' => (string) Illuminate\Support\Str::ulid(),
+                        'monitoring_id' => $monitoring->id,
+                        'user_id' => $monitoring->user_id,
+                        'notification_on_failure' => (bool) $monitoring->notification_on_failure,
+                        'notification_channels' => $monitoring->notification_channels,
+                        'ssl_expiry_warning_days' => (int) ($monitoring->ssl_expiry_warning_days ?? 7),
+                        'created_at' => $monitoring->created_at,
+                        'updated_at' => $monitoring->updated_at,
+                    ];
+                }
+
+                if ($rows !== []) {
+                    DB::table('monitoring_notification_preferences')->insert($rows);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('monitoring_notification_preferences');
+    }
+};

--- a/database/migrations/2026_06_21_000300_create_monitoring_notification_states_table.php
+++ b/database/migrations/2026_06_21_000300_create_monitoring_notification_states_table.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('monitoring_notification_states', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('monitoring_notification_id');
+            $table->foreignUlid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamp('read_at')->nullable();
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('monitoring_notification_id', 'mnotif_states_notification_fk')
+                ->references('id')
+                ->on('monitoring_notifications')
+                ->cascadeOnDelete();
+            $table->unique(['monitoring_notification_id', 'user_id'], 'monitoring_notification_states_notification_user_unique');
+            $table->index(['user_id', 'read_at'], 'monitoring_notification_states_user_read_idx');
+        });
+
+        DB::table('monitoring_notifications')
+            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
+            ->whereNotNull('monitorings.user_id')
+            ->orderBy('monitoring_notifications.id')
+            ->select([
+                'monitoring_notifications.id',
+                'monitoring_notifications.read',
+                'monitoring_notifications.sent',
+                'monitoring_notifications.created_at',
+                'monitoring_notifications.updated_at',
+                'monitorings.user_id',
+            ])
+            ->chunk(500, function ($notifications): void {
+                $rows = [];
+
+                foreach ($notifications as $notification) {
+                    $rows[] = [
+                        'id' => (string) Illuminate\Support\Str::ulid(),
+                        'monitoring_notification_id' => $notification->id,
+                        'user_id' => $notification->user_id,
+                        'read_at' => $notification->read ? $notification->updated_at : null,
+                        'sent_at' => $notification->sent ? $notification->updated_at : null,
+                        'created_at' => $notification->created_at,
+                        'updated_at' => $notification->updated_at,
+                    ];
+                }
+
+                if ($rows !== []) {
+                    DB::table('monitoring_notification_states')->insert($rows);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('monitoring_notification_states');
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,3 +25,9 @@ Distributed scanning nodes and workers are maintained separately in the [WebGuar
 ## Runtime Responsibilities
 
 The core application coordinates monitor configuration, status aggregation, notification delivery, user and package administration, public status output, and API access. Queue workers handle asynchronous monitoring and notification work so the web interface stays responsive.
+
+## Team Ownership
+
+Monitorings are either private (`user_id`) or team-owned (`team_id`). Private monitorings remain visible only to their owner. Team-owned monitorings are visible to all team members, while create, update, delete, reset, and ownership-move actions require a team admin role.
+
+Team notification channels are not shared. Notification channel configuration stays on the user profile, and per-monitoring notification preferences/read states are stored per user so each team member can choose delivery channels independently.

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,8 +18,9 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 ## Product Surface
 
 - **Real-time dashboard:** visualize monitoring data with statistics and charts.
+- **Team collaboration:** create teams, invite registered or new users by email, assign admin/member roles, and share team-owned monitorings with read-only members.
 - **Admin panel:** manage users, subscription packages, and API usage logs.
-- **REST API:** access monitoring data programmatically and integrate WebGuard with external systems.
+- **REST API:** access monitoring data, manage teams, and create or move team monitorings programmatically.
 - **SLA badge:** display website monitoring status on external sites with a compact SLA badge that shows live status, uptime proof, and public trust context.
 - **Public status pages:** publish monitoring status, uptime, recent incidents, and active or upcoming maintenance windows for users and customers.
 - **Global language switch:** switch between supported languages from both public and authenticated top navigation.
@@ -28,4 +29,5 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 ## Notifications
 
 - **Flexible notifications:** receive notifications for status changes, SSL expiry, and domain expiry through in-app notifications and configurable Slack, Telegram, Discord, Microsoft Teams, and webhook channels.
+- **Per-user team notifications:** each team member keeps their own notification channel choices and read state for shared team monitorings.
 - **Weekly monitoring digest:** email weekly uptime, incident, downtime, SSL, and domain expiry summaries to active users.

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -307,6 +307,7 @@ return [
         'updated' => 'Überwachung erfolgreich aktualisiert.',
         'deleted' => 'Überwachung erfolgreich gelöscht.',
         'results_deleted' => 'Überwachungsergebnisse werden in Kürze gelöscht.',
+        'notification_preferences_updated' => 'Benachrichtigungseinstellungen wurden aktualisiert.',
         'public_label_slug_will_be_generated' => 'Die URL des öffentlichen Labels wird nach dem Speichern generiert.',
         'no_server_instances' => 'Keine aktiven Serverinstanzen verfügbar. Bitte kontaktieren Sie einen Administrator.',
     ],

--- a/resources/lang/de/status_page.php
+++ b/resources/lang/de/status_page.php
@@ -66,5 +66,6 @@ return [
     ],
     'validation' => [
         'fix_errors' => 'Bitte korrigieren Sie die markierten Statusseiten-Einstellungen.',
+        'monitoring_not_accessible' => 'Die ausgewählte Überwachung ist nicht zugänglich.',
     ],
 ];

--- a/resources/lang/de/team.php
+++ b/resources/lang/de/team.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Teams',
+    'create' => [
+        'title' => 'Team erstellen',
+    ],
+    'edit' => [
+        'title' => ':team bearbeiten',
+    ],
+    'fields' => [
+        'name' => 'Name',
+        'description' => 'Beschreibung',
+        'email' => 'E-Mail',
+        'role' => 'Rolle',
+        'members' => 'Mitglieder',
+        'monitorings' => 'Überwachungen',
+        'created_at' => 'Erstellt',
+    ],
+    'roles' => [
+        'admin' => 'Admin',
+        'member' => 'Mitglied',
+    ],
+    'messages' => [
+        'created' => 'Team wurde erstellt.',
+        'updated' => 'Team wurde aktualisiert.',
+        'deleted' => 'Team wurde gelöscht.',
+        'member_updated' => 'Teammitglied wurde aktualisiert.',
+        'member_removed' => 'Teammitglied wurde entfernt.',
+        'left' => 'Sie haben das Team verlassen.',
+        'invitation_sent' => 'Einladung wurde versendet.',
+        'invitation_revoked' => 'Einladung wurde zurückgezogen.',
+        'invitation_accepted' => 'Einladung wurde angenommen.',
+        'login_to_accept' => 'Melden Sie sich mit der eingeladenen E-Mail-Adresse an oder registrieren Sie sich, um die Einladung anzunehmen.',
+    ],
+    'validation' => [
+        'last_admin' => 'Ein Team muss immer mindestens einen Admin haben.',
+        'already_member' => 'Diese E-Mail-Adresse gehört bereits zu einem Teammitglied.',
+        'email_mismatch' => 'Diese Einladung wurde für eine andere E-Mail-Adresse ausgestellt.',
+        'not_admin' => 'Für diese Aktion müssen Sie Team-Admin sein.',
+        'not_member' => 'Sie sind kein Mitglied dieses Teams.',
+        'delete_last_admin' => 'Dieser Nutzer ist der letzte Admin von :team.',
+    ],
+    'actions' => [
+        'create' => 'Team erstellen',
+        'edit' => 'Team bearbeiten',
+        'delete' => 'Team löschen',
+        'invite' => 'Mitglied einladen',
+        'revoke' => 'Zurückziehen',
+        'remove' => 'Entfernen',
+        'leave' => 'Team verlassen',
+        'save_role' => 'Rolle speichern',
+    ],
+    'sections' => [
+        'members' => 'Mitglieder',
+        'invitations' => 'Offene Einladungen',
+        'invite' => 'Mitglied einladen',
+        'details' => 'Teamdetails',
+        'notification_preferences' => 'Ihre Benachrichtigungseinstellungen',
+    ],
+    'empty' => [
+        'teams' => 'Noch keine Teams vorhanden.',
+        'invitations' => 'Keine offenen Einladungen.',
+    ],
+    'ownership' => [
+        'private' => 'Privat',
+        'team' => 'Team',
+        'select_label' => 'Besitz',
+        'private_help' => 'Private Überwachungen sind nur für Sie sichtbar.',
+        'team_help' => 'Team-Überwachungen sind für alle Teammitglieder sichtbar. Nur Team-Admins können sie bearbeiten.',
+        'move_to_team' => 'In Team verschieben',
+        'move_to_private' => 'Privat übernehmen',
+        'moved_to_team' => 'Überwachung wurde ins Team verschoben.',
+        'moved_to_private' => 'Überwachung wurde in privaten Besitz verschoben.',
+        'no_admin_teams' => 'Sie sind noch in keinem Team Admin.',
+    ],
+    'mail' => [
+        'invitation' => [
+            'subject' => 'Einladung zu :team',
+            'heading' => 'Sie wurden zu :team eingeladen',
+            'intro' => 'Nehmen Sie die Einladung an, um Team-Überwachungen für :team zu sehen.',
+            'action' => 'Einladung annehmen',
+            'expires' => 'Diese Einladung läuft am :date ab.',
+            'outro' => 'Falls Sie diese Einladung nicht erwartet haben, können Sie diese E-Mail ignorieren.',
+        ],
+    ],
+];

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -307,6 +307,7 @@ return [
         'updated' => 'Monitoring updated successfully.',
         'deleted' => 'Monitoring deleted successfully.',
         'results_deleted' => 'Monitoring results will be deleted shortly.',
+        'notification_preferences_updated' => 'Notification preferences updated.',
         'public_label_slug_will_be_generated' => 'The public label URL will be generated after saving.',
         'no_server_instances' => 'No active server instances are available. Please contact an administrator.',
     ],

--- a/resources/lang/en/status_page.php
+++ b/resources/lang/en/status_page.php
@@ -66,5 +66,6 @@ return [
     ],
     'validation' => [
         'fix_errors' => 'Please fix the highlighted status page settings.',
+        'monitoring_not_accessible' => 'The selected monitoring is not accessible.',
     ],
 ];

--- a/resources/lang/en/team.php
+++ b/resources/lang/en/team.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Teams',
+    'create' => [
+        'title' => 'Create team',
+    ],
+    'edit' => [
+        'title' => 'Edit :team',
+    ],
+    'fields' => [
+        'name' => 'Name',
+        'description' => 'Description',
+        'email' => 'Email',
+        'role' => 'Role',
+        'members' => 'Members',
+        'monitorings' => 'Monitorings',
+        'created_at' => 'Created',
+    ],
+    'roles' => [
+        'admin' => 'Admin',
+        'member' => 'Member',
+    ],
+    'messages' => [
+        'created' => 'Team created.',
+        'updated' => 'Team updated.',
+        'deleted' => 'Team deleted.',
+        'member_updated' => 'Team member updated.',
+        'member_removed' => 'Team member removed.',
+        'left' => 'You left the team.',
+        'invitation_sent' => 'Invitation sent.',
+        'invitation_revoked' => 'Invitation revoked.',
+        'invitation_accepted' => 'Invitation accepted.',
+        'login_to_accept' => 'Log in or register with the invited email address to accept the team invitation.',
+    ],
+    'validation' => [
+        'last_admin' => 'A team must always have at least one admin.',
+        'already_member' => 'This email address already belongs to a team member.',
+        'email_mismatch' => 'This invitation was issued for a different email address.',
+        'not_admin' => 'You must be a team admin for this action.',
+        'not_member' => 'You are not a member of this team.',
+        'delete_last_admin' => 'This user is the last admin of :team.',
+    ],
+    'actions' => [
+        'create' => 'Create team',
+        'edit' => 'Edit team',
+        'delete' => 'Delete team',
+        'invite' => 'Invite member',
+        'revoke' => 'Revoke',
+        'remove' => 'Remove',
+        'leave' => 'Leave team',
+        'save_role' => 'Save role',
+    ],
+    'sections' => [
+        'members' => 'Members',
+        'invitations' => 'Pending invitations',
+        'invite' => 'Invite member',
+        'details' => 'Team details',
+        'notification_preferences' => 'Your notification preferences',
+    ],
+    'empty' => [
+        'teams' => 'No teams yet.',
+        'invitations' => 'No pending invitations.',
+    ],
+    'ownership' => [
+        'private' => 'Private',
+        'team' => 'Team',
+        'select_label' => 'Ownership',
+        'private_help' => 'Private monitorings are visible only to you.',
+        'team_help' => 'Team monitorings are visible to all team members. Only team admins can edit them.',
+        'move_to_team' => 'Move to team',
+        'move_to_private' => 'Move to private',
+        'moved_to_team' => 'Monitoring moved to team.',
+        'moved_to_private' => 'Monitoring moved to private ownership.',
+        'no_admin_teams' => 'You are not an admin of any team yet.',
+    ],
+    'mail' => [
+        'invitation' => [
+            'subject' => 'Invitation to join :team',
+            'heading' => 'You have been invited to :team',
+            'intro' => 'Accept this invitation to view team monitorings for :team.',
+            'action' => 'Accept invitation',
+            'expires' => 'This invitation expires on :date.',
+            'outro' => 'If you did not expect this invitation, you can ignore this email.',
+        ],
+    ],
+];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -131,7 +131,7 @@
 
                         <div class="mt-4">
                             <x-input-label for="register_email" :value="__('auth.register.email')" />
-                            <x-text-input id="register_email" type="email" name="email" :value="old('email')" required
+                            <x-text-input id="register_email" type="email" name="email" :value="old('email', request('email'))" required
                                 autocomplete="username" />
                             <x-input-error :messages="$errors->get('email')" />
                         </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -24,6 +24,10 @@
                         {{ __('monitoring_group.title') }}
                     </x-nav-link>
 
+                    <x-nav-link :href="route('teams.index')" :active="request()->routeIs('teams.*')">
+                        {{ __('team.title') }}
+                    </x-nav-link>
+
                     <x-nav-link :href="route('status-pages.index')" :active="request()->routeIs('status-pages.*')">
                         {{ __('status_page.title') }}
                     </x-nav-link>
@@ -141,6 +145,10 @@
 
             <x-responsive-nav-link :href="route('monitoring-groups.index')" :active="request()->routeIs('monitoring-groups.*')">
                 {{ __('monitoring_group.title') }}
+            </x-responsive-nav-link>
+
+            <x-responsive-nav-link :href="route('teams.index')" :active="request()->routeIs('teams.*')">
+                {{ __('team.title') }}
             </x-responsive-nav-link>
 
             <x-responsive-nav-link :href="route('status-pages.index')" :active="request()->routeIs('status-pages.*')">

--- a/resources/views/mail/team-invitation.blade.php
+++ b/resources/views/mail/team-invitation.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.mail')
+
+@section('title', __('team.mail.invitation.subject', ['team' => $invitation->team->name]))
+
+@section('content')
+    <h1>{{ __('team.mail.invitation.heading', ['team' => $invitation->team->name]) }}</h1>
+    <p>{{ __('team.mail.invitation.intro', ['team' => $invitation->team->name]) }}</p>
+
+    <p>
+        <a href="{{ $acceptUrl }}" class="button">
+            {{ __('team.mail.invitation.action') }}
+        </a>
+    </p>
+
+    <p>{{ __('team.mail.invitation.expires', ['date' => $invitation->expires_at?->toDayDateTimeString()]) }}</p>
+    <p>{{ __('team.mail.invitation.outro') }}</p>
+@endsection

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -36,6 +36,8 @@
         'value' => (string) $monitoringGroup->id,
         'label' => $monitoringGroup->name,
     ])->values();
+    $adminTeams = $adminTeams ?? collect();
+    $selectedTeamId = old('team_id', $monitoring->team_id ?? '');
     $selectedPreferredLocations = old(
         'preferred_locations',
         old('preferred_location', isset($monitoring) ? $monitoring->preferredLocationCodes() : [$serverInstances->first()?->code])
@@ -112,6 +114,29 @@
         <x-input-label for="name" :value="__('monitoring.form.name')" />
         <x-text-input id="name" type="text" name="name" :value="old('name', $monitoring->name ?? '')" required />
         <x-input-error :messages="$errors->get('name')" />
+    </div>
+
+    <div class="mt-4">
+        <x-input-label for="team_id" :value="__('team.ownership.select_label')" />
+        @if (isset($monitoring))
+            <x-text-input id="team_id" class="cursor-not-allowed" :value="$monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private')" readonly />
+        @else
+            <x-select-input id="team_id" name="team_id" class="mt-1 block w-full">
+                <option value="">{{ __('team.ownership.private') }}</option>
+                @foreach ($adminTeams as $team)
+                    <option value="{{ $team->id }}" @selected($selectedTeamId === $team->id)>
+                        {{ __('team.ownership.team') }}: {{ $team->name }}
+                    </option>
+                @endforeach
+            </x-select-input>
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                {{ __('team.ownership.private_help') }}
+                @if ($adminTeams->isNotEmpty())
+                    {{ __('team.ownership.team_help') }}
+                @endif
+            </p>
+        @endif
+        <x-input-error :messages="$errors->get('team_id')" />
     </div>
 
     <div class="mt-4">

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -54,6 +54,12 @@
                     @if (request('group_id'))
                         <x-text-input type="hidden" name="group_id" :value="request('group_id')" />
                     @endif
+                    @if (request('team_id'))
+                        <x-text-input type="hidden" name="team_id" :value="request('team_id')" />
+                    @endif
+                    @if (request('ownership'))
+                        <x-text-input type="hidden" name="ownership" :value="request('ownership')" />
+                    @endif
                     @if (request('sort'))
                         <x-text-input type="hidden" name="sort" :value="request('sort')" />
                     @endif
@@ -160,6 +166,63 @@
                                 @foreach ($monitoringGroups as $monitoringGroup)
                                     <option value="{{ $monitoringGroup->id }}" @selected(request('group_id') === $monitoringGroup->id)>
                                         {{ $monitoringGroup->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div x-data="{
+                            selectedOwnership: '{{ request('ownership') ?? '' }}',
+                            updateOwnership() {
+                                const url = new URL(window.location.href);
+                                const params = new URLSearchParams(window.location.search);
+
+                                if (this.selectedOwnership) {
+                                    params.set('ownership', this.selectedOwnership);
+                                } else {
+                                    params.delete('ownership');
+                                }
+
+                                url.search = params.toString();
+                                window.location.href = url.toString();
+                            }
+                        }" class="relative">
+                            <label for="ownership-select" class="sr-only">{{ __('team.ownership.select_label') }}</label>
+                            <select id="ownership-select" x-model="selectedOwnership" @change="updateOwnership"
+                                class="rounded-md border border-gray-300 p-2 pr-8 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+                                <option value="">{{ __('search.filter.all') }}</option>
+                                <option value="private" @selected(request('ownership') === 'private')>{{ __('team.ownership.private') }}</option>
+                                <option value="team" @selected(request('ownership') === 'team')>{{ __('team.ownership.team') }}</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div x-data="{
+                            selectedTeam: '{{ request('team_id') ?? '' }}',
+                            updateTeam() {
+                                const url = new URL(window.location.href);
+                                const params = new URLSearchParams(window.location.search);
+
+                                if (this.selectedTeam) {
+                                    params.set('team_id', this.selectedTeam);
+                                } else {
+                                    params.delete('team_id');
+                                }
+
+                                url.search = params.toString();
+                                window.location.href = url.toString();
+                            }
+                        }" class="relative">
+                            <label for="team-select" class="sr-only">{{ __('team.title') }}</label>
+                            <select id="team-select" x-model="selectedTeam" @change="updateTeam"
+                                class="rounded-md border border-gray-300 p-2 pr-8 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+                                <option value="">{{ __('team.title') }}</option>
+                                @foreach ($teams as $team)
+                                    <option value="{{ $team->id }}" @selected(request('team_id') === $team->id)>
+                                        {{ $team->name }}
                                     </option>
                                 @endforeach
                             </select>

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -29,11 +29,14 @@
                     {{ __('monitoring.index.table.maintenance') }}
                 </x-badge>
             @endif
+            <x-badge type="{{ $monitoring->isTeamOwned() ? 'info' : 'success' }}">
+                {{ $monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private') }}
+            </x-badge>
         </x-heading>
 
         <div class="ml-auto flex flex-wrap items-start gap-2 sm:items-center">
 
-            @if (!Auth::user()->isDemo())
+            @if ($canManageMonitoring)
                 <div class="relative" x-data="{ open: false }">
                     <x-secondary-button @click="open = !open">
                         {{ __('monitoring.actions.heading') }}
@@ -48,6 +51,32 @@
                             class="block px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
                             {{ __('monitoring.actions.edit') }}
                         </a>
+                        @if (!$monitoring->isTeamOwned() && $adminTeams->isNotEmpty())
+                            <form method="POST" action="{{ route('monitorings.team-ownership.store', $monitoring) }}"
+                                class="px-4 py-2">
+                                @csrf
+                                <label for="move-team-{{ $monitoring->id }}" class="sr-only">{{ __('team.ownership.move_to_team') }}</label>
+                                <select id="move-team-{{ $monitoring->id }}" name="team_id"
+                                    class="mb-2 w-full rounded-md border border-gray-300 p-2 text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+                                    @foreach ($adminTeams as $team)
+                                        <option value="{{ $team->id }}">{{ $team->name }}</option>
+                                    @endforeach
+                                </select>
+                                <button type="submit" class="block w-full text-left text-gray-700 hover:bg-gray-100 sm:text-right">
+                                    {{ __('team.ownership.move_to_team') }}
+                                </button>
+                            </form>
+                        @endif
+                        @if ($monitoring->isTeamOwned())
+                            <form method="POST" action="{{ route('monitorings.team-ownership.destroy', $monitoring) }}">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit"
+                                    class="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
+                                    {{ __('team.ownership.move_to_private') }}
+                                </button>
+                            </form>
+                        @endif
                         <form method="POST" action="{{ route('monitorings.destroyResults', $monitoring) }}"
                             data-confirm-message="{{ __('monitoring.actions.reset.confirmation') }}">
                             @csrf
@@ -324,6 +353,60 @@
             @endforeach
 
         </div>
+
+        @if (!Auth::user()->isDemo())
+            @php
+                $selectedNotificationChannels = $notificationPreference->notification_channels ?? [];
+                $selectedNotificationChannels = is_array($selectedNotificationChannels) ? $selectedNotificationChannels : [];
+                $enabledNotificationChannels = Auth::user()->enabledNotificationChannelKeys();
+            @endphp
+
+            <x-container class="mb-4">
+                <x-heading type="h2">{{ __('team.sections.notification_preferences') }}</x-heading>
+                <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
+                    class="mt-4 space-y-4">
+                    @csrf
+                    @method('PATCH')
+
+                    <x-text-checkbox id="notification_on_failure" name="notification_on_failure" value="1"
+                        :checked="$notificationPreference->notification_on_failure"
+                        label="{{ __('monitoring.form.notification_on_failure_enabled') }}" />
+
+                    <div>
+                        <x-input-label for="notification_channels" :value="__('monitoring.form.notification_channels')" />
+                        @if ($enabledNotificationChannels === [])
+                            <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                {{ __('monitoring.form.notification_channels_empty') }}
+                            </x-paragraph>
+                        @else
+                            <div class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                                @foreach ($enabledNotificationChannels as $channel)
+                                    <label class="flex items-center gap-2 rounded-md border border-gray-200 p-3 text-sm dark:border-gray-700">
+                                        <input type="checkbox" name="notification_channels[]" value="{{ $channel }}"
+                                            class="rounded-sm border-gray-300 text-purple-600 shadow-xs focus:border-purple-300 focus:ring-3 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
+                                            @checked(in_array($channel, $selectedNotificationChannels, true))>
+                                        <span>{{ __('profile.notification_settings.channels.' . $channel . '.title') }}</span>
+                                    </label>
+                                @endforeach
+                            </div>
+                        @endif
+                        <x-input-error :messages="$errors->get('notification_channels')" />
+                        <x-input-error :messages="$errors->get('notification_channels.*')" />
+                    </div>
+
+                    <div>
+                        <x-input-label for="ssl_expiry_warning_days" :value="__('monitoring.form.ssl_expiry_warning_days')" />
+                        <x-text-input id="ssl_expiry_warning_days" type="number" min="1" max="365"
+                            name="ssl_expiry_warning_days" :value="old('ssl_expiry_warning_days', $notificationPreference->ssl_expiry_warning_days)" required />
+                        <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
+                    </div>
+
+                    <x-primary-button>
+                        {{ __('button.save') }}
+                    </x-primary-button>
+                </form>
+            </x-container>
+        @endif
 
         <div class="my-4" id="uptime-calendar-{{ $monitoring->id }}">
             <x-heading type="h2" class="mb-2">{{ __('monitoring.detail.calendar.heading') }}</x-heading>

--- a/resources/views/teams/_form.blade.php
+++ b/resources/views/teams/_form.blade.php
@@ -1,0 +1,23 @@
+@csrf
+@if (isset($team))
+    @method('PATCH')
+@endif
+
+<div class="space-y-4">
+    <div>
+        <x-input-label for="name" :value="__('team.fields.name')" />
+        <x-text-input id="name" type="text" name="name" :value="old('name', $team->name ?? '')" required autofocus />
+        <x-input-error :messages="$errors->get('name')" />
+    </div>
+
+    <div>
+        <x-input-label for="description" :value="__('team.fields.description')" />
+        <textarea id="description" name="description" rows="4"
+            class="mt-1 w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">{{ old('description', $team->description ?? '') }}</textarea>
+        <x-input-error :messages="$errors->get('description')" />
+    </div>
+
+    <x-primary-button>
+        {{ __('button.save') }}
+    </x-primary-button>
+</div>

--- a/resources/views/teams/create.blade.php
+++ b/resources/views/teams/create.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('team.create.title') }}</x-heading>
+    </x-slot>
+
+    <x-main>
+        <x-container>
+            <form method="POST" action="{{ route('teams.store') }}">
+                @include('teams._form')
+            </form>
+        </x-container>
+    </x-main>
+</x-app-layout>

--- a/resources/views/teams/edit.blade.php
+++ b/resources/views/teams/edit.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('team.edit.title', ['team' => $team->name]) }}</x-heading>
+    </x-slot>
+
+    <x-main>
+        <x-container>
+            <form method="POST" action="{{ route('teams.update', $team) }}">
+                @include('teams._form', ['team' => $team])
+            </form>
+        </x-container>
+    </x-main>
+</x-app-layout>

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-heading type="h1">{{ __('team.title') }}</x-heading>
+
+        @if (!Auth::user()->isDemo())
+            <x-primary-button :href="route('teams.create')" class="sm:ml-auto">
+                {{ __('team.actions.create') }}
+            </x-primary-button>
+        @endif
+    </x-slot>
+
+    <x-main>
+        <x-container>
+            @if ($teams->count() === 0)
+                <x-paragraph>{{ __('team.empty.teams') }}</x-paragraph>
+            @else
+                <div class="space-y-3">
+                    @foreach ($teams as $team)
+                        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 py-3 last:border-b-0 dark:border-gray-700">
+                            <div>
+                                <x-heading type="h2">{{ $team->name }}</x-heading>
+                                @if ($team->description)
+                                    <x-paragraph class="text-sm text-gray-600 dark:text-gray-400">{{ $team->description }}</x-paragraph>
+                                @endif
+                                <x-paragraph class="mt-1 text-sm text-gray-500">
+                                    {{ __('team.fields.members') }}: {{ $team->memberships_count }}
+                                    · {{ __('team.fields.monitorings') }}: {{ $team->monitorings_count }}
+                                </x-paragraph>
+                            </div>
+
+                            <x-secondary-button :href="route('teams.show', $team)">
+                                {{ __('button.show') }}
+                            </x-secondary-button>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+
+            {{ $teams->links() }}
+        </x-container>
+    </x-main>
+</x-app-layout>

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -1,0 +1,147 @@
+@php
+    use App\Enums\TeamRole;
+@endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <div>
+            <x-heading type="h1">{{ $team->name }}</x-heading>
+            @if ($team->description)
+                <x-paragraph>{{ $team->description }}</x-paragraph>
+            @endif
+        </div>
+
+        <div class="ml-auto flex flex-wrap gap-2">
+            @if ($isTeamAdmin)
+                <x-secondary-button :href="route('teams.edit', $team)">
+                    {{ __('team.actions.edit') }}
+                </x-secondary-button>
+                <form method="POST" action="{{ route('teams.destroy', $team) }}"
+                    data-confirm-message="{{ __('team.actions.delete') }}">
+                    @csrf
+                    @method('DELETE')
+                    <x-danger-button>
+                        {{ __('team.actions.delete') }}
+                    </x-danger-button>
+                </form>
+            @endif
+            <form method="POST" action="{{ route('teams.leave', $team) }}">
+                @csrf
+                @method('DELETE')
+                <x-secondary-button>
+                    {{ __('team.actions.leave') }}
+                </x-secondary-button>
+            </form>
+            <x-secondary-button :href="route('teams.index')">
+                {{ __('button.back') }}
+            </x-secondary-button>
+        </div>
+    </x-slot>
+
+    <x-main>
+        <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <x-container>
+                <x-heading type="h2">{{ __('team.sections.members') }}</x-heading>
+
+                <div class="mt-4 space-y-3">
+                    @foreach ($team->memberships as $membership)
+                        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 pb-3 last:border-b-0 dark:border-gray-700">
+                            <div>
+                                <x-paragraph class="font-semibold">{{ $membership->user->name }}</x-paragraph>
+                                <x-paragraph class="text-sm text-gray-500">{{ $membership->user->email }}</x-paragraph>
+                            </div>
+
+                            <div class="flex flex-wrap items-center gap-2">
+                                @if ($isTeamAdmin)
+                                    <form method="POST" action="{{ route('teams.members.update', [$team, $membership]) }}"
+                                        class="flex items-center gap-2">
+                                        @csrf
+                                        @method('PATCH')
+                                        <x-select-input name="role" class="min-w-32">
+                                            @foreach (TeamRole::cases() as $role)
+                                                <option value="{{ $role->value }}" @selected($membership->role === $role)>
+                                                    {{ __('team.roles.' . $role->value) }}
+                                                </option>
+                                            @endforeach
+                                        </x-select-input>
+                                        <x-secondary-button>
+                                            {{ __('team.actions.save_role') }}
+                                        </x-secondary-button>
+                                    </form>
+
+                                    <form method="POST" action="{{ route('teams.members.destroy', [$team, $membership]) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <x-danger-button>
+                                            {{ __('team.actions.remove') }}
+                                        </x-danger-button>
+                                    </form>
+                                @else
+                                    <x-badge type="info">{{ __('team.roles.' . $membership->role->value) }}</x-badge>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </x-container>
+
+            <div class="space-y-6">
+                @if ($isTeamAdmin)
+                    <x-container>
+                        <x-heading type="h2">{{ __('team.sections.invite') }}</x-heading>
+
+                        <form method="POST" action="{{ route('teams.invitations.store', $team) }}" class="mt-4 space-y-4">
+                            @csrf
+                            <div>
+                                <x-input-label for="email" :value="__('team.fields.email')" />
+                                <x-text-input id="email" type="email" name="email" :value="old('email')" required />
+                                <x-input-error :messages="$errors->get('email')" />
+                            </div>
+                            <div>
+                                <x-input-label for="role" :value="__('team.fields.role')" />
+                                <x-select-input id="role" name="role" required>
+                                    @foreach (TeamRole::cases() as $role)
+                                        <option value="{{ $role->value }}">{{ __('team.roles.' . $role->value) }}</option>
+                                    @endforeach
+                                </x-select-input>
+                                <x-input-error :messages="$errors->get('role')" />
+                            </div>
+                            <x-primary-button>
+                                {{ __('team.actions.invite') }}
+                            </x-primary-button>
+                        </form>
+                    </x-container>
+                @endif
+
+                <x-container>
+                    <x-heading type="h2">{{ __('team.sections.invitations') }}</x-heading>
+
+                    @if ($team->invitations->count() === 0)
+                        <x-paragraph class="mt-3">{{ __('team.empty.invitations') }}</x-paragraph>
+                    @else
+                        <div class="mt-4 space-y-3">
+                            @foreach ($team->invitations as $invitation)
+                                <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 pb-3 last:border-b-0 dark:border-gray-700">
+                                    <div>
+                                        <x-paragraph class="font-semibold">{{ $invitation->email }}</x-paragraph>
+                                        <x-paragraph class="text-sm text-gray-500">{{ __('team.roles.' . $invitation->role->value) }}</x-paragraph>
+                                    </div>
+
+                                    @if ($isTeamAdmin)
+                                        <form method="POST" action="{{ route('teams.invitations.destroy', [$team, $invitation]) }}">
+                                            @csrf
+                                            @method('DELETE')
+                                            <x-danger-button>
+                                                {{ __('team.actions.revoke') }}
+                                            </x-danger-button>
+                                        </form>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </x-container>
+            </div>
+        </div>
+    </x-main>
+</x-app-layout>

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\MonitoringManagementController;
+use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\TeamInvitationController;
+use App\Http\Controllers\Api\TeamMemberController;
 use App\Http\Controllers\ApiController;
 use Illuminate\Support\Facades\Route;
 
@@ -11,6 +15,13 @@ use Illuminate\Support\Facades\Route;
  * This is to ensure that the documentation is generated in a logical order.
  */
 Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): void {
+    Route::get('/', [MonitoringManagementController::class, 'index']);
+    Route::post('/', [MonitoringManagementController::class, 'store']);
+    Route::patch('/{monitoring}', [MonitoringManagementController::class, 'update']);
+    Route::delete('/{monitoring}', [MonitoringManagementController::class, 'destroy']);
+    Route::post('/{monitoring}/team-ownership', [MonitoringManagementController::class, 'moveToTeam']);
+    Route::delete('/{monitoring}/team-ownership', [MonitoringManagementController::class, 'moveToPrivate']);
+
     Route::get('/{monitoring}', [ApiController::class, 'all']);
 
     Route::get('/{monitoring}/status', [ApiController::class, 'status']);
@@ -23,3 +34,12 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
     Route::get('/{monitoring}/ssl', [ApiController::class, 'sslStatus']);
     Route::get('/{monitoring}/uptime-calendar', [ApiController::class, 'uptimeCalendar']);
 });
+
+Route::apiResource('teams', TeamController::class);
+Route::get('/teams/{team}/members', [TeamMemberController::class, 'index']);
+Route::patch('/teams/{team}/members/{membership}', [TeamMemberController::class, 'update']);
+Route::delete('/teams/{team}/members/{membership}', [TeamMemberController::class, 'destroy']);
+Route::get('/teams/{team}/invitations', [TeamInvitationController::class, 'index']);
+Route::post('/teams/{team}/invitations', [TeamInvitationController::class, 'store']);
+Route::delete('/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy']);
+Route::post('/team-invitations/{token}/accept', [TeamInvitationController::class, 'accept']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,8 @@ use App\Http\Controllers\MaintenanceController;
 use App\Http\Controllers\MonitoringController;
 use App\Http\Controllers\MonitoringGroupController;
 use App\Http\Controllers\MonitoringLocationsController;
+use App\Http\Controllers\MonitoringNotificationPreferenceController;
+use App\Http\Controllers\MonitoringOwnershipController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PublicFeatureController;
@@ -24,6 +26,10 @@ use App\Http\Controllers\PublicStatusPageController;
 use App\Http\Controllers\StatusPageController;
 use App\Http\Controllers\StatusPageIncidentUpdateController;
 use App\Http\Controllers\StatusPageSubscriberController;
+use App\Http\Controllers\TeamController;
+use App\Http\Controllers\TeamInvitationAcceptController;
+use App\Http\Controllers\TeamInvitationController;
+use App\Http\Controllers\TeamMemberController;
 use App\Support\SitemapPages;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Session\Middleware\StartSession;
@@ -71,6 +77,8 @@ Route::get('/gdpr', [LegalController::class, 'gdpr'])
 Route::match(['get', 'post'], '/locale', [LocaleController::class, 'update'])->name('locale.switch');
 Route::match(['get', 'post'], '/heartbeat/{token}', HeartbeatPingController::class)->name('monitorings.heartbeat.ping');
 Route::permanentRedirect('/api/docs', '/api/reference')->name('api.docs.redirect');
+Route::get('/team-invitations/{token}/accept', TeamInvitationAcceptController::class)
+    ->name('team-invitations.accept');
 
 // Public sitemap.xml
 Route::get('/sitemap.xml', function () {
@@ -127,6 +135,23 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::get('/maintenance', [MaintenanceController::class, 'index'])->name('maintenance.index');
     Route::post('/maintenance', [MaintenanceController::class, 'store'])->name('maintenance.store');
     Route::delete('/maintenance', [MaintenanceController::class, 'destroy'])->name('maintenance.destroy');
+    Route::post('/monitorings/{monitoring}/team-ownership', [MonitoringOwnershipController::class, 'moveToTeam'])
+        ->name('monitorings.team-ownership.store');
+    Route::delete('/monitorings/{monitoring}/team-ownership', [MonitoringOwnershipController::class, 'moveToPrivate'])
+        ->name('monitorings.team-ownership.destroy');
+    Route::patch('/monitorings/{monitoring}/notification-preferences', [MonitoringNotificationPreferenceController::class, 'update'])
+        ->name('monitorings.notification-preferences.update');
+    Route::resource('teams', TeamController::class)->names('teams');
+    Route::post('/teams/{team}/invitations', [TeamInvitationController::class, 'store'])
+        ->name('teams.invitations.store');
+    Route::delete('/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])
+        ->name('teams.invitations.destroy');
+    Route::patch('/teams/{team}/members/{membership}', [TeamMemberController::class, 'update'])
+        ->name('teams.members.update');
+    Route::delete('/teams/{team}/members/{membership}', [TeamMemberController::class, 'destroy'])
+        ->name('teams.members.destroy');
+    Route::delete('/teams/{team}/leave', [TeamMemberController::class, 'leave'])
+        ->name('teams.leave');
     Route::resource('monitoring-groups', MonitoringGroupController::class)
         ->except(['show'])
         ->parameters(['monitoring-groups' => 'monitoringGroup'])

--- a/tests/Feature/Api/TeamApiTest.php
+++ b/tests/Feature/Api/TeamApiTest.php
@@ -21,12 +21,12 @@ class TeamApiTest extends TestCase
         $member = User::factory()->create();
         $outsider = User::factory()->create();
 
-        $createResponse = $this->actingAs($admin)->postJson('/api/v1/teams', [
+        $testResponse = $this->actingAs($admin)->postJson('/api/v1/teams', [
             'name' => 'API Team',
             'description' => 'Managed through API',
         ]);
 
-        $createResponse->assertCreated()->assertJsonPath('data.name', 'API Team');
+        $testResponse->assertCreated()->assertJsonPath('data.name', 'API Team');
         $team = Team::query()->where('name', 'API Team')->firstOrFail();
 
         $team->memberships()->create([
@@ -41,13 +41,13 @@ class TeamApiTest extends TestCase
         $this->actingAs($outsider)->getJson('/api/v1/teams/' . $team->id)
             ->assertNotFound();
 
-        $membership = $team->memberships()->where('user_id', $member->id)->firstOrFail();
+        $teamMembership = $team->memberships()->where('user_id', $member->id)->firstOrFail();
 
-        $this->actingAs($member)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id, [
+        $this->actingAs($member)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $teamMembership->id, [
             'role' => TeamRole::ADMIN->value,
         ])->assertForbidden();
 
-        $this->actingAs($admin)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id, [
+        $this->actingAs($admin)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $teamMembership->id, [
             'role' => TeamRole::ADMIN->value,
         ])->assertOk()->assertJsonPath('data.role', TeamRole::ADMIN->value);
 

--- a/tests/Feature/Api/TeamApiTest.php
+++ b/tests/Feature/Api/TeamApiTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\TeamRole;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class TeamApiTest extends TestCase
+{
+    public function test_team_api_exposes_visible_teams_and_admin_management(): void
+    {
+        Mail::fake();
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $outsider = User::factory()->create();
+
+        $createResponse = $this->actingAs($admin)->postJson('/api/v1/teams', [
+            'name' => 'API Team',
+            'description' => 'Managed through API',
+        ]);
+
+        $createResponse->assertCreated()->assertJsonPath('data.name', 'API Team');
+        $team = Team::query()->where('name', 'API Team')->firstOrFail();
+
+        $team->memberships()->create([
+            'user_id' => $member->id,
+            'role' => TeamRole::MEMBER,
+        ]);
+
+        $this->actingAs($member)->getJson('/api/v1/teams')
+            ->assertOk()
+            ->assertJsonFragment(['name' => 'API Team']);
+
+        $this->actingAs($outsider)->getJson('/api/v1/teams/' . $team->id)
+            ->assertNotFound();
+
+        $membership = $team->memberships()->where('user_id', $member->id)->firstOrFail();
+
+        $this->actingAs($member)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id, [
+            'role' => TeamRole::ADMIN->value,
+        ])->assertForbidden();
+
+        $this->actingAs($admin)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id, [
+            'role' => TeamRole::ADMIN->value,
+        ])->assertOk()->assertJsonPath('data.role', TeamRole::ADMIN->value);
+
+        $this->actingAs($admin)->postJson('/api/v1/teams/' . $team->id . '/invitations', [
+            'email' => 'api-invite@example.com',
+            'role' => TeamRole::MEMBER->value,
+        ])->assertCreated();
+    }
+}

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -71,7 +71,7 @@ class AuditLogTest extends TestCase
             'notification_channels' => [
                 'slack' => [
                     'enabled' => '1',
-                    'webhook_url' => 'https://hooks.slack.test/services/raw-secret',
+                    'webhook_url' => 'https://hooks.slack.com/services/raw-secret',
                 ],
                 'telegram' => [
                     'enabled' => '1',
@@ -80,11 +80,11 @@ class AuditLogTest extends TestCase
                 ],
                 'discord' => [
                     'enabled' => '0',
-                    'webhook_url' => 'https://discord.test/api/webhooks/raw-secret',
+                    'webhook_url' => 'https://discord.com/api/webhooks/raw-secret',
                 ],
                 'webhook' => [
                     'enabled' => '1',
-                    'url' => 'https://example.test/raw-webhook-secret',
+                    'url' => 'https://example.com/raw-webhook-secret',
                 ],
             ],
         ]);

--- a/tests/Feature/TeamMonitoringTest.php
+++ b/tests/Feature/TeamMonitoringTest.php
@@ -27,13 +27,13 @@ class TeamMonitoringTest extends TestCase
         $admin = User::factory()->create();
         $registeredUser = User::factory()->create(['email' => 'registered@example.com']);
 
-        $createResponse = $this->actingAs($admin)->post(route('teams.store'), [
+        $testResponse = $this->actingAs($admin)->post(route('teams.store'), [
             'name' => 'Operations',
             'description' => 'Production monitoring',
         ]);
 
         $team = Team::query()->where('name', 'Operations')->firstOrFail();
-        $createResponse->assertRedirect(route('teams.show', $team));
+        $testResponse->assertRedirect(route('teams.show', $team));
         $this->assertDatabaseHas('team_memberships', [
             'team_id' => $team->id,
             'user_id' => $admin->id,
@@ -164,7 +164,7 @@ class TeamMonitoringTest extends TestCase
             'created_by_user_id' => $admin->id,
         ]);
 
-        $notification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is down',
@@ -172,14 +172,14 @@ class TeamMonitoringTest extends TestCase
             'sent' => true,
         ]);
 
-        $this->actingAs($member)->post(route('notifications.markAsRead', $notification))->assertRedirect();
+        $this->actingAs($member)->post(route('notifications.markAsRead', $monitoringNotification))->assertRedirect();
 
         $this->assertNotNull(MonitoringNotificationState::query()
-            ->where('monitoring_notification_id', $notification->id)
+            ->where('monitoring_notification_id', $monitoringNotification->id)
             ->where('user_id', $member->id)
             ->value('read_at'));
         $this->assertNull(MonitoringNotificationState::query()
-            ->where('monitoring_notification_id', $notification->id)
+            ->where('monitoring_notification_id', $monitoringNotification->id)
             ->where('user_id', $admin->id)
             ->value('read_at'));
     }

--- a/tests/Feature/TeamMonitoringTest.php
+++ b/tests/Feature/TeamMonitoringTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringType;
+use App\Enums\NotificationType;
+use App\Enums\TeamRole;
+use App\Mail\TeamInvitationMail;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationState;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class TeamMonitoringTest extends TestCase
+{
+    public function test_user_can_create_team_and_invite_registered_or_unregistered_members(): void
+    {
+        Mail::fake();
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $registeredUser = User::factory()->create(['email' => 'registered@example.com']);
+
+        $createResponse = $this->actingAs($admin)->post(route('teams.store'), [
+            'name' => 'Operations',
+            'description' => 'Production monitoring',
+        ]);
+
+        $team = Team::query()->where('name', 'Operations')->firstOrFail();
+        $createResponse->assertRedirect(route('teams.show', $team));
+        $this->assertDatabaseHas('team_memberships', [
+            'team_id' => $team->id,
+            'user_id' => $admin->id,
+            'role' => TeamRole::ADMIN->value,
+        ]);
+
+        $this->actingAs($admin)->post(route('teams.invitations.store', $team), [
+            'email' => $registeredUser->email,
+            'role' => TeamRole::MEMBER->value,
+        ])->assertRedirect();
+
+        $this->actingAs($admin)->post(route('teams.invitations.store', $team), [
+            'email' => 'new-user@example.com',
+            'role' => TeamRole::ADMIN->value,
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('team_invitations', ['team_id' => $team->id, 'email' => $registeredUser->email]);
+        $this->assertDatabaseHas('team_invitations', ['team_id' => $team->id, 'email' => 'new-user@example.com']);
+        Mail::assertSent(TeamInvitationMail::class, 2);
+    }
+
+    public function test_last_team_admin_cannot_leave_be_demoted_or_removed(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $membership = $team->memberships()->create([
+            'user_id' => $admin->id,
+            'role' => TeamRole::ADMIN,
+        ]);
+
+        $this->actingAs($admin)->delete(route('teams.leave', $team))
+            ->assertSessionHasErrors('role');
+
+        $this->actingAs($admin)->patch(route('teams.members.update', [$team, $membership]), [
+            'role' => TeamRole::MEMBER->value,
+        ])->assertSessionHasErrors('role');
+
+        $this->actingAs($admin)->delete(route('teams.members.destroy', [$team, $membership]))
+            ->assertSessionHasErrors('role');
+
+        $this->assertDatabaseHas('team_memberships', [
+            'id' => $membership->id,
+            'role' => TeamRole::ADMIN->value,
+        ]);
+    }
+
+    public function test_team_admin_can_create_team_monitoring_and_member_can_only_view_it(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+
+        $this->actingAs($admin)->post(route('monitorings.store'), [
+            ...$this->monitoringPayload(),
+            'team_id' => $team->id,
+        ])->assertRedirect(route('monitorings.index'));
+
+        $monitoring = Monitoring::query()->withoutGlobalScopes()->where('name', 'Team API')->firstOrFail();
+
+        $this->assertNull($monitoring->user_id);
+        $this->assertSame($team->id, $monitoring->team_id);
+
+        $this->actingAs($member)->get(route('monitorings.show', $monitoring))->assertOk();
+        $this->actingAs($member)->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')->assertOk();
+        $this->actingAs($member)->get(route('monitorings.edit', $monitoring))->assertForbidden();
+        $this->actingAs($member)->delete(route('monitorings.destroy', $monitoring))->assertForbidden();
+    }
+
+    public function test_private_monitoring_can_move_to_team_and_back_to_private(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $monitoring = Monitoring::factory()->for($admin)->create();
+
+        $this->actingAs($admin)->post(route('monitorings.team-ownership.store', $monitoring), [
+            'team_id' => $team->id,
+        ])->assertRedirect(route('monitorings.show', $monitoring));
+
+        $monitoring->refresh();
+        $this->assertNull($monitoring->user_id);
+        $this->assertSame($team->id, $monitoring->team_id);
+
+        $this->actingAs($admin)->delete(route('monitorings.team-ownership.destroy', $monitoring))
+            ->assertRedirect(route('monitorings.show', $monitoring));
+
+        $monitoring->refresh();
+        $this->assertSame($admin->id, $monitoring->user_id);
+        $this->assertNull($monitoring->team_id);
+    }
+
+    public function test_deleting_team_deletes_team_monitorings_but_keeps_private_monitorings(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $teamMonitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'created_by_user_id' => $admin->id,
+        ]);
+        $privateMonitoring = Monitoring::factory()->for($admin)->create();
+
+        $this->actingAs($admin)->delete(route('teams.destroy', $team))->assertRedirect(route('teams.index'));
+
+        $this->assertDatabaseMissing('teams', ['id' => $team->id]);
+        $this->assertDatabaseMissing('monitorings', ['id' => $teamMonitoring->id]);
+        $this->assertDatabaseHas('monitorings', ['id' => $privateMonitoring->id]);
+    }
+
+    public function test_team_notification_read_state_is_independent_per_member(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+        $monitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'created_by_user_id' => $admin->id,
+        ]);
+
+        $notification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is down',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        $this->actingAs($member)->post(route('notifications.markAsRead', $notification))->assertRedirect();
+
+        $this->assertNotNull(MonitoringNotificationState::query()
+            ->where('monitoring_notification_id', $notification->id)
+            ->where('user_id', $member->id)
+            ->value('read_at'));
+        $this->assertNull(MonitoringNotificationState::query()
+            ->where('monitoring_notification_id', $notification->id)
+            ->where('user_id', $admin->id)
+            ->value('read_at'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function monitoringPayload(): array
+    {
+        return [
+            'name' => 'Team API',
+            'type' => MonitoringType::HTTP->value,
+            'target' => 'https://example.com',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'timeout' => 5,
+            'preferred_location' => 'de-1',
+            'public_label_enabled' => false,
+            'notification_on_failure' => true,
+            'notification_channels' => [],
+            'failure_confirmation_threshold' => 2,
+            'ssl_expiry_warning_days' => 7,
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- Added teams with admin/member roles, email-token invitations, member management, and last-admin protections.
- Added team-owned monitorings, private-to-team/team-to-private ownership moves, read-only team member access, and team-aware web/API monitoring management.
- Added per-user notification preferences and read states for shared team monitorings, plus updated dispatch, expiry warnings, digests, unread counts, and notification board queries.
- Added team UI, translations, invitation mail, REST endpoints, documentation updates, and focused feature/API tests.

## Why
Teams need to collaborate on shared monitorings while keeping private monitorings private and preserving user-owned notification channels.

## Testing
- Docker: `php artisan migrate --force` against a temporary MySQL validation database
- Docker: `composer test` (496 passed, 3 skipped because the PHP container lacks the git binary for changelog/case-sensitivity tests)
- Docker: `composer analyse`
- Docker: `bun install --frozen-lockfile`
- Docker: `bun run build`
- Local: full Pest suite and PHPStan were also run before Docker became available

## Risks / follow-up
- Team billing/quota rules remain scoped out; private monitoring limits still apply only to private monitorings.
- Team-owned monitoring groups/status pages are not introduced yet; private groups are detached when moving a monitoring into a team.