### PR TITLE
fix: move monitoring notification preferences to edit page

### DIFF
--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -233,10 +233,8 @@ class MonitoringController extends Controller
      * @param  Monitoring  $monitoring  The monitoring instance to display.
      * @return View The view displaying the monitoring details.
      */
-    public function show(
-        Monitoring $monitoring,
-        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver
-    ): View {
+    public function show(Monitoring $monitoring): View
+    {
         /** @var User $user */
         $user = Auth::user();
         $monitoring->loadMissing('domainResult', 'team');
@@ -245,7 +243,6 @@ class MonitoringController extends Controller
             'monitoring' => $monitoring,
             'canManageMonitoring' => $monitoring->isManageableBy($user) && ! $user->isDemo(),
             'adminTeams' => Team::query()->administeredBy($user)->orderBy('name')->get(['teams.id', 'teams.name']),
-            'notificationPreference' => $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user),
         ]);
     }
 
@@ -255,11 +252,15 @@ class MonitoringController extends Controller
      * @param  Monitoring  $monitoring  The monitoring instance to edit.
      * @return View The view for editing the monitoring.
      */
-    public function edit(Monitoring $monitoring): View
-    {
+    public function edit(
+        Monitoring $monitoring,
+        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver
+    ): View {
         abort_if(Auth::user()->isDemo(), 403);
         abort_unless($monitoring->isManageableBy(Auth::user()), 403);
 
+        /** @var User $user */
+        $user = Auth::user();
         $monitoring->loadMissing('groups', 'team');
         $types = MonitoringType::cases();
         $serverInstances = ServerInstance::query()
@@ -274,11 +275,12 @@ class MonitoringController extends Controller
             'monitoring' => $monitoring,
             'types' => $types,
             'serverInstances' => $serverInstances,
-            'enabledNotificationChannels' => Auth::user()->enabledNotificationChannelKeys(),
+            'enabledNotificationChannels' => $user->enabledNotificationChannelKeys(),
             'monitoringGroups' => $monitoring->isPrivateOwned()
-                ? Auth::user()->monitoringGroups()->orderBy('name')->get(['id', 'name'])
+                ? $user->monitoringGroups()->orderBy('name')->get(['id', 'name'])
                 : collect(),
-            'adminTeams' => Auth::user()->administeredTeams()->orderBy('name')->get(['teams.id', 'teams.name']),
+            'adminTeams' => $user->administeredTeams()->orderBy('name')->get(['teams.id', 'teams.name']),
+            'notificationPreference' => $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user),
         ]);
     }
 

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -446,6 +446,15 @@
                 <x-heading type="h2">{{ __('monitoring.form.sections.notifications') }}</x-heading>
             </div>
 
+    @if (isset($monitoring))
+        <input type="hidden" name="notification_on_failure" value="{{ old('notification_on_failure', $monitoring->notification_on_failure ?? true) ? '1' : '0' }}">
+        @foreach ($selectedNotificationChannels as $channel)
+            <input type="hidden" name="notification_channels[]" value="{{ $channel }}">
+        @endforeach
+        <input type="hidden" name="ssl_expiry_warning_days" value="{{ old('ssl_expiry_warning_days', $monitoring->ssl_expiry_warning_days ?? 7) }}">
+    @endif
+
+    @unless (isset($monitoring))
     <div class="mt-4">
         <x-input-label for="notification_on_failure" :value="__('monitoring.form.notification_on_failure')" />
         <label class="relative inline-flex cursor-pointer items-center">
@@ -458,6 +467,7 @@
                 class="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">{{ __('monitoring.form.notification_on_failure_enabled') }}</span>
         </label>
     </div>
+    @endunless
 
     <div class="mt-4">
         <x-input-label for="failure_confirmation_threshold" :value="__('monitoring.form.failure_confirmation_threshold')" />
@@ -469,6 +479,7 @@
         <x-input-error :messages="$errors->get('failure_confirmation_threshold')" />
     </div>
 
+    @unless (isset($monitoring))
     <div class="mt-4">
         <x-input-label for="notification_channels" :value="__('monitoring.form.notification_channels')" />
         @if (count($enabledNotificationChannels) > 0)
@@ -501,6 +512,7 @@
         </p>
         <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
     </div>
+    @endunless
 
         </section>
 

