### PR TITLE
fix: handle demo maintenance manageable ids

### DIFF
--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -56,7 +56,7 @@ class MaintenanceController extends Controller
                 'none' => $monitorings->count() - $activeMaintenanceCount - $upcomingMaintenanceCount - $expiredMaintenanceCount,
             ],
             'manageableMonitorings' => $manageableMonitorings,
-            'manageableMonitoringIds' => $manageableMonitorings->modelKeys(),
+            'manageableMonitoringIds' => $manageableMonitorings->pluck('id')->all(),
             'monitoringGroups' => $canManageMaintenance
                 ? $user->monitoringGroups()
                     ->withCount('monitorings')


### PR DESCRIPTION
## What changed
- Replaced `modelKeys()` with `pluck('id')->all()` when passing manageable monitoring IDs to the maintenance view.

## Why
Demo users receive an empty support collection for manageable monitorings, and support collections do not implement `modelKeys()`. This fixes the failing demo-user maintenance page test.

## Testing
- `git diff --check`
- Attempted targeted Docker Pest run for `tests/Feature/MaintenanceManagementTest.php --filter "demo user can view but not manage maintenance"`, but Docker Desktop returned a 500 from the engine API while Compose listed containers.

## Risks
- Runtime verification is pending in CI because local Docker is unavailable.