### PR TITLE
test: cover under-tested paths

### DIFF
--- a/tests/Feature/Admin/DemoMonitoringAdminTest.php
+++ b/tests/Feature/Admin/DemoMonitoringAdminTest.php
@@ -106,6 +106,81 @@ class DemoMonitoringAdminTest extends TestCase
         ]);
     }
 
+    public function test_create_redirects_when_demo_user_reached_monitoring_limit(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 1]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+        Monitoring::factory()->for($demoUser)->create();
+
+        $this->actingAs($admin)->get(route('admin.demo-monitorings.create'))
+            ->assertRedirect(route('admin.demo-monitorings.index'))
+            ->assertSessionHasErrors(['limit']);
+    }
+
+    public function test_create_redirects_when_no_active_server_instances_exist(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+        ServerInstance::query()->update(['is_active' => false]);
+
+        $this->actingAs($admin)->get(route('admin.demo-monitorings.create'))
+            ->assertRedirect(route('admin.demo-monitorings.index'))
+            ->assertSessionHasErrors(['preferred_location']);
+    }
+
+    public function test_create_form_renders_when_demo_user_has_capacity_and_active_instances(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+        ServerInstance::query()->create([
+            'code' => 'admin-demo-create',
+            'ip_address' => '10.0.0.12',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($admin)->get(route('admin.demo-monitorings.create'))
+            ->assertOk()
+            ->assertSeeText('admin-demo-create');
+    }
+
+    public function test_store_redirects_when_demo_user_reached_monitoring_limit(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 1]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $demoUser = User::factory()->create([
+            'role' => UserRole::DEMO,
+            'package_id' => $package->id,
+        ]);
+        Monitoring::factory()->for($demoUser)->create();
+
+        $this->actingAs($admin)->post(route('admin.demo-monitorings.store'), [
+            'name' => 'Blocked Demo Check',
+            'type' => MonitoringType::HTTP->value,
+            'target' => 'https://blocked.example.test',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'timeout' => 5,
+            'http_method' => 'get',
+            'expected_http_statuses' => '200-299',
+            'preferred_location' => 'de-1',
+            'notification_on_failure' => '1',
+            'ssl_expiry_warning_days' => 7,
+        ])->assertRedirect(route('admin.demo-monitorings.index'))
+            ->assertSessionHasErrors(['limit']);
+    }
+
     public function test_admin_can_edit_monitoring_for_demo_user(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 5]);

--- a/tests/Feature/Admin/PackageControllerCoverageTest.php
+++ b/tests/Feature/Admin/PackageControllerCoverageTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\Package;
+use App\Models\User;
+use Tests\TestCase;
+
+class PackageControllerCoverageTest extends TestCase
+{
+    public function test_admin_can_filter_packages_and_receive_async_rows(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 5, 'price' => 9.99, 'is_selectable' => true]);
+        Package::factory()->create(['monitoring_limit' => 50, 'price' => 49.99, 'is_selectable' => false]);
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        $this->actingAs($admin)
+            ->getJson(route('admin.packages.index', [
+                'search' => '49',
+                'is_selectable' => '0',
+                'sort' => 'price',
+                'direction' => 'desc',
+            ]))
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('pagination.per_page', 10)
+            ->assertJsonPath('pagination.current_page', 1)
+            ->assertSee('49.99');
+    }
+
+    public function test_admin_can_create_edit_update_and_delete_unused_package(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+
+        $this->actingAs($admin)->get(route('admin.packages.create'))->assertOk();
+
+        $this->actingAs($admin)->post(route('admin.packages.store'), [
+            'monitoring_limit' => 12,
+            'price' => 14.99,
+            'is_selectable' => '1',
+        ])->assertRedirect(route('admin.packages.index'))
+            ->assertSessionHas('success', __('admin.packages.messages.package_created'));
+
+        $package = Package::query()->withoutGlobalScope('selectable')->where('monitoring_limit', 12)->firstOrFail();
+
+        $this->actingAs($admin)->get(route('admin.packages.edit', $package))->assertOk();
+
+        $this->actingAs($admin)->put(route('admin.packages.update', $package), [
+            'monitoring_limit' => 15,
+            'price' => 19.99,
+            'is_selectable' => '0',
+        ])->assertRedirect(route('admin.packages.index'))
+            ->assertSessionHas('success', __('admin.packages.messages.package_updated'));
+
+        $this->assertDatabaseHas('packages', [
+            'id' => $package->id,
+            'monitoring_limit' => 15,
+            'is_selectable' => false,
+        ]);
+
+        $this->actingAs($admin)->delete(route('admin.packages.destroy', $package))
+            ->assertRedirect(route('admin.packages.index'))
+            ->assertSessionHas('success', __('admin.packages.messages.package_deleted'));
+
+        $this->assertDatabaseMissing('packages', ['id' => $package->id]);
+    }
+
+    public function test_admin_cannot_delete_package_assigned_to_users(): void
+    {
+        $package = Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        User::factory()->create(['package_id' => $package->id]);
+
+        $this->actingAs($admin)->delete(route('admin.packages.destroy', $package))
+            ->assertRedirect(route('admin.packages.index'))
+            ->assertSessionHas('error', __('admin.packages.messages.package_in_use'));
+
+        $this->assertDatabaseHas('packages', ['id' => $package->id]);
+    }
+}

--- a/tests/Feature/Api/ApiControllerTest.php
+++ b/tests/Feature/Api/ApiControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Tests\Feature\Api;
 
 use App\Enums\MonitoringStatus;
+use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringDailyResult;
 use App\Models\MonitoringResponse;
+use App\Models\MonitoringSslResult;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -174,6 +176,71 @@ class ApiControllerTest extends TestCase
         $testResponse->assertJsonCount(30, '2026-04.days');
         $testResponse->assertJsonPath('2026-04.days.9.uptime_percentage', 75);
         $testResponse->assertJsonPath('2026-04.monthly_average_uptime', 75);
+    }
+
+    public function test_response_times_endpoint_returns_monitoring_response_payload(): void
+    {
+        Date::setTestNow('2026-04-20 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => Date::now()->subDay(),
+        ]);
+        MonitoringResponse::query()->forceCreate([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 123.4,
+            'created_at' => Date::now()->subHour(),
+            'updated_at' => Date::now()->subHour(),
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/response-times?days=1');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('aggregated.avg', 123.4);
+        $testResponse->assertJsonPath('data.0.avg', 123.4);
+    }
+
+    public function test_incidents_endpoint_returns_incident_payload(): void
+    {
+        Date::setTestNow('2026-04-20 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subHours(2),
+            'up_at' => Date::now()->subHour(),
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/incidents?days=1');
+
+        $testResponse->assertOk();
+        $this->assertNotNull($testResponse->json('0.down_at'));
+        $this->assertNotNull($testResponse->json('0.up_at'));
+    }
+
+    public function test_ssl_status_endpoint_returns_ssl_payload(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'expires_at' => '2026-12-01 00:00:00',
+            'issuer' => 'Example CA',
+            'issued_at' => '2026-01-01 00:00:00',
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/v1/monitorings/' . $monitoring->id . '/ssl');
+
+        $testResponse->assertOk();
+        $testResponse->assertJsonPath('valid', true);
+        $testResponse->assertJsonPath('issuer', 'Example CA');
     }
 
     public function test_results_endpoint_exposes_http_status_code_for_historical_entries(): void

--- a/tests/Feature/Api/InternalMonitoringCallbackTest.php
+++ b/tests/Feature/Api/InternalMonitoringCallbackTest.php
@@ -116,11 +116,11 @@ class InternalMonitoringCallbackTest extends TestCase
     {
         Package::factory()->create();
         $user = User::factory()->create();
-        $assignedInstance = $this->serverInstance('internal-callback-assigned');
+        $serverInstance = $this->serverInstance('internal-callback-assigned');
         $otherInstance = $this->serverInstance('internal-callback-other');
         $monitoring = Monitoring::factory()->for($user)->create([
-            'preferred_location' => $assignedInstance->code,
-            'preferred_locations' => [$assignedInstance->code],
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
         ]);
 
         $this->withHeaders($this->instanceHeaders($otherInstance))

--- a/tests/Feature/Api/InternalMonitoringCallbackTest.php
+++ b/tests/Feature/Api/InternalMonitoringCallbackTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class InternalMonitoringCallbackTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_instance_can_store_and_close_incidents_for_assigned_monitoring(): void
+    {
+        Date::setTestNow('2026-06-27 09:00:00');
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $serverInstance = $this->serverInstance('internal-callback-1');
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
+        ]);
+
+        $this->withHeaders($this->instanceHeaders($serverInstance))
+            ->postJson(route('v1.internal.incidents.store'), [
+                'monitoring_id' => $monitoring->id,
+                'down_at' => Date::now()->subMinutes(10)->toDateTimeString(),
+            ])->assertOk()
+            ->assertJsonPath('message', 'Incident stored successfully.');
+
+        $this->assertDatabaseHas('incidents', [
+            'monitoring_id' => $monitoring->id,
+            'up_at' => null,
+        ]);
+
+        $this->withHeaders($this->instanceHeaders($serverInstance))
+            ->putJson(route('v1.internal.incidents.update', $monitoring), [
+                'up_at' => Date::now()->toDateTimeString(),
+            ])->assertOk()
+            ->assertJsonPath('message', 'Incident updated successfully.');
+
+        $this->assertNotNull(Incident::query()->where('monitoring_id', $monitoring->id)->firstOrFail()->up_at);
+    }
+
+    public function test_instance_update_incident_returns_not_found_without_open_incident(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $serverInstance = $this->serverInstance('internal-callback-2');
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
+        ]);
+
+        $this->withHeaders($this->instanceHeaders($serverInstance))
+            ->putJson(route('v1.internal.incidents.update', $monitoring), [
+                'up_at' => now()->toDateTimeString(),
+            ])->assertNotFound()
+            ->assertJsonPath('message', 'No open incident found for this monitoring.');
+    }
+
+    public function test_instance_can_store_ssl_and_domain_results_for_assigned_monitoring(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $serverInstance = $this->serverInstance('internal-callback-3');
+        $httpMonitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
+        ]);
+        $domainMonitoring = Monitoring::factory()->domainExpiration()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
+            'type' => MonitoringType::DOMAIN_EXPIRATION,
+            'target' => 'example.test',
+        ]);
+
+        $this->withHeaders($this->instanceHeaders($serverInstance))
+            ->postJson(route('v1.internal.ssl-results.store'), [
+                'monitoring_id' => $httpMonitoring->id,
+                'is_valid' => true,
+                'expires_at' => '2026-12-01 00:00:00',
+                'issuer' => 'Example CA',
+                'issued_at' => '2026-01-01 00:00:00',
+            ])->assertOk()
+            ->assertJsonPath('message', 'SSL result stored successfully.');
+
+        $this->withHeaders($this->instanceHeaders($serverInstance))
+            ->postJson(route('v1.internal.domain-results.store'), [
+                'monitoring_id' => $domainMonitoring->id,
+                'is_valid' => true,
+                'expires_at' => '2027-01-01 00:00:00',
+                'registrar' => 'Example Registrar',
+                'checked_at' => '2026-06-27 08:00:00',
+            ])->assertOk()
+            ->assertJsonPath('message', 'Domain expiration result stored successfully.');
+
+        $this->assertDatabaseHas('monitoring_ssl_results', ['monitoring_id' => $httpMonitoring->id, 'issuer' => 'Example CA']);
+        $this->assertDatabaseHas('monitoring_domain_results', ['monitoring_id' => $domainMonitoring->id, 'registrar' => 'Example Registrar']);
+    }
+
+    public function test_unassigned_instance_cannot_store_callback_payloads(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $assignedInstance = $this->serverInstance('internal-callback-assigned');
+        $otherInstance = $this->serverInstance('internal-callback-other');
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $assignedInstance->code,
+            'preferred_locations' => [$assignedInstance->code],
+        ]);
+
+        $this->withHeaders($this->instanceHeaders($otherInstance))
+            ->postJson(route('v1.internal.monitoring-responses.store'), [
+                'monitoring_id' => $monitoring->id,
+                'status' => MonitoringStatus::UP->value,
+                'response_time' => 100,
+            ])->assertForbidden()
+            ->assertJsonPath('message', 'Unauthorized monitoring');
+    }
+
+    private function serverInstance(string $code): ServerInstance
+    {
+        return ServerInstance::query()->create([
+            'code' => $code,
+            'ip_address' => '192.0.2.56',
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function instanceHeaders(ServerInstance $serverInstance): array
+    {
+        return [
+            'X-INSTANCE-CODE' => $serverInstance->code,
+            'X-API-KEY' => 'test-token-1234567890',
+        ];
+    }
+}

--- a/tests/Feature/Api/MonitoringManagementApiTest.php
+++ b/tests/Feature/Api/MonitoringManagementApiTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringType;
+use App\Enums\TeamRole;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\Team;
+use App\Models\TeamMembership;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MonitoringManagementApiTest extends TestCase
+{
+    public function test_user_can_manage_private_monitorings_through_api(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $serverInstance = $this->serverInstance('api-management-1');
+        Sanctum::actingAs($user);
+
+        $createResponse = $this->postJson('/api/v1/monitorings', $this->monitoringPayload([
+            'name' => 'API Created Check',
+            'target' => 'https://created.example.test',
+            'preferred_locations' => [$serverInstance->code],
+        ]));
+
+        $createResponse->assertCreated();
+        $monitoring = Monitoring::query()->where('name', 'API Created Check')->firstOrFail();
+        $this->assertSame($user->id, $monitoring->user_id);
+
+        $this->getJson('/api/v1/monitorings?per_page=1')
+            ->assertOk()
+            ->assertJsonPath('data.0.name', 'API Created Check');
+
+        $this->patchJson('/api/v1/monitorings/' . $monitoring->id, $this->monitoringPayload([
+            'name' => 'API Updated Check',
+            'target' => 'https://updated.example.test',
+            'status' => MonitoringLifecycleStatus::PAUSED->value,
+            'preferred_locations' => [$serverInstance->code],
+        ]))->assertOk()
+            ->assertJsonPath('data.name', 'API Updated Check')
+            ->assertJsonPath('data.public_label_enabled', false);
+
+        $this->deleteJson('/api/v1/monitorings/' . $monitoring->id)->assertNoContent();
+        $this->assertSoftDeleted('monitorings', ['id' => $monitoring->id]);
+    }
+
+    public function test_user_can_move_manageable_monitoring_between_private_and_team_ownership(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 5]);
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        TeamMembership::factory()->for($team)->for($user)->admin()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/v1/monitorings/' . $monitoring->id . '/team-ownership', [
+            'team_id' => $team->id,
+        ])->assertOk()
+            ->assertJsonPath('data.team_id', $team->id)
+            ->assertJsonPath('data.user_id', null);
+
+        $this->deleteJson('/api/v1/monitorings/' . $monitoring->id . '/team-ownership')
+            ->assertOk()
+            ->assertJsonPath('data.user_id', $user->id)
+            ->assertJsonPath('data.team_id', null);
+    }
+
+    public function test_store_rejects_private_monitoring_when_package_limit_is_reached(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 1]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $serverInstance = $this->serverInstance('api-management-limit');
+        Monitoring::factory()->for($user)->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/v1/monitorings', $this->monitoringPayload([
+            'name' => 'Over Limit',
+            'preferred_locations' => [$serverInstance->code],
+        ]))->assertUnprocessable()
+            ->assertJsonPath('message', __('monitoring.messages.limit_reached'));
+    }
+
+    public function test_non_admin_cannot_move_monitoring_to_team(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        TeamMembership::factory()->for($team)->for($user)->create(['role' => TeamRole::MEMBER]);
+        $monitoring = Monitoring::factory()->for($user)->create();
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/v1/monitorings/' . $monitoring->id . '/team-ownership', [
+            'team_id' => $team->id,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['team_id']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function monitoringPayload(array $overrides = []): array
+    {
+        return array_replace([
+            'name' => 'API Check',
+            'type' => MonitoringType::HTTP->value,
+            'target' => 'https://api.example.test',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'timeout' => 5,
+            'http_method' => 'get',
+            'expected_http_statuses' => '200-299',
+            'preferred_locations' => ['api-management-1'],
+            'notification_on_failure' => true,
+            'failure_confirmation_threshold' => 1,
+            'ssl_expiry_warning_days' => 7,
+        ], $overrides);
+    }
+
+    private function serverInstance(string $code): ServerInstance
+    {
+        return ServerInstance::query()->create([
+            'code' => $code,
+            'ip_address' => '192.0.2.55',
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/Api/MonitoringManagementApiTest.php
+++ b/tests/Feature/Api/MonitoringManagementApiTest.php
@@ -25,13 +25,13 @@ class MonitoringManagementApiTest extends TestCase
         $serverInstance = $this->serverInstance('api-management-1');
         Sanctum::actingAs($user);
 
-        $createResponse = $this->postJson('/api/v1/monitorings', $this->monitoringPayload([
+        $testResponse = $this->postJson('/api/v1/monitorings', $this->monitoringPayload([
             'name' => 'API Created Check',
             'target' => 'https://created.example.test',
             'preferred_locations' => [$serverInstance->code],
         ]));
 
-        $createResponse->assertCreated();
+        $testResponse->assertCreated();
         $monitoring = Monitoring::query()->where('name', 'API Created Check')->firstOrFail();
         $this->assertSame($user->id, $monitoring->user_id);
 

--- a/tests/Feature/Api/TeamApiCoverageTest.php
+++ b/tests/Feature/Api/TeamApiCoverageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\TeamRole;
+use App\Enums\UserRole;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeamApiCoverageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_team_api_show_update_destroy_member_index_and_member_destroy_paths(): void
+    {
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create([
+            'name' => 'API Coverage',
+            'created_by_user_id' => $admin->id,
+        ]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $membership = $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+        TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'pending-api@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'pending-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $this->actingAs($member)->getJson('/api/v1/teams/' . $team->id)
+            ->assertOk()
+            ->assertJsonPath('data.name', 'API Coverage');
+        $this->actingAs($member)->getJson('/api/v1/teams/' . $team->id . '/members')
+            ->assertOk()
+            ->assertJsonFragment(['email' => $member->email]);
+        $this->actingAs($admin)->getJson('/api/v1/teams/' . $team->id . '/invitations')
+            ->assertOk()
+            ->assertJsonFragment(['email' => 'pending-api@example.com']);
+        $this->actingAs($admin)->patchJson('/api/v1/teams/' . $team->id, [
+            'name' => 'API Updated',
+            'description' => 'Changed',
+        ])->assertOk()->assertJsonPath('data.name', 'API Updated');
+        $this->actingAs($admin)->deleteJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id)
+            ->assertNoContent();
+        $this->assertDatabaseMissing('team_memberships', ['id' => $membership->id]);
+        $this->actingAs($admin)->deleteJson('/api/v1/teams/' . $team->id)
+            ->assertNoContent();
+        $this->assertDatabaseMissing('teams', ['id' => $team->id]);
+    }
+
+    public function test_team_api_demo_user_write_paths_are_forbidden(): void
+    {
+        $demoUser = User::factory()->create(['role' => UserRole::DEMO]);
+        $team = Team::factory()->create(['created_by_user_id' => $demoUser->id]);
+        $membership = $team->memberships()->create(['user_id' => $demoUser->id, 'role' => TeamRole::ADMIN]);
+
+        $this->actingAs($demoUser)->postJson('/api/v1/teams', [
+            'name' => 'Blocked',
+        ])->assertForbidden();
+        $this->actingAs($demoUser)->patchJson('/api/v1/teams/' . $team->id, [
+            'name' => 'Blocked',
+        ])->assertForbidden();
+        $this->actingAs($demoUser)->deleteJson('/api/v1/teams/' . $team->id)->assertForbidden();
+        $this->actingAs($demoUser)->patchJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id, [
+            'role' => TeamRole::MEMBER->value,
+        ])->assertForbidden();
+        $this->actingAs($demoUser)->deleteJson('/api/v1/teams/' . $team->id . '/members/' . $membership->id)
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Auth/UnderCoveredAuthControllerTest.php
+++ b/tests/Feature/Auth/UnderCoveredAuthControllerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Auth;
+
+use App\Enums\UserRole;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class UnderCoveredAuthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_confirm_password_view_validation_and_success_redirect(): void
+    {
+        $user = User::factory()->create(['password' => 'secret-password']);
+
+        $this->actingAs($user)->get(route('password.confirm'))->assertOk();
+
+        $this->actingAs($user)->post(route('password.confirm'), [
+            'password' => 'wrong-password',
+        ])->assertSessionHasErrors('password');
+
+        $this->actingAs($user)->post(route('password.confirm'), [
+            'password' => 'secret-password',
+        ])->assertRedirect(route('dashboard', absolute: false));
+
+        $this->assertNotNull(session('auth.password_confirmed_at'));
+    }
+
+    public function test_email_verification_notification_redirects_verified_users_and_sends_for_unverified_users(): void
+    {
+        Notification::fake();
+
+        $verifiedUser = User::factory()->create();
+        $this->actingAs($verifiedUser)
+            ->post(route('verification.send'))
+            ->assertRedirect(route('dashboard', absolute: false));
+
+        $unverifiedUser = User::factory()->unverified()->create();
+        $this->actingAs($unverifiedUser)
+            ->post(route('verification.send'))
+            ->assertSessionHas('status', 'verification-link-sent');
+
+        Notification::assertSentTo($unverifiedUser, VerifyEmail::class);
+    }
+
+    public function test_verification_prompt_and_verify_email_controller_paths(): void
+    {
+        Event::fake([Verified::class]);
+
+        $verifiedUser = User::factory()->create();
+        $this->actingAs($verifiedUser)
+            ->get(route('verification.notice'))
+            ->assertRedirect(route('dashboard', absolute: false));
+
+        $unverifiedUser = User::factory()->unverified()->create();
+        $this->actingAs($unverifiedUser)
+            ->get(route('verification.notice'))
+            ->assertOk();
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $unverifiedUser->id, 'hash' => sha1($unverifiedUser->email)],
+            false
+        );
+
+        $this->actingAs($unverifiedUser)
+            ->get($verificationUrl)
+            ->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
+
+        $this->assertTrue($unverifiedUser->refresh()->hasVerifiedEmail());
+        Event::assertDispatched(Verified::class);
+
+        $alreadyVerifiedUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $verifiedUser->id, 'hash' => sha1($verifiedUser->email)],
+            false
+        );
+
+        $this->actingAs($verifiedUser)
+            ->get($alreadyVerifiedUrl)
+            ->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
+    }
+
+    public function test_demo_login_credentials_returns_not_found_without_demo_user(): void
+    {
+        $this->getJson(route('demo-login.credentials'))
+            ->assertNotFound()
+            ->assertJson(['error' => __('auth.guest_login.no_guest_user_found')]);
+
+        User::factory()->create([
+            'role' => UserRole::DEMO,
+            'email' => 'demo@example.com',
+        ]);
+
+        $this->getJson(route('demo-login.credentials'))
+            ->assertOk()
+            ->assertJson(['email' => 'demo@example.com']);
+    }
+
+    public function test_login_request_dispatches_lockout_after_too_many_attempts(): void
+    {
+        Event::fake([Lockout::class]);
+
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $this->post(route('login'), [
+                'email' => 'locked@example.com',
+                'password' => 'wrong-password',
+            ])->assertSessionHasErrors('email');
+        }
+
+        $this->post(route('login'), [
+            'email' => 'locked@example.com',
+            'password' => 'wrong-password',
+        ])->assertSessionHasErrors('email');
+
+        Event::assertDispatched(Lockout::class);
+    }
+}

--- a/tests/Feature/Console/UnderCoveredCommandBehaviorTest.php
+++ b/tests/Feature/Console/UnderCoveredCommandBehaviorTest.php
@@ -106,15 +106,15 @@ class UnderCoveredCommandBehaviorTest extends TestCase
     {
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create();
-        $oldReadNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+        $monitoringNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is up',
             'read' => false,
             'sent' => true,
         ]);
