### PR TITLE
docs: establish repository agent governance

### DIFF
--- a/.agent/skills/README.md
+++ b/.agent/skills/README.md
@@ -1,0 +1,19 @@
+# Shared Agent Skills
+
+Read the applicable `AGENTS.md` first. Identify relevant skills, read only those skills, and keep `AGENTS.md` authoritative. If instructions conflict, report the conflict and apply the stricter or safer rule.
+
+| Skill | Purpose | Use when | File |
+| ----- | ------- | -------- | ---- |
+| Implement Feature | Add new repository behavior | A task adds user-facing or API behavior | `implement-feature/SKILL.md` |
+| Fix Bug | Repair incorrect behavior | A defect, regression, or failing test must be fixed | `fix-bug/SKILL.md` |
+| Write Tests | Add or improve coverage | Tests are the primary task or coverage is missing | `write-tests/SKILL.md` |
+| Refactor Code | Improve structure without behavior changes | Existing code needs simplification or reshaping | `refactor-code/SKILL.md` |
+| Review Code | Review a change set | The task asks for review or risk assessment | `review-code/SKILL.md` |
+| Update Dependencies | Change Composer or Bun dependencies | Dependencies or lockfiles are intentionally updated | `update-dependencies/SKILL.md` |
+| Database Change | Change schema, migrations, models, or factories | Persistence behavior changes | `database-change/SKILL.md` |
+| API Change | Change REST or internal instance contracts | API routes, controllers, requests, resources, or auth change | `api-change/SKILL.md` |
+| Frontend Change | Change Blade, TypeScript, CSS, or assets | UI, frontend behavior, localization, or build inputs change | `frontend-change/SKILL.md` |
+| Security Review | Assess security risk | The task asks for a security review or hardening | `security-review/SKILL.md` |
+| Documentation Change | Update repository docs | Setup, usage, testing, deployment, or behavior docs change | `documentation-change/SKILL.md` |
+| CI/CD Change | Change GitHub workflows or release automation | CI, tag, dependency update, or workflow files change | `ci-cd-change/SKILL.md` |
+| Docker Change | Change container build or compose runtime | Dockerfile, compose, scripts, healthchecks, or container env change | `docker-change/SKILL.md` |

--- a/.agent/skills/api-change/SKILL.md
+++ b/.agent/skills/api-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: API Change
+
+## Purpose
+
+Change REST, mobile, public, or internal instance API behavior safely.
+
+## When to Use
+
+Use for API routes, controllers, requests, resources, tokens, response payloads, internal instance compatibility, or public badge/card endpoints.
+
+## When Not to Use
+
+Do not use for purely server-rendered Blade changes with no API contract impact.
+
+## Required Context
+
+Read relevant routes, controllers, requests, resources/data payloads, auth middleware, tests, and Scribe-related docs if generation is part of the task.
+
+## Relevant Project Areas
+
+`routes/api.php`, `routes/api/`, `app/Http/Controllers/Api`, `app/Http/Requests/Api`, `app/Http/Resources`, `app/Data`, `tests/Feature/Api`.
+
+## Procedure
+
+1. Identify whether the endpoint is public, authenticated, mobile, admin, or internal instance-facing.
+2. Preserve stable response shapes unless a breaking change is explicit.
+3. Validate input and enforce ownership, roles, tokens, or instance authentication.
+4. Keep internal instance APIs compatible with `webguard-instance`.
+5. Add feature tests for auth, validation, success, failure, and data isolation.
+
+## Validation
+
+Run targeted API feature tests and static analysis for shared payload changes.
+
+## Expected Output
+
+Report contract changes, tests, and compatibility risks.
+
+## Constraints
+
+Do not leak private monitoring, team, token, or notification data through public endpoints.
+
+## Completion Criteria
+
+The API behavior is validated, authorized, documented when required, and compatibility risks are stated.

--- a/.agent/skills/ci-cd-change/SKILL.md
+++ b/.agent/skills/ci-cd-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: CI/CD Change
+
+## Purpose
+
+Change GitHub Actions workflows or release/dependency automation safely.
+
+## When to Use
+
+Use for `.github/workflows`, `.github/scripts`, CI checks, tag/release automation, or dependency update workflows.
+
+## When Not to Use
+
+Do not use for application code changes unless CI configuration also changes.
+
+## Required Context
+
+Read the target workflow, related scripts, package managers, Docker assumptions, and validation commands.
+
+## Relevant Project Areas
+
+`.github/workflows/ci.yml`, `.github/workflows/tag.yml`, `.github/workflows/weekly-dependency-update.yml`, `.github/scripts/`, `composer.json`, `package.json`.
+
+## Procedure
+
+1. Keep workflow changes minimal and scoped.
+2. Preserve required CI coverage: frontend build, PHPStan, and Pest.
+3. Keep permissions least-privilege.
+4. Avoid exposing secrets in logs.
+5. Validate YAML and script syntax where possible.
+
+## Validation
+
+Run local equivalents for changed commands when possible, such as `composer analyse`, `composer test`, or `bun run build`.
+
+## Expected Output
+
+Report workflow changes, local equivalents run, and any checks only CI can validate.
+
+## Constraints
+
+Do not change release, tag, secret, or deployment behavior without explicit task need.
+
+## Completion Criteria
+
+Workflow changes are syntactically valid, least-privilege, and preserve repository quality gates.

