### PR TITLE
fix(deploy): let Coolify manage proxy labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://webguard.test
 SERVICE_URL_PHP=http://webguard.test
-SERVICE_FQDN_PHP=webguard.test
 APP_TIMEZONE=Europe/Berlin
 
 IMPRINT_OPERATOR_NAME=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,28 +100,6 @@ services:
         aliases:
           - webguard-core
           - webguard-api
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=${WEBGUARD_NETWORK:-webguard-network}
-      - traefik.http.middlewares.webguard-${COOLIFY_RESOURCE_UUID:-local}-redirect.redirectscheme.scheme=https
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.rule=Host(`${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.entrypoints=http
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.middlewares=webguard-${COOLIFY_RESOURCE_UUID:-local}-redirect
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-http.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.rule=Host(`${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.entrypoints=https
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.tls=true
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.tls.certresolver=letsencrypt
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.entrypoints=http
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.entrypoints=https
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls=true
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls.certresolver=letsencrypt
-      - traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}
-      - traefik.http.services.webguard-${COOLIFY_RESOURCE_UUID:-local}.loadbalancer.server.port=8080
 
   schedule:
     container_name: webguard-schedule

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,6 @@ Minimum `.env` fields for production:
 
 ```env
 SERVICE_URL_PHP=https://webguard.example.com
-SERVICE_FQDN_PHP=webguard.example.com
 APP_KEY=base64:...
 WEBGUARD_NETWORK=coolify
 DOCKER_SSL_MODE=off
@@ -120,7 +119,7 @@ MAIL_FROM_ADDRESS=noreply@example.com
 MAIL_FROM_NAME=WebGuard
 ```
 
-When using Coolify, set concrete values instead of referencing another variable inside the value. For example, use `SERVICE_URL_PHP=https://webguard.example.com`, `SERVICE_FQDN_PHP=webguard.example.com`, `SMTP_USERNAME=noreply@example.com`, `MAIL_FROM_NAME=WebGuard`, and `GITHUB_REDIRECT_URI=https://webguard.example.com/auth/github/callback`. Do not use values such as `APP_URL={$SERVICE_URL_PHP}` or `MAIL_USERNAME=${MAIL_FROM_ADDRESS}` because Docker Compose evaluates the env file during build and can warn or substitute empty strings before the container starts.
+When using Coolify, set concrete values instead of referencing another variable inside the value. For example, use `SERVICE_URL_PHP=https://webguard.example.com`, `SMTP_USERNAME=noreply@example.com`, `MAIL_FROM_NAME=WebGuard`, and `GITHUB_REDIRECT_URI=https://webguard.example.com/auth/github/callback`. Do not use values such as `APP_URL={$SERVICE_URL_PHP}` or `MAIL_USERNAME=${MAIL_FROM_ADDRESS}` because Docker Compose evaluates the env file during build and can warn or substitute empty strings before the container starts.
 
 For Docker deployments, use `SMTP_USERNAME` as the input variable. The Compose file passes it into the container as Laravel's `MAIL_USERNAME`. This avoids Docker Compose expanding old values such as `MAIL_USERNAME=${MAIL_FROM_ADDRESS}` during Coolify builds.
 
@@ -172,7 +171,9 @@ The bundled `mysql` and `redis` services are behind the `internal-services` Comp
 
 Coolify detects variables that are referenced in `docker-compose.yml` and exposes them in its UI. Keep production secrets as runtime variables in Coolify and override `DB_HOST`, `DB_PASSWORD`, `REDIS_HOST`, `REDIS_PASSWORD`, and mail credentials there.
 
-For Coolify/Traefik routing, set `SERVICE_URL_PHP` to the public URL with protocol, for example `https://webguard-test.m-breuer.dev`, and set `SERVICE_FQDN_PHP` to the public hostname without protocol, for example `webguard-test.m-breuer.dev`. The production Compose labels route this hostname to the PHP container on internal port `8080` and request a Let's Encrypt certificate through Coolify's `letsencrypt` resolver.
+For Coolify routing, assign the public domain to the `php` service in Coolify and route it to internal port `8080`; for example, use `https://webguard-test.m-breuer.dev:8080` in the Coolify domain field. Set `SERVICE_URL_PHP` to the same public URL without the internal port, for example `https://webguard-test.m-breuer.dev`, so Laravel generates correct absolute URLs.
+
+Do not add custom Traefik labels that reference `SERVICE_FQDN_PHP` or Docker Compose defaults such as `${SERVICE_FQDN_PHP:-webguard.example.com}` in Coolify. Coolify generates the proxy routing and Let's Encrypt labels from the assigned domain; shipping custom labels can leave unresolved placeholders in Traefik and cause invalid `HostSNI` or ACME identifiers.
 
 The application listens internally on `8080` for HTTP and `8443` for optional container-level HTTPS. For Coolify deployments, keep `DOCKER_SSL_MODE=off` and let Coolify/Traefik generate and terminate public TLS.
 

--- a/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
+++ b/tests/Feature/HeartbeatQueueDeploymentConfigTest.php
@@ -349,56 +349,27 @@ PHP
         rmdir($appBaseDirectory);
     }
 
