### PR TITLE
Fix team nested route bindings

### DIFF
--- a/tests/Feature/Api/TeamApiTest.php
+++ b/tests/Feature/Api/TeamApiTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api;
 use App\Enums\TeamRole;
 use App\Models\Package;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -57,6 +58,28 @@ class TeamApiTest extends TestCase
         ])->assertCreated();
     }
 
+    public function test_team_api_allows_admin_to_revoke_pending_invitation(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $teamInvitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'api-pending@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'api-pending-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addWeek(),
+        ]);
+
+        $this->actingAs($admin)
+            ->deleteJson('/api/v1/teams/' . $team->id . '/invitations/' . $teamInvitation->id)
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('team_invitations', ['id' => $teamInvitation->id]);
+    }
+
     public function test_team_api_member_routes_reject_memberships_from_another_team(): void
     {
         Package::factory()->create();
@@ -64,10 +87,7 @@ class TeamApiTest extends TestCase
         $otherMember = User::factory()->create();
 
         $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
-        $team->memberships()->create([
-            'user_id' => $admin->id,
-            'role' => TeamRole::ADMIN,
-        ]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
 
         $otherTeam = Team::factory()->create(['created_by_user_id' => $admin->id]);
         $otherMembership = $otherTeam->memberships()->create([
@@ -78,6 +98,9 @@ class TeamApiTest extends TestCase
         $this->actingAs($admin)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $otherMembership->id, [
             'role' => TeamRole::ADMIN->value,
         ])->assertNotFound();
+
+        $this->actingAs($admin)->deleteJson('/api/v1/teams/' . $team->id . '/members/' . $otherMembership->id)
+            ->assertNotFound();
 
         $this->assertDatabaseHas('team_memberships', [
             'id' => $otherMembership->id,

--- a/tests/Feature/TeamMonitoringTest.php
+++ b/tests/Feature/TeamMonitoringTest.php
@@ -14,6 +14,7 @@ use App\Models\MonitoringNotification;
 use App\Models\MonitoringNotificationState;
 use App\Models\Package;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -53,6 +54,28 @@ class TeamMonitoringTest extends TestCase
         $this->assertDatabaseHas('team_invitations', ['team_id' => $team->id, 'email' => $registeredUser->email]);
         $this->assertDatabaseHas('team_invitations', ['team_id' => $team->id, 'email' => 'new-user@example.com']);
         Mail::assertSent(TeamInvitationMail::class, 2);
+    }
+
+    public function test_team_admin_can_revoke_pending_invitation(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $teamInvitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'pending@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'pending-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addWeek(),
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('teams.invitations.destroy', [$team, $teamInvitation]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('team_invitations', ['id' => $teamInvitation->id]);
     }
 
     public function test_last_team_admin_cannot_leave_be_demoted_or_removed(): void
@@ -157,6 +180,38 @@ class TeamMonitoringTest extends TestCase
         $monitoring->refresh();
         $this->assertSame($admin->id, $monitoring->user_id);
         $this->assertNull($monitoring->team_id);
+    }
+
+    public function test_api_private_monitoring_can_move_to_team_and_back_to_private(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $monitoring = Monitoring::factory()->for($admin)->create(['created_by_user_id' => null]);
+
+        $this->actingAs($admin)->postJson('/api/v1/monitorings/' . $monitoring->id . '/team-ownership', [
+            'team_id' => $team->id,
+        ])->assertOk()
+            ->assertJsonPath('data.user_id', null)
+            ->assertJsonPath('data.team_id', $team->id)
+            ->assertJsonPath('data.created_by_user_id', $admin->id);
+
+        $monitoring->refresh();
+        $this->assertNull($monitoring->user_id);
+        $this->assertSame($team->id, $monitoring->team_id);
+        $this->assertSame($admin->id, $monitoring->created_by_user_id);
+
+        $this->actingAs($admin)->deleteJson('/api/v1/monitorings/' . $monitoring->id . '/team-ownership')
+            ->assertOk()
+            ->assertJsonPath('data.user_id', $admin->id)
+            ->assertJsonPath('data.team_id', null)
+            ->assertJsonPath('data.created_by_user_id', $admin->id);
+
+        $monitoring->refresh();
+        $this->assertSame($admin->id, $monitoring->user_id);
+        $this->assertNull($monitoring->team_id);
+        $this->assertSame($admin->id, $monitoring->created_by_user_id);
     }
 
     public function test_deleting_team_deletes_team_monitorings_but_keeps_private_monitorings(): void


### PR DESCRIPTION
## Summary
- align nested team membership and invitation route placeholders with controller argument names
- add focused coverage for cross-team API membership rejection
- add API coverage for moving private monitorings to a team and back

## Validation
- Docker coverage command attempted: `composer test:coverage` inside the project PHP container, but it failed because no code coverage driver is installed
- `APP_ENV=testing ./vendor/bin/pest tests/Feature/Api/TeamApiTest.php tests/Feature/TeamMonitoringTest.php`
- `APP_ENV=testing composer test`
- `APP_ENV=testing composer analyse`
- `APP_ENV=testing ./vendor/bin/pint --dirty --test`