--- a/.agent/skills/database-change/SKILL.md
+++ b/.agent/skills/database-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Database Change
+
+## Purpose
+
+Change schema, persistence models, factories, or seed data safely.
+
+## When to Use
+
+Use for migrations, model casts/relationships, factories, seeders, database indexes, or persistence behavior.
+
+## When Not to Use
+
+Do not use for read-only service changes that do not affect stored data.
+
+## Required Context
+
+Read relevant migrations, models, factories, tests, and any MySQL compatibility tests.
+
+## Relevant Project Areas
+
+`database/migrations`, `database/factories`, `database/seeders`, `app/Models`, `app/Services`, `tests/Feature`.
+
+## Procedure
+
+1. Add new migrations rather than editing shared migrations.
+2. Preserve MySQL compatibility and note SQLite test limitations.
+3. Update models, casts, factories, validation, and API responses together.
+4. Use constraints, indexes, and defaults deliberately.
+5. Add migration or feature tests for meaningful behavior.
+
+## Validation
+
+Run targeted tests and `php artisan migrate`. Use MySQL-backed validation when SQLite cannot represent the risk.
+
+## Expected Output
+
+Report schema/data changes, tests, migrations run, and compatibility concerns.
+
+## Constraints
+
+Do not use production data in seeds, tests, logs, or fixtures.
+
+## Completion Criteria
+
+Schema and model behavior are consistent, migration path is valid, and relevant tests pass.

--- a/.agent/skills/docker-change/SKILL.md
+++ b/.agent/skills/docker-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Docker Change
+
+## Purpose
+
+Change container build, compose, local development, or runtime behavior safely.
+
+## When to Use
+
+Use for `Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `docker/`, or `start-dev.sh` changes.
+
+## When Not to Use
+
+Do not use for application-only behavior with no container impact.
+
+## Required Context
+
+Read Docker files, compose services, environment variables, docs/installation.md, and relevant healthcheck or entrypoint scripts.
+
+## Relevant Project Areas
+
+`Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `docker/`, `start-dev.sh`, `docs/installation.md`.
+
+## Procedure
+
+1. Preserve production and local-development separation between compose files.
+2. Keep secrets in environment variables, not images or docs examples with real values.
+3. Maintain PHP, worker, node, MySQL, Redis, Traefik, and Mailpit service expectations.
+4. Update docs when setup or operations change.
+5. Prefer project-defined compose commands for validation.
+
+## Validation
+
+Run the narrowest relevant Docker Compose config, build, startup, migration, healthcheck, test, or frontend build command.
+
+## Expected Output
+
+Report container behavior changed, commands run, and any environment assumptions.
+
+## Constraints
+
+Do not rely on host-global tools when Docker can perform the check.
+
+## Completion Criteria
+
+Container configuration is consistent, documented when needed, and validated or skipped with stated risk.

--- a/.agent/skills/documentation-change/SKILL.md
+++ b/.agent/skills/documentation-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Documentation Change
+
+## Purpose
+
+Update repository documentation accurately and concisely.
+
+## When to Use
+
+Use for changes to setup, Docker operations, testing, deployment, APIs, public behavior, contribution workflow, or architecture docs.
+
+## When Not to Use
+
+Do not use for generated documentation unless the task explicitly includes generation.
+
+## Required Context
+
+Read the user-visible behavior or config being documented and the relevant existing docs.
+
+## Relevant Project Areas
+
+`README.md`, `docs/`, `AGENTS.md`, `.agent/skills/`, supported adapter files.
+
+## Procedure
+
+1. Update the narrowest relevant document.
+2. Keep root `README.md` concise and link details in `docs/`.
+3. Verify commands and paths exist before documenting them.
+4. Avoid duplicating content across docs.
+5. Keep language factual and repository-specific.
+
+## Validation
+
+Run documentation structure tests when links, required topics, or doc organization change.
+
+## Expected Output
+
+Report docs changed and any validation skipped.
+
+## Constraints
+
+Do not make unverified claims or document nonexistent commands.
+
+## Completion Criteria
+
+Documentation matches the implemented repository behavior and remains concise.

--- a/.agent/skills/fix-bug/SKILL.md
+++ b/.agent/skills/fix-bug/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Fix Bug
+
+## Purpose
+
+Repair incorrect WebGuard Core behavior without broad rewrites.
+
+## When to Use
+
+Use when a failing test, reported regression, exception, incorrect response, UI defect, queue issue, or data bug must be fixed.
+
+## When Not to Use
+
+Do not use when the task is a planned feature, pure refactor, or dependency update.
+
+## Required Context
+
+Read the failing output or report, the smallest relevant implementation path, related tests, and recent patterns in nearby code.
+
+## Relevant Project Areas
+
+Usually `app/`, `routes/`, `resources/`, `database/`, and `tests/`.
+
+## Procedure
+
+1. Reproduce or reason from the failing observable behavior.
+2. Identify the narrow cause and avoid unrelated cleanup.
+3. Add a regression test where feasible.
+4. Fix the cause at the appropriate layer.
+5. Check for authorization, privacy, and compatibility side effects.
+
+## Validation
+
+Run the regression test or smallest relevant Pest file. Run broader checks when the fix touches shared logic.
+
+## Expected Output
+
+State the defect fixed, tests run, and any remaining risk.
+
+## Constraints
+
+Do not remove or weaken tests, validation, authorization, or user-visible guarantees to make the bug disappear.
+
+## Completion Criteria
+
+The reported behavior is fixed, regression coverage exists or an exception is explained, and relevant validation passes.

