### PR TITLE
fix: update marketing navigation auth buttons

### DIFF
--- a/resources/lang/de/welcome.php
+++ b/resources/lang/de/welcome.php
@@ -18,7 +18,7 @@ return [
         'feature_pages' => 'Feature-Seiten',
         'api_docs' => 'API-Doku',
         'proof' => 'Einordnung',
-        'get_started' => 'Jetzt starten',
+        'get_started' => 'Registrieren',
         'demo_access' => 'Demo-Zugang',
         'login' => 'Anmelden',
         'dashboard' => 'Dashboard',

--- a/resources/lang/en/welcome.php
+++ b/resources/lang/en/welcome.php
@@ -18,7 +18,7 @@ return [
         'feature_pages' => 'Feature Pages',
         'api_docs' => 'API Docs',
         'proof' => 'Context',
-        'get_started' => 'Start now',
+        'get_started' => 'Register',
         'demo_access' => 'Demo access',
         'login' => 'Login',
         'dashboard' => 'Dashboard',

--- a/resources/views/components/marketing-layout.blade.php
+++ b/resources/views/components/marketing-layout.blade.php
@@ -68,9 +68,9 @@
                             class="!border-purple-600 !bg-purple-600 !text-white !normal-case !tracking-normal hover:!bg-purple-700 focus:!ring-purple-500 dark:!border-purple-400 dark:!bg-purple-400 dark:!text-slate-950 dark:hover:!bg-purple-300 dark:focus:!ring-purple-300">
                             {{ __('welcome.nav.get_started') }}
                         </x-primary-button>
-                        <x-secondary-button :href="route('login', ['mode' => 'demo'])"
+                        <x-secondary-button :href="route('login')"
                             class="!border-slate-300 !bg-white !text-slate-700 !normal-case !tracking-normal transition hover:!border-slate-400 hover:!bg-slate-100 dark:!border-slate-600 dark:!bg-slate-900/70 dark:!text-slate-100 dark:hover:!border-slate-500 dark:hover:!bg-slate-800">
-                            {{ __('welcome.nav.demo_access') }}
+                            {{ __('welcome.nav.login') }}
                         </x-secondary-button>
                     </div>
                 </x-main>

--- a/tests/Feature/PublicFeaturePagesTest.php
+++ b/tests/Feature/PublicFeaturePagesTest.php
@@ -61,8 +61,10 @@ class PublicFeaturePagesTest extends TestCase
         $testResponse->assertSeeHtml(route('public-features.index'));
         $testResponse->assertSeeHtml(route('scribe'));
         $testResponse->assertSeeHtml(route('welcome') . '#proof');
-        $testResponse->assertSeeHtml(route('register'));
-        $testResponse->assertSeeHtml(route('login', ['mode' => 'demo']));
+        $testResponse->assertSeeHtml('href="' . route('register') . '"');
+        $testResponse->assertSeeHtml('href="' . route('login') . '"');
+        $testResponse->assertSeeText(__('welcome.nav.get_started'));
+        $testResponse->assertSeeText(__('welcome.nav.login'));
         $testResponse->assertSeeHtml(route('locale.switch', ['locale' => 'en']));
         $testResponse->assertSeeHtml(route('locale.switch', ['locale' => 'de']));
         $testResponse->assertSeeHtml(sprintf('<link rel="canonical" href="%s">', route('public-features.index')));


### PR DESCRIPTION
## What changed
- Changed the marketing navigation secondary auth button from demo access to the normal login route.
- Renamed the marketing navigation primary auth button from start copy to registration copy in German and English.
- Updated the marketing navigation feature test to assert the exact register and login links and labels.

## Why
The public navigation should offer direct login access while keeping registration as the primary sign-up action.

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps -e AUTORUN_ENABLED=false php ./vendor/bin/pest tests/Feature/PublicFeaturePagesTest.php`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps -e AUTORUN_ENABLED=false php ./vendor/bin/pest tests/Feature/WelcomePageCopyTest.php`

Both commands passed. Pest emitted asset file warnings in this fresh worktree because built frontend assets were not present.

## Risks
Low. The change is limited to marketing navigation labels/routes and matching feature-test expectations.