-        $oldReadNotification->forceFill(['created_at' => now()->subMonths(2)])->saveQuietly();
-        MonitoringNotificationState::query()->where('monitoring_notification_id', $oldReadNotification->id)->update([
+        $monitoringNotification->forceFill(['created_at' => now()->subMonths(2)])->saveQuietly();
+        MonitoringNotificationState::query()->where('monitoring_notification_id', $monitoringNotification->id)->update([
             'read_at' => now()->subMonth(),
         ]);
         $oldUnreadNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
@@ -137,7 +137,7 @@ class UnderCoveredCommandBehaviorTest extends TestCase
             ->expectsOutput('Deleted 1 old read notifications.')
             ->assertSuccessful();
 
-        $this->assertDatabaseMissing('monitoring_notifications', ['id' => $oldReadNotification->id]);
+        $this->assertDatabaseMissing('monitoring_notifications', ['id' => $monitoringNotification->id]);
         $this->assertDatabaseHas('monitoring_notifications', ['id' => $oldUnreadNotification->id]);
         $this->assertDatabaseHas('monitoring_notifications', ['id' => $recentReadNotification->id]);
     }
@@ -148,8 +148,8 @@ class UnderCoveredCommandBehaviorTest extends TestCase
             ->expectsOutput("Admin user 'admin@example.com' created successfully with password 'password'.")
             ->assertSuccessful();
 
-        $admin = User::query()->where('email', 'admin@example.com')->firstOrFail();
-        $this->assertSame(UserRole::ADMIN, $admin->role);
+        $model = User::query()->where('email', 'admin@example.com')->firstOrFail();
+        $this->assertSame(UserRole::ADMIN, $model->role);
 
         $this->artisan('user:create-admin admin@example.com')
             ->expectsOutput('A user with this email already exists.')
@@ -158,8 +158,8 @@ class UnderCoveredCommandBehaviorTest extends TestCase
 
     public function test_console_kernel_registers_commands_and_accepts_empty_schedule(): void
     {
-        $kernel = app(Kernel::class);
-        $schedule = app(Schedule::class);
+        $kernel = resolve(Kernel::class);
+        $schedule = resolve(Schedule::class);
 
         $scheduleMethod = new ReflectionMethod($kernel, 'schedule');
         $scheduleMethod->invoke($kernel, $schedule);

--- a/tests/Feature/Console/UnderCoveredCommandBehaviorTest.php
+++ b/tests/Feature/Console/UnderCoveredCommandBehaviorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Kernel;
+use App\Enums\MonitoringStatus;
+use App\Enums\NotificationType;
+use App\Enums\UserRole;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationState;
+use App\Models\MonitoringResponse;
+use App\Models\MonitoringResponseArchived;
+use App\Models\MonitoringSslResult;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class UnderCoveredCommandBehaviorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_purge_soft_deleted_monitorings_removes_related_rows(): void
+    {
+        $monitoring = Monitoring::factory()->for(User::factory())->create();
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'response_time' => 123.45,
+        ]);
+        MonitoringDailyResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'date' => now()->toDateString(),
+            'uptime_total' => 60,
+            'downtime_total' => 0,
+            'unknown_total' => 0,
+            'uptime_percentage' => 100,
+            'downtime_percentage' => 0,
+            'unknown_percentage' => 0,
+            'uptime_minutes' => 60,
+            'downtime_minutes' => 0,
+            'unknown_minutes' => 0,
+            'avg_response_time' => 123.45,
+            'incidents_count' => 0,
+        ]);
+        MonitoringResponseArchived::query()->create([
+            'id' => 'archived-response-1',
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'response_time' => 456.78,
+            'created_at' => now()->subMonths(2),
+        ]);
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'valid' => true,
+            'issuer' => 'Example CA',
+            'expires_at' => now()->addMonth(),
+            'checked_at' => now(),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => now()->subHour(),
+            'up_at' => now(),
+        ]);
+        MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is down',
+            'read' => true,
+            'sent' => true,
+        ]);
+        $monitoring->delete();
+
+        $this->artisan('monitoring:purge-soft-deleted')
+            ->expectsOutput('Deleting soft-deleted monitorings and their related data...')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('monitorings', ['id' => $monitoring->id]);
+        $this->assertSame(0, MonitoringResponse::query()->where('monitoring_id', $monitoring->id)->count());
+        $this->assertSame(0, MonitoringNotification::query()->withoutGlobalScopes()->where('monitoring_id', $monitoring->id)->count());
+    }
+
+    public function test_purge_soft_deleted_monitorings_reports_empty_work(): void
+    {
+        $this->artisan('monitoring:purge-soft-deleted')
+            ->expectsOutput('No soft-deleted monitorings found.')
+            ->assertSuccessful();
+    }
+
+    public function test_prune_read_notifications_deletes_only_old_fully_read_notifications(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $oldReadNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is up',
+            'read' => false,
+            'sent' => true,
+        ]);
+        $oldReadNotification->forceFill(['created_at' => now()->subMonths(2)])->saveQuietly();
+        MonitoringNotificationState::query()->where('monitoring_notification_id', $oldReadNotification->id)->update([
+            'read_at' => now()->subMonth(),
+        ]);
+        $oldUnreadNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is down',
+            'read' => false,
+            'sent' => true,
+        ]);
+        $oldUnreadNotification->forceFill(['created_at' => now()->subMonths(2)])->saveQuietly();
+        $recentReadNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is up',
+            'read' => true,
+            'sent' => true,
+        ]);
+
+        $this->artisan('notifications:prune-read')
+            ->expectsOutput('Deleted 1 old read notifications.')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('monitoring_notifications', ['id' => $oldReadNotification->id]);
+        $this->assertDatabaseHas('monitoring_notifications', ['id' => $oldUnreadNotification->id]);
+        $this->assertDatabaseHas('monitoring_notifications', ['id' => $recentReadNotification->id]);
+    }
+
+    public function test_create_admin_user_creates_admin_and_rejects_duplicates(): void
+    {
+        $this->artisan('user:create-admin admin@example.com')
+            ->expectsOutput("Admin user 'admin@example.com' created successfully with password 'password'.")
+            ->assertSuccessful();
+
+        $admin = User::query()->where('email', 'admin@example.com')->firstOrFail();
+        $this->assertSame(UserRole::ADMIN, $admin->role);
+
+        $this->artisan('user:create-admin admin@example.com')
+            ->expectsOutput('A user with this email already exists.')
+            ->assertFailed();
+    }
+
+    public function test_console_kernel_registers_commands_and_accepts_empty_schedule(): void
+    {
+        $kernel = app(Kernel::class);
+        $schedule = app(Schedule::class);
+
+        $scheduleMethod = new ReflectionMethod($kernel, 'schedule');
+        $scheduleMethod->invoke($kernel, $schedule);
+
+        $commandsMethod = new ReflectionMethod($kernel, 'commands');
+        $commandsMethod->invoke($kernel);
+
+        $this->assertArrayHasKey('monitoring:purge-soft-deleted', Artisan::all());
+    }
+}

