### PR TITLE
fix(teams): preserve nested route bindings

### DIFF
--- a/app/Services/Teams/TeamMembershipService.php
+++ b/app/Services/Teams/TeamMembershipService.php
@@ -88,11 +88,10 @@ class TeamMembershipService
 
     private function assertNotLastAdmin(TeamMembership $teamMembership): void
     {
-        if (! $teamMembership->team) {
-            $teamMembership->load('team');
-        }
-
-        $adminCount = $teamMembership->team->adminCount();
+        $adminCount = TeamMembership::query()
+            ->where('team_id', $teamMembership->team_id)
+            ->where('role', TeamRole::ADMIN)
+            ->count();
 
         if ($adminCount <= 1) {
             throw ValidationException::withMessages([

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -37,9 +37,9 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
 Route::apiResource('teams', TeamController::class);
 Route::get('/teams/{team}/members', [TeamMemberController::class, 'index']);
-Route::patch('/teams/{team}/members/{membership}', [TeamMemberController::class, 'update']);
-Route::delete('/teams/{team}/members/{membership}', [TeamMemberController::class, 'destroy']);
+Route::patch('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'update']);
+Route::delete('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'destroy']);
 Route::get('/teams/{team}/invitations', [TeamInvitationController::class, 'index']);
 Route::post('/teams/{team}/invitations', [TeamInvitationController::class, 'store']);
-Route::delete('/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy']);
+Route::delete('/teams/{team}/invitations/{teamInvitation}', [TeamInvitationController::class, 'destroy']);
 Route::post('/team-invitations/{token}/accept', [TeamInvitationController::class, 'accept']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -144,11 +144,11 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::resource('teams', TeamController::class)->names('teams');
     Route::post('/teams/{team}/invitations', [TeamInvitationController::class, 'store'])
         ->name('teams.invitations.store');
-    Route::delete('/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])
+    Route::delete('/teams/{team}/invitations/{teamInvitation}', [TeamInvitationController::class, 'destroy'])
         ->name('teams.invitations.destroy');
-    Route::patch('/teams/{team}/members/{membership}', [TeamMemberController::class, 'update'])
+    Route::patch('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'update'])
         ->name('teams.members.update');
-    Route::delete('/teams/{team}/members/{membership}', [TeamMemberController::class, 'destroy'])
+    Route::delete('/teams/{team}/members/{teamMembership}', [TeamMemberController::class, 'destroy'])
         ->name('teams.members.destroy');
     Route::delete('/teams/{team}/leave', [TeamMemberController::class, 'leave'])
         ->name('teams.leave');

--- a/tests/Feature/Api/TeamApiTest.php
+++ b/tests/Feature/Api/TeamApiTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api;
 use App\Enums\TeamRole;
 use App\Models\Package;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -55,5 +56,27 @@ class TeamApiTest extends TestCase
             'email' => 'api-invite@example.com',
             'role' => TeamRole::MEMBER->value,
         ])->assertCreated();
+    }
+
+    public function test_team_api_allows_admin_to_revoke_pending_invitation(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $teamInvitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'api-pending@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'api-pending-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addWeek(),
+        ]);
+
+        $this->actingAs($admin)
+            ->deleteJson('/api/v1/teams/' . $team->id . '/invitations/' . $teamInvitation->id)
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('team_invitations', ['id' => $teamInvitation->id]);
     }
 }

--- a/tests/Feature/TeamMonitoringTest.php
+++ b/tests/Feature/TeamMonitoringTest.php
@@ -14,6 +14,7 @@ use App\Models\MonitoringNotification;
 use App\Models\MonitoringNotificationState;
 use App\Models\Package;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -53,6 +54,28 @@ class TeamMonitoringTest extends TestCase
         $this->assertDatabaseHas('team_invitations', ['team_id' => $team->id, 'email' => $registeredUser->email]);
         $this->assertDatabaseHas('team_invitations', ['team_id' => $team->id, 'email' => 'new-user@example.com']);
         Mail::assertSent(TeamInvitationMail::class, 2);
+    }
+
+    public function test_team_admin_can_revoke_pending_invitation(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $teamInvitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'pending@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'pending-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addWeek(),
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('teams.invitations.destroy', [$team, $teamInvitation]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('team_invitations', ['id' => $teamInvitation->id]);
     }
 
     public function test_last_team_admin_cannot_leave_be_demoted_or_removed(): void


### PR DESCRIPTION
## Summary
- preserve Laravel route model binding for nested team members and invitations
- avoid stale loaded team relationships when checking last-admin protection
- add focused web and API tests for revoking pending team invitations

## Validation
- Docker Pest coverage with Xdebug and HTML report: `./vendor/bin/pest --coverage --coverage-html storage/framework/coverage --min=0` (508 passed, 3 skipped, total 84.7%)
- Docker targeted Pest: `./vendor/bin/pest tests/Feature/Api/TeamApiTest.php tests/Feature/TeamMonitoringTest.php` (9 passed)
- Docker PHPStan: `composer analyse` (no errors)

## Notes
- The first coverage attempt exposed failing team route-binding tests before the report could be generated.
- The PHP image did not include a coverage driver, so Xdebug was installed inside the one-shot Docker container for the coverage run.