--- a/.agent/skills/frontend-change/SKILL.md
+++ b/.agent/skills/frontend-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Frontend Change
+
+## Purpose
+
+Change Blade UI, TypeScript behavior, CSS, assets, or frontend build inputs.
+
+## When to Use
+
+Use for pages, components, layouts, translations, Alpine/TypeScript components, Tailwind classes, Chart.js usage, or Vite assets.
+
+## When Not to Use
+
+Do not use for backend-only behavior with no rendered or asset impact.
+
+## Required Context
+
+Read relevant Blade views, components, translations, TypeScript files, styles, tests, and existing design patterns.
+
+## Relevant Project Areas
+
+`resources/views`, `resources/js`, `resources/css`, `resources/lang`, `resources/images`, `tests/Feature`, `tests/Browser`.
+
+## Procedure
+
+1. Reuse existing Blade components and TypeScript utilities.
+2. Keep UI text localized where surrounding code uses translations.
+3. Preserve accessibility, responsive behavior, theme behavior, and validation errors.
+4. Keep interactive code typed and scoped to clear DOM ownership.
+5. Add feature or browser tests for rendered or interactive behavior.
+
+## Validation
+
+Run `bun run build` for asset changes and targeted feature/browser tests for UI behavior.
+
+## Expected Output
+
+Report UI behavior changed, files, build/test validation, and residual visual risks.
+
+## Constraints
+
+Do not add unnecessary frontend dependencies or bundle weight.
+
+## Completion Criteria
+
+The UI change renders correctly, builds successfully, and relevant behavior is tested.

--- a/.agent/skills/implement-feature/SKILL.md
+++ b/.agent/skills/implement-feature/SKILL.md
@@ -1,0 +1,44 @@
+# Skill: Implement Feature
+
+## Purpose
+
+Add new WebGuard Core behavior with minimal, tested, reviewable changes.
+
+## When to Use
+
+Use when adding a new dashboard, admin, public page, API, monitoring, notification, team, package, or legal/content behavior.
+
+## When Not to Use
+
+Do not use for pure bug fixes, dependency updates, security-only reviews, or documentation-only work.
+
+## Required Context
+
+Read the task, relevant routes/controllers/services/views/tests, related docs, and any narrower skill such as API Change, Frontend Change, Database Change, or Write Tests.
+
+## Relevant Project Areas
+
+`app/`, `routes/`, `resources/`, `database/`, `tests/`, `docs/`.
+
+## Procedure
+
+1. Identify the smallest existing pattern that matches the feature.
+2. Place business logic in services, requests, jobs, commands, support classes, enums, or data classes rather than controllers or views.
+3. Preserve authorization, ownership, localization, queue, and notification patterns.
+4. Update tests and docs where behavior or setup changes.
+
+## Validation
+
+Run targeted Pest tests first. Add `composer analyse`, full `composer test`, or `bun run build` when the change touches shared backend, API, or frontend behavior.
+
+## Expected Output
+
+Report changed behavior, files, validations, and remaining risks only.
+
+## Constraints
+
+Do not implement `webguard-instance` scanning-node behavior in this repository unless changing the core contract.
+
+## Completion Criteria
+
+The feature is implemented, covered by relevant tests, documented when needed, and validated with the narrowest sufficient checks.

--- a/.agent/skills/refactor-code/SKILL.md
+++ b/.agent/skills/refactor-code/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Refactor Code
+
+## Purpose
+
+Improve structure while preserving WebGuard Core behavior.
+
+## When to Use
+
+Use when simplifying duplication, moving logic to established layers, or improving maintainability without changing outcomes.
+
+## When Not to Use
+
+Do not use when behavior change is required unless paired with Implement Feature or Fix Bug.
+
+## Required Context
+
+Read the code being changed, its tests, callers, routes, views, and public API surfaces.
+
+## Relevant Project Areas
+
+Any application area, especially `app/Services`, `app/Support`, `app/Http`, `resources/views`, and `resources/js`.
+
+## Procedure
+
+1. Define the preserved behavior before editing.
+2. Prefer existing abstractions and naming patterns.
+3. Keep moves and edits small enough for review.
+4. Avoid formatting unrelated files.
+5. Update tests only for changed structure or improved behavior assertions.
+
+## Validation
+
+Run existing targeted tests for the affected behavior and static analysis when PHP contracts change.
+
+## Expected Output
+
+Describe the structural change and validation.
+
+## Constraints
+
+Do not introduce new abstraction layers without concrete benefit.
+
+## Completion Criteria
+
+Behavior is unchanged, code is simpler or clearer, and relevant tests still pass.

--- a/.agent/skills/review-code/SKILL.md
+++ b/.agent/skills/review-code/SKILL.md
@@ -1,0 +1,44 @@
+# Skill: Review Code
+
+## Purpose
+
+Assess a change set for defects, regressions, security risks, and missing tests.
+
+## When to Use
+
+Use when asked to review code, a diff, a pull request, or local changes.
+
+## When Not to Use
+
+Do not use as the primary workflow for implementing new behavior unless the task also requests fixes.
+
+## Required Context
+
+Read the diff, touched files, relevant tests, and applicable architecture or docs.
+
+## Relevant Project Areas
+
+Changed files and their directly related callers, tests, routes, views, migrations, and configs.
+
+## Procedure
+
+1. Identify behavior, security, data, compatibility, and validation risks.
+2. Prioritize concrete findings by severity.
+3. Include file and line references.
+4. Separate findings from questions and summaries.
+
+## Validation
+
+Run targeted checks only if the review asks for validation or local execution is needed to confirm a finding.
+
+## Expected Output
+
+Findings first, then open questions or assumptions, then a brief summary only if useful.
+
+## Constraints
+
+Do not report style preferences unless they cause maintainability, correctness, or security risk.
+
+## Completion Criteria
+
+The review identifies actionable issues or states clearly that none were found, with test gaps or residual risk noted.