--- a/tests/Feature/Jobs/ApiAndDeletionJobsTest.php
+++ b/tests/Feature/Jobs/ApiAndDeletionJobsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\DeleteUser;
+use App\Jobs\LogApiUsage;
+use App\Models\ApiLog;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class ApiAndDeletionJobsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_delete_user_job_deletes_user_and_owned_monitorings(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        (new DeleteUser($user))->handle();
+
+        $this->assertDatabaseMissing('monitorings', ['id' => $monitoring->id]);
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    public function test_log_api_usage_job_creates_api_log(): void
+    {
+        $user = User::factory()->create();
+
+        (new LogApiUsage($user->id, 'api.v1.monitorings.index'))->handle();
+
+        $this->assertDatabaseHas('api_logs', [
+            'user_id' => $user->id,
+            'route' => 'api.v1.monitorings.index',
+        ]);
+    }
+
+    public function test_log_api_usage_job_logs_storage_failures(): void
+    {
+        Log::spy();
+
+        (new LogApiUsage('missing-user', 'api.v1.monitorings.index'))->handle();
+
+        $this->assertSame(0, ApiLog::query()->count());
+        Log::shouldHaveReceived('error')->once();
+    }
+}

--- a/tests/Feature/Mail/MailableContractTest.php
+++ b/tests/Feature/Mail/MailableContractTest.php
@@ -37,7 +37,7 @@ class MailableContractTest extends TestCase
             'name' => 'Operations',
             'created_by_user_id' => $inviter->id,
         ]);
-        $invitation = TeamInvitation::query()->create([
+        $teamInvitation = TeamInvitation::query()->create([
             'team_id' => $team->id,
             'email' => 'new-member@example.com',
             'role' => TeamRole::MEMBER,
@@ -46,13 +46,13 @@ class MailableContractTest extends TestCase
             'expires_at' => now()->addDay(),
         ]);
 
-        $mail = new TeamInvitationMail($invitation, 'invite-token');
+        $teamInvitationMail = new TeamInvitationMail($teamInvitation, 'invite-token');
 
-        $this->assertSame(__('team.mail.invitation.subject', ['team' => 'Operations']), $mail->envelope()->subject);
-        $this->assertSame('mail.team-invitation', $mail->content()->view);
+        $this->assertSame(__('team.mail.invitation.subject', ['team' => 'Operations']), $teamInvitationMail->envelope()->subject);
+        $this->assertSame('mail.team-invitation', $teamInvitationMail->content()->view);
         $this->assertSame(
             route('team-invitations.accept', ['token' => 'invite-token']),
-            $mail->content()->with['acceptUrl']
+            $teamInvitationMail->content()->with['acceptUrl']
         );
     }
 
@@ -62,24 +62,24 @@ class MailableContractTest extends TestCase
             'name' => 'Public API',
             'public_label_enabled' => true,
         ]);
-        $subscriber = StatusPageSubscriber::query()->create([
+        $statusPageSubscriber = StatusPageSubscriber::query()->create([
             'monitoring_id' => $monitoring->id,
             'email' => 'subscriber@example.com',
             'confirmation_token_hash' => StatusPageSubscriber::hashToken('confirm-token'),
             'unsubscribe_token' => 'unsubscribe-token',
         ]);
 
-        $mail = new StatusPageSubscriptionConfirmationMail($subscriber, 'confirm-token');
+        $statusPageSubscriptionConfirmationMail = new StatusPageSubscriptionConfirmationMail($statusPageSubscriber, 'confirm-token');
 
-        $this->assertSame(__('mail.status_page_subscription_confirmation.subject', ['monitoringName' => 'Public API']), $mail->envelope()->subject);
-        $this->assertSame('mail.status-page-subscription-confirmation', $mail->content()->view);
-        $this->assertSame($subscriber->id, $mail->content()->with['subscriber']->id);
-        $this->assertSame($monitoring->id, $mail->content()->with['monitoring']->id);
+        $this->assertSame(__('mail.status_page_subscription_confirmation.subject', ['monitoringName' => 'Public API']), $statusPageSubscriptionConfirmationMail->envelope()->subject);
+        $this->assertSame('mail.status-page-subscription-confirmation', $statusPageSubscriptionConfirmationMail->content()->view);
+        $this->assertSame($statusPageSubscriber->id, $statusPageSubscriptionConfirmationMail->content()->with['subscriber']->id);
+        $this->assertSame($monitoring->id, $statusPageSubscriptionConfirmationMail->content()->with['monitoring']->id);
         $this->assertSame(
             route('public-label.subscribers.confirm', ['monitoring' => $monitoring, 'token' => 'confirm-token']),
-            $mail->content()->with['confirmUrl']
+            $statusPageSubscriptionConfirmationMail->content()->with['confirmUrl']
         );
-        $this->assertSame([], $mail->attachments());
+        $this->assertSame([], $statusPageSubscriptionConfirmationMail->attachments());
     }
 
     public function test_status_page_status_update_mail_exposes_status_and_unsubscribe_contract(): void
@@ -88,14 +88,14 @@ class MailableContractTest extends TestCase
             'name' => 'Public API',
             'public_label_enabled' => true,
         ]);
-        $subscriber = StatusPageSubscriber::query()->create([
+        $statusPageSubscriber = StatusPageSubscriber::query()->create([
             'monitoring_id' => $monitoring->id,
             'email' => 'subscriber@example.com',
             'confirmation_token_hash' => null,
             'unsubscribe_token' => 'unsubscribe-token',
             'verified_at' => now(),
         ]);
-        $notification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is down',
@@ -103,22 +103,22 @@ class MailableContractTest extends TestCase
             'sent' => true,
         ]);
 
-        $mail = new StatusPageStatusUpdateMail($subscriber, $notification, 'down');
+        $statusPageStatusUpdateMail = new StatusPageStatusUpdateMail($statusPageSubscriber, $monitoringNotification, 'down');
 
         $this->assertSame(__('mail.status_page_status_update.subject', [
             'monitoringName' => 'Public API',
             'status' => 'DOWN',
-        ]), $mail->envelope()->subject);
-        $this->assertSame('mail.status-page-status-update', $mail->content()->view);
-        $this->assertSame($monitoring->id, $mail->content()->with['monitoring']->id);
-        $this->assertSame($notification->id, $mail->content()->with['notification']->id);
-        $this->assertSame('down', $mail->content()->with['status']);
-        $this->assertSame('DOWN', $mail->content()->with['statusLabel']);
-        $this->assertSame(route('public-label', $monitoring), $mail->content()->with['statusPageUrl']);
+        ]), $statusPageStatusUpdateMail->envelope()->subject);
+        $this->assertSame('mail.status-page-status-update', $statusPageStatusUpdateMail->content()->view);
+        $this->assertSame($monitoring->id, $statusPageStatusUpdateMail->content()->with['monitoring']->id);
+        $this->assertSame($monitoringNotification->id, $statusPageStatusUpdateMail->content()->with['notification']->id);
+        $this->assertSame('down', $statusPageStatusUpdateMail->content()->with['status']);
+        $this->assertSame('DOWN', $statusPageStatusUpdateMail->content()->with['statusLabel']);
+        $this->assertSame(route('public-label', $monitoring), $statusPageStatusUpdateMail->content()->with['statusPageUrl']);
         $this->assertSame(
             route('public-label.subscribers.unsubscribe', ['monitoring' => $monitoring, 'token' => 'unsubscribe-token']),
-            $mail->content()->with['unsubscribeUrl']
+            $statusPageStatusUpdateMail->content()->with['unsubscribeUrl']
         );
-        $this->assertSame([], $mail->attachments());
+        $this->assertSame([], $statusPageStatusUpdateMail->attachments());
     }
 }

--- a/tests/Feature/Mail/MailableContractTest.php
+++ b/tests/Feature/Mail/MailableContractTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mail;
+
+use App\Enums\NotificationType;
+use App\Enums\TeamRole;
+use App\Mail\StatusPageStatusUpdateMail;
+use App\Mail\StatusPageSubscriptionConfirmationMail;
+use App\Mail\TeamInvitationMail;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\Package;
+use App\Models\StatusPageSubscriber;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MailableContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_team_invitation_mail_exposes_subject_view_and_accept_url(): void
+    {
+        $inviter = User::factory()->create();
+        $team = Team::factory()->create([
+            'name' => 'Operations',
+            'created_by_user_id' => $inviter->id,
+        ]);
+        $invitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'new-member@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'invite-token'),
+            'invited_by_user_id' => $inviter->id,
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $mail = new TeamInvitationMail($invitation, 'invite-token');
+
+        $this->assertSame(__('team.mail.invitation.subject', ['team' => 'Operations']), $mail->envelope()->subject);
+        $this->assertSame('mail.team-invitation', $mail->content()->view);
+        $this->assertSame(
+            route('team-invitations.accept', ['token' => 'invite-token']),
+            $mail->content()->with['acceptUrl']
+        );
+    }
+
+    public function test_status_page_subscription_confirmation_mail_exposes_confirmation_contract(): void
+    {
+        $monitoring = Monitoring::factory()->for(User::factory())->create([
+            'name' => 'Public API',
+            'public_label_enabled' => true,
+        ]);
+        $subscriber = StatusPageSubscriber::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'email' => 'subscriber@example.com',
+            'confirmation_token_hash' => StatusPageSubscriber::hashToken('confirm-token'),
+            'unsubscribe_token' => 'unsubscribe-token',
+        ]);
+
+        $mail = new StatusPageSubscriptionConfirmationMail($subscriber, 'confirm-token');
+
+        $this->assertSame(__('mail.status_page_subscription_confirmation.subject', ['monitoringName' => 'Public API']), $mail->envelope()->subject);
+        $this->assertSame('mail.status-page-subscription-confirmation', $mail->content()->view);
+        $this->assertSame($subscriber->id, $mail->content()->with['subscriber']->id);
+        $this->assertSame($monitoring->id, $mail->content()->with['monitoring']->id);
+        $this->assertSame(
+            route('public-label.subscribers.confirm', ['monitoring' => $monitoring, 'token' => 'confirm-token']),
+            $mail->content()->with['confirmUrl']
+        );
+        $this->assertSame([], $mail->attachments());
+    }
+
+    public function test_status_page_status_update_mail_exposes_status_and_unsubscribe_contract(): void
+    {
+        $monitoring = Monitoring::factory()->for(User::factory())->create([
+            'name' => 'Public API',
+            'public_label_enabled' => true,
+        ]);
+        $subscriber = StatusPageSubscriber::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'email' => 'subscriber@example.com',
+            'confirmation_token_hash' => null,
+            'unsubscribe_token' => 'unsubscribe-token',
+            'verified_at' => now(),
+        ]);
+        $notification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is down',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        $mail = new StatusPageStatusUpdateMail($subscriber, $notification, 'down');
+
+        $this->assertSame(__('mail.status_page_status_update.subject', [
+            'monitoringName' => 'Public API',
+            'status' => 'DOWN',
+        ]), $mail->envelope()->subject);
+        $this->assertSame('mail.status-page-status-update', $mail->content()->view);
+        $this->assertSame($monitoring->id, $mail->content()->with['monitoring']->id);
+        $this->assertSame($notification->id, $mail->content()->with['notification']->id);
+        $this->assertSame('down', $mail->content()->with['status']);
+        $this->assertSame('DOWN', $mail->content()->with['statusLabel']);
+        $this->assertSame(route('public-label', $monitoring), $mail->content()->with['statusPageUrl']);
+        $this->assertSame(
+            route('public-label.subscribers.unsubscribe', ['monitoring' => $monitoring, 'token' => 'unsubscribe-token']),
+            $mail->content()->with['unsubscribeUrl']
+        );
+        $this->assertSame([], $mail->attachments());
+    }
+}

