### PR TITLE
feat: add GEO schema markup

### DIFF
--- a/app/Support/Seo/StructuredData.php
+++ b/app/Support/Seo/StructuredData.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Seo;
+
+use App\Http\Controllers\PublicFeatureController;
+use Illuminate\Support\Str;
+use JsonException;
+
+class StructuredData
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function marketingPage(string $title, string $description, string $url, string $logoUrl): array
+    {
+        $baseUrl = url('/');
+        $routeName = request()->route()?->getName();
+        $graph = [
+            self::organization($baseUrl, $logoUrl),
+            self::website($baseUrl),
+            self::softwareApplication($baseUrl),
+            self::webPage($title, $description, $url, $baseUrl),
+        ];
+
+        $breadcrumbs = self::breadcrumbs($routeName, $url);
+
+        if ($breadcrumbs !== []) {
+            $graph[] = self::breadcrumbList($breadcrumbs, $url);
+        }
+
+        if ($routeName === 'public-features.index') {
+            $featureList = self::featureItemList();
+
+            $graph[] = $featureList;
+            $graph[3]['mainEntity'] = ['@id' => $featureList['@id']];
+        }
+
+        if ($routeName === 'public-features.show') {
+            $feature = self::currentFeature();
+
+            if ($feature !== null) {
+                $graph[] = $feature;
+                $graph[3]['about'] = ['@id' => $feature['@id']];
+                $graph[3]['mainEntity'] = ['@id' => $feature['@id']];
+            }
+        }
+
+        return [
+            '@context' => 'https://schema.org',
+            '@graph' => $graph,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     *
+     * @throws JsonException
+     */
+    public static function toJson(array $data): string
+    {
+        return json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function organization(string $baseUrl, string $logoUrl): array
+    {
+        return [
+            '@type' => 'Organization',
+            '@id' => $baseUrl . '#organization',
+            'name' => __('app.name'),
+            'url' => $baseUrl,
+            'logo' => [
+                '@type' => 'ImageObject',
+                'url' => $logoUrl,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function website(string $baseUrl): array
+    {
+        return [
+            '@type' => 'WebSite',
+            '@id' => $baseUrl . '#website',
+            'name' => __('app.name'),
+            'url' => $baseUrl,
+            'inLanguage' => str_replace('_', '-', app()->getLocale()),
+            'publisher' => ['@id' => $baseUrl . '#organization'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function softwareApplication(string $baseUrl): array
+    {
+        return [
+            '@type' => 'SoftwareApplication',
+            '@id' => $baseUrl . '#software',
+            'name' => __('app.name'),
+            'applicationCategory' => 'BusinessApplication',
+            'applicationSubCategory' => 'Website monitoring and incident communication',
+            'operatingSystem' => 'Web',
+            'description' => __('app.description'),
+            'url' => route('welcome'),
+            'publisher' => ['@id' => $baseUrl . '#organization'],
+            'audience' => [
+                '@type' => 'Audience',
+                'audienceType' => 'SaaS teams, operators, developers, and website owners',
+            ],
+            'featureList' => self::featureNames(),
+            'offers' => [
+                '@type' => 'Offer',
+                'price' => '0',
+                'priceCurrency' => 'EUR',
+                'availability' => 'https://schema.org/InStock',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function webPage(string $title, string $description, string $url, string $baseUrl): array
+    {
+        return [
+            '@type' => 'WebPage',
+            '@id' => $url . '#webpage',
+            'url' => $url,
+            'name' => $title,
+            'description' => $description,
+            'isPartOf' => ['@id' => $baseUrl . '#website'],
+            'publisher' => ['@id' => $baseUrl . '#organization'],
+            'inLanguage' => str_replace('_', '-', app()->getLocale()),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function featureItemList(): array
+    {
+        return [
+            '@type' => 'ItemList',
+            '@id' => route('public-features.index') . '#feature-list',
+            'name' => __('public_features.index.hero.title'),
+            'itemListElement' => collect(PublicFeatureController::features())
+                ->keys()
+                ->values()
+                ->map(fn (string $slug, int $index): array => [
+                    '@type' => 'ListItem',
+                    'position' => $index + 1,
+                    'url' => route('public-features.show', $slug),
+                    'name' => self::featureTitle($slug),
+                ])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function currentFeature(): ?array
+    {
+        $slug = request()->route('feature');
+
+        if (! is_string($slug) || ! array_key_exists($slug, PublicFeatureController::features())) {
+            return null;
+        }
+
+        $featureKey = PublicFeatureController::features()[$slug]['key'];
+
+        return [
+            '@type' => 'DefinedTerm',
+            '@id' => route('public-features.show', $slug) . '#feature',
+            'name' => self::featureTitle($slug),
+            'description' => (string) __('public_features.features.' . $featureKey . '.lead'),
+            'url' => route('public-features.show', $slug),
+            'inDefinedTermSet' => [
+                '@type' => 'DefinedTermSet',
+                '@id' => route('public-features.index') . '#feature-list',
+                'name' => __('public_features.index.hero.title'),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function featureNames(): array
+    {
+        return collect(PublicFeatureController::features())
+            ->keys()
+            ->map(fn (string $slug): string => self::featureTitle($slug))
+            ->values()
+            ->all();
+    }
+
+    private static function featureTitle(string $slug): string
+    {
+        $feature = PublicFeatureController::features()[$slug];
+
+        return (string) __('public_features.features.' . $feature['key'] . '.title');
+    }
+
+    /**
+     * @return list<array{name: string, item: string}>
+     */
+    private static function breadcrumbs(?string $routeName, string $url): array
+    {
+        $breadcrumbs = [
+            ['name' => __('app.name'), 'item' => route('welcome')],
+        ];
+
+        if ($routeName === 'welcome') {
+            return $breadcrumbs;
+        }
+
+        if ($routeName === 'public-features.index') {
+            $breadcrumbs[] = ['name' => __('public_features.footer_link'), 'item' => $url];
+
+            return $breadcrumbs;
+        }
+
+        if ($routeName === 'public-features.show') {
+            $slug = request()->route('feature');
+
+            $breadcrumbs[] = ['name' => __('public_features.footer_link'), 'item' => route('public-features.index')];
+
+            if (is_string($slug) && array_key_exists($slug, PublicFeatureController::features())) {
+                $breadcrumbs[] = ['name' => self::featureTitle($slug), 'item' => $url];
+            }
+
+            return $breadcrumbs;
+        }
+
+        $routeLabel = Str::of((string) $routeName)->replace('-', ' ')->title()->toString();
+
+        if ($routeLabel !== '') {
+            $breadcrumbs[] = ['name' => $routeLabel, 'item' => $url];
+        }
+
+        return $breadcrumbs;
+    }
+
+    /**
+     * @param  list<array{name: string, item: string}>  $breadcrumbs
+     * @return array<string, mixed>
+     */
+    private static function breadcrumbList(array $breadcrumbs, string $url): array
+    {
+        return [
+            '@type' => 'BreadcrumbList',
+            '@id' => $url . '#breadcrumb',
+            'itemListElement' => collect($breadcrumbs)
+                ->values()
+                ->map(fn (array $breadcrumb, int $index): array => [
+                    '@type' => 'ListItem',
+                    'position' => $index + 1,
+                    'name' => $breadcrumb['name'],
+                    'item' => $breadcrumb['item'],
+                ])
+                ->all(),
+        ];
+    }
+}

--- a/resources/views/components/marketing-layout.blade.php
+++ b/resources/views/components/marketing-layout.blade.php
@@ -4,6 +4,19 @@
     if (! in_array($theme, ['light', 'dark', 'system'], true)) {
         $theme = 'system';
     }
+
+    $seoTitle = isset($title) ? trim((string) $title) : __('app.title');
+    $seoDescription = isset($description) ? trim((string) $description) : __('app.description');
+    $seoKeywords = isset($keywords) ? trim((string) $keywords) : __('app.keywords');
+    $seoCanonical = isset($canonical) ? trim((string) $canonical) : url('/');
+    $seoOgTitle = isset($ogTitle) ? trim((string) $ogTitle) : __('app.og_title');
+    $seoOgDescription = isset($ogDescription) ? trim((string) $ogDescription) : __('app.og_description');
+    $seoOgUrl = isset($ogUrl) ? trim((string) $ogUrl) : $seoCanonical;
+    $seoOgImage = isset($ogImage) ? trim((string) $ogImage) : Vite::asset('resources/images/Logo-WebGuard.png');
+    $seoTwitterTitle = isset($twitterTitle) ? trim((string) $twitterTitle) : $seoOgTitle;
+    $seoTwitterDescription = isset($twitterDescription) ? trim((string) $twitterDescription) : $seoOgDescription;
+    $seoTwitterImage = isset($twitterImage) ? trim((string) $twitterImage) : $seoOgImage;
+    $structuredData = \App\Support\Seo\StructuredData::marketingPage($seoTitle, $seoDescription, $seoCanonical, Vite::asset('resources/images/Logo-WebGuard.png'));
 @endphp
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="{{ $theme === 'dark' ? 'dark' : '' }}" data-theme="{{ $theme }}">
 
@@ -14,27 +27,31 @@
 
     {!! $head ?? '' !!}
 
-    <title>{{ isset($title) ? trim($title) : __('app.title') }}</title>
+    <title>{{ $seoTitle }}</title>
 
     <link rel="icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
     <link rel="apple-touch-icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
 
-    <meta name="description" content="{{ isset($description) ? trim($description) : __('app.description') }}">
-    <meta name="keywords" content="{{ isset($keywords) ? trim($keywords) : __('app.keywords') }}">
+    <meta name="description" content="{{ $seoDescription }}">
+    <meta name="keywords" content="{{ $seoKeywords }}">
     <meta name="author" content="{{ __('app.author') }}">
 
-    <meta property="og:title" content="{{ isset($ogTitle) ? trim($ogTitle) : __('app.og_title') }}">
-    <meta property="og:description" content="{{ isset($ogDescription) ? trim($ogDescription) : __('app.og_description') }}">
+    <meta property="og:title" content="{{ $seoOgTitle }}">
+    <meta property="og:description" content="{{ $seoOgDescription }}">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ isset($ogUrl) ? trim($ogUrl) : url('/') }}">
-    <meta property="og:image" content="{{ isset($ogImage) ? trim($ogImage) : Vite::asset('resources/images/Logo-WebGuard.png') }}">
+    <meta property="og:url" content="{{ $seoOgUrl }}">
+    <meta property="og:image" content="{{ $seoOgImage }}">
 
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{{ isset($twitterTitle) ? trim($twitterTitle) : (isset($ogTitle) ? trim($ogTitle) : __('app.og_title')) }}">
-    <meta name="twitter:description" content="{{ isset($twitterDescription) ? trim($twitterDescription) : (isset($ogDescription) ? trim($ogDescription) : __('app.og_description')) }}">
-    <meta name="twitter:image" content="{{ isset($twitterImage) ? trim($twitterImage) : (isset($ogImage) ? trim($ogImage) : Vite::asset('resources/images/Logo-WebGuard.png')) }}">
+    <meta name="twitter:title" content="{{ $seoTwitterTitle }}">
+    <meta name="twitter:description" content="{{ $seoTwitterDescription }}">
+    <meta name="twitter:image" content="{{ $seoTwitterImage }}">
 
-    <link rel="canonical" href="{{ isset($canonical) ? trim($canonical) : url('/') }}">
+    <link rel="canonical" href="{{ $seoCanonical }}">
+
+    <script type="application/ld+json">
+        {!! \App\Support\Seo\StructuredData::toJson($structuredData) !!}
+    </script>
 
     @vite(['resources/css/app.css', 'resources/js/app.ts'])
 </head>

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -10,25 +10,6 @@
     <x-slot:ogDescription>{{ __('public_features.index.seo.og_description') }}</x-slot:ogDescription>
     <x-slot:canonical>{{ route('public-features.index') }}</x-slot:canonical>
 
-    <x-slot:head>
-        @php
-            $structuredData = [
-                '@context' => 'https://schema.org',
-                '@type' => 'ItemList',
-                'name' => __('public_features.index.hero.title'),
-                'itemListElement' => $featureItems->keys()->values()->map(fn (string $slug, int $index): array => [
-                    '@type' => 'ListItem',
-                    'position' => $index + 1,
-                    'url' => route('public-features.show', $slug),
-                    'name' => __('public_features.features.' . $features[$slug]['key'] . '.title'),
-                ])->all(),
-            ];
-        @endphp
-        <script type="application/ld+json">
-            {!! json_encode($structuredData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
-        </script>
-    </x-slot:head>
-
     <main>
         <header class="border-b border-slate-200/80 dark:border-slate-800/70">
             <x-main class="grid w-full gap-10 py-14 lg:grid-cols-[1fr_0.72fr] lg:items-center lg:py-20">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -21,28 +21,6 @@
     <x-slot:twitterImage>{{ Vite::asset('resources/images/landing-hero-purple.webp') }}</x-slot:twitterImage>
     <x-slot:canonical>{{ route('welcome') }}</x-slot:canonical>
 
-    <x-slot:head>
-        @php
-            $structuredData = [
-                '@context' => 'https://schema.org',
-                '@type' => 'SoftwareApplication',
-                'name' => __('app.name'),
-                'applicationCategory' => 'BusinessApplication',
-                'operatingSystem' => 'Web',
-                'description' => __('welcome.seo.description'),
-                'url' => route('welcome'),
-                'offers' => [
-                    '@type' => 'Offer',
-                    'price' => '0',
-                    'priceCurrency' => 'EUR',
-                ],
-            ];
-        @endphp
-        <script type="application/ld+json">
-            {!! json_encode($structuredData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
-        </script>
-    </x-slot:head>
-
     <main>
         <header class="border-b border-slate-200/80 bg-white dark:border-slate-800/70 dark:bg-slate-950">
             <x-main class="grid w-full gap-10 py-12 lg:grid-cols-[0.95fr_1.05fr] lg:items-center lg:py-16">

--- a/tests/Feature/PublicFeaturePagesTest.php
+++ b/tests/Feature/PublicFeaturePagesTest.php
@@ -37,6 +37,10 @@ class PublicFeaturePagesTest extends TestCase
         $testResponse->assertSeeText(__('public_features.features.' . $feature['key'] . '.title'));
         $testResponse->assertSeeText(__('public_features.show.how_it_helps'));
         $testResponse->assertSeeHtml(sprintf('<link rel="canonical" href="%s">', route('public-features.show', $slug)));
+        $testResponse->assertSeeHtml('"@type":"DefinedTerm"');
+        $testResponse->assertSeeHtml('"@id":"' . route('public-features.show', $slug) . '#feature"');
+        $testResponse->assertSeeHtml('"name":"' . __('public_features.features.' . $feature['key'] . '.title') . '"');
+        $testResponse->assertSeeHtml('"mainEntity":{"@id":"' . route('public-features.show', $slug) . '#feature"}');
     }
 
     public function test_feature_overview_links_all_public_feature_pages_and_api_docs(): void
@@ -49,6 +53,10 @@ class PublicFeaturePagesTest extends TestCase
         foreach (PublicFeatureController::slugs() as $slug) {
             $testResponse->assertSeeHtml(route('public-features.show', $slug));
         }
+
+        $testResponse->assertSeeHtml('"@type":"ItemList"');
+        $testResponse->assertSeeHtml('"@id":"' . route('public-features.index') . '#feature-list"');
+        $testResponse->assertSeeHtml('"itemListElement":');
     }
 
     public function test_public_feature_overview_uses_marketing_navigation_shell(): void

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -104,9 +104,15 @@ class PublicIndexingTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('<script type="application/ld+json">');
+        $testResponse->assertSeeHtml('"@graph":');
+        $testResponse->assertSeeHtml('"@type":"Organization"');
+        $testResponse->assertSeeHtml('"@type":"WebSite"');
         $testResponse->assertSeeHtml('"@type":"SoftwareApplication"');
         $testResponse->assertSeeHtml('"applicationCategory":"BusinessApplication"');
         $testResponse->assertSeeHtml('"url":"' . route('welcome') . '"');
+        $testResponse->assertSeeHtml('"featureList":');
+        $testResponse->assertSeeHtml('"HTTP Monitoring"');
+        $testResponse->assertSeeHtml('"REST API and Integrations"');
         $testResponse->assertSeeHtml('"price":"0"');
         $testResponse->assertSeeHtml('"priceCurrency":"EUR"');
     }


### PR DESCRIPTION
## What changed

- Added a central structured-data builder for marketing pages.
- Marketing pages now emit a JSON-LD `@graph` with Organization, WebSite, SoftwareApplication, WebPage, and BreadcrumbList entities.
- Feature overview pages include an ItemList entity and feature detail pages include a DefinedTerm entity so crawlers and generative engines can understand WebGuard capabilities more explicitly.
- Removed duplicated page-local JSON-LD snippets from the welcome and feature index views.
- Updated public indexing and feature page tests to cover the richer structured data contract.

## Why

Generative Engine Optimization benefits from consistent, machine-readable context about the product, publisher, canonical pages, feature set, and individual feature pages. Centralizing the markup avoids drift between marketing views and keeps future schema changes testable.

## Testing

- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=sqlite DB_DATABASE=':memory:' ./vendor/bin/pest tests/Feature/PublicIndexingTest.php tests/Feature/PublicFeaturePagesTest.php`
- `./vendor/bin/phpstan analyse app/Support/Seo/StructuredData.php --memory-limit=1G`
- `./vendor/bin/pint app/Support/Seo/StructuredData.php tests/Feature/PublicIndexingTest.php tests/Feature/PublicFeaturePagesTest.php`

Docker validation was attempted first, but Docker Desktop was not startable in the local environment. Host validation used project dependencies installed with `--ignore-platform-req=ext-redis` because the local PHP installation lacks the Redis extension.

## Risks and follow-up

- The change affects the shared marketing layout, so all indexable marketing pages now receive the base JSON-LD graph.
- Public label/status pages use separate layouts and are not changed by this PR.