--- a/.agent/skills/security-review/SKILL.md
+++ b/.agent/skills/security-review/SKILL.md
@@ -1,0 +1,44 @@
+# Skill: Security Review
+
+## Purpose
+
+Assess or improve security posture for WebGuard Core changes.
+
+## When to Use
+
+Use when the task asks for security review, hardening, auth checks, secret handling, privacy, webhook safety, or API exposure analysis.
+
+## When Not to Use
+
+Do not use for ordinary feature work unless security is the main concern; apply `AGENTS.md` security rules regardless.
+
+## Required Context
+
+Read the changed code, trust boundaries, routes, middleware, requests, policies or ownership services, config, and tests.
+
+## Relevant Project Areas
+
+`app/Http`, `app/Services`, `app/Rules`, `app/Support`, `config`, `routes`, `tests/Feature`, `resources/views`.
+
+## Procedure
+
+1. Trace input, authorization, persistence, output, logging, and external calls.
+2. Check authentication, authorization, ownership, CSRF, signed URL, Sanctum, and role enforcement.
+3. Check injection risks, escaping, sensitive logging, token exposure, and SSRF-like URL handling.
+4. Add or recommend tests for confirmed risks.
+
+## Validation
+
+Run targeted security-relevant feature or unit tests and static analysis where useful.
+
+## Expected Output
+
+Report confirmed findings with impact, affected files, and remediation or validation.
+
+## Constraints
+
+Do not disclose secrets or create proof-of-concept payloads that risk external systems.
+
+## Completion Criteria
+
+Material security risks are identified or mitigated, tests cover changed protections, and residual risk is stated.

--- a/.agent/skills/update-dependencies/SKILL.md
+++ b/.agent/skills/update-dependencies/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Update Dependencies
+
+## Purpose
+
+Change Composer or Bun dependencies safely.
+
+## When to Use
+
+Use when `composer.json`, `composer.lock`, `package.json`, or `bun.lock` intentionally changes.
+
+## When Not to Use
+
+Do not use for code-only changes that do not alter dependencies.
+
+## Required Context
+
+Read the dependency request, manifests, lockfile impact, and relevant CI workflow expectations.
+
+## Relevant Project Areas
+
+`composer.json`, `composer.lock`, `package.json`, `bun.lock`, `.github/workflows/`, `Dockerfile`, `docker/node/Dockerfile`.
+
+## Procedure
+
+1. Confirm the package manager and intended update scope.
+2. Avoid unrelated upgrades and unrequested major versions.
+3. Review security, maintenance, license, size, and overlap with existing packages.
+4. Update code or config for changed APIs when needed.
+5. Review lockfile changes.
+
+## Validation
+
+Run install/update commands in Docker where possible, then relevant tests and `bun run build` for frontend dependencies.
+
+## Expected Output
+
+Report packages changed, lockfiles changed, validations, and risk.
+
+## Constraints
+
+Do not change lockfiles without a dependency operation or dependency-related reason.
+
+## Completion Criteria
+
+Dependencies are updated intentionally, lockfiles are consistent, and relevant validation passes.

--- a/.agent/skills/write-tests/SKILL.md
+++ b/.agent/skills/write-tests/SKILL.md
@@ -1,0 +1,44 @@
+# Skill: Write Tests
+
+## Purpose
+
+Add focused Pest coverage for WebGuard Core behavior.
+
+## When to Use
+
+Use when tests are requested directly or implementation changes need coverage.
+
+## When Not to Use
+
+Do not use for documentation-only changes unless documentation structure or links are tested.
+
+## Required Context
+
+Read `docs/test-concept.md`, `tests/Pest.php`, `tests/TestCase.php`, relevant factories, and nearby tests for the same feature area.
+
+## Relevant Project Areas
+
+`tests/Unit`, `tests/Feature`, `tests/Browser`, `database/factories`, `app/`, `routes/`, `resources/`.
+
+## Procedure
+
+1. Choose Unit, Feature, or Browser based on observable risk.
+2. Use factories, fakes, named routes, and explicit assertions.
+3. Cover authorization, validation, isolation, edge cases, and failure paths where relevant.
+4. Keep test data minimal and deterministic.
+
+## Validation
+
+Run the targeted Pest file or filter inside Docker when possible.
+
+## Expected Output
+
+Report coverage added and validation result.
+
+## Constraints
+
+Avoid external network access, order-dependent tests, broad fixtures, and implementation-only assertions.
+
+## Completion Criteria
+
+Tests fail for the intended broken behavior where applicable, pass after implementation, and do not weaken existing coverage.

--- a/.cursor/rules/webguard-core.mdc
+++ b/.cursor/rules/webguard-core.mdc
@@ -2,7 +2,8 @@
 alwaysApply: true
 ---
 
-# Cursor Instructions
+# Cursor Adapter
 
 Follow the canonical repository instructions in `AGENTS.md`.
 