--- a/tests/Feature/Models/MonitoringRelatedModelsTest.php
+++ b/tests/Feature/Models/MonitoringRelatedModelsTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Enums\IncidentUpdateStatus;
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Enums\NotificationType;
+use App\Enums\TeamRole;
+use App\Models\Incident;
+use App\Models\IncidentUpdate;
+use App\Models\Monitoring;
+use App\Models\MonitoringDomainResult;
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationPreference;
+use App\Models\MonitoringNotificationState;
+use App\Models\MonitoringResponse;
+use App\Models\MonitoringSslResult;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Services\Notifications\MonitoringNotificationStateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonitoringRelatedModelsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_domain_and_ssl_results_expose_monitoring_user_relations_and_casts(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        $domainResult = MonitoringDomainResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'expires_at' => '2026-07-27 00:00:00',
+            'is_valid' => 1,
+            'registrar' => 'Example Registrar',
+            'checked_at' => '2026-06-27 00:00:00',
+        ]);
+        $sslResult = MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'expires_at' => '2026-07-27 00:00:00',
+            'is_valid' => 0,
+            'issuer' => 'Example CA',
+            'issued_at' => '2026-01-27 00:00:00',
+        ]);
+
+        $this->assertTrue($domainResult->is_valid);
+        $this->assertSame($monitoring->id, $domainResult->monitoring->id);
+        $this->assertSame($user->id, $domainResult->user->id);
+        $this->assertFalse($sslResult->is_valid);
+        $this->assertSame($monitoring->id, $sslResult->monitoring->id);
+        $this->assertSame($user->id, $sslResult->user->id);
+    }
+
+    public function test_team_invitation_pending_state_scope_relations_and_casts(): void
+    {
+        $inviter = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $inviter->id]);
+        $pendingInvitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'pending@example.com',
+            'role' => TeamRole::ADMIN,
+            'token_hash' => hash('sha256', 'pending-token'),
+            'invited_by_user_id' => $inviter->id,
+            'expires_at' => now()->addDay(),
+        ]);
+        $expiredInvitation = TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'expired@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'expired-token'),
+            'invited_by_user_id' => $inviter->id,
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $this->assertTrue($pendingInvitation->isPending());
+        $this->assertFalse($expiredInvitation->isPending());
+        $this->assertSame(TeamRole::ADMIN, $pendingInvitation->role);
+        $this->assertSame($team->id, $pendingInvitation->team->id);
+        $this->assertSame($inviter->id, $pendingInvitation->invitedBy->id);
+        $this->assertTrue(TeamInvitation::query()->pending()->whereKey($pendingInvitation->id)->exists());
+        $this->assertFalse(TeamInvitation::query()->pending()->whereKey($expiredInvitation->id)->exists());
+    }
+
+    public function test_monitoring_notification_states_track_read_state_and_service_updates(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $notification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is up',
+            'read' => false,
+            'sent' => false,
+        ]);
+
+        /** @var MonitoringNotificationState $state */
+        $state = MonitoringNotificationState::query()
+            ->where('monitoring_notification_id', $notification->id)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+
+        $this->assertSame($notification->id, $state->monitoringNotification->id);
+        $this->assertSame($user->id, $state->user->id);
+        $this->assertFalse($state->isRead());
+
+        app(MonitoringNotificationStateService::class)->markRead($notification, $user);
+        $this->assertTrue($state->fresh()->isRead());
+
+        $state->forceFill(['read_at' => now()])->save();
+
+        $this->assertTrue($state->fresh()->isRead());
+    }
+
+    public function test_monitoring_response_preference_and_incident_update_relations_and_casts(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        $response = MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => '200',
+            'response_time' => '123.45',
+            'server_health_metrics' => ['cpu' => 20],
+        ]);
+        $preference = MonitoringNotificationPreference::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'user_id' => $user->id,
+            'notification_on_failure' => true,
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 45,
+        ]);
+        $incident = Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => now()->subHour(),
+            'up_at' => now(),
+        ]);
+        $incidentUpdate = IncidentUpdate::query()->create([
+            'incident_id' => $incident->id,
+            'status' => IncidentUpdateStatus::RESOLVED,
+            'message' => 'Recovered',
+        ]);
+
+        $this->assertSame(MonitoringStatus::UP, $response->status);
+        $this->assertSame(200, $response->http_status_code);
+        $this->assertSame(123.45, $response->response_time);
+        $this->assertSame(['cpu' => 20], $response->server_health_metrics);
+        $this->assertSame($monitoring->id, $response->monitoring->id);
+        $this->assertSame($user->id, $response->user->id);
+
+        $this->assertTrue($preference->notification_on_failure);
+        $this->assertSame(['mail'], $preference->notification_channels);
+        $this->assertSame(45, $preference->ssl_expiry_warning_days);
+        $this->assertSame($monitoring->id, $preference->monitoring->id);
+        $this->assertSame($user->id, $preference->user->id);
+
+        $this->assertSame(IncidentUpdateStatus::RESOLVED, $incidentUpdate->status);
+        $this->assertSame($incident->id, $incidentUpdate->incident->id);
+    }
+
+    public function test_monitoring_ownership_visibility_maintenance_locations_scopes_and_activity_options(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $outsider = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+
+        $privateMonitoring = Monitoring::factory()->for($owner)->create([
+            'type' => MonitoringType::HEARTBEAT,
+            'status' => MonitoringLifecycleStatus::ACTIVE,
+            'preferred_location' => 'de-1',
+            'preferred_locations' => ['de-1', 'us-1', ''],
+            'maintenance_from' => now()->subMinute(),
+            'maintenance_until' => null,
+        ]);
+        $teamMonitoring = Monitoring::factory()->serverHealth()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'created_by_user_id' => $admin->id,
+            'status' => MonitoringLifecycleStatus::PAUSED,
+            'preferred_location' => 'us-1',
+            'preferred_locations' => ['us-1'],
+            'maintenance_from' => now()->subHour(),
+            'maintenance_until' => now()->addHour(),
+        ]);
+        Monitoring::factory()->for($outsider)->create([
+            'preferred_location' => 'nl-1',
+            'preferred_locations' => ['nl-1'],
+        ]);
+
+        $this->assertTrue($privateMonitoring->isActive());
+        $this->assertFalse($privateMonitoring->isPaused());
+        $this->assertTrue($privateMonitoring->isHeartbeat());
+        $this->assertFalse($privateMonitoring->isServerHealth());
+        $this->assertTrue($privateMonitoring->isPrivateOwned());
+        $this->assertFalse($privateMonitoring->isTeamOwned());
+        $this->assertTrue($privateMonitoring->isVisibleTo($owner));
+        $this->assertFalse($privateMonitoring->isVisibleTo($outsider));
+        $this->assertTrue($privateMonitoring->isManageableBy($owner));
+        $this->assertFalse($privateMonitoring->isManageableBy($outsider));
+        $this->assertTrue($privateMonitoring->isUnderMaintenance());
+        $this->assertSame(['de-1', 'us-1'], $privateMonitoring->preferredLocationCodes());
+
+        $this->assertTrue($teamMonitoring->isPaused());
+        $this->assertTrue($teamMonitoring->isServerHealth());
+        $this->assertTrue($teamMonitoring->isTeamOwned());
+        $this->assertFalse($teamMonitoring->isPrivateOwned());
+        $this->assertTrue($teamMonitoring->isVisibleTo($member));
+        $this->assertTrue($teamMonitoring->isManageableBy($admin));
+        $this->assertFalse($teamMonitoring->isManageableBy($member));
+        $this->assertTrue($teamMonitoring->isUnderMaintenance());
+
+        $this->assertTrue(Monitoring::query()->withoutGlobalScope('user')->active()->whereKey($privateMonitoring->id)->exists());
+        $this->assertTrue(Monitoring::query()->withoutGlobalScope('user')->paused()->whereKey($teamMonitoring->id)->exists());
+        $this->assertTrue(Monitoring::query()->withoutGlobalScope('user')->visibleTo($member)->whereKey($teamMonitoring->id)->exists());
+        $this->assertTrue(Monitoring::query()->withoutGlobalScope('user')->manageableBy($admin)->whereKey($teamMonitoring->id)->exists());
+        $this->assertTrue(Monitoring::query()->withoutGlobalScope('user')->privateOwnedBy($owner)->whereKey($privateMonitoring->id)->exists());
+        $this->assertTrue(Monitoring::query()->withoutGlobalScope('user')->assignedToLocation('us-1')->whereKey($teamMonitoring->id)->exists());
+        $activityLogOptions = $privateMonitoring->getActivitylogOptions();
+
+        $this->assertSame('monitoring', $activityLogOptions->logName);
+        $this->assertSame('monitoring_created', ($activityLogOptions->descriptionForEvent)('created'));
+    }
+}

--- a/tests/Feature/Models/MonitoringRelatedModelsTest.php
+++ b/tests/Feature/Models/MonitoringRelatedModelsTest.php
@@ -43,14 +43,14 @@ class MonitoringRelatedModelsTest extends TestCase
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create();
 
-        $domainResult = MonitoringDomainResult::query()->create([
+        $monitoringDomainResult = MonitoringDomainResult::query()->create([
             'monitoring_id' => $monitoring->id,
             'expires_at' => '2026-07-27 00:00:00',
             'is_valid' => 1,
             'registrar' => 'Example Registrar',
             'checked_at' => '2026-06-27 00:00:00',
         ]);
-        $sslResult = MonitoringSslResult::query()->create([
+        $monitoringSslResult = MonitoringSslResult::query()->create([
             'monitoring_id' => $monitoring->id,
             'expires_at' => '2026-07-27 00:00:00',
             'is_valid' => 0,
@@ -58,19 +58,19 @@ class MonitoringRelatedModelsTest extends TestCase
             'issued_at' => '2026-01-27 00:00:00',
         ]);
 
-        $this->assertTrue($domainResult->is_valid);
-        $this->assertSame($monitoring->id, $domainResult->monitoring->id);
-        $this->assertSame($user->id, $domainResult->user->id);
-        $this->assertFalse($sslResult->is_valid);
-        $this->assertSame($monitoring->id, $sslResult->monitoring->id);
-        $this->assertSame($user->id, $sslResult->user->id);
+        $this->assertTrue($monitoringDomainResult->is_valid);
+        $this->assertSame($monitoring->id, $monitoringDomainResult->monitoring->id);
+        $this->assertSame($user->id, $monitoringDomainResult->user->id);
+        $this->assertFalse($monitoringSslResult->is_valid);
+        $this->assertSame($monitoring->id, $monitoringSslResult->monitoring->id);
+        $this->assertSame($user->id, $monitoringSslResult->user->id);
     }
 
     public function test_team_invitation_pending_state_scope_relations_and_casts(): void
     {
         $inviter = User::factory()->create();
         $team = Team::factory()->create(['created_by_user_id' => $inviter->id]);
-        $pendingInvitation = TeamInvitation::query()->create([
+        $teamInvitation = TeamInvitation::query()->create([
             'team_id' => $team->id,
             'email' => 'pending@example.com',
             'role' => TeamRole::ADMIN,
@@ -87,12 +87,12 @@ class MonitoringRelatedModelsTest extends TestCase
             'expires_at' => now()->subDay(),
         ]);
 
-        $this->assertTrue($pendingInvitation->isPending());
+        $this->assertTrue($teamInvitation->isPending());
         $this->assertFalse($expiredInvitation->isPending());
-        $this->assertSame(TeamRole::ADMIN, $pendingInvitation->role);
-        $this->assertSame($team->id, $pendingInvitation->team->id);
-        $this->assertSame($inviter->id, $pendingInvitation->invitedBy->id);
-        $this->assertTrue(TeamInvitation::query()->pending()->whereKey($pendingInvitation->id)->exists());
+        $this->assertSame(TeamRole::ADMIN, $teamInvitation->role);
+        $this->assertSame($team->id, $teamInvitation->team->id);
+        $this->assertSame($inviter->id, $teamInvitation->invitedBy->id);
+        $this->assertTrue(TeamInvitation::query()->pending()->whereKey($teamInvitation->id)->exists());
         $this->assertFalse(TeamInvitation::query()->pending()->whereKey($expiredInvitation->id)->exists());
     }
 
@@ -100,7 +100,7 @@ class MonitoringRelatedModelsTest extends TestCase
     {
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create();
-        $notification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is up',
@@ -108,22 +108,22 @@ class MonitoringRelatedModelsTest extends TestCase
             'sent' => false,
         ]);
 
-        /** @var MonitoringNotificationState $state */
-        $state = MonitoringNotificationState::query()
-            ->where('monitoring_notification_id', $notification->id)
+        /** @var MonitoringNotificationState $monitoringNotificationState */
+        $monitoringNotificationState = MonitoringNotificationState::query()
+            ->where('monitoring_notification_id', $monitoringNotification->id)
             ->where('user_id', $user->id)
             ->firstOrFail();
 
-        $this->assertSame($notification->id, $state->monitoringNotification->id);
-        $this->assertSame($user->id, $state->user->id);
-        $this->assertFalse($state->isRead());
+        $this->assertSame($monitoringNotification->id, $monitoringNotificationState->monitoringNotification->id);
+        $this->assertSame($user->id, $monitoringNotificationState->user->id);
+        $this->assertFalse($monitoringNotificationState->isRead());
 
-        app(MonitoringNotificationStateService::class)->markRead($notification, $user);
-        $this->assertTrue($state->fresh()->isRead());
+        resolve(MonitoringNotificationStateService::class)->markRead($monitoringNotification, $user);
+        $this->assertTrue($monitoringNotificationState->fresh()->isRead());
 
-        $state->forceFill(['read_at' => now()])->save();
+        $monitoringNotificationState->forceFill(['read_at' => now()])->save();
 
-        $this->assertTrue($state->fresh()->isRead());
+        $this->assertTrue($monitoringNotificationState->fresh()->isRead());
     }
 
     public function test_monitoring_response_preference_and_incident_update_relations_and_casts(): void
@@ -131,14 +131,14 @@ class MonitoringRelatedModelsTest extends TestCase
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create();
 
-        $response = MonitoringResponse::query()->create([
+        $monitoringResponse = MonitoringResponse::query()->create([
             'monitoring_id' => $monitoring->id,
             'status' => MonitoringStatus::UP,
             'http_status_code' => '200',
             'response_time' => '123.45',
             'server_health_metrics' => ['cpu' => 20],
         ]);
-        $preference = MonitoringNotificationPreference::query()->create([
+        $monitoringNotificationPreference = MonitoringNotificationPreference::query()->create([
             'monitoring_id' => $monitoring->id,
             'user_id' => $user->id,
             'notification_on_failure' => true,
@@ -156,18 +156,18 @@ class MonitoringRelatedModelsTest extends TestCase
             'message' => 'Recovered',
         ]);
 
-        $this->assertSame(MonitoringStatus::UP, $response->status);
-        $this->assertSame(200, $response->http_status_code);
-        $this->assertSame(123.45, $response->response_time);
-        $this->assertSame(['cpu' => 20], $response->server_health_metrics);
-        $this->assertSame($monitoring->id, $response->monitoring->id);
-        $this->assertSame($user->id, $response->user->id);
+        $this->assertSame(MonitoringStatus::UP, $monitoringResponse->status);
+        $this->assertSame(200, $monitoringResponse->http_status_code);
+        $this->assertSame(123.45, $monitoringResponse->response_time);
+        $this->assertSame(['cpu' => 20], $monitoringResponse->server_health_metrics);
+        $this->assertSame($monitoring->id, $monitoringResponse->monitoring->id);
+        $this->assertSame($user->id, $monitoringResponse->user->id);
 
-        $this->assertTrue($preference->notification_on_failure);
-        $this->assertSame(['mail'], $preference->notification_channels);
-        $this->assertSame(45, $preference->ssl_expiry_warning_days);
-        $this->assertSame($monitoring->id, $preference->monitoring->id);
-        $this->assertSame($user->id, $preference->user->id);
+        $this->assertTrue($monitoringNotificationPreference->notification_on_failure);
+        $this->assertSame(['mail'], $monitoringNotificationPreference->notification_channels);
+        $this->assertSame(45, $monitoringNotificationPreference->ssl_expiry_warning_days);
+        $this->assertSame($monitoring->id, $monitoringNotificationPreference->monitoring->id);
+        $this->assertSame($user->id, $monitoringNotificationPreference->user->id);
 
         $this->assertSame(IncidentUpdateStatus::RESOLVED, $incidentUpdate->status);
         $this->assertSame($incident->id, $incidentUpdate->incident->id);

--- a/tests/Feature/MonitoringNotificationPreferenceControllerTest.php
+++ b/tests/Feature/MonitoringNotificationPreferenceControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\UserRole;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotificationPreference;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonitoringNotificationPreferenceControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_owner_preference_update_syncs_private_monitoring_defaults(): void
+    {
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'mail' => ['enabled' => true],
+                'slack' => ['enabled' => true],
+            ],
+        ]);
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'notification_on_failure' => true,
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 30,
+        ]);
+
+        $this->actingAs($user)->patch(route('monitorings.notification-preferences.update', $monitoring), [
+            'notification_on_failure' => '0',
+            'notification_channels' => ['slack', 'slack'],
+            'ssl_expiry_warning_days' => 14,
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('monitoring_notification_preferences', [
+            'monitoring_id' => $monitoring->id,
+            'user_id' => $user->id,
+            'notification_on_failure' => false,
+            'ssl_expiry_warning_days' => 14,
+        ]);
+        $this->assertSame(['slack'], MonitoringNotificationPreference::query()->firstOrFail()->notification_channels);
+        $monitoring->refresh();
+        $this->assertFalse($monitoring->notification_on_failure);
+        $this->assertSame(['slack'], $monitoring->notification_channels);
+        $this->assertSame(14, $monitoring->ssl_expiry_warning_days);
+    }
+
+    public function test_team_member_preference_does_not_sync_monitoring_defaults(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create([
+            'notification_channels' => ['mail' => ['enabled' => true]],
+        ]);
+        $team = Team::factory()->create(['created_by_user_id' => $owner->id]);
+        $team->memberships()->create(['user_id' => $owner->id, 'role' => 'admin']);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => 'member']);
+        $monitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'notification_on_failure' => true,
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 30,
+        ]);
+
+        $this->actingAs($member)->patch(route('monitorings.notification-preferences.update', $monitoring), [
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 7,
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('monitoring_notification_preferences', [
+            'monitoring_id' => $monitoring->id,
+            'user_id' => $member->id,
+            'notification_on_failure' => false,
+            'ssl_expiry_warning_days' => 7,
+        ]);
+        $this->assertTrue($monitoring->refresh()->notification_on_failure);
+        $this->assertSame(30, $monitoring->ssl_expiry_warning_days);
+    }
+
+    public function test_preference_update_blocks_demo_and_invisible_monitorings(): void
+    {
+        $demoUser = User::factory()->create(['role' => UserRole::DEMO]);
+        $demoMonitoring = Monitoring::factory()->for($demoUser)->create();
+
+        $this->actingAs($demoUser)->patch(route('monitorings.notification-preferences.update', $demoMonitoring), [
+            'ssl_expiry_warning_days' => 7,
+        ])->assertForbidden();
+
+        $owner = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($owner)->create();
+        $otherUser = User::factory()->create();
+        $this->actingAs($otherUser)->patch(route('monitorings.notification-preferences.update', $monitoring), [
+            'ssl_expiry_warning_days' => 7,
+        ])->assertNotFound();
+    }
+}

--- a/tests/Feature/Notifications/NotificationRouterTest.php
+++ b/tests/Feature/Notifications/NotificationRouterTest.php
@@ -268,6 +268,123 @@ class NotificationRouterTest extends TestCase
         ]);
     }
 