--- a/resources/views/monitorings/_notification_preferences.blade.php
+++ b/resources/views/monitorings/_notification_preferences.blade.php
@@ -1,0 +1,52 @@
+@php
+    $selectedNotificationChannels = $notificationPreference->notification_channels ?? [];
+    $selectedNotificationChannels = is_array($selectedNotificationChannels) ? $selectedNotificationChannels : [];
+    $enabledNotificationChannels = $enabledNotificationChannels ?? Auth::user()->enabledNotificationChannelKeys();
+    $fieldIdPrefix = $fieldIdPrefix ?? 'monitoring_notification_preference';
+@endphp
+
+<x-container class="mb-4">
+    <x-heading type="h2">{{ __('team.sections.notification_preferences') }}</x-heading>
+    <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
+        class="mt-4 space-y-4">
+        @csrf
+        @method('PATCH')
+
+        <x-text-checkbox id="{{ $fieldIdPrefix }}_notification_on_failure" name="notification_on_failure" value="1"
+            :checked="$notificationPreference->notification_on_failure"
+            label="{{ __('monitoring.form.notification_on_failure_enabled') }}" />
+
+        <div>
+            <x-input-label for="{{ $fieldIdPrefix }}_notification_channels" :value="__('monitoring.form.notification_channels')" />
+            @if ($enabledNotificationChannels === [])
+                <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                    {{ __('monitoring.form.notification_channels_empty') }}
+                </x-paragraph>
+            @else
+                <div id="{{ $fieldIdPrefix }}_notification_channels" class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    @foreach ($enabledNotificationChannels as $channel)
+                        <label class="flex items-center gap-2 rounded-md border border-gray-200 p-3 text-sm dark:border-gray-700">
+                            <input type="checkbox" name="notification_channels[]" value="{{ $channel }}"
+                                class="rounded-sm border-gray-300 text-purple-600 shadow-xs focus:border-purple-300 focus:ring-3 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
+                                @checked(in_array($channel, $selectedNotificationChannels, true))>
+                            <span>{{ __('profile.notification_settings.channels.' . $channel . '.title') }}</span>
+                        </label>
+                    @endforeach
+                </div>
+            @endif
+            <x-input-error :messages="$errors->get('notification_channels')" />
+            <x-input-error :messages="$errors->get('notification_channels.*')" />
+        </div>
+
+        <div>
+            <x-input-label for="{{ $fieldIdPrefix }}_ssl_expiry_warning_days" :value="__('monitoring.form.ssl_expiry_warning_days')" />
+            <x-text-input id="{{ $fieldIdPrefix }}_ssl_expiry_warning_days" type="number" min="1" max="365"
+                name="ssl_expiry_warning_days" :value="old('ssl_expiry_warning_days', $notificationPreference->ssl_expiry_warning_days)" required />
+            <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
+        </div>
+
+        <x-primary-button>
+            {{ __('button.save') }}
+        </x-primary-button>
+    </form>
+</x-container>

--- a/resources/views/monitorings/edit.blade.php
+++ b/resources/views/monitorings/edit.blade.php
@@ -22,6 +22,8 @@
                 @include('monitorings._form')
             </form>
         </x-container>
+
+        @include('monitorings._notification_preferences', ['fieldIdPrefix' => 'edit_notification_preference'])
     </x-main>
 </x-app-layout>
 <script>

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -354,60 +354,6 @@
 
         </div>
 