+Use `.agent/skills/README.md` to select only relevant skills from `.agent/skills/`. Do not duplicate or contradict canonical rules. Keep edits focused, validate through the project Docker setup when possible, and report results concisely.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,5 @@
-# GitHub Copilot Instructions
+# GitHub Copilot Adapter
 
 Follow the canonical repository instructions in `AGENTS.md`.
 
+Read any nearest local `AGENTS.md` and use `.agent/skills/README.md` to identify relevant shared skills in `.agent/skills/`. Keep suggestions scoped to the task, preserve existing Laravel and frontend patterns, and keep output concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,109 +1,293 @@
-# Agent Context
+# Repository Agent Instructions
 
-These instructions apply to all coding agents working in this repository.
+These instructions apply to every human or AI coding agent working in this repository, regardless of the tool, model, IDE, extension, CLI, automation platform, or execution environment.
 
-## Project Scope
+## Scope and Applicability
 
-WebGuard Core is the Laravel Management Core & API for WebGuard. It owns the
-dashboard, admin panel, public status pages, REST API, monitoring orchestration,
-notification workflows, package administration, and legal/public content.
+- This root `AGENTS.md` is the canonical source for repository-wide rules.
+- Local `AGENTS.md` files MAY add directory-specific implementation rules. The nearest applicable `AGENTS.md` takes precedence for local details.
+- Local rules MUST NOT weaken security, privacy, compliance, or reviewability requirements in this file.
+- Agent-specific files, prompts, IDE rules, and automation adapters MUST be thin references to this file, local `AGENTS.md` files, and `.agent/skills/`.
+- Shared skills in `.agent/skills/` supplement these rules and MUST NOT contradict them.
 
-Distributed scanning nodes are maintained in the separate `webguard-instance`
-repository. Do not implement instance-node behavior in this repository unless
-the core API contract or integration surface explicitly requires it.
+## Instruction Priority
 
-## Technology Context
+Apply instructions in this order:
 
-- Backend: Laravel 13 on PHP 8.5+.
-- Tests: Pest, PHPUnit configuration in `phpunit.xml`, Pest Browser Plugin.
-- Frontend: Vite, Tailwind CSS, Alpine.js, TypeScript, Chart.js.
+1. Explicit task requirements and acceptance criteria.
+2. Security, privacy, legal, and compliance requirements.
+3. Nearest applicable local `AGENTS.md`.
+4. This root `AGENTS.md`.
+5. Existing architecture and established repository patterns.
+6. Repository configuration.
+7. Tests and technical documentation.
+8. Official language and framework documentation.
+9. Established community standards.
+10. Explicitly documented assumptions.
+
+Agents MUST NOT invent business requirements. When instructions conflict, report the conflict and apply the stricter or safer rule.
+
+## Project Overview
+
+WebGuard Core is the Laravel Management Core & API for WebGuard. It owns the dashboard, admin panel, public status pages, REST API, monitoring orchestration, notification workflows, package administration, and legal/public content. Distributed scanning nodes live in the separate `webguard-instance` repository; do not implement scanning-node behavior here unless the core API contract or integration surface requires it.
+
+Primary stack:
+
+- Backend: PHP 8.5+, Laravel 13, Laravel Sanctum, Socialite, Scribe, Spatie activity log and sitemap.
+- Frontend: Blade, Vite, Tailwind CSS, Alpine.js, TypeScript, Chart.js, Axios.
 - Runtime services: MySQL-compatible database, Redis cache and queues, SMTP mail.
-- Local Docker: `docker-compose.yml` plus `docker-compose.override.yml`.
-- Local helper: `./start-dev.sh` starts the development stack and opens a PHP container shell.
+- Tests: Pest, PHPUnit config, Pest Browser Plugin, SQLite in-memory defaults.
+- Tooling: Composer, Bun, Larastan/PHPStan, Laravel Pint, Docker Compose.
 
-## Required Workflow
+Important areas:
 
