### PR TITLE
fix: preserve team route model bindings

### DIFF
--- a/app/Services/Teams/TeamMembershipService.php
+++ b/app/Services/Teams/TeamMembershipService.php
@@ -88,11 +88,10 @@ class TeamMembershipService
 
     private function assertNotLastAdmin(TeamMembership $teamMembership): void
     {
-        if (! $teamMembership->team) {
-            $teamMembership->load('team');
-        }
-
-        $adminCount = $teamMembership->team->adminCount();
+        $adminCount = TeamMembership::query()
+            ->where('team_id', $teamMembership->team_id)
+            ->where('role', TeamRole::ADMIN)
+            ->count();
 
         if ($adminCount <= 1) {
             throw ValidationException::withMessages([

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -37,9 +37,9 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
 Route::apiResource('teams', TeamController::class);
 Route::get('/teams/{team}/members', [TeamMemberController::class, 'index']);
-Route::patch('/teams/{team}/members/{membership}', [TeamMemberController::class, 'update']);
-Route::delete('/teams/{team}/members/{membership}', [TeamMemberController::class, 'destroy']);
+Route::patch('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'update']);
+Route::delete('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'destroy']);
 Route::get('/teams/{team}/invitations', [TeamInvitationController::class, 'index']);
 Route::post('/teams/{team}/invitations', [TeamInvitationController::class, 'store']);
-Route::delete('/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy']);
+Route::delete('/teams/{team}/invitations/{teamInvitation}', [TeamInvitationController::class, 'destroy']);
 Route::post('/team-invitations/{token}/accept', [TeamInvitationController::class, 'accept']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -144,11 +144,11 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::resource('teams', TeamController::class)->names('teams');
     Route::post('/teams/{team}/invitations', [TeamInvitationController::class, 'store'])
         ->name('teams.invitations.store');
-    Route::delete('/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])
+    Route::delete('/teams/{team}/invitations/{teamInvitation}', [TeamInvitationController::class, 'destroy'])
         ->name('teams.invitations.destroy');
-    Route::patch('/teams/{team}/members/{membership}', [TeamMemberController::class, 'update'])
+    Route::patch('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'update'])
         ->name('teams.members.update');
-    Route::delete('/teams/{team}/members/{membership}', [TeamMemberController::class, 'destroy'])
+    Route::delete('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'destroy'])
         ->name('teams.members.destroy');
     Route::delete('/teams/{team}/leave', [TeamMemberController::class, 'leave'])
         ->name('teams.leave');


### PR DESCRIPTION
## What changed
- Renamed nested team route parameters to match the typed controller parameters for team memberships and invitations.
- Count team admins directly from memberships when enforcing the last-admin rule.

## Why
- The merged team monitoring PR failed CI after automatic refactoring renamed controller parameters used by Laravel implicit route model binding.
- The direct admin count avoids stale relationship state when validating last-admin changes.

## Testing
- docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm -e AUTORUN_ENABLED=false php ./vendor/bin/pest --colors=never tests/Feature/TeamMonitoringTest.php tests/Feature/Api/TeamApiTest.php tests/Feature/AuditLogTest.php
- docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm -e AUTORUN_ENABLED=false php ./vendor/bin/pest --colors=never --parallel
- docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm -e AUTORUN_ENABLED=false php composer analyse

## Risks
- Low; route URLs are unchanged, only internal route parameter names now match the controller method signatures.