### PR TITLE
test: cover marketing navigation refresh

### DIFF
--- a/tests/Feature/PublicFeaturePagesTest.php
+++ b/tests/Feature/PublicFeaturePagesTest.php
@@ -51,6 +51,24 @@ class PublicFeaturePagesTest extends TestCase
         }
     }
 
+    public function test_public_feature_overview_uses_marketing_navigation_shell(): void
+    {
+        $testResponse = $this->get(route('public-features.index'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml(sprintf('aria-label="%s"', e(__('welcome.nav.aria'))));
+        $testResponse->assertSeeHtml(route('welcome') . '#features');
+        $testResponse->assertSeeHtml(route('public-features.index'));
+        $testResponse->assertSeeHtml(route('scribe'));
+        $testResponse->assertSeeHtml(route('welcome') . '#proof');
+        $testResponse->assertSeeHtml(route('register'));
+        $testResponse->assertSeeHtml(route('login', ['mode' => 'demo']));
+        $testResponse->assertSeeHtml(route('locale.switch', ['locale' => 'en']));
+        $testResponse->assertSeeHtml(route('locale.switch', ['locale' => 'de']));
+        $testResponse->assertSeeHtml(sprintf('<link rel="canonical" href="%s">', route('public-features.index')));
+        $testResponse->assertSeeHtml(sprintf('alt="%s"', e(__('welcome.nav.logo_alt'))));
+    }
+
     public function test_monitoring_locations_feature_slug_redirects_to_the_standalone_page(): void
     {
         $testResponse = $this->get(route('public-features.show', 'monitoring-locations'));

--- a/tests/Feature/WelcomePageCopyTest.php
+++ b/tests/Feature/WelcomePageCopyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Enums\SupportedLanguage;
+use App\Http\Controllers\PublicFeatureController;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
@@ -124,5 +125,39 @@ class WelcomePageCopyTest extends TestCase
 
         $secondResponse->assertOk();
         $secondResponse->assertSeeText('1 Minute');
+    }
+
+    public function test_welcome_page_links_each_feature_cluster_to_public_feature_pages(): void
+    {
+        $testResponse = $this->get(route('welcome'));
+
+        $testResponse->assertOk();
+
+        $expectedClusterSlugs = [
+            'http-monitoring',
+            'keyword-monitoring',
+            'status-code-monitoring',
+            'ping-monitoring',
+            'port-monitoring',
+            'dns-record-monitoring',
+            'heartbeat-monitoring',
+            'notifications',
+            'weekly-digest',
+            'public-status-pages',
+            'public-labels',
+            'status-badges',
+            'api',
+            'server-health-monitoring',
+            'monitoring-groups',
+        ];
+
+        foreach ($expectedClusterSlugs as $slug) {
+            $this->assertContains($slug, PublicFeatureController::slugs());
+            $testResponse->assertSeeHtml(route('public-features.show', $slug));
+        }
+
+        $testResponse->assertSeeHtml(sprintf('alt="%s"', e(__('welcome.visuals.photos.hero_alt'))));
+        $testResponse->assertSeeHtml(sprintf('alt="%s"', e(__('welcome.visuals.photos.status_alt'))));
+        $testResponse->assertSeeHtml(sprintf('alt="%s"', e(__('welcome.visuals.photos.workflow_alt'))));
     }
 }

--- a/tests/Feature/WelcomePageCopyTest.php
+++ b/tests/Feature/WelcomePageCopyTest.php
@@ -151,9 +151,9 @@ class WelcomePageCopyTest extends TestCase
             'monitoring-groups',
         ];
 
-        foreach ($expectedClusterSlugs as $slug) {
-            $this->assertContains($slug, PublicFeatureController::slugs());
-            $testResponse->assertSeeHtml(route('public-features.show', $slug));
+        foreach ($expectedClusterSlugs as $expectedClusterSlug) {
+            $this->assertContains($expectedClusterSlug, PublicFeatureController::slugs());
+            $testResponse->assertSeeHtml(route('public-features.show', $expectedClusterSlug));
         }
 
         $testResponse->assertSeeHtml(sprintf('alt="%s"', e(__('welcome.visuals.photos.hero_alt'))));


### PR DESCRIPTION
## Summary
- add homepage assertions for refreshed feature cluster links and marketing image alt contracts
- add public feature overview assertions for the shared marketing navigation shell, locale links, canonical URL, and primary CTAs

## Validation
- Docker: `composer test:coverage` with temporary Xdebug in disposable PHP container: 523 passed, 3 skipped, 84.8% total coverage before selecting gaps
- Docker: `./vendor/bin/pest --coverage-html coverage --min=0` with temporary Xdebug: 523 passed, 3 skipped; generated HTML coverage report inspected
- Docker: `./vendor/bin/pest tests/Feature/WelcomePageCopyTest.php tests/Feature/PublicFeaturePagesTest.php`: 14 passed, 201 assertions
- Docker: `composer test`: 525 passed, 3 skipped, 3467 assertions
- Docker: `composer analyse`: no errors