-1. Inspect the current worktree before editing.
-2. Read the relevant application, test, and documentation files before making changes.
-3. Keep changes focused on the requested behavior.
-4. Preserve unrelated user changes; do not revert files you did not intentionally change.
-5. Prefer existing Laravel, Pest, Blade, service, DTO, enum, factory, and route patterns.
-6. Add or update tests for new behavior and regressions.
-7. Update documentation when user-facing behavior, setup, deployment, or testing expectations change.
-8. Do not commit secrets, generated local artifacts, dependency directories, logs, or machine-specific files.
+- `app/`: Laravel controllers, requests, models, services, jobs, mail, observers, support classes, DTO-style data classes, enums, and console commands.
+- `routes/`: web, auth, console, and API route definitions, including internal and external API segments.
+- `resources/`: Blade views, translations, TypeScript, CSS, images, and frontend components.
+- `database/`: migrations, factories, and seeders.
+- `tests/`: unit, feature, and browser tests.
+- `docker/`, `Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `start-dev.sh`: container build and runtime configuration.
+- `.github/workflows/`: CI, tag release notes, and dependency update workflows.
+- `docs/`: installation, architecture, testing, features, and contribution documentation.
 
-## Docker-First Commands
+## Source of Truth
 
-Work inside Docker whenever technically possible. Prefer project-defined Docker
-configuration over host-global tools.
+Use this technical priority:
 
-Use this compose command shape:
+1. Existing implementation and established patterns.
+2. Project configuration.
+3. Tests.
+4. Repository documentation.
+5. Official Laravel, PHP, Pest, Tailwind, Vite, TypeScript, and related package documentation.
+6. Established standards.
+
+Agents MUST NOT replace existing conventions with personal preferences without a concrete technical reason.
+
+## Token-Efficient Work
+
+- Read only files relevant to the current task.
+- Do not scan the full repository when targeted inspection is sufficient.
+- Prefer precise searches over broad file reads.
+- Avoid repeatedly reading unchanged files.
+- Do not restate the complete task before starting.
+- Do not repeat rules already defined here.
+- Keep plans concise and focused on execution-critical steps.
+- Do not narrate routine tool usage.
+- Report only findings that affect implementation, validation, risk, or review.
+- Prefer diffs and targeted edits over rewriting complete files.
+- Avoid creating abstractions, documentation, comments, tests, or files that are not required.
+- Do not produce large code excerpts in final responses when file references are sufficient.
+- Do not duplicate the same information across summaries, findings, and completion reports.
+- Use concise tables or short lists when they reduce repetition.
+- Preserve correctness, security, and completeness; token efficiency MUST NOT justify skipping required analysis or validation.
+
+Final output SHOULD normally contain only what changed, changed files, validations executed, and unresolved issues, assumptions, or risks.
+
+## Language and Framework Standards
+
+- PHP code MUST follow Laravel conventions and the configured Pint rules in `pint.json`.
+- PHP files SHOULD use `declare(strict_types=1);`; Pint enforces strict types.
+- Use typed properties, parameters, and return types for public interfaces where practical.
+- Keep controllers thin. Put reusable business logic in services, support classes, jobs, requests, policies, or DTO-style data classes that match existing patterns.
+- Use Form Request classes for reusable validation and authorization logic.
+- Use Eloquent models, relationships, casts, scopes, factories, and migrations consistently with existing code.
+- Prefer named routes over hard-coded application URLs.
+- Use Laravel fakes for mail, notifications, queues, events, cache, and HTTP boundaries in tests.
+- Keep TypeScript strict and small. Put reusable frontend behavior in `resources/js/components` or `resources/js/utils`.
+- Keep Blade accessible, localized where existing pages use translations, and consistent with components in `resources/views/components`.
+- Do not add external network calls in tests.
+- Log operationally useful context without secrets, tokens, credentials, or personal data.
+
+## Architecture Rules
+
+- The core owns management UI, API contracts, orchestration, notifications, aggregation, user/team/package administration, legal pages, and public status output.
+- Distributed probe/scanner behavior belongs in `webguard-instance`; this repository may expose or adapt core API contracts for instances.
+- Business logic SHOULD live in services, jobs, commands, requests, support classes, enums, or data classes instead of Blade views or controllers.
+- API controllers MUST validate request input, authorize access, and return stable response shapes.
+- External providers such as SMTP, Slack, Discord, Teams, Telegram, FCM, APNS, Socialite, and webhooks MUST stay behind existing Laravel configuration or service boundaries.
+- Queue and scheduler changes MUST account for the default and `heartbeat` queues.
+- New abstractions require a concrete reduction in duplication, complexity, or risk.
+
+## Code Quality
+
+- Run configured formatting, static analysis, tests, and builds relevant to the change.
+- Keep functions and methods focused; avoid speculative abstractions.
+- Remove dead code, commented-out code, unused imports, and unused variables.
+- Use meaningful constants or enums instead of unexplained literals when values represent business rules.
+- Comments SHOULD explain why, not restate what the code says.
+- Do not introduce unintended public API, route, schema, or behavior changes.
+- Identify breaking changes explicitly.
+- Do not add broad disable comments, ignore rules, unsafe casts, or weakened checks only to bypass tooling.
+- Do not weaken existing quality gates, validation, authentication, authorization, or tests.
+
+## Naming Conventions
+
+- Use existing Laravel naming conventions for controllers, models, requests, jobs, mailables, commands, observers, services, factories, seeders, migrations, routes, and tests.
+- PHP classes use PascalCase; methods and variables use camelCase; database tables and columns use snake_case.
+- Enums, DTO-style data classes, services, jobs, and commands MUST have domain-specific names.
+- Test names and filenames SHOULD describe observable behavior.
+- API endpoint names, route names, and translation keys MUST be stable, descriptive, and consistent with surrounding files.
+- Frontend component and utility filenames SHOULD follow the existing kebab-case or descriptive TypeScript naming in `resources/js`.
+
+## Testing Rules
+
+- Follow `docs/test-concept.md`.
+- Use `tests/Unit` for services, support classes, DTO-style payload logic, enum helpers, and deterministic calculations.
+- Use `tests/Feature` for routes, controllers, requests, middleware, commands, jobs, mail, notifications, database behavior, API contracts, and authorization.
+- Use `tests/Browser` for rendered UI, responsive layout, JavaScript interactions, and behavior that feature tests cannot validate.
+- New or changed business logic MUST have tests unless the change is documentation-only or a justified exception is reported.
+- Bug fixes SHOULD include a regression test that fails before the fix where feasible.
+- Tests MUST be deterministic, isolated, and use factories or fakes instead of broad fixtures or live services.
+- Do not remove, weaken, skip, or rewrite tests merely to make changes pass.
+- Do not update snapshots or generated outputs without verifying the behavioral reason.
+
+## Validation Commands
+
+Run commands inside Docker when technically possible, using:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.override.yml ...
 ```
 
-Common commands:
+Verified project commands:
 