+    public function test_router_revokes_unregistered_mobile_push_device_when_another_device_succeeds(): void
+    {
+        config([
+            'services.fcm.project_id' => 'webguard-test',
+            'services.fcm.access_token' => 'test-access-token',
+        ]);
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'mobile_push' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
+        $staleDevice = MobilePushDevice::factory()->for($user)->create([
+            'push_token' => 'stale-fcm-token',
+            'token_hash' => hash('sha256', 'stale-fcm-token'),
+        ]);
+        $activeDevice = MobilePushDevice::factory()->for($user)->create([
+            'push_token' => 'active-fcm-token',
+            'token_hash' => hash('sha256', 'active-fcm-token'),
+        ]);
+
+        Http::fake(function ($request) {
+            if (data_get($request->data(), 'message.token') === 'stale-fcm-token') {
+                return Http::response(['error' => ['status' => 'UNREGISTERED']], 404);
+            }
+
+            return Http::response(['name' => 'projects/webguard-test/messages/456'], 200);
+        });
+
+        $notificationPayload = new NotificationPayload(
+            eventType: NotificationEventType::INCIDENT,
+            title: 'Monitoring incident',
+            message: 'Service is down.',
+            severity: 'critical',
+            monitoringId: '01TEST',
+            monitoringName: 'API',
+            monitoringTarget: 'https://example.test',
+            occurredAt: now()
+        );
+
+        $wasDelivered = resolve(NotificationRouter::class)->dispatch($user, $notificationPayload, ['mobile_push']);
+
+        $this->assertTrue($wasDelivered);
+        Http::assertSentCount(2);
+        $this->assertDatabaseHas('mobile_push_devices', [
+            'id' => $staleDevice->id,
+            'enabled' => false,
+        ]);
+        $this->assertNotNull($staleDevice->fresh()->revoked_at);
+        $this->assertDatabaseHas('mobile_push_devices', [
+            'id' => $activeDevice->id,
+            'enabled' => true,
+            'revoked_at' => null,
+        ]);
+        $this->assertNotNull($activeDevice->fresh()->last_seen_at);
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'channel' => 'mobile_push',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::SENT->value,
+        ]);
+    }
+
+    public function test_router_records_failed_mobile_push_delivery_when_every_device_is_rejected(): void
+    {
+        config([
+            'services.fcm.project_id' => 'webguard-test',
+            'services.fcm.access_token' => 'test-access-token',
+        ]);
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'mobile_push' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
+        $staleDevice = MobilePushDevice::factory()->for($user)->create([
+            'push_token' => 'gone-fcm-token',
+            'token_hash' => hash('sha256', 'gone-fcm-token'),
+        ]);
+
+        Http::fake([
+            'https://fcm.googleapis.com/*' => Http::response(['error' => ['message' => 'Requested entity was not found']], 404),
+        ]);
+
+        $notificationPayload = new NotificationPayload(
+            eventType: NotificationEventType::INCIDENT,
+            title: 'Monitoring incident',
+            message: 'Service is down.',
+            severity: 'critical',
+            monitoringId: '01TEST',
+            monitoringName: 'API',
+            monitoringTarget: 'https://example.test',
+            occurredAt: now()
+        );
+
+        $wasDelivered = resolve(NotificationRouter::class)->dispatch($user, $notificationPayload, ['mobile_push']);
+
+        $this->assertFalse($wasDelivered);
+        $this->assertDatabaseHas('mobile_push_devices', [
+            'id' => $staleDevice->id,
+            'enabled' => false,
+        ]);
+        $this->assertNotNull($staleDevice->fresh()->revoked_at);
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'channel' => 'mobile_push',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::FAILED->value,
+        ]);
+    }
+
     public function test_router_sends_to_apns_mobile_push_devices(): void
     {
         $privateKey = $this->test_ec_private_key();

--- a/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
+++ b/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
@@ -12,7 +12,9 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use RuntimeException;
 use Tests\TestCase;
 
 class SendServerInstanceHealthAlertsCommandTest extends TestCase
@@ -150,6 +152,35 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
         $this->assertSame('never_seen', $lateInstance->fresh()->last_health_alert_status);
     }
 
+    public function test_never_seen_alert_uses_minimum_one_minute_grace_period(): void
+    {
+        config(['monitoring.instance_never_seen_alert_after_minutes' => 0]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'scanner-minimum-grace-1',
+            'ip_address' => '192.0.2.48',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => null,
+        ]);
+        $serverInstance->forceFill([
+            'created_at' => Date::now()->subMinutes(2),
+            'updated_at' => Date::now()->subMinutes(2),
+        ])->saveQuietly();
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertSent(ServerInstanceHealthAlertMail::class, function (ServerInstanceHealthAlertMail $serverInstanceHealthAlertMail) use ($admin, $serverInstance): bool {
+            return $serverInstanceHealthAlertMail->hasTo($admin->email)
+                && $serverInstanceHealthAlertMail->serverInstance->is($serverInstance)
+                && $serverInstanceHealthAlertMail->healthStatus === 'never_seen';
+        });
+    }
+
     public function test_does_not_repeat_same_never_seen_alert(): void
     {
         config(['monitoring.instance_never_seen_alert_after_minutes' => 15]);
@@ -211,6 +242,91 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
         $serverInstance->refresh();
         $this->assertSame('healthy', $serverInstance->last_health_alert_status);
         $this->assertSame(Date::now()->toDateTimeString(), $serverInstance->last_health_alerted_at?->toDateTimeString());
+    }
+
+    public function test_healthy_instance_without_previous_problem_does_not_alert(): void
+    {
+        config(['monitoring.instance_stale_after_minutes' => 10]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        User::factory()->create(['role' => UserRole::ADMIN]);
+        ServerInstance::query()->create([
+            'code' => 'scanner-already-healthy-1',
+            'ip_address' => '192.0.2.49',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subMinute(),
+            'last_health_alert_status' => 'healthy',
+            'last_health_alerted_at' => Date::now()->subHour(),
+        ]);
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_blank_admin_email_is_skipped_without_blocking_alert_state_update(): void
+    {
+        config(['monitoring.instance_stale_after_minutes' => 10]);
+        Date::setTestNow('2026-06-11 10:00:00');
+        Mail::fake();
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $admin->forceFill(['email' => ''])->saveQuietly();
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'scanner-blank-admin-email-1',
+            'ip_address' => '192.0.2.50',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subMinutes(15),
+        ]);
+
+        Artisan::call('notifications:send-server-instance-health-alerts');
+
+        Mail::assertNothingSent();
+        $this->assertSame('stale', $serverInstance->fresh()->last_health_alert_status);
+    }
+
+    public function test_mail_delivery_failures_are_logged_without_stopping_command(): void
+    {
+        config(['monitoring.instance_stale_after_minutes' => 10]);
+        Date::setTestNow('2026-06-11 10:00:00');
+
+        Package::factory()->create();
+        $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'scanner-mail-failure-1',
+            'ip_address' => '192.0.2.51',
+            'api_key_hash' => 'valid-instance-key',
+            'is_active' => true,
+            'last_seen_at' => Date::now()->subMinutes(15),
+        ]);
+
+        Mail::shouldReceive('to')
+            ->once()
+            ->with($admin->email)
+            ->andReturn(new class
+            {
+                public function send(mixed $mailable): void
+                {
+                    throw new RuntimeException('SMTP unavailable');
+                }
+            });
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Failed to send server instance health alert.', \Mockery::on(function (array $context) use ($admin, $serverInstance): bool {
+                return $context['server_instance_id'] === $serverInstance->id
+                    && $context['server_instance_code'] === $serverInstance->code
+                    && $context['health_status'] === 'stale'
+                    && $context['admin_id'] === $admin->id
+                    && $context['exception'] === 'SMTP unavailable';
+            }));
+
+        $this->assertSame(0, Artisan::call('notifications:send-server-instance-health-alerts'));
+        $this->assertSame('stale', $serverInstance->fresh()->last_health_alert_status);
     }
 
     public function test_inactive_instances_do_not_alert(): void

--- a/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
+++ b/tests/Feature/Notifications/SendServerInstanceHealthAlertsCommandTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use Mockery;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -317,7 +318,7 @@ class SendServerInstanceHealthAlertsCommandTest extends TestCase
             });
         Log::shouldReceive('error')
             ->once()
-            ->with('Failed to send server instance health alert.', \Mockery::on(function (array $context) use ($admin, $serverInstance): bool {
+            ->with('Failed to send server instance health alert.', Mockery::on(function (array $context) use ($admin, $serverInstance): bool {
                 return $context['server_instance_id'] === $serverInstance->id
                     && $context['server_instance_code'] === $serverInstance->code
                     && $context['health_status'] === 'stale'

--- a/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
+++ b/tests/Feature/Notifications/SendUnreadNotificationsReminderCommandTest.php
@@ -245,6 +245,32 @@ class SendUnreadNotificationsReminderCommandTest extends TestCase
         }
     }
 
+    public function test_unread_reminder_skips_user_with_blank_email(): void
+    {
+        Package::factory()->create();
+
+        $user = User::factory()->create([
+            'unread_notifications_reminder_enabled' => true,
+            'unread_notifications_reminder_frequency' => 'daily',
+        ]);
+        $user->forceFill(['email' => ''])->saveQuietly();
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'DOWN',
+            'read' => false,
+            'sent' => true,
+        ]);
+
+        Mail::fake();
+
+        Artisan::call('notifications:remind-unread-weekly');
+
+        Mail::assertNothingSent();
+    }
+
     public function test_weekly_and_monthly_reminders_are_sent_when_due(): void
     {
         Date::setTestNow('2026-06-01 08:00:00');

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -277,9 +277,9 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
 
             Artisan::call('notifications:send-weekly-monitoring-digest');
 
-            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $mail): bool => $mail->hasTo($dailyUser->email));
-            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $mail): bool => $mail->hasTo($monthlyUser->email));
-            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $mail): bool => $mail->hasTo($weeklyDefaultUser->email));
+            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail): bool => $weeklyMonitoringDigestMail->hasTo($dailyUser->email));
+            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail): bool => $weeklyMonitoringDigestMail->hasTo($monthlyUser->email));
+            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $weeklyMonitoringDigestMail): bool => $weeklyMonitoringDigestMail->hasTo($weeklyDefaultUser->email));
         } finally {
             Date::setTestNow();
         }

--- a/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
+++ b/tests/Feature/Notifications/SendWeeklyMonitoringDigestCommandTest.php
@@ -250,6 +250,63 @@ class SendWeeklyMonitoringDigestCommandTest extends TestCase
         });
     }
 
+    public function test_weekly_digest_respects_daily_and_monthly_due_dates(): void
+    {
+        Date::setTestNow('2026-06-01 09:00:00');
+
+        try {
+            Package::factory()->create();
+            $dailyUser = User::factory()->create([
+                'monitoring_digest_enabled' => true,
+                'monitoring_digest_frequency' => 'daily',
+            ]);
+            $monthlyUser = User::factory()->create([
+                'monitoring_digest_enabled' => true,
+                'monitoring_digest_frequency' => 'monthly',
+            ]);
+            $weeklyDefaultUser = User::factory()->create([
+                'monitoring_digest_enabled' => true,
+                'monitoring_digest_frequency' => '',
+            ]);
+
+            foreach ([$dailyUser, $monthlyUser, $weeklyDefaultUser] as $user) {
+                Monitoring::factory()->for($user)->create();
+            }
+
+            Mail::fake();
+
+            Artisan::call('notifications:send-weekly-monitoring-digest');
+
+            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $mail): bool => $mail->hasTo($dailyUser->email));
+            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $mail): bool => $mail->hasTo($monthlyUser->email));
+            Mail::assertSent(WeeklyMonitoringDigestMail::class, fn (WeeklyMonitoringDigestMail $mail): bool => $mail->hasTo($weeklyDefaultUser->email));
+        } finally {
+            Date::setTestNow();
+        }
+    }
+
+    public function test_weekly_digest_skips_monthly_frequency_when_not_first_day(): void
+    {
+        Date::setTestNow('2026-06-02 09:00:00');
+
+        try {
+            Package::factory()->create();
+            $monthlyUser = User::factory()->create([
+                'monitoring_digest_enabled' => true,
+                'monitoring_digest_frequency' => 'monthly',
+            ]);
+            Monitoring::factory()->for($monthlyUser)->create();
+
+            Mail::fake();
+
+            Artisan::call('notifications:send-weekly-monitoring-digest');
+
+            Mail::assertNothingSent();
+        } finally {
+            Date::setTestNow();
+        }
+    }
+
     public function test_does_not_send_weekly_digest_to_users_without_active_monitorings(): void
     {
         Date::setTestNow('2026-04-20 09:00:00');

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Enums\IncidentUpdateStatus;
+use App\Enums\StatusPageComponentSource;
 use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringGroup;
@@ -91,6 +92,107 @@ class StatusPageManagementTest extends TestCase
             'monitoring_id' => $apiMonitoring->id,
             'position' => 0,
         ]);