-        @if (!Auth::user()->isDemo())
-            @php
-                $selectedNotificationChannels = $notificationPreference->notification_channels ?? [];
-                $selectedNotificationChannels = is_array($selectedNotificationChannels) ? $selectedNotificationChannels : [];
-                $enabledNotificationChannels = Auth::user()->enabledNotificationChannelKeys();
-            @endphp
-
-            <x-container class="mb-4">
-                <x-heading type="h2">{{ __('team.sections.notification_preferences') }}</x-heading>
-                <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
-                    class="mt-4 space-y-4">
-                    @csrf
-                    @method('PATCH')
-
-                    <x-text-checkbox id="notification_on_failure" name="notification_on_failure" value="1"
-                        :checked="$notificationPreference->notification_on_failure"
-                        label="{{ __('monitoring.form.notification_on_failure_enabled') }}" />
-
-                    <div>
-                        <x-input-label for="notification_channels" :value="__('monitoring.form.notification_channels')" />
-                        @if ($enabledNotificationChannels === [])
-                            <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                {{ __('monitoring.form.notification_channels_empty') }}
-                            </x-paragraph>
-                        @else
-                            <div class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                                @foreach ($enabledNotificationChannels as $channel)
-                                    <label class="flex items-center gap-2 rounded-md border border-gray-200 p-3 text-sm dark:border-gray-700">
-                                        <input type="checkbox" name="notification_channels[]" value="{{ $channel }}"
-                                            class="rounded-sm border-gray-300 text-purple-600 shadow-xs focus:border-purple-300 focus:ring-3 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
-                                            @checked(in_array($channel, $selectedNotificationChannels, true))>
-                                        <span>{{ __('profile.notification_settings.channels.' . $channel . '.title') }}</span>
-                                    </label>
-                                @endforeach
-                            </div>
-                        @endif
-                        <x-input-error :messages="$errors->get('notification_channels')" />
-                        <x-input-error :messages="$errors->get('notification_channels.*')" />
-                    </div>
-
-                    <div>
-                        <x-input-label for="ssl_expiry_warning_days" :value="__('monitoring.form.ssl_expiry_warning_days')" />
-                        <x-text-input id="ssl_expiry_warning_days" type="number" min="1" max="365"
-                            name="ssl_expiry_warning_days" :value="old('ssl_expiry_warning_days', $notificationPreference->ssl_expiry_warning_days)" required />
-                        <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
-                    </div>
-
-                    <x-primary-button>
-                        {{ __('button.save') }}
-                    </x-primary-button>
-                </form>
-            </x-container>
-        @endif
-
         <div class="my-4" id="uptime-calendar-{{ $monitoring->id }}">
             <x-heading type="h2" class="mb-2">{{ __('monitoring.detail.calendar.heading') }}</x-heading>
 

--- a/tests/Feature/MonitoringNotificationSettingsTest.php
+++ b/tests/Feature/MonitoringNotificationSettingsTest.php
@@ -73,11 +73,28 @@ class MonitoringNotificationSettingsTest extends TestCase
         $testResponse->assertSeeText(__('monitoring.form.sections.sharing'));
         $testResponse->assertSeeText(__('monitoring.form.sections.notifications'));
         $testResponse->assertSeeText(__('monitoring.form.sections.operations'));
+        $testResponse->assertSeeText(__('team.sections.notification_preferences'));
         $testResponse->assertSeeText(__('monitoring.form.notification_channels'));
         $testResponse->assertSeeText(__('profile.notification_settings.channels.slack.title'));
         $testResponse->assertSeeText(__('profile.notification_settings.channels.telegram.title'));
         $testResponse->assertDontSeeText(__('profile.notification_settings.channels.webhook.title'));
+        $testResponse->assertSeeHtml('action="' . route('monitorings.notification-preferences.update', $monitoring) . '"');
         $testResponse->assertSeeHtml('value="14"');
+    }
+
+    public function test_detail_page_does_not_show_monitoring_notification_preferences(): void
+    {
+        $monitoring = Monitoring::factory()->for($this->user)->create([
+            'type' => MonitoringType::HTTP,
+            'target' => 'https://example.com',
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $testResponse = $this->actingAs($this->user)->get(route('monitorings.show', $monitoring));
+
+        $testResponse->assertOk();
+        $testResponse->assertDontSeeText(__('team.sections.notification_preferences'));
+        $testResponse->assertDontSeeHtml('action="' . route('monitorings.notification-preferences.update', $monitoring) . '"');
     }
 
     public function test_update_persists_per_monitoring_channels_and_ssl_warning_window(): void


### PR DESCRIPTION
## What changed
- Moved the per-monitoring notification preferences card from the monitoring detail page to the monitoring edit page.
- Extracted the preferences UI into a reusable Blade partial.
- Kept the base monitoring edit form from rendering duplicate visible notification preference controls.
- Added feature coverage for the edit-page placement and detail-page removal.

## Why
Notification preferences are editing controls, so they belong on the monitoring edit page rather than the read-focused detail page.

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps -e AUTORUN_ENABLED=false php ./vendor/bin/pest tests/Feature/MonitoringNotificationSettingsTest.php`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps -e AUTORUN_ENABLED=false php ./vendor/bin/pint app/Http/Controllers/MonitoringController.php tests/Feature/MonitoringNotificationSettingsTest.php`

## Risks
- The edit page now has a separate save action for notification preferences, matching the existing dedicated update route.