### PR TITLE
fix: make maintenance page read-only for guests

### DIFF
--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -20,17 +20,29 @@ class MaintenanceController extends Controller
     {
         /** @var User $user */
         $user = Auth::user();
+        $manageableMonitorings = ! $user->isDemo()
+            ? Monitoring::query()
+                ->manageableBy($user)
+                ->orderBy('name')
+                ->get(['id', 'name'])
+            : collect();
+        $canManageMaintenance = $manageableMonitorings->isNotEmpty();
 
         return view('maintenance.index', [
             'monitorings' => Monitoring::query()
-                ->manageableBy($user)
+                ->visibleTo($user)
                 ->with('groups:id,name')
                 ->orderBy('name')
                 ->get(),
-            'monitoringGroups' => $user->monitoringGroups()
-                ->withCount('monitorings')
-                ->orderBy('name')
-                ->get(['id', 'name']),
+            'manageableMonitorings' => $manageableMonitorings,
+            'manageableMonitoringIds' => $manageableMonitorings->modelKeys(),
+            'monitoringGroups' => $canManageMaintenance
+                ? $user->monitoringGroups()
+                    ->withCount('monitorings')
+                    ->orderBy('name')
+                    ->get(['id', 'name'])
+                : collect(),
+            'canManageMaintenance' => $canManageMaintenance,
         ]);
     }
 

