### PR TITLE
test: cover mobile push failure paths

### DIFF
--- a/tests/Feature/Notifications/NotificationRouterTest.php
+++ b/tests/Feature/Notifications/NotificationRouterTest.php
@@ -9,10 +9,12 @@ use App\Enums\NotificationEventType;
 use App\Models\MobilePushDevice;
 use App\Models\Package;
 use App\Models\User;
+use App\Services\Notifications\Channels\MobilePushChannelDriver;
 use App\Services\Notifications\NotificationPayload;
 use App\Services\Notifications\NotificationRouter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use RuntimeException;
 use Tests\TestCase;
 
 class NotificationRouterTest extends TestCase
@@ -319,6 +321,146 @@ class NotificationRouterTest extends TestCase
             && $request->hasHeader('apns-push-type', 'alert')
             && data_get($request->data(), 'aps.alert.title') === 'Monitoring incident'
             && data_get($request->data(), 'monitoring_id') === '01TEST');
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'channel' => 'mobile_push',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::SENT->value,
+        ]);
+    }
+
+    public function test_mobile_push_driver_requires_user_context(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Mobile push user context is missing.');
+
+        resolve(MobilePushChannelDriver::class)->send(
+            new NotificationPayload(
+                eventType: NotificationEventType::INCIDENT,
+                title: 'Monitoring incident',
+                message: 'Service is down.',
+                severity: 'critical',
+                monitoringId: '01TEST',
+                monitoringName: 'API',
+                monitoringTarget: 'https://example.test',
+                occurredAt: now()
+            ),
+            []
+        );
+    }
+
+    public function test_router_revokes_invalid_mobile_push_device_when_delivery_fails(): void
+    {
+        config([
+            'services.fcm.project_id' => 'webguard-test',
+            'services.fcm.access_token' => 'test-access-token',
+        ]);
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'mobile_push' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
+        $device = MobilePushDevice::factory()->for($user)->create([
+            'push_token' => 'expired-fcm-token',
+            'token_hash' => hash('sha256', 'expired-fcm-token'),
+        ]);
+
+        Http::fake([
+            'https://fcm.googleapis.com/*' => Http::response([
+                'error' => [
+                    'message' => 'Requested entity was not found',
+                ],
+            ], 404),
+        ]);
+
+        $wasDelivered = resolve(NotificationRouter::class)->dispatch(
+            $user,
+            new NotificationPayload(
+                eventType: NotificationEventType::INCIDENT,
+                title: 'Monitoring incident',
+                message: 'Service is down.',
+                severity: 'critical',
+                monitoringId: '01TEST',
+                monitoringName: 'API',
+                monitoringTarget: 'https://example.test',
+                occurredAt: now()
+            ),
+            ['mobile_push']
+        );
+
+        $this->assertFalse($wasDelivered);
+        $this->assertFalse($device->fresh()->enabled);
+        $this->assertNotNull($device->fresh()->revoked_at);
+        $this->assertDatabaseHas('notification_channel_deliveries', [
+            'user_id' => $user->id,
+            'channel' => 'mobile_push',
+            'event_type' => NotificationEventType::INCIDENT->value,
+            'status' => NotificationDeliveryStatus::FAILED->value,
+        ]);
+    }
+
+    public function test_router_keeps_mobile_push_delivery_successful_when_one_device_fails(): void
+    {
+        $privateKey = $this->test_ec_private_key();
+
+        config([
+            'services.fcm.project_id' => 'webguard-test',
+            'services.fcm.access_token' => 'test-access-token',
+            'services.apns.key_id' => 'ABC123DEFG',
+            'services.apns.team_id' => 'TEAM123456',
+            'services.apns.bundle_id' => 'dev.marcelbreuer.webguard',
+            'services.apns.private_key' => $privateKey,
+            'services.apns.environment' => 'development',
+        ]);
+
+        Package::factory()->create();
+        $user = User::factory()->create([
+            'notification_channels' => [
+                'mobile_push' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]);
+        $successfulDevice = MobilePushDevice::factory()->for($user)->create([
+            'push_token' => 'active-fcm-token',
+            'token_hash' => hash('sha256', 'active-fcm-token'),
+            'last_seen_at' => now()->subDay(),
+        ]);
+        $failedDevice = MobilePushDevice::factory()->for($user)->create([
+            'platform' => 'ios',
+            'push_provider' => 'apns',
+            'push_token' => 'bad-apns-token',
+            'token_hash' => hash('sha256', 'bad-apns-token'),
+        ]);
+
+        Http::fake([
+            'https://fcm.googleapis.com/*' => Http::response(['name' => 'projects/webguard-test/messages/123'], 200),
+            'https://api.sandbox.push.apple.com/*' => Http::response(['reason' => 'BadDeviceToken'], 400),
+        ]);
+
+        $wasDelivered = resolve(NotificationRouter::class)->dispatch(
+            $user,
+            new NotificationPayload(
+                eventType: NotificationEventType::INCIDENT,
+                title: 'Monitoring incident',
+                message: 'Service is down.',
+                severity: 'critical',
+                monitoringId: '01TEST',
+                monitoringName: 'API',
+                monitoringTarget: 'https://example.test',
+                occurredAt: now()
+            ),
+            ['mobile_push']
+        );
+
+        $this->assertTrue($wasDelivered);
+        $this->assertTrue($successfulDevice->fresh()->last_seen_at->isToday());
+        $this->assertFalse($failedDevice->fresh()->enabled);
+        $this->assertNotNull($failedDevice->fresh()->revoked_at);
         $this->assertDatabaseHas('notification_channel_deliveries', [
             'user_id' => $user->id,
             'channel' => 'mobile_push',


### PR DESCRIPTION
## Summary

Adds focused coverage for mobile push notification failure paths introduced around APNs/mobile push delivery:

- missing mobile push user context on the driver
- invalid FCM token revocation when all active devices fail
- partial success when one device sends and an APNs device returns `BadDeviceToken`

## Initial Coverage Result

Initial Docker coverage run passed with total line coverage at 84.8%.

Relevant changed production areas from the mobile auth/APNs work were evaluated from the generated coverage output:

- `MobileAuthController`: 100.0%
- `MobilePushDeviceController`: 96.4%
- `MobileLoginRequest`: 100.0%
- `StoreMobilePushDeviceRequest`: 100.0%
- `ApnsClient`: 85.7%
- `MobilePushChannelDriver`: 63.0%

## Identified Coverage Gap

`MobilePushChannelDriver` was below the 80% threshold. The uncovered behavior was concentrated in failure and edge paths: missing user context, send failures, invalid-token revocation, and partial delivery failures.

## Tests Added

Updated `tests/Feature/Notifications/NotificationRouterTest.php` with three focused tests covering:

- driver exception when `user_id` context is missing
- failed mobile push delivery revoking an invalid FCM device token
- successful delivery with one FCM device while an APNs bad token is revoked

## Final Coverage Result

Final Docker coverage with regenerated HTML report passed. Relevant changed areas are now above the required 80% threshold:

- `MobilePushChannelDriver`: 98.15% lines, 53 / 54; 80.00% methods, 4 / 5
- `ApnsClient`: 88.31% lines, 68 / 77
- overall app line coverage: 85.22%

HTML report entrypoint generated locally at `coverage/index.html` during validation and not committed.

## Validation

Commands run inside Docker:

```bash
docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --entrypoint sh php -lc 'composer test:coverage'
docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --user root --entrypoint sh php -lc 'install-php-extensions xdebug >/tmp/xdebug-install.log 2>&1 && XDEBUG_MODE=coverage composer test:coverage'
docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --user root --entrypoint sh php -lc 'install-php-extensions xdebug >/tmp/xdebug-install.log 2>&1 && rm -rf coverage && XDEBUG_MODE=coverage ./vendor/bin/pest --coverage-html coverage --min=0'
docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --entrypoint sh php -lc './vendor/bin/pest tests/Feature/Notifications/NotificationRouterTest.php'
docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --entrypoint sh php -lc 'composer test'
docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --entrypoint sh php -lc './vendor/bin/pint --test tests/Feature/Notifications/NotificationRouterTest.php'
```

Results:

- focused notification router tests: 10 passed
- full Pest suite: 532 passed, 3 skipped
- final coverage suite: 532 passed, 3 skipped
- Pint check: passed