### PR TITLE
Allow team admins to schedule maintenance

### DIFF
--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
-use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 class MaintenanceController extends Controller
@@ -23,7 +22,8 @@ class MaintenanceController extends Controller
         $user = Auth::user();
 
         return view('maintenance.index', [
-            'monitorings' => $user->monitorings()
+            'monitorings' => Monitoring::query()
+                ->manageableBy($user)
                 ->with('groups:id,name')
                 ->orderBy('name')
                 ->get(),
@@ -55,16 +55,23 @@ class MaintenanceController extends Controller
     public function destroy(Request $request): RedirectResponse
     {
         abort_if($request->user()?->isDemo(), 403);
+        /** @var User $user */
+        $user = $request->user();
 
         $validated = $request->validate([
             'monitoring_id' => [
                 'required',
                 'string',
-                Rule::exists('monitorings', 'id')->where('user_id', $request->user()?->id),
+                function ($attribute, $value, $fail) use ($user): void {
+                    if (! Monitoring::query()->manageableBy($user)->whereKey((string) $value)->exists()) {
+                        $fail(__('validation.exists', ['attribute' => __('maintenance.form.monitoring')]));
+                    }
+                },
             ],
         ]);
 
         Monitoring::query()
+            ->manageableBy($user)
             ->whereKey($validated['monitoring_id'])
             ->update([
                 'maintenance_from' => null,
@@ -77,7 +84,9 @@ class MaintenanceController extends Controller
 
     private function targetMonitorings(MaintenanceRequest $maintenanceRequest): Builder
     {
-        $query = Monitoring::query();
+        /** @var User $user */
+        $user = $maintenanceRequest->user();
+        $query = Monitoring::query()->manageableBy($user);
 
         if ($maintenanceRequest->string('scope')->toString() === 'group') {
             return $query->whereHas('groups', function ($builder) use ($maintenanceRequest): void {

--- a/app/Http/Requests/MaintenanceRequest.php
+++ b/app/Http/Requests/MaintenanceRequest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\Monitoring;
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class MaintenanceRequest extends FormRequest
 {
@@ -25,7 +28,6 @@ class MaintenanceRequest extends FormRequest
                 'nullable',
                 'required_if:scope,monitoring',
                 'string',
-                Rule::exists('monitorings', 'id')->where('user_id', $this->user()?->id),
             ],
             'monitoring_group_id' => [
                 'nullable',
@@ -35,6 +37,35 @@ class MaintenanceRequest extends FormRequest
             ],
             'maintenance_from' => ['required', 'date'],
             'maintenance_until' => ['nullable', 'date', 'after:maintenance_from'],
+        ];
+    }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($this->string('scope')->toString() !== 'monitoring' || $validator->errors()->has('monitoring_id')) {
+                    return;
+                }
+
+                $user = $this->user();
+                $monitoringId = $this->string('monitoring_id')->toString();
+
+                if (! $user instanceof User || $monitoringId === '') {
+                    return;
+                }
+
+                $isManageable = Monitoring::query()
+                    ->manageableBy($user)
+                    ->whereKey($monitoringId)
+                    ->exists();
+
+                if (! $isManageable) {
+                    $validator->errors()->add('monitoring_id', __('validation.exists', [
+                        'attribute' => __('maintenance.form.monitoring'),
+                    ]));
+                }
+            },
         ];
     }
 }

--- a/app/Http/Requests/MaintenanceRequest.php
+++ b/app/Http/Requests/MaintenanceRequest.php
@@ -6,9 +6,9 @@ namespace App\Http\Requests;
 
 use App\Models\Monitoring;
 use App\Models\User;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Validator;
 
 class MaintenanceRequest extends FormRequest
 {

--- a/tests/Feature/MaintenanceManagementTest.php
+++ b/tests/Feature/MaintenanceManagementTest.php
@@ -6,10 +6,12 @@ namespace Tests\Feature;
 
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
+use App\Enums\TeamRole;
 use App\Models\Monitoring;
 use App\Models\MonitoringGroup;
 use App\Models\Package;
 use App\Models\ServerInstance;
+use App\Models\Team;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -108,6 +110,93 @@ class MaintenanceManagementTest extends TestCase
             'id' => $outsideMonitoring->id,
             'maintenance_from' => null,
             'maintenance_until' => null,
+        ]);
+    }
+
+    public function test_team_admin_can_schedule_and_clear_maintenance_for_team_monitoring(): void
+    {
+        $team = Team::factory()->create(['created_by_user_id' => $this->user->id]);
+        $team->memberships()->create([
+            'user_id' => $this->user->id,
+            'role' => TeamRole::ADMIN,
+        ]);
+        $monitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'created_by_user_id' => $this->user->id,
+            'name' => 'Team API',
+            'preferred_location' => $this->serverInstance->code,
+        ]);
+
+        $this->actingAs($this->user)->get(route('maintenance.index'))
+            ->assertOk()
+            ->assertSeeText('Team API');
+
+        $this->actingAs($this->user)->post(route('maintenance.store'), [
+            'scope' => 'monitoring',
+            'monitoring_id' => $monitoring->id,
+            'maintenance_from' => '2026-07-03T10:00',
+            'maintenance_until' => '2026-07-03T11:00',
+        ])->assertRedirect(route('maintenance.index'));
+
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'maintenance_from' => '2026-07-03 10:00:00',
+            'maintenance_until' => '2026-07-03 11:00:00',
+        ]);
+
+        $this->actingAs($this->user)->delete(route('maintenance.destroy'), [
+            'monitoring_id' => $monitoring->id,
+        ])->assertRedirect(route('maintenance.index'));
+
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'maintenance_from' => null,
+            'maintenance_until' => null,
+        ]);
+    }
+
+    public function test_team_member_cannot_schedule_or_clear_team_monitoring_maintenance(): void
+    {
+        $member = User::factory()->create(['package_id' => Package::factory()->create()->id]);
+        $team = Team::factory()->create(['created_by_user_id' => $this->user->id]);
+        $team->memberships()->create([
+            'user_id' => $this->user->id,
+            'role' => TeamRole::ADMIN,
+        ]);
+        $team->memberships()->create([
+            'user_id' => $member->id,
+            'role' => TeamRole::MEMBER,
+        ]);
+        $monitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'created_by_user_id' => $this->user->id,
+            'name' => 'Shared API',
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+
+        $this->actingAs($member)->get(route('maintenance.index'))
+            ->assertOk()
+            ->assertDontSeeText('Shared API');
+
+        $this->actingAs($member)->post(route('maintenance.store'), [
+            'scope' => 'monitoring',
+            'monitoring_id' => $monitoring->id,
+            'maintenance_from' => '2026-07-03T10:00',
+            'maintenance_until' => '2026-07-03T11:00',
+        ])->assertSessionHasErrors(['monitoring_id']);
+
+        $this->actingAs($member)->delete(route('maintenance.destroy'), [
+            'monitoring_id' => $monitoring->id,
+        ])->assertSessionHasErrors(['monitoring_id']);
+
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
         ]);
     }
 


### PR DESCRIPTION
## Summary
- allow central maintenance scheduling to include monitorings manageable by the current user, including team-owned monitorings for team admins
- validate schedule and clear actions against the existing monitoring manageability scope
- add regression coverage for team admin access and team member denial

## Testing
- Docker: `./vendor/bin/pest tests/Feature/MaintenanceManagementTest.php`
- Docker: `./vendor/bin/pint app/Http/Controllers/MaintenanceController.php app/Http/Requests/MaintenanceRequest.php tests/Feature/MaintenanceManagementTest.php`
- Docker: `composer analyse`
- Docker: `composer test -- --parallel`

## Rollout
No migrations or configuration changes required.