-```bash
-docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer test
-docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer analyse
-docker compose -f docker-compose.yml -f docker-compose.override.yml exec php php artisan migrate
-docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun install
-docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun run build
-```
+| Purpose | Command |
+| --- | --- |
+| Start local Docker stack | `./start-dev.sh` |
+| Backend tests | `docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer test` |
+| Targeted Pest test | `docker compose -f docker-compose.yml -f docker-compose.override.yml exec php ./vendor/bin/pest tests/Feature/MonitoringExpectedHttpStatusesTest.php` |
+| Static analysis | `docker compose -f docker-compose.yml -f docker-compose.override.yml exec php composer analyse` |
+| Migrations | `docker compose -f docker-compose.yml -f docker-compose.override.yml exec php php artisan migrate` |
+| Frontend install | `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun install` |
+| Frontend build | `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm node bun run build` |
+| One queue job | `docker compose -f docker-compose.yml -f docker-compose.override.yml exec queue-default php artisan queue:work redis --once` |
 
-Use host commands only when Docker is unavailable or a task explicitly requires
-host execution. Record that exception in the handoff.
+Host commands MAY be used only when Docker is unavailable or a task explicitly requires host execution. State the exception and remaining risk.
 
-## Testing Instructions
+Validation matrix:
 
-Follow `docs/test-concept.md`.
+| Change type | Required validation |
+| --- | --- |
+| Documentation | Relevant docs review; run documentation structure tests when links or required topics change |
+| Backend service/support logic | Targeted unit tests; PHPStan when type or shared logic risk exists |
+| Route/controller/request/Blade | Targeted feature tests |
+| API contract | Targeted API feature tests and compatibility review |
+| Job/command/scheduler/notification | Targeted feature tests for scheduling and side effects |
+| Database/migration | Migration or compatibility test; use MySQL when SQLite cannot model the risk |
+| Frontend/asset/TypeScript | `bun run build`; browser test for interaction or responsive behavior |
+| Docker/infrastructure/CI | Syntax/configuration review and the narrowest runnable build or workflow-equivalent check |
+| Dependencies | Clean install or update command, lockfile review, relevant tests, and build |
 
-Use:
+If a command cannot be executed, agents MUST state why.
 
-- `tests/Unit` for services, support classes, DTO-style payload logic, enum helpers,
-  and deterministic calculations.
-- `tests/Feature` for routes, controllers, requests, middleware, commands, jobs,
-  mail, notifications, database behavior, API contracts, and authorization.
-- `tests/Browser` for rendered UI, responsive layout, JavaScript interactions,
-  and behavior that cannot be validated through feature tests.
+## Dependency Management
 
-The default suite uses SQLite in-memory, array mail/cache/session drivers, and
-sync queues. Tests that require MySQL, Redis, Docker, or queue workers must make
-that dependency explicit.
+- Composer and `composer.lock` are authoritative for PHP dependencies.
+- Bun and `bun.lock` are authoritative for frontend dependencies.
+- Add dependencies only when existing framework or repository code cannot reasonably solve the problem.
+- Consider security, maintenance, license, package size, runtime impact, and overlap with existing libraries.
+- Do not change lockfiles without a corresponding dependency operation.
+- Do not perform unrelated upgrades or unrequested major-version updates.
+- Keep dependency updates focused and review lockfile changes.
 
-For targeted validation, run the smallest relevant Pest file or filter first.
-For cross-cutting changes, run the full Pest suite, PHPStan, and the frontend build.
+## Security, Privacy, and Compliance
 
-## Code Standards
+- Do not commit secrets, credentials, tokens, production personal data, logs, or machine-specific files.
+- Use `.env` and existing Laravel configuration for secrets and environment-specific values.
+- Validate input at trust boundaries and escape output in the correct context.
+- Do not bypass authentication, authorization, signed URLs, CSRF, Sanctum, role checks, or ownership checks.
+- Use Eloquent/query builder parameter binding; avoid SQL injection and shell injection risks.
+- Keep default access restrictive and errors safe for public output.
+- Do not log sensitive values, internal tokens, authorization headers, push credentials, webhook secrets, or private keys.
+- Do not disable security controls or add telemetry/external services without approval.
+- Do not upload repository content or data to external systems without authorization.
+- Legal, GDPR, imprint, terms, and privacy pages MUST remain accurate and configuration-driven where existing code requires environment values.
 
-- Keep PHP files strict typed where the surrounding code uses `declare(strict_types=1);`.
-- Use Laravel conventions for validation, authorization, routing, queues, mail,
-  notifications, factories, casts, and configuration.
-- Keep controllers thin; put reusable business logic in services or support classes.
-- Prefer named route generation over hard-coded application URLs.
-- Prefer factories and Laravel test fakes over broad fixtures or live integrations.
-- Avoid external network access in tests.
-- Keep Blade markup accessible, localized where appropriate, and consistent with existing components.
-- Keep TypeScript behavior small, typed, and tied to existing component patterns.
+## Database and Migration Rules
 
-## Quality Gates
+- Use Laravel migrations, Eloquent models, casts, factories, and seeders.
+- Previously shared or executed migrations MUST NOT be edited unless the repository explicitly requires a corrective migration strategy.
+- Prefer new migrations for schema changes.
+- Add indexes, constraints, defaults, and backfills deliberately; account for MySQL compatibility and SQLite test limitations.
+- Use transactions where the database and migration operation support them.
+- Keep seed data non-sensitive and deterministic.
+- Update factories and tests when schema changes require it.
 