+    }
+
+    public function test_user_can_list_show_edit_update_and_delete_status_page(): void
+    {
+        Date::setTestNow('2026-06-27 10:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
+        $group = MonitoringGroup::factory()->for($user)->create(['name' => 'Core Group']);
+        $group->monitorings()->attach($monitoring->id);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Old Status',
+            'slug' => 'old-status',
+            'description' => 'Old description',
+            'is_public' => true,
+        ]);
+        $component = $statusPage->components()->create([
+            'name' => 'Core',
+            'position' => 0,
+            'source_type' => StatusPageComponentSource::MONITORING_GROUP,
+            'monitoring_group_id' => $group->id,
+        ]);
+        $component->monitorings()->attach($monitoring->id, ['position' => 0]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subDay(),
+            'up_at' => Date::now()->subHours(23),
+        ]);
+
+        $this->actingAs($user)->get(route('status-pages.index'))
+            ->assertOk()
+            ->assertSeeText('Old Status');
+
+        $this->actingAs($user)->get(route('status-pages.show', $statusPage))
+            ->assertOk()
+            ->assertSeeText('Old Status');
+
+        $this->actingAs($user)->get(route('status-pages.edit', $statusPage))
+            ->assertOk()
+            ->assertSeeText('Old Status')
+            ->assertSeeText('Primary API');
+
+        $this->actingAs($user)->put(route('status-pages.update', $statusPage), [
+            'name' => 'Updated Status',
+            'slug' => 'updated-status',
+            'description' => 'Updated description',
+            'is_public' => '0',
+            'components' => [
+                [
+                    'name' => 'Updated API',
+                    'source_type' => StatusPageComponentSource::MANUAL->value,
+                    'monitoring_ids' => [$monitoring->id],
+                ],
+                [
+                    'name' => 'Updated Group',
+                    'source_type' => StatusPageComponentSource::MONITORING_GROUP->value,
+                    'monitoring_group_id' => $group->id,
+                ],
+            ],
+        ])->assertRedirect(route('status-pages.show', $statusPage))
+            ->assertSessionHas('success', __('status_page.messages.updated'));
+
+        $this->assertDatabaseHas('status_pages', [
+            'id' => $statusPage->id,
+            'name' => 'Updated Status',
+            'slug' => 'updated-status',
+            'is_public' => false,
+        ]);
+        $this->assertDatabaseHas('status_page_components', [
+            'status_page_id' => $statusPage->id,
+            'name' => 'Updated Group',
+            'source_type' => StatusPageComponentSource::MONITORING_GROUP->value,
+            'monitoring_group_id' => $group->id,
+        ]);
+
+        $this->actingAs($user)->delete(route('status-pages.destroy', $statusPage))
+            ->assertRedirect(route('status-pages.index'))
+            ->assertSessionHas('success', __('status_page.messages.deleted'));
+
+        $this->assertDatabaseMissing('status_pages', ['id' => $statusPage->id]);
+    }
+
+    public function test_demo_user_cannot_open_mutating_status_page_screens(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $demoUser = User::factory()->create([
+            'package_id' => $package->id,
+            'role' => \App\Enums\UserRole::DEMO,
+        ]);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $demoUser->id,
+            'name' => 'Demo Status',
+            'slug' => 'demo-status',
+            'is_public' => true,
+        ]);
+
+        $this->actingAs($demoUser)->get(route('status-pages.create'))->assertForbidden();
+        $this->actingAs($demoUser)->get(route('status-pages.edit', $statusPage))->assertForbidden();
+        $this->actingAs($demoUser)->delete(route('status-pages.destroy', $statusPage))->assertForbidden();
     }
 
     public function test_status_page_group_components_cannot_reference_another_users_groups(): void

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use App\Enums\IncidentUpdateStatus;
 use App\Enums\StatusPageComponentSource;
+use App\Enums\UserRole;
 use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringGroup;
@@ -110,13 +111,13 @@ class StatusPageManagementTest extends TestCase
             'description' => 'Old description',
             'is_public' => true,
         ]);
-        $component = $statusPage->components()->create([
+        $statusPageComponent = $statusPage->components()->create([
             'name' => 'Core',
             'position' => 0,
             'source_type' => StatusPageComponentSource::MONITORING_GROUP,
             'monitoring_group_id' => $group->id,
         ]);
-        $component->monitorings()->attach($monitoring->id, ['position' => 0]);
+        $statusPageComponent->monitorings()->attach($monitoring->id, ['position' => 0]);
         Incident::query()->create([
             'monitoring_id' => $monitoring->id,
             'down_at' => Date::now()->subDay(),
@@ -181,7 +182,7 @@ class StatusPageManagementTest extends TestCase
         $package = Package::factory()->create(['monitoring_limit' => 10]);
         $demoUser = User::factory()->create([
             'package_id' => $package->id,
-            'role' => \App\Enums\UserRole::DEMO,
+            'role' => UserRole::DEMO,
         ]);
         $statusPage = StatusPage::query()->create([
             'user_id' => $demoUser->id,

--- a/tests/Feature/TeamControllerCoverageTest.php
+++ b/tests/Feature/TeamControllerCoverageTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\TeamRole;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeamControllerCoverageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_team_pages_render_index_create_show_and_edit(): void
+    {
+        $admin = User::factory()->create();
+        $team = Team::factory()->create([
+            'name' => 'Coverage Team',
+            'created_by_user_id' => $admin->id,
+        ]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'pending@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'pending-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $this->actingAs($admin)->get(route('teams.index'))
+            ->assertOk()
+            ->assertSeeText('Coverage Team');
+        $this->actingAs($admin)->get(route('teams.create'))->assertOk();
+        $this->actingAs($admin)->get(route('teams.show', $team))
+            ->assertOk()
+            ->assertSeeText('pending@example.com');
+        $this->actingAs($admin)->get(route('teams.edit', $team))
+            ->assertOk()
+            ->assertSeeText('Coverage Team');
+
+        $member = User::factory()->create();
+        $membership = $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+        $this->actingAs($admin)->patch(route('teams.members.update', [$team, $membership]), [
+            'role' => TeamRole::ADMIN->value,
+        ])->assertRedirect();
+        $this->actingAs($admin)->delete(route('teams.members.destroy', [$team, $membership]))
+            ->assertRedirect();
+        $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+        $this->actingAs($member)->delete(route('teams.leave', $team))
+            ->assertRedirect(route('teams.index'));
+    }
+
+    public function test_team_update_destroy_and_invitation_accept_controller_paths(): void
+    {
+        $admin = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $team = Team::factory()->create([
+            'name' => 'Old Name',
+            'created_by_user_id' => $admin->id,
+        ]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+
+        $this->actingAs($admin)->patch(route('teams.update', $team), [
+            'name' => 'New Name',
+            'description' => 'Updated',
+        ])->assertRedirect(route('teams.show', $team));
+        $this->assertDatabaseHas('teams', ['id' => $team->id, 'name' => 'New Name']);
+
+        TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'accept-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $this->app['auth']->guard()->logout();
+
+        $this->get(route('team-invitations.accept', 'accept-token'))
+            ->assertRedirect(route('login'))
+            ->assertSessionHas('status', __('team.messages.login_to_accept'));
+
+        $this->actingAs($invitedUser)->get(route('team-invitations.accept', 'accept-token'))
+            ->assertRedirect(route('teams.show', $team));
+        $this->assertDatabaseHas('team_memberships', [
+            'team_id' => $team->id,
+            'user_id' => $invitedUser->id,
+        ]);
+
+        $this->actingAs($admin)->delete(route('teams.destroy', $team))
+            ->assertRedirect(route('teams.index'));
+        $this->assertDatabaseMissing('teams', ['id' => $team->id]);
+    }
+
+    public function test_invitation_accept_redirects_new_users_to_prefilled_registration(): void
+    {
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        TeamInvitation::query()->create([
+            'team_id' => $team->id,
+            'email' => 'new-person@example.com',
+            'role' => TeamRole::MEMBER,
+            'token_hash' => hash('sha256', 'register-token'),
+            'invited_by_user_id' => $admin->id,
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $this->get(route('team-invitations.accept', 'register-token'))
+            ->assertRedirect(route('register', ['mode' => 'register', 'email' => 'new-person@example.com']));
+    }
+}

--- a/tests/Feature/TeamControllerCoverageTest.php
+++ b/tests/Feature/TeamControllerCoverageTest.php
@@ -9,6 +9,7 @@ use App\Models\Package;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use Illuminate\Contracts\Auth\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -88,7 +89,7 @@ class TeamControllerCoverageTest extends TestCase
             'expires_at' => now()->addDay(),
         ]);
 
-        $this->app['auth']->guard()->logout();
+        $this->app->make(Factory::class)->guard()->logout();
 
         $this->get(route('team-invitations.accept', 'accept-token'))
             ->assertRedirect(route('login'))

--- a/tests/Feature/UserObserverTest.php
+++ b/tests/Feature/UserObserverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\User;
+use Exception;
+use Tests\TestCase;
+
+class UserObserverTest extends TestCase
+{
+    public function test_user_observer_assigns_cheapest_selectable_package(): void
+    {
+        $expensivePackage = Package::factory()->create([
+            'monitoring_limit' => 10,
+            'price' => 10,
+            'is_selectable' => true,
+        ]);
+        $cheapestPackage = Package::factory()->create([
+            'monitoring_limit' => 5,
+            'price' => 0,
+            'is_selectable' => true,
+        ]);
+
+        $user = User::factory()->create(['package_id' => null]);
+
+        $this->assertSame($cheapestPackage->id, $user->package_id);
+        $this->assertNotSame($expensivePackage->id, $user->package_id);
+    }
+
+    public function test_user_observer_falls_back_to_first_package_when_none_are_selectable(): void
+    {
+        $fallbackPackage = Package::factory()->create([
+            'price' => 99,
+            'is_selectable' => false,
+        ]);
+
+        $user = User::factory()->create(['package_id' => null]);
+
+        $this->assertSame($fallbackPackage->id, $user->package_id);
+    }
+
+    public function test_user_observer_throws_when_no_package_exists(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No packages available to assign to new user.');
+
+        User::factory()->create(['package_id' => null]);
+    }
+}

--- a/tests/Unit/Data/MonitoringPayloadSerializationTest.php
+++ b/tests/Unit/Data/MonitoringPayloadSerializationTest.php
@@ -15,7 +15,7 @@ class MonitoringPayloadSerializationTest extends TestCase
 {
     public function test_incident_payload_serializes_to_api_shape(): void
     {
-        $payload = new MonitoringIncidentPayload(
+        $monitoringIncidentPayload = new MonitoringIncidentPayload(
             downAt: '2026-06-27T08:00:00+00:00',
             upAt: null,
         );
@@ -23,16 +23,16 @@ class MonitoringPayloadSerializationTest extends TestCase
         $this->assertSame([
             'down_at' => '2026-06-27T08:00:00+00:00',
             'up_at' => null,
-        ], $payload->toArray());
-        $this->assertSame($payload->toArray(), $payload->jsonSerialize());
+        ], $monitoringIncidentPayload->toArray());
+        $this->assertSame($monitoringIncidentPayload->toArray(), $monitoringIncidentPayload->jsonSerialize());
     }
 
     public function test_uptime_calendar_payload_serializes_nested_months_and_days(): void
     {
-        $day = new MonitoringUptimeCalendarDayPayload('2026-06-27', 99.95);
-        $month = new MonitoringUptimeCalendarMonthPayload(new Collection([$day]), 99.95);
-        $payload = new MonitoringUptimeCalendarPayload(new Collection([
-            '2026-06' => $month,
+        $monitoringUptimeCalendarDayPayload = new MonitoringUptimeCalendarDayPayload('2026-06-27', 99.95);
+        $monitoringUptimeCalendarMonthPayload = new MonitoringUptimeCalendarMonthPayload(new Collection([$monitoringUptimeCalendarDayPayload]), 99.95);
+        $monitoringUptimeCalendarPayload = new MonitoringUptimeCalendarPayload(new Collection([
+            '2026-06' => $monitoringUptimeCalendarMonthPayload,
         ]));
 
         $expected = [
@@ -50,10 +50,10 @@ class MonitoringPayloadSerializationTest extends TestCase
         $this->assertSame([
             'date' => '2026-06-27',
             'uptime_percentage' => 99.95,
-        ], $day->toArray());
-        $this->assertSame($day->toArray(), $day->jsonSerialize());
-        $this->assertSame($expected['2026-06'], $month->jsonSerialize());
-        $this->assertSame($expected, $payload->toArray());
-        $this->assertSame($expected, $payload->jsonSerialize());
+        ], $monitoringUptimeCalendarDayPayload->toArray());
+        $this->assertSame($monitoringUptimeCalendarDayPayload->toArray(), $monitoringUptimeCalendarDayPayload->jsonSerialize());
+        $this->assertSame($expected['2026-06'], $monitoringUptimeCalendarMonthPayload->jsonSerialize());
+        $this->assertSame($expected, $monitoringUptimeCalendarPayload->toArray());
+        $this->assertSame($expected, $monitoringUptimeCalendarPayload->jsonSerialize());
     }
 }

--- a/tests/Unit/Data/MonitoringPayloadSerializationTest.php
+++ b/tests/Unit/Data/MonitoringPayloadSerializationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Data;
+
+use App\Data\MonitoringIncidentPayload;
+use App\Data\MonitoringUptimeCalendarDayPayload;
+use App\Data\MonitoringUptimeCalendarMonthPayload;
+use App\Data\MonitoringUptimeCalendarPayload;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class MonitoringPayloadSerializationTest extends TestCase
+{
+    public function test_incident_payload_serializes_to_api_shape(): void
+    {
+        $payload = new MonitoringIncidentPayload(
+            downAt: '2026-06-27T08:00:00+00:00',
+            upAt: null,
+        );
+
+        $this->assertSame([
+            'down_at' => '2026-06-27T08:00:00+00:00',
+            'up_at' => null,
+        ], $payload->toArray());
+        $this->assertSame($payload->toArray(), $payload->jsonSerialize());
+    }
+
+    public function test_uptime_calendar_payload_serializes_nested_months_and_days(): void
+    {
+        $day = new MonitoringUptimeCalendarDayPayload('2026-06-27', 99.95);
+        $month = new MonitoringUptimeCalendarMonthPayload(new Collection([$day]), 99.95);
+        $payload = new MonitoringUptimeCalendarPayload(new Collection([
+            '2026-06' => $month,
+        ]));
+
+        $expected = [
+            '2026-06' => [
+                'days' => [
+                    [
+                        'date' => '2026-06-27',
+                        'uptime_percentage' => 99.95,
+                    ],
+                ],
+                'monthly_average_uptime' => 99.95,
+            ],
+        ];
+
+        $this->assertSame([
+            'date' => '2026-06-27',
+            'uptime_percentage' => 99.95,
+        ], $day->toArray());
+        $this->assertSame($day->toArray(), $day->jsonSerialize());
+        $this->assertSame($expected['2026-06'], $month->jsonSerialize());
+        $this->assertSame($expected, $payload->toArray());
+        $this->assertSame($expected, $payload->jsonSerialize());
+    }
+}

--- a/tests/Unit/Enums/EnumHelperTest.php
+++ b/tests/Unit/Enums/EnumHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\NotificationEventType;
+use App\Enums\StatusPageComponentSource;
+use App\Enums\SupportedLanguage;
+use Tests\TestCase;
+
+class EnumHelperTest extends TestCase
+{
+    public function test_notification_event_type_values_return_all_wire_values(): void
+    {
+        $this->assertSame([
+            'incident',
+            'recovery',
+            'ssl_expiring',
+            'ssl_expired',
+            'domain_expiring',
+            'domain_expired',
+        ], NotificationEventType::values());
+    }
+
+    public function test_status_page_component_source_values_return_all_wire_values(): void
+    {
+        $this->assertSame([
+            'manual',
+            'monitoring_group',
+        ], StatusPageComponentSource::values());
+    }
+
+    public function test_supported_language_helpers_expose_labels_and_cookie_contract(): void
+    {
+        $this->assertSame(['en', 'de'], SupportedLanguage::values());
+        $this->assertSame(SupportedLanguage::EN, SupportedLanguage::default());
+        $this->assertSame([
+            'en' => 'English',
+            'de' => 'Deutsch',
+        ], SupportedLanguage::toArray());
+        $this->assertTrue(SupportedLanguage::isSupported('en'));
+        $this->assertFalse(SupportedLanguage::isSupported(null));
+        $this->assertFalse(SupportedLanguage::isSupported('fr'));
+        $this->assertSame('webguard_locale', SupportedLanguage::cookieName());
+        $this->assertSame(525600, SupportedLanguage::cookieDurationMinutes());
+    }
+}

--- a/tests/Unit/Http/Requests/AdminRequestRulesTest.php
+++ b/tests/Unit/Http/Requests/AdminRequestRulesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http\Requests;
+
+use App\Enums\UserRole;
+use App\Http\Requests\StorePackageRequest;
+use App\Http\Requests\StoreUserRequest;
+use App\Http\Requests\UpdatePackageRequest;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rules\Enum;
+use Tests\TestCase;
+
+class AdminRequestRulesTest extends TestCase
+{
+    public function test_package_requests_share_admin_authorization_and_rules(): void
+    {
+        Auth::shouldReceive('user')
+            ->twice()
+            ->andReturn(new User(['role' => UserRole::ADMIN]));
+
+        foreach ([new StorePackageRequest(), new UpdatePackageRequest()] as $request) {
+            $this->assertTrue($request->authorize());
+            $this->assertSame([
+                'monitoring_limit' => ['required', 'integer', 'min:1'],
+                'price' => ['required', 'numeric', 'min:0'],
+                'is_selectable' => ['boolean'],
+            ], $request->rules());
+        }
+    }
+
+    public function test_store_user_request_requires_admin_and_user_fields(): void
+    {
+        Auth::shouldReceive('user')
+            ->once()
+            ->andReturn(new User(['role' => UserRole::ADMIN]));
+
+        $request = new StoreUserRequest();
+        $rules = $request->rules();
+
+        $this->assertTrue($request->authorize());
+        $this->assertSame(['required', 'string', 'max:255'], $rules['name']);
+        $this->assertSame(['required', 'string', 'email', 'max:255', 'unique:' . User::class], $rules['email']);
+        $this->assertSame(['required', 'string', 'min:8'], $rules['password']);
+        $this->assertSame('required', $rules['role'][0]);
+        $this->assertInstanceOf(Enum::class, $rules['role'][1]);
+    }
+}

--- a/tests/Unit/Http/Requests/AdminRequestRulesTest.php
+++ b/tests/Unit/Http/Requests/AdminRequestRulesTest.php
@@ -37,10 +37,10 @@ class AdminRequestRulesTest extends TestCase
             ->once()
             ->andReturn(new User(['role' => UserRole::ADMIN]));
 
-        $request = new StoreUserRequest();
-        $rules = $request->rules();
+        $storeUserRequest = new StoreUserRequest();
+        $rules = $storeUserRequest->rules();
 
-        $this->assertTrue($request->authorize());
+        $this->assertTrue($storeUserRequest->authorize());
         $this->assertSame(['required', 'string', 'max:255'], $rules['name']);
         $this->assertSame(['required', 'string', 'email', 'max:255', 'unique:' . User::class], $rules['email']);
         $this->assertSame(['required', 'string', 'min:8'], $rules['password']);

--- a/tests/Unit/Http/Requests/MonitoringApiRequestAuthorizationTest.php
+++ b/tests/Unit/Http/Requests/MonitoringApiRequestAuthorizationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http\Requests;
+
+use App\Http\Requests\Api\MonitoringApiRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonitoringApiRequestAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authorization_allows_routes_without_monitoring_model(): void
+    {
+        $request = new class extends MonitoringApiRequest
+        {
+            public function rules(): array
+            {
+                return [];
+            }
+        };
+        $request->setRouteResolver(fn (): object => new class
+        {
+            public function parameter(string $name, mixed $default = null): mixed
+            {
+                return $default;
+            }
+        });
+
+        $this->assertTrue($request->authorize());
+    }
+}

--- a/tests/Unit/Models/MonitoringNotificationBehaviorTest.php
+++ b/tests/Unit/Models/MonitoringNotificationBehaviorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Enums\NotificationType;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonitoringNotificationBehaviorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_status_identifier_keys_relations_scopes_and_translated_messages(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Public API']);
+        $downNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is DOWN',
+            'read' => true,
+            'sent' => true,
+        ]);
+        $unknownNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Status changed',
+            'read' => false,
+            'sent' => false,
+        ]);
+        $sslNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'SSL_EXPIRED',
+            'read' => false,
+            'sent' => false,
+        ]);
+        $domainNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::DOMAIN_EXPIRY,
+            'message' => 'DOMAIN_EXPIRING',
+            'read' => false,
+            'sent' => false,
+        ]);
+        $genericNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::SSL_EXPIRY,
+            'message' => 'Plain message',
+            'read' => true,
+            'sent' => false,
+        ]);
+
+        $this->assertSame('unknown', MonitoringNotification::extractStatusChangeIdentifierFromMessage('no signal'));
+        $this->assertSame('maintenance', $downNotification->statusChangeIdentifier(true));
+        $this->assertSame('notifications.status_change.down', $downNotification->statusChangeKey());
+        $this->assertTrue($downNotification->monitoring->is($monitoring));
+        $this->assertGreaterThan(0, $downNotification->states()->count());
+        $this->assertSame(__('notifications.status_messages.down', ['name' => 'Public API']), $downNotification->translated_message);
+        $this->assertSame('Status changed', $unknownNotification->translated_message);
+        $this->assertSame(__('notifications.ssl_messages.expired', ['name' => 'Public API']), $sslNotification->translated_message);
+        $this->assertSame(__('notifications.domain_messages.expiring', ['name' => 'Public API']), $domainNotification->translated_message);
+        $this->assertSame('Plain message', $genericNotification->translated_message);
+        $this->assertNotSame('', $downNotification->created_at_for_humans);
+        $this->assertSame(2, MonitoringNotification::query()->withoutGlobalScopes()->read()->count());
+        $this->assertSame(3, MonitoringNotification::query()->withoutGlobalScopes()->unread()->count());
+        $this->assertSame(2, MonitoringNotification::query()->withoutGlobalScopes()->statusChange()->count());
+        $this->assertSame(2, MonitoringNotification::query()->withoutGlobalScopes()->sslExpiry()->count());
+        $this->assertSame(1, MonitoringNotification::query()->withoutGlobalScopes()->domainExpiry()->count());
+
+        $this->actingAs($user);
+        $this->assertSame(2, MonitoringNotification::query()->withoutGlobalScopes()->read()->count());
+        $this->assertSame(3, MonitoringNotification::query()->withoutGlobalScopes()->unread()->count());
+    }
+
+    public function test_created_notification_state_is_created_for_each_team_member(): void
+    {
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => 'admin']);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => 'member']);
+        $monitoring = Monitoring::factory()->create(['user_id' => null, 'team_id' => $team->id]);
+
+        $notification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is up',
+            'read' => true,
+            'sent' => true,
+        ]);
+
+        $this->assertDatabaseHas('monitoring_notification_states', [
+            'monitoring_notification_id' => $notification->id,
+            'user_id' => $admin->id,
+        ]);
+        $this->assertDatabaseHas('monitoring_notification_states', [
+            'monitoring_notification_id' => $notification->id,
+            'user_id' => $member->id,
+        ]);
+    }
+}

