### PR TITLE
fix(api): exclude mobile app tokens from usage limits

### DIFF
--- a/app/Http/Middleware/TrackApiUsage.php
+++ b/app/Http/Middleware/TrackApiUsage.php
@@ -8,6 +8,8 @@ use App\Jobs\LogApiUsage;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\PersonalAccessToken;
 use Symfony\Component\HttpFoundation\Response;
 
 class TrackApiUsage
@@ -25,6 +27,10 @@ class TrackApiUsage
             $user = auth('sanctum')->user();
 
             if ($user) {
+                if ($this->isMobileAppToken($user->currentAccessToken())) {
+                    return $next($request);
+                }
+
                 $key = 'api:' . $user->getAuthIdentifier();
 
                 if (RateLimiter::tooManyAttempts($key, 5)) {
@@ -42,5 +48,14 @@ class TrackApiUsage
         }
 
         abort(403);
+    }
+
+    private function isMobileAppToken(mixed $accessToken): bool
+    {
+        if (! $accessToken instanceof PersonalAccessToken) {
+            return false;
+        }
+
+        return Str::startsWith($accessToken->name, ['ios-app:', 'android-app:']);
     }
 }

--- a/tests/Feature/Api/ApiControllerTest.php
+++ b/tests/Feature/Api/ApiControllerTest.php
@@ -77,6 +77,42 @@ class ApiControllerTest extends TestCase
         $this->assertLessThanOrEqual(60, $retryAfter);
     }
 
+    public function test_api_access_tokens_are_rate_limited_and_logged(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $token = $user->createToken('api-access')->plainTextToken;
+
+        foreach (range(1, 5) as $_) {
+            $this->withToken($token)
+                ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+                ->assertOk();
+        }
+
+        $this->withToken($token)
+            ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+            ->assertTooManyRequests();
+
+        $this->assertDatabaseCount('api_logs', 5);
+    }
+
+    public function test_mobile_app_tokens_are_not_rate_limited_or_logged_as_api_usage(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $token = $user->createToken('ios-app:Marcel iPhone')->plainTextToken;
+
+        foreach (range(1, 6) as $_) {
+            $this->withToken($token)
+                ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+                ->assertOk();
+        }
+
+        $this->assertDatabaseCount('api_logs', 0);
+    }
+
     public function test_all_endpoint_returns_combined_monitoring_payload_without_nested_controller_responses(): void
     {
         Date::setTestNow('2026-04-12 12:00:00');


### PR DESCRIPTION
## What changed
- Excludes mobile app Sanctum tokens from API usage rate limiting and API usage logging.
- Adds coverage proving explicit API tokens are still limited and logged while mobile app tokens are not.

## Why
Mobile app traffic can use authenticated `/api/v1/*` endpoints, but app usage should not count against explicit API usage limits.

## Testing
- `./vendor/bin/pest tests/Feature/Api/ApiControllerTest.php`
- `./vendor/bin/pint app/Http/Middleware/TrackApiUsage.php tests/Feature/Api/ApiControllerTest.php`
- `composer analyse`

## Risks
- Mobile token detection currently follows the existing Sanctum token name prefixes: `ios-app:` and `android-app:`.