-Before handing off a change, run the relevant checks inside Docker when possible:
+## API and Integration Rules
 
-- Targeted Pest tests for changed behavior.
-- `composer test` for broad backend changes.
-- `composer analyse` for PHP type/static-analysis risk.
-- `bun run build` for frontend or asset changes.
+- API changes MUST validate requests, enforce authentication/authorization, and preserve stable response formats unless a breaking change is explicit.
+- Internal instance APIs under `routes/api/internal.php` are compatibility-sensitive for `webguard-instance`.
+- Public badge/card/status endpoints MUST avoid leaking private monitoring data.
+- Use appropriate status codes, pagination, error messages, rate limits, and idempotency patterns consistent with existing API code.
+- External notification channels and push integrations MUST handle failures without exposing secrets or blocking unrelated delivery paths.
+- Scribe documentation generation exists; update generated API documentation only when intentionally requested or part of the release process.
 
-If a check cannot be run, state why and identify the remaining risk.
+## Frontend Rules
 
-## Documentation Standards
+- Reuse Blade components in `resources/views/components` and existing TypeScript components before adding new structures.
+- Keep UI text localized where surrounding views use `resources/lang`.
+- Preserve accessible labels, focus states, form errors, responsive behavior, and dark/theme behavior where present.
+- Use Tailwind classes consistently with existing Blade markup.
+- Keep Alpine and TypeScript behavior small, typed, and bound to clear DOM ownership.
+- Include loading, empty, validation, and error states for changed user workflows when relevant.
+- Do not introduce unnecessary bundle weight.
 
-- Keep root `README.md` concise and link expanded documentation from `docs/`.
-- Put testing strategy in `docs/test-concept.md`.
+## Documentation Rules
+
+- Update documentation when setup, Docker operations, deployment, testing expectations, public behavior, API usage, or configuration changes.
+- Keep root `README.md` concise and link expanded docs from `docs/`.
 - Put setup and Docker operations in `docs/installation.md`.
+- Put testing strategy in `docs/test-concept.md`.
 - Put contribution workflow in `docs/contributing.md`.
-- Keep documentation language factual and repository-specific.
-- Keep agent-specific adapter files minimal and point them back to this file.
+- Do not make unverified claims or manually edit generated documentation.
+
+## Git and Change Scope
+
+- Keep changes limited to the task.
+- Do not perform unrelated refactors or formatting of untouched files.
+- Do not overwrite local changes you did not make.
+- Do not use destructive Git commands unless explicitly requested.
+- Do not commit, push, tag, release, or open pull requests without explicit instruction.
+- Do not modify CI/CD, infrastructure, deployment, or security configuration unless required by the task.
+- Keep changes small, reviewable, and easy to revert.
+- Do not include AI-assistant, automation-tool, or code-generation branding in code comments, documentation, commit messages, PR text, or branch names unless explicitly required.
+
+## Shared Skills
+
+- Shared skills live under `.agent/skills/<skill-name>/SKILL.md`.
+- Agents MUST read only the skills relevant to the current task.
+- Skills are tool-independent and repository-specific.
+- Skills MUST NOT override this file.
+- Agents MUST NOT modify skills unless explicitly requested.
+- Skill output must remain concise and token-efficient.
+
+Start with `.agent/skills/README.md` when selecting skills.
+
+## Agent Workflow
+
+1. Read the task and acceptance criteria.
+2. Read this file and any nearest local `AGENTS.md`.
+3. Identify and read only relevant skills.
+4. Inspect relevant files and existing patterns.
+5. Evaluate architecture, dependencies, security, and validation risk.
+6. Plan the smallest viable change.
+7. Implement the change.
+8. Add or update tests and documentation when required.
+9. Run relevant validation commands.
+10. Review the diff for unintended changes.
+11. Report changes, validation, assumptions, and remaining risks concisely.
+
+Agents MUST NOT begin implementation before checking applicable rules and skills.
+
+## Definition of Done
+
+A task is complete only when:
+
+- Acceptance criteria are met.
+- Architecture rules are followed.
+- Relevant tests exist or a justified exception is reported.
+- Required validation succeeds or skipped checks are disclosed with risk.
+- Security and privacy requirements are met.
+- Documentation is updated where required.
+- No unintended files changed.
+- Assumptions and remaining risks are stated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,7 @@
-# Claude Instructions
+# Claude Code Adapter
 
 Follow the canonical repository instructions in `AGENTS.md`.
 
+Before changing files, read the nearest applicable `AGENTS.md` and only the relevant shared skills from `.agent/skills/README.md` and `.agent/skills/`.
+
+Keep changes scoped, preserve user work, prefer Docker-based validation, and keep plans and final output concise.


### PR DESCRIPTION
## What changed

- Expanded `AGENTS.md` into the canonical, tool-independent repository governance source.
- Added shared task skills under `.agent/skills/` for recurring repository workflows.
- Updated Claude Code, Cursor, and GitHub Copilot adapters to reference the canonical rules and shared skills without duplicating them.

## Why

This gives current and future coding agents one consistent source of project rules, validation expectations, security requirements, and token-efficient workflow guidance.

## Testing

- `git diff --check`
- Verified every shared `SKILL.md` contains the required section structure.
- Verified documented project files and command source files exist.
- `docker compose -f docker-compose.yml -f docker-compose.override.yml config --quiet` with dummy required environment values.

Pest was not run because this is a governance/docs-only change and `vendor/` is not installed in the worktree.