--- a/tests/Unit/Models/MonitoringNotificationBehaviorTest.php
+++ b/tests/Unit/Models/MonitoringNotificationBehaviorTest.php
@@ -28,7 +28,7 @@ class MonitoringNotificationBehaviorTest extends TestCase
     {
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Public API']);
-        $downNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+        $monitoringNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is DOWN',
@@ -65,16 +65,16 @@ class MonitoringNotificationBehaviorTest extends TestCase
         ]);
 
         $this->assertSame('unknown', MonitoringNotification::extractStatusChangeIdentifierFromMessage('no signal'));
-        $this->assertSame('maintenance', $downNotification->statusChangeIdentifier(true));
-        $this->assertSame('notifications.status_change.down', $downNotification->statusChangeKey());
-        $this->assertTrue($downNotification->monitoring->is($monitoring));
-        $this->assertGreaterThan(0, $downNotification->states()->count());
-        $this->assertSame(__('notifications.status_messages.down', ['name' => 'Public API']), $downNotification->translated_message);
+        $this->assertSame('maintenance', $monitoringNotification->statusChangeIdentifier(true));
+        $this->assertSame('notifications.status_change.down', $monitoringNotification->statusChangeKey());
+        $this->assertTrue($monitoringNotification->monitoring->is($monitoring));
+        $this->assertGreaterThan(0, $monitoringNotification->states()->count());
+        $this->assertSame(__('notifications.status_messages.down', ['name' => 'Public API']), $monitoringNotification->translated_message);
         $this->assertSame('Status changed', $unknownNotification->translated_message);
         $this->assertSame(__('notifications.ssl_messages.expired', ['name' => 'Public API']), $sslNotification->translated_message);
         $this->assertSame(__('notifications.domain_messages.expiring', ['name' => 'Public API']), $domainNotification->translated_message);
         $this->assertSame('Plain message', $genericNotification->translated_message);
-        $this->assertNotSame('', $downNotification->created_at_for_humans);
+        $this->assertNotSame('', $monitoringNotification->created_at_for_humans);
         $this->assertSame(2, MonitoringNotification::query()->withoutGlobalScopes()->read()->count());
         $this->assertSame(3, MonitoringNotification::query()->withoutGlobalScopes()->unread()->count());
         $this->assertSame(2, MonitoringNotification::query()->withoutGlobalScopes()->statusChange()->count());
@@ -95,7 +95,7 @@ class MonitoringNotificationBehaviorTest extends TestCase
         $team->memberships()->create(['user_id' => $member->id, 'role' => 'member']);
         $monitoring = Monitoring::factory()->create(['user_id' => null, 'team_id' => $team->id]);
 
-        $notification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+        $monitoringNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is up',
@@ -104,11 +104,11 @@ class MonitoringNotificationBehaviorTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('monitoring_notification_states', [
-            'monitoring_notification_id' => $notification->id,
+            'monitoring_notification_id' => $monitoringNotification->id,
             'user_id' => $admin->id,
         ]);
         $this->assertDatabaseHas('monitoring_notification_states', [
-            'monitoring_notification_id' => $notification->id,
+            'monitoring_notification_id' => $monitoringNotification->id,
             'user_id' => $member->id,
         ]);
     }

--- a/tests/Unit/Services/FcmClientTest.php
+++ b/tests/Unit/Services/FcmClientTest.php
@@ -7,8 +7,8 @@ namespace Tests\Unit\Services;
 use App\Enums\NotificationEventType;
 use App\Services\Notifications\FcmClient;
 use App\Services\Notifications\NotificationPayload;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -48,7 +48,7 @@ class FcmClientTest extends TestCase
             monitoringId: '01TEST',
             monitoringName: 'API',
             monitoringTarget: 'https://example.test',
-            occurredAt: Carbon::parse('2026-06-27 08:00:00', 'UTC'),
+            occurredAt: Date::parse('2026-06-27 08:00:00', 'UTC'),
             meta: ['notification_id' => '01NOTIFICATION'],
         ));
 
@@ -56,7 +56,7 @@ class FcmClientTest extends TestCase
         Http::assertSent(fn ($request): bool => $request->url() === 'https://oauth.example.test/token'
             && data_get($request->data(), 'grant_type') === 'urn:ietf:params:oauth:grant-type:jwt-bearer'
             && is_string(data_get($request->data(), 'assertion'))
-            && substr_count((string) data_get($request->data(), 'assertion'), '.') === 2);
+            && mb_substr_count(data_get($request->data(), 'assertion'), '.') === 2);
         Http::assertSent(fn ($request): bool => $request->url() === 'https://fcm.googleapis.com/v1/projects/webguard-test/messages:send'
             && $request->hasHeader('Authorization', 'Bearer oauth-access-token')
             && data_get($request->data(), 'message.token') === 'fcm-device-token'

--- a/tests/Unit/Services/FcmClientTest.php
+++ b/tests/Unit/Services/FcmClientTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Enums\NotificationEventType;
+use App\Services\Notifications\FcmClient;
+use App\Services\Notifications\NotificationPayload;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FcmClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function test_service_account_json_is_exchanged_for_access_token_before_sending_notification(): void
+    {
+        config([
+            'services.fcm.project_id' => 'webguard-test',
+            'services.fcm.access_token' => '',
+            'services.fcm.service_account_json' => json_encode([
+                'client_email' => 'firebase-admin@example.test',
+                'private_key' => $this->rsaPrivateKey(),
+                'token_uri' => 'https://oauth.example.test/token',
+            ], JSON_THROW_ON_ERROR),
+            'services.fcm.service_account_path' => '',
+            'services.fcm.token_uri' => 'https://oauth.example.test/token',
+        ]);
+
+        Http::fake([
+            'https://oauth.example.test/token' => Http::response(['access_token' => 'oauth-access-token'], 200),
+            'https://fcm.googleapis.com/*' => Http::response(['name' => 'projects/webguard-test/messages/789'], 200),
+        ]);
+
+        $response = (new FcmClient())->sendToToken('fcm-device-token', new NotificationPayload(
+            eventType: NotificationEventType::INCIDENT,
+            title: 'Monitoring incident',
+            message: 'Service is down.',
+            severity: 'critical',
+            monitoringId: '01TEST',
+            monitoringName: 'API',
+            monitoringTarget: 'https://example.test',
+            occurredAt: Carbon::parse('2026-06-27 08:00:00', 'UTC'),
+            meta: ['notification_id' => '01NOTIFICATION'],
+        ));
+
+        $this->assertSame(['name' => 'projects/webguard-test/messages/789'], $response);
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://oauth.example.test/token'
+            && data_get($request->data(), 'grant_type') === 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+            && is_string(data_get($request->data(), 'assertion'))
+            && substr_count((string) data_get($request->data(), 'assertion'), '.') === 2);
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://fcm.googleapis.com/v1/projects/webguard-test/messages:send'
+            && $request->hasHeader('Authorization', 'Bearer oauth-access-token')
+            && data_get($request->data(), 'message.token') === 'fcm-device-token'
+            && data_get($request->data(), 'message.notification.title') === 'Monitoring incident'
+            && data_get($request->data(), 'message.data.notification_id') === '01NOTIFICATION'
+            && data_get($request->data(), 'message.android.notification.channel_id') === 'monitoring_alerts'
+            && data_get($request->data(), 'message.apns.payload.aps.category') === 'MONITORING_ALERT');
+    }
+
+    private function rsaPrivateKey(): string
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        $privateKey = '';
+        openssl_pkey_export($key, $privateKey);
+
+        return $privateKey;
+    }
+}