--- a/app/Http/Requests/MaintenanceRequest.php
+++ b/app/Http/Requests/MaintenanceRequest.php
@@ -14,7 +14,7 @@ class MaintenanceRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user() !== null;
+        return $this->user() !== null && ! $this->user()->isDemo();
     }
 
     /**

--- a/resources/views/maintenance/index.blade.php
+++ b/resources/views/maintenance/index.blade.php
@@ -4,74 +4,79 @@
     </x-slot>
 
     <x-main>
-        <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)]">
-            <x-container>
-                <x-heading type="h2">{{ __('maintenance.schedule.heading') }}</x-heading>
-                <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                    {{ __('maintenance.schedule.description') }}
-                </x-paragraph>
+        <div @class([
+            'grid gap-6',
+            'lg:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)]' => $canManageMaintenance,
+        ])>
+            @if ($canManageMaintenance)
+                <x-container>
+                    <x-heading type="h2">{{ __('maintenance.schedule.heading') }}</x-heading>
+                    <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        {{ __('maintenance.schedule.description') }}
+                    </x-paragraph>
 
-                <form method="POST" action="{{ route('maintenance.store') }}" class="mt-6 space-y-4" x-data="{ scope: @js(old('scope', 'monitoring')) }">
-                    @csrf
+                    <form method="POST" action="{{ route('maintenance.store') }}" class="mt-6 space-y-4" x-data="{ scope: @js(old('scope', 'monitoring')) }">
+                        @csrf
 
-                    <div>
-                        <x-input-label for="scope" :value="__('maintenance.form.scope')" />
-                        <x-select-input id="scope" class="mt-1 block w-full" name="scope" x-model="scope">
-                            <option value="monitoring">{{ __('maintenance.form.scopes.monitoring') }}</option>
-                            <option value="group">{{ __('maintenance.form.scopes.group') }}</option>
-                        </x-select-input>
-                        <x-input-error :messages="$errors->get('scope')" />
-                    </div>
-
-                    <div>
-                        <div x-show="scope === 'monitoring'">
-                            <x-input-label for="monitoring_id" :value="__('maintenance.form.monitoring')" />
-                            <x-select-input id="monitoring_id" class="mt-1 block w-full" name="monitoring_id">
-                                <option value="">{{ __('maintenance.form.select_monitoring') }}</option>
-                                @foreach ($monitorings as $monitoring)
-                                    <option value="{{ $monitoring->id }}" @selected(old('monitoring_id') === $monitoring->id)>
-                                        {{ $monitoring->name }}
-                                    </option>
-                                @endforeach
-                            </x-select-input>
-                            <x-input-error :messages="$errors->get('monitoring_id')" />
-                        </div>
-
-                        <div x-show="scope === 'group'">
-                            <x-input-label for="monitoring_group_id" :value="__('maintenance.form.group')" />
-                            <x-select-input id="monitoring_group_id" class="mt-1 block w-full" name="monitoring_group_id">
-                                <option value="">{{ __('maintenance.form.select_group') }}</option>
-                                @foreach ($monitoringGroups as $monitoringGroup)
-                                    <option value="{{ $monitoringGroup->id }}" @selected(old('monitoring_group_id') === $monitoringGroup->id)>
-                                        {{ $monitoringGroup->name }} ({{ $monitoringGroup->monitorings_count }})
-                                    </option>
-                                @endforeach
-                            </x-select-input>
-                            <x-input-error :messages="$errors->get('monitoring_group_id')" />
-                        </div>
-                    </div>
-
-                    <div class="grid gap-4 sm:grid-cols-2">
                         <div>
-                            <x-input-label for="maintenance_from" :value="__('maintenance.form.from')" />
-                            <x-text-input id="maintenance_from" type="datetime-local" name="maintenance_from" :value="old('maintenance_from')" required />
-                            <x-input-error :messages="$errors->get('maintenance_from')" />
+                            <x-input-label for="scope" :value="__('maintenance.form.scope')" />
+                            <x-select-input id="scope" class="mt-1 block w-full" name="scope" x-model="scope">
+                                <option value="monitoring">{{ __('maintenance.form.scopes.monitoring') }}</option>
+                                <option value="group">{{ __('maintenance.form.scopes.group') }}</option>
+                            </x-select-input>
+                            <x-input-error :messages="$errors->get('scope')" />
                         </div>
 
                         <div>
-                            <x-input-label for="maintenance_until" :value="__('maintenance.form.until')" />
-                            <x-text-input id="maintenance_until" type="datetime-local" name="maintenance_until" :value="old('maintenance_until')" />
-                            <x-input-error :messages="$errors->get('maintenance_until')" />
+                            <div x-show="scope === 'monitoring'">
+                                <x-input-label for="monitoring_id" :value="__('maintenance.form.monitoring')" />
+                                <x-select-input id="monitoring_id" class="mt-1 block w-full" name="monitoring_id">
+                                    <option value="">{{ __('maintenance.form.select_monitoring') }}</option>
+                                    @foreach ($manageableMonitorings as $monitoring)
+                                        <option value="{{ $monitoring->id }}" @selected(old('monitoring_id') === $monitoring->id)>
+                                            {{ $monitoring->name }}
+                                        </option>
+                                    @endforeach
+                                </x-select-input>
+                                <x-input-error :messages="$errors->get('monitoring_id')" />
+                            </div>
+
+                            <div x-show="scope === 'group'">
+                                <x-input-label for="monitoring_group_id" :value="__('maintenance.form.group')" />
+                                <x-select-input id="monitoring_group_id" class="mt-1 block w-full" name="monitoring_group_id">
+                                    <option value="">{{ __('maintenance.form.select_group') }}</option>
+                                    @foreach ($monitoringGroups as $monitoringGroup)
+                                        <option value="{{ $monitoringGroup->id }}" @selected(old('monitoring_group_id') === $monitoringGroup->id)>
+                                            {{ $monitoringGroup->name }} ({{ $monitoringGroup->monitorings_count }})
+                                        </option>
+                                    @endforeach
+                                </x-select-input>
+                                <x-input-error :messages="$errors->get('monitoring_group_id')" />
+                            </div>
                         </div>
-                    </div>
 
-                    <p class="text-sm text-gray-600 dark:text-gray-400">
-                        {{ __('maintenance.form.help') }}
-                    </p>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <x-input-label for="maintenance_from" :value="__('maintenance.form.from')" />
+                                <x-text-input id="maintenance_from" type="datetime-local" name="maintenance_from" :value="old('maintenance_from')" required />
+                                <x-input-error :messages="$errors->get('maintenance_from')" />
+                            </div>
 
-                    <x-primary-button>{{ __('maintenance.actions.schedule') }}</x-primary-button>
-                </form>
-            </x-container>
+                            <div>
+                                <x-input-label for="maintenance_until" :value="__('maintenance.form.until')" />
+                                <x-text-input id="maintenance_until" type="datetime-local" name="maintenance_until" :value="old('maintenance_until')" />
+                                <x-input-error :messages="$errors->get('maintenance_until')" />
+                            </div>
+                        </div>
+
+                        <p class="text-sm text-gray-600 dark:text-gray-400">
+                            {{ __('maintenance.form.help') }}
+                        </p>
+
+                        <x-primary-button>{{ __('maintenance.actions.schedule') }}</x-primary-button>
+                    </form>
+                </x-container>
+            @endif
 
             <x-container>
                 <div class="flex flex-wrap items-start justify-between gap-3">
@@ -122,16 +127,18 @@
                                     </div>
                                 </dl>
 
-                                <form method="POST" action="{{ route('maintenance.destroy') }}" class="mt-4">
-                                    @csrf
-                                    @method('DELETE')
-                                    <input type="hidden" name="monitoring_id" value="{{ $monitoring->id }}">
-                                    <x-secondary-button
-                                        x-data
-                                        x-on:click.prevent="if (confirm('{{ __('maintenance.actions.clear_confirmation') }}')) $el.closest('form').submit()">
-                                        {{ __('maintenance.actions.clear') }}
-                                    </x-secondary-button>
-                                </form>
+                                @if ($canManageMaintenance && in_array($monitoring->id, $manageableMonitoringIds, true))
+                                    <form method="POST" action="{{ route('maintenance.destroy') }}" class="mt-4">
+                                        @csrf
+                                        @method('DELETE')
+                                        <input type="hidden" name="monitoring_id" value="{{ $monitoring->id }}">
+                                        <x-secondary-button
+                                            x-data
+                                            x-on:click.prevent="if (confirm('{{ __('maintenance.actions.clear_confirmation') }}')) $el.closest('form').submit()">
+                                            {{ __('maintenance.actions.clear') }}
+                                        </x-secondary-button>
+                                    </form>
+                                @endif
                             @endif
                         </div>
                     @empty

--- a/tests/Feature/MaintenanceManagementTest.php
+++ b/tests/Feature/MaintenanceManagementTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
 use App\Enums\TeamRole;
+use App\Enums\UserRole;
 use App\Models\Monitoring;
 use App\Models\MonitoringGroup;
 use App\Models\Package;
@@ -156,7 +157,7 @@ class MaintenanceManagementTest extends TestCase
         ]);
     }
 
-    public function test_team_member_cannot_schedule_or_clear_team_monitoring_maintenance(): void
+    public function test_team_member_can_view_but_not_manage_team_monitoring_maintenance(): void
     {
         $member = User::factory()->create(['package_id' => Package::factory()->create()->id]);
         $team = Team::factory()->create(['created_by_user_id' => $this->user->id]);
@@ -180,7 +181,10 @@ class MaintenanceManagementTest extends TestCase
 
         $this->actingAs($member)->get(route('maintenance.index'))
             ->assertOk()
-            ->assertDontSeeText('Shared API');
+            ->assertSeeText('Shared API')
+            ->assertSeeText(__('maintenance.status.expired'))
+            ->assertDontSeeHtml('action="' . route('maintenance.store') . '"')
+            ->assertDontSeeHtml('action="' . route('maintenance.destroy') . '"');
 
         $this->actingAs($member)->post(route('maintenance.store'), [
             'scope' => 'monitoring',
@@ -192,6 +196,46 @@ class MaintenanceManagementTest extends TestCase
         $this->actingAs($member)->delete(route('maintenance.destroy'), [
             'monitoring_id' => $monitoring->id,
         ])->assertSessionHasErrors(['monitoring_id']);
+
+        $this->assertDatabaseHas('monitorings', [
+            'id' => $monitoring->id,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+    }
+
+    public function test_demo_user_can_view_but_not_manage_maintenance(): void
+    {
+        $demoUser = User::factory()->create([
+            'package_id' => Package::factory()->create()->id,
+            'role' => UserRole::DEMO,
+        ]);
+        $monitoring = Monitoring::factory()->for($demoUser)->create([
+            'name' => 'Demo API',
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+
+        $this->actingAs($demoUser)->get(route('maintenance.index'))
+            ->assertOk()
+            ->assertSeeText('Demo API')
+            ->assertSeeText(__('maintenance.status.expired'))
+            ->assertDontSeeHtml('action="' . route('maintenance.store') . '"')
+            ->assertDontSeeHtml('action="' . route('maintenance.destroy') . '"')
+            ->assertDontSeeHtml('name="maintenance_from"')
+            ->assertDontSeeHtml('name="maintenance_until"');
+
+        $this->actingAs($demoUser)->post(route('maintenance.store'), [
+            'scope' => 'monitoring',
+            'monitoring_id' => $monitoring->id,
+            'maintenance_from' => '2026-07-03T10:00',
+            'maintenance_until' => '2026-07-03T11:00',
+        ])->assertForbidden();
+
+        $this->actingAs($demoUser)->delete(route('maintenance.destroy'), [
+            'monitoring_id' => $monitoring->id,
+        ])->assertForbidden();
 
         $this->assertDatabaseHas('monitorings', [
             'id' => $monitoring->id,


### PR DESCRIPTION
## What changed
- Maintenance index now lists monitorings visible to the current user, while write controls only render when the user has at least one manageable monitoring.
- Demo users are blocked at the maintenance request authorization layer and no longer see schedule or clear controls.
- Team members can view shared team maintenance windows without being able to schedule or clear them.

## Why
Guests and read-only team members should be able to inspect maintenance status without receiving UI affordances or request paths for editing maintenance windows.

## Testing
- Added/updated feature coverage in `tests/Feature/MaintenanceManagementTest.php` for demo users and team members.
- Could not run the targeted Pest file in Docker because Docker Desktop returned a 500 from the engine API while Compose listed containers.
- Host PHP/Composer and `vendor/` were not available, so no host fallback test run was possible.

## Risks
- Validation is pending in CI because local Docker execution was unavailable.