-    public function test_production_php_container_declares_coolify_traefik_labels(): void
+    public function test_production_php_container_exposes_http_port_for_coolify_proxy(): void
     {
         $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
 
         $this->assertIsString($composeConfiguration);
-        $this->assertStringContainsString('traefik.enable=true', $composeConfiguration);
-        $this->assertStringContainsString('traefik.docker.network=${WEBGUARD_NETWORK:-webguard-network}', $composeConfiguration);
-        $this->assertStringContainsString('Host(`${SERVICE_FQDN_PHP:-webguard.example.com}`)', $composeConfiguration);
-        $this->assertStringContainsString('entrypoints=https', $composeConfiguration);
-        $this->assertStringContainsString('tls.certresolver=letsencrypt', $composeConfiguration);
-        $this->assertStringContainsString('loadbalancer.server.port=8080', $composeConfiguration);
+        $this->assertStringContainsString('expose:', $composeConfiguration);
+        $this->assertStringContainsString('- "8080"', $composeConfiguration);
+        $this->assertStringNotContainsString('traefik.http.routers.', $composeConfiguration);
+        $this->assertStringNotContainsString('Host(`${SERVICE_FQDN_PHP', $composeConfiguration);
+        $this->assertStringNotContainsString('Host(`www.${SERVICE_FQDN_PHP', $composeConfiguration);
     }
 
-    public function test_production_php_container_routes_www_host_to_app(): void
+    public function test_production_compose_lets_coolify_generate_proxy_labels(): void
     {
         $composeConfiguration = file_get_contents(base_path('docker-compose.yml'));
 
         $this->assertIsString($composeConfiguration);
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.entrypoints=http',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-http.service=webguard-${COOLIFY_RESOURCE_UUID:-local}',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.rule=Host(`www.${SERVICE_FQDN_PHP:-webguard.example.com}`) && PathPrefix(`/`)',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.entrypoints=https',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls=true',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.tls.certresolver=letsencrypt',
-            $composeConfiguration
-        );
-        $this->assertStringContainsString(
-            'traefik.http.routers.webguard-${COOLIFY_RESOURCE_UUID:-local}-www-https.service=webguard-${COOLIFY_RESOURCE_UUID:-local}',
-            $composeConfiguration
-        );
+        $this->assertStringNotContainsString('SERVICE_FQDN_PHP', $composeConfiguration);
+        $this->assertStringNotContainsString('COOLIFY_RESOURCE_UUID', $composeConfiguration);
+        $this->assertStringNotContainsString('tls.certresolver=letsencrypt', $composeConfiguration);
+        $this->assertStringNotContainsString('loadbalancer.server.port=8080', $composeConfiguration);
         $this->assertStringNotContainsString('www-redirect.redirectregex', $composeConfiguration);
     }
 }


### PR DESCRIPTION
## What changed
- Removed production Traefik router labels from `docker-compose.yml` so Coolify can generate proxy and Let's Encrypt labels from the assigned domain.
- Removed `SERVICE_FQDN_PHP` from the example environment because the compose file no longer consumes it.
- Updated installation docs to configure the Coolify domain on the `php` service using internal port `8080` while keeping `SERVICE_URL_PHP` as the public Laravel URL.
- Updated deployment config tests to prevent reintroducing unresolved Coolify/Compose placeholders in production proxy labels.

## Why
Coolify/Traefik was receiving literal placeholders such as `${SERVICE_FQDN_PHP:-webguard.example.com}` in `Host`/`HostSNI` rules and ACME identifiers. Those are invalid hostnames, so route registration and certificate issuance failed.

## Testing
- `./vendor/bin/pest tests/Feature/HeartbeatQueueDeploymentConfigTest.php` passed locally: 23 tests.
- Rendered production compose with required variables and confirmed the `php` service resolves `APP_URL`, exposes `8080`, and does not include custom Traefik labels or unresolved Coolify placeholders.

## Notes
Docker-based test execution could not be run on the local machine because Docker Desktop reported that it was unable to start. Host PHP was used for the focused Pest test as a fallback.