--- a/tests/Unit/Services/Teams/TeamServiceEdgeTest.php
+++ b/tests/Unit/Services/Teams/TeamServiceEdgeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Teams;
+
+use App\Enums\NotificationType;
+use App\Enums\TeamRole;
+use App\Mail\TeamInvitationMail;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationPreference;
+use App\Models\MonitoringNotificationState;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Teams\TeamInvitationService;
+use App\Services\Teams\TeamMembershipService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class TeamServiceEdgeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_invite_normalizes_email_replaces_pending_invitation_and_rejects_members(): void
+    {
+        Mail::fake();
+
+        $admin = User::factory()->create();
+        $member = User::factory()->create(['email' => 'member@example.com']);
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+        $service = app(TeamInvitationService::class);
+
+        $firstInvitation = $service->invite($team, $admin, ' New.User@Example.COM ', TeamRole::MEMBER);
+        $secondInvitation = $service->invite($team, $admin, 'new.user@example.com', TeamRole::ADMIN);
+
+        $this->assertDatabaseMissing('team_invitations', ['id' => $firstInvitation->id]);
+        $this->assertSame('new.user@example.com', $secondInvitation->email);
+        $this->assertSame(TeamRole::ADMIN, $secondInvitation->role);
+        Mail::assertSent(TeamInvitationMail::class, 2);
+
+        $this->expectException(ValidationException::class);
+        $service->invite($team, $admin, 'member@example.com', TeamRole::MEMBER);
+    }
+
+    public function test_accept_rejects_email_mismatch_and_accepts_matching_pending_invitation(): void
+    {
+        Mail::fake();
+
+        $admin = User::factory()->create();
+        $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
+        $otherUser = User::factory()->create(['email' => 'other@example.com']);
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $service = app(TeamInvitationService::class);
+        $service->invite($team, $admin, $invitedUser->email, TeamRole::MEMBER);
+        $token = $this->latestInvitationTokenFromMail();
+
+        try {
+            $service->accept($token, $otherUser);
+            $this->fail('Expected an email mismatch validation exception.');
+        } catch (ValidationException $exception) {
+            $this->assertArrayHasKey('email', $exception->errors());
+        }
+
+        $acceptedTeam = $service->accept($token, $invitedUser);
+
+        $this->assertTrue($acceptedTeam->is($team));
+        $this->assertDatabaseHas('team_memberships', [
+            'team_id' => $team->id,
+            'user_id' => $invitedUser->id,
+            'role' => TeamRole::MEMBER->value,
+        ]);
+        $this->assertDatabaseMissing('team_invitations', [
+            'team_id' => $team->id,
+            'accepted_at' => null,
+        ]);
+    }
+
+    public function test_removing_member_deletes_monitoring_preferences_and_notification_states(): void
+    {
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+        $membership = $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
+        $monitoring = Monitoring::factory()->create(['user_id' => null, 'team_id' => $team->id]);
+        $notification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => NotificationType::STATUS_CHANGE,
+            'message' => 'Monitoring is down',
+            'read' => false,
+            'sent' => false,
+        ]);
+        MonitoringNotificationPreference::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'user_id' => $member->id,
+            'notification_on_failure' => true,
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 30,
+        ]);
+        MonitoringNotificationState::query()->where([
+            'monitoring_notification_id' => $notification->id,
+            'user_id' => $member->id,
+        ])->firstOrFail();
+
+        app(TeamMembershipService::class)->remove($membership);
+
+        $this->assertDatabaseMissing('team_memberships', ['id' => $membership->id]);
+        $this->assertDatabaseMissing('monitoring_notification_preferences', [
+            'monitoring_id' => $monitoring->id,
+            'user_id' => $member->id,
+        ]);
+        $this->assertDatabaseMissing('monitoring_notification_states', [
+            'monitoring_notification_id' => $notification->id,
+            'user_id' => $member->id,
+        ]);
+    }
+
+    private function latestInvitationTokenFromMail(): string
+    {
+        $mail = Mail::sent(TeamInvitationMail::class)->last();
+
+        $acceptUrl = $mail->content()->with['acceptUrl'];
+        $segments = explode('/', trim((string) parse_url($acceptUrl, PHP_URL_PATH), '/'));
+
+        return $segments[count($segments) - 2];
+    }
+}

--- a/tests/Unit/Services/Teams/TeamServiceEdgeTest.php
+++ b/tests/Unit/Services/Teams/TeamServiceEdgeTest.php
@@ -43,10 +43,10 @@ class TeamServiceEdgeTest extends TestCase
         $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
         $teamInvitationService = resolve(TeamInvitationService::class);
 
-        $firstInvitation = $teamInvitationService->invite($team, $admin, ' New.User@Example.COM ', TeamRole::MEMBER);
+        $teamInvitation = $teamInvitationService->invite($team, $admin, ' New.User@Example.COM ', TeamRole::MEMBER);
         $secondInvitation = $teamInvitationService->invite($team, $admin, 'new.user@example.com', TeamRole::ADMIN);
 
-        $this->assertDatabaseMissing('team_invitations', ['id' => $firstInvitation->id]);
+        $this->assertDatabaseMissing('team_invitations', ['id' => $teamInvitation->id]);
         $this->assertSame('new.user@example.com', $secondInvitation->email);
         $this->assertSame(TeamRole::ADMIN, $secondInvitation->role);
         Mail::assertSent(TeamInvitationMail::class, 2);

--- a/tests/Unit/Services/Teams/TeamServiceEdgeTest.php
+++ b/tests/Unit/Services/Teams/TeamServiceEdgeTest.php
@@ -41,10 +41,10 @@ class TeamServiceEdgeTest extends TestCase
         $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
         $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
         $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
-        $service = app(TeamInvitationService::class);
+        $teamInvitationService = resolve(TeamInvitationService::class);
 
-        $firstInvitation = $service->invite($team, $admin, ' New.User@Example.COM ', TeamRole::MEMBER);
-        $secondInvitation = $service->invite($team, $admin, 'new.user@example.com', TeamRole::ADMIN);
+        $firstInvitation = $teamInvitationService->invite($team, $admin, ' New.User@Example.COM ', TeamRole::MEMBER);
+        $secondInvitation = $teamInvitationService->invite($team, $admin, 'new.user@example.com', TeamRole::ADMIN);
 
         $this->assertDatabaseMissing('team_invitations', ['id' => $firstInvitation->id]);
         $this->assertSame('new.user@example.com', $secondInvitation->email);
@@ -52,7 +52,7 @@ class TeamServiceEdgeTest extends TestCase
         Mail::assertSent(TeamInvitationMail::class, 2);
 
         $this->expectException(ValidationException::class);
-        $service->invite($team, $admin, 'member@example.com', TeamRole::MEMBER);
+        $teamInvitationService->invite($team, $admin, 'member@example.com', TeamRole::MEMBER);
     }
 
     public function test_accept_rejects_email_mismatch_and_accepts_matching_pending_invitation(): void
@@ -64,18 +64,18 @@ class TeamServiceEdgeTest extends TestCase
         $otherUser = User::factory()->create(['email' => 'other@example.com']);
         $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
         $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
-        $service = app(TeamInvitationService::class);
-        $service->invite($team, $admin, $invitedUser->email, TeamRole::MEMBER);
+        $teamInvitationService = resolve(TeamInvitationService::class);
+        $teamInvitationService->invite($team, $admin, $invitedUser->email, TeamRole::MEMBER);
         $token = $this->latestInvitationTokenFromMail();
 
         try {
-            $service->accept($token, $otherUser);
+            $teamInvitationService->accept($token, $otherUser);
             $this->fail('Expected an email mismatch validation exception.');
         } catch (ValidationException $exception) {
             $this->assertArrayHasKey('email', $exception->errors());
         }
 
-        $acceptedTeam = $service->accept($token, $invitedUser);
+        $acceptedTeam = $teamInvitationService->accept($token, $invitedUser);
 
         $this->assertTrue($acceptedTeam->is($team));
         $this->assertDatabaseHas('team_memberships', [
@@ -97,7 +97,7 @@ class TeamServiceEdgeTest extends TestCase
         $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
         $membership = $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::MEMBER]);
         $monitoring = Monitoring::factory()->create(['user_id' => null, 'team_id' => $team->id]);
-        $notification = MonitoringNotification::query()->withoutGlobalScopes()->create([
+        $monitoringNotification = MonitoringNotification::query()->withoutGlobalScopes()->create([
             'monitoring_id' => $monitoring->id,
             'type' => NotificationType::STATUS_CHANGE,
             'message' => 'Monitoring is down',
@@ -112,11 +112,11 @@ class TeamServiceEdgeTest extends TestCase
             'ssl_expiry_warning_days' => 30,
         ]);
         MonitoringNotificationState::query()->where([
-            'monitoring_notification_id' => $notification->id,
+            'monitoring_notification_id' => $monitoringNotification->id,
             'user_id' => $member->id,
         ])->firstOrFail();
 
-        app(TeamMembershipService::class)->remove($membership);
+        resolve(TeamMembershipService::class)->remove($membership);
 
         $this->assertDatabaseMissing('team_memberships', ['id' => $membership->id]);
         $this->assertDatabaseMissing('monitoring_notification_preferences', [
@@ -124,7 +124,7 @@ class TeamServiceEdgeTest extends TestCase
             'user_id' => $member->id,
         ]);
         $this->assertDatabaseMissing('monitoring_notification_states', [
-            'monitoring_notification_id' => $notification->id,
+            'monitoring_notification_id' => $monitoringNotification->id,
             'user_id' => $member->id,
         ]);
     }
@@ -134,7 +134,7 @@ class TeamServiceEdgeTest extends TestCase
         $mail = Mail::sent(TeamInvitationMail::class)->last();
 
         $acceptUrl = $mail->content()->with['acceptUrl'];
-        $segments = explode('/', trim((string) parse_url($acceptUrl, PHP_URL_PATH), '/'));
+        $segments = explode('/', mb_trim((string) parse_url($acceptUrl, PHP_URL_PATH), '/'));
 
         return $segments[count($segments) - 2];
     }

--- a/tests/Unit/Support/DnsRecordExpectationTest.php
+++ b/tests/Unit/Support/DnsRecordExpectationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\DnsRecordExpectation;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class DnsRecordExpectationTest extends TestCase
+{
+    public function test_record_types_and_record_type_normalization(): void
+    {
+        $this->assertSame(['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SOA', 'CAA'], DnsRecordExpectation::recordTypes());
+        $this->assertSame('AAAA', DnsRecordExpectation::normalizeRecordType(' aaaa '));
+        $this->assertNull(DnsRecordExpectation::normalizeRecordType('   '));
+        $this->assertNull(DnsRecordExpectation::normalizeRecordType(['A']));
+    }
+
+    public function test_expected_values_are_parsed_normalized_deduplicated_and_sorted(): void
+    {
+        $this->assertSame([], DnsRecordExpectation::normalizeValues(null, 'TXT'));
+        $this->assertSame([], DnsRecordExpectation::normalizeValues(" \n ", 'TXT'));
+        $this->assertSame(['192.0.2.1', '192.0.2.2'], DnsRecordExpectation::normalizeValues("192.0.2.2\n192.0.2.1\n192.0.2.1", 'A'));
+        $this->assertSame(['2001:db8::1'], DnsRecordExpectation::normalizeValues(['2001:DB8::1'], 'AAAA'));
+        $this->assertSame(['mail.example.com'], DnsRecordExpectation::normalizeValues('MAIL.Example.COM.', 'CNAME'));
+        $this->assertSame(['10 mail.example.com'], DnsRecordExpectation::normalizeValues('010 MAIL.Example.COM.', 'MX'));
+        $this->assertSame(['plain text'], DnsRecordExpectation::normalizeValues('  plain   text  ', 'TXT'));
+        $this->assertSame(['ns.example.com'], DnsRecordExpectation::normalizeValues('["NS.Example.COM."]', 'NS'));
+    }
+
+    public function test_expected_values_reject_invalid_shapes_and_addresses(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DnsRecordExpectation::normalizeValues(['192.0.2.1', ['nested']], 'A');
+    }
+
+    public function test_expected_values_reject_invalid_json(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DnsRecordExpectation::normalizeValues('[not-json', 'TXT');
+    }
+
+    public function test_expected_values_reject_invalid_ip_records(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DnsRecordExpectation::normalizeValues('example.com', 'A');
+    }
+}

--- a/tests/Unit/Support/MonitoringResponseHistoryTest.php
+++ b/tests/Unit/Support/MonitoringResponseHistoryTest.php
@@ -7,7 +7,6 @@ namespace Tests\Unit\Support;
 use App\Models\MonitoringResponse;
 use App\Models\MonitoringResponseArchived;
 use App\Support\MonitoringResponseHistory;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Tests\TestCase;
 
@@ -15,15 +14,15 @@ class MonitoringResponseHistoryTest extends TestCase
 {
     public function test_query_for_end_date_uses_archived_rows_before_recent_window(): void
     {
-        Date::setTestNow(Carbon::parse('2026-06-27 12:00:00'));
+        Date::setTestNow(Date::parse('2026-06-27 12:00:00'));
 
         $this->assertSame(
             MonitoringResponseArchived::class,
-            MonitoringResponseHistory::queryForEndDate(Carbon::parse('2026-06-19 23:59:59'))->getModel()::class
+            MonitoringResponseHistory::queryForEndDate(Date::parse('2026-06-19 23:59:59'))->getModel()::class
         );
         $this->assertSame(
             MonitoringResponse::class,
-            MonitoringResponseHistory::queryForEndDate(Carbon::parse('2026-06-20 00:00:00'))->getModel()::class
+            MonitoringResponseHistory::queryForEndDate(Date::parse('2026-06-20 00:00:00'))->getModel()::class
         );
     }
 

--- a/tests/Unit/Support/MonitoringResponseHistoryTest.php
+++ b/tests/Unit/Support/MonitoringResponseHistoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Models\MonitoringResponse;
+use App\Models\MonitoringResponseArchived;
+use App\Support\MonitoringResponseHistory;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class MonitoringResponseHistoryTest extends TestCase
+{
+    public function test_query_for_end_date_uses_archived_rows_before_recent_window(): void
+    {
+        Date::setTestNow(Carbon::parse('2026-06-27 12:00:00'));
+
+        $this->assertSame(
+            MonitoringResponseArchived::class,
+            MonitoringResponseHistory::queryForEndDate(Carbon::parse('2026-06-19 23:59:59'))->getModel()::class
+        );
+        $this->assertSame(
+            MonitoringResponse::class,
+            MonitoringResponseHistory::queryForEndDate(Carbon::parse('2026-06-20 00:00:00'))->getModel()::class
+        );
+    }
+
+    public function test_grouping_and_sqlite_period_expression_are_stable(): void
+    {
+        $this->assertSame('%Y-%m-%d %H', MonitoringResponseHistory::groupingForDays(1));
+        $this->assertSame('%Y-%m-%d', MonitoringResponseHistory::groupingForDays(30));
+        $this->assertSame('%Y-%m', MonitoringResponseHistory::groupingForDays(31));
+        $this->assertSame("strftime('%Y-%m-%d', checked_at)", MonitoringResponseHistory::periodExpression('checked_at', '%Y-%m-%d'));
+    }
+}


### PR DESCRIPTION
## What changed
- Added focused Pest coverage for the files that were below 80% line/element coverage.
- Covered API monitoring management, internal monitoring callbacks, status page CRUD, admin package/demo monitoring paths, notification commands, model helpers, request rules, mailables, jobs, and related support classes.

## Why
The coverage report showed recently changed areas below the 80% threshold. These tests close those directly related gaps without changing production behavior.

## Testing
- Docker targeted Pest group for the added/updated tests: passed.
- Docker coverage: `XDEBUG_MODE=coverage php artisan test --coverage-clover storage/coverage-clover.xml --min=0` passed.
- Parsed `storage/coverage-clover.xml`: no files below 80%.

## Notes
The Docker coverage run still emits existing `.env` file warnings from the coverage container, but exits successfully and generates the Clover report.