### PR TITLE
feat: add maintenance table filters and sorting

### DIFF
--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -7,7 +7,9 @@ namespace App\Http\Controllers;
 use App\Http\Requests\MaintenanceRequest;
 use App\Models\Monitoring;
 use App\Models\User;
+use App\Support\Admin\AsyncTable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -16,10 +18,16 @@ use Illuminate\View\View;
 
 class MaintenanceController extends Controller
 {
-    public function index(): View
+    public function index(Request $request): View|JsonResponse
     {
         /** @var User $user */
         $user = Auth::user();
+        $validated = $request->validate(AsyncTable::requestRules([
+            'search' => ['nullable', 'string', 'max:100'],
+            'maintenance_status' => ['nullable', 'string', 'in:active,upcoming,expired,none'],
+            'monitoring_group_id' => ['nullable', 'string', 'exists:monitoring_groups,id'],
+        ], ['name', 'maintenance_status', 'maintenance_from', 'maintenance_until']));
+        $asyncTableOptions = AsyncTable::options($validated, 'name', 'asc', 25);
         $manageableMonitorings = ! $user->isDemo()
             ? Monitoring::query()
                 ->manageableBy($user)
@@ -45,9 +53,33 @@ class MaintenanceController extends Controller
                 && $monitoring->maintenance_from !== null
                 && ! $monitoring->maintenance_from->isFuture())
             ->count();
+        $tableQuery = Monitoring::query()
+            ->visibleTo($user)
+            ->with('groups:id,name')
+            ->when($validated['search'] ?? null, function (Builder $builder, string $search): void {
+                $builder->where(function (Builder $builder) use ($search): void {
+                    $builder->where('name', 'like', '%' . $search . '%')
+                        ->orWhere('target', 'like', '%' . $search . '%')
+                        ->orWhereHas('groups', fn (Builder $builder): Builder => $builder->where('name', 'like', '%' . $search . '%'));
+                });
+            })
+            ->when($validated['monitoring_group_id'] ?? null, fn (Builder $builder, string $groupId): Builder => $builder->whereHas('groups', fn (Builder $builder): Builder => $builder->where('monitoring_groups.id', $groupId)));
+
+        $this->applyMaintenanceStatusFilter($tableQuery, (string) ($validated['maintenance_status'] ?? ''));
+        $this->applyMaintenanceSort($tableQuery, $asyncTableOptions->sort, $asyncTableOptions->direction);
+
+        $lengthAwarePaginator = $tableQuery->paginate($asyncTableOptions->perPage);
+
+        if ($request->expectsJson()) {
+            return AsyncTable::json($lengthAwarePaginator, 'maintenance.partials.rows', [
+                'monitorings' => $lengthAwarePaginator,
+                'canManageMaintenance' => $canManageMaintenance,
+                'manageableMonitoringIds' => $manageableMonitorings->pluck('id')->all(),
+            ]);
+        }
 
         return view('maintenance.index', [
-            'monitorings' => $monitorings,
+            'monitorings' => $lengthAwarePaginator,
             'maintenanceStats' => [
                 'total' => $monitorings->count(),
                 'active' => $activeMaintenanceCount,
@@ -57,13 +89,39 @@ class MaintenanceController extends Controller
             ],
             'manageableMonitorings' => $manageableMonitorings,
             'manageableMonitoringIds' => $manageableMonitorings->pluck('id')->all(),
-            'monitoringGroups' => $canManageMaintenance
-                ? $user->monitoringGroups()
-                    ->withCount('monitorings')
-                    ->orderBy('name')
-                    ->get(['id', 'name'])
-                : collect(),
+            'monitoringGroups' => $user->monitoringGroups()
+                ->withCount('monitorings')
+                ->orderBy('name')
+                ->get(['id', 'name']),
             'canManageMaintenance' => $canManageMaintenance,
+            'filters' => [
+                [
+                    'name' => 'maintenance_status',
+                    'label' => __('maintenance.table.status_filter'),
+                    'placeholder' => __('search.filter.text', ['attribute' => __('maintenance.table.status_filter')]),
+                    'options' => [
+                        'active' => __('maintenance.status.active'),
+                        'upcoming' => __('maintenance.status.upcoming'),
+                        'expired' => __('maintenance.status.expired'),
+                        'none' => __('maintenance.status.none'),
+                    ],
+                ],
+                [
+                    'name' => 'monitoring_group_id',
+                    'label' => __('maintenance.table.group_filter'),
+                    'placeholder' => __('search.filter.text', ['attribute' => __('maintenance.table.group_filter')]),
+                    'options' => $user->monitoringGroups()
+                        ->orderBy('name')
+                        ->pluck('name', 'id')
+                        ->all(),
+                ],
+            ],
+            'activeFilters' => [
+                'maintenance_status' => (string) ($validated['maintenance_status'] ?? ''),
+                'monitoring_group_id' => (string) ($validated['monitoring_group_id'] ?? ''),
+            ],
+            'sort' => $asyncTableOptions->sort,
+            'direction' => $asyncTableOptions->direction,
         ]);
     }
 
@@ -128,5 +186,58 @@ class MaintenanceController extends Controller
         }
 
         return $query->whereKey($maintenanceRequest->string('monitoring_id')->toString());
+    }
+
+    private function applyMaintenanceStatusFilter(Builder $builder, string $maintenanceStatus): void
+    {
+        if ($maintenanceStatus === '') {
+            return;
+        }
+
+        $now = Date::now();
+
+        match ($maintenanceStatus) {
+            'active' => $builder
+                ->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '<=', $now)
+                ->where(function (Builder $builder) use ($now): void {
+                    $builder->whereNull('maintenance_until')
+                        ->orWhere('maintenance_until', '>=', $now);
+                }),
+            'upcoming' => $builder
+                ->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '>', $now),
+            'expired' => $builder
+                ->whereNotNull('maintenance_from')
+                ->whereNotNull('maintenance_until')
+                ->where('maintenance_until', '<', $now),
+            'none' => $builder->whereNull('maintenance_from'),
+            default => null,
+        };
+    }
+
+    private function applyMaintenanceSort(Builder $builder, string $sort, string $direction): void
+    {
+        if ($sort === 'maintenance_status') {
+            $now = Date::now();
+            $builder
+                ->orderByRaw(
+                    "case
+                        when maintenance_from is not null and maintenance_from <= ? and (maintenance_until is null or maintenance_until >= ?) then 0
+                        when maintenance_from is not null and maintenance_from > ? then 1
+                        when maintenance_from is not null then 2
+                        else 3
+                    end {$direction}",
+                    [$now, $now, $now]
+                )
+                ->orderBy('name');
+
+            return;
+        }
+
+        $builder
+            ->orderBy($sort, $direction)
+            ->orderBy('name')
+            ->orderBy('id');
     }
 }

--- a/resources/lang/de/maintenance.php
+++ b/resources/lang/de/maintenance.php
@@ -32,6 +32,8 @@ return [
     'table' => [
         'groups' => 'Gruppen',
         'actions' => 'Aktionen',
+        'status_filter' => 'Wartungsstatus',
+        'group_filter' => 'Monitoring-Gruppe',
     ],
     'status' => [
         'active' => 'Aktiv',

--- a/resources/lang/en/maintenance.php
+++ b/resources/lang/en/maintenance.php
@@ -32,6 +32,8 @@ return [
     'table' => [
         'groups' => 'Groups',
         'actions' => 'Actions',
+        'status_filter' => 'Maintenance status',
+        'group_filter' => 'Monitoring group',
     ],
     'status' => [
         'active' => 'Active',

--- a/resources/views/maintenance/index.blade.php
+++ b/resources/views/maintenance/index.blade.php
@@ -111,93 +111,31 @@
                         <dd class="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $maintenanceStats['none'] }}</dd>
                     </div>
                 </dl>
-
-                <div class="mt-6 overflow-hidden rounded-md border border-gray-200 dark:border-gray-700">
-                    <div class="max-h-[36rem] overflow-auto">
-                        <table class="min-w-full divide-y divide-gray-200 text-left text-sm dark:divide-gray-700">
-                            <thead class="sticky top-0 z-10 bg-gray-50 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-gray-700 dark:text-gray-300">
-                                <tr>
-                                    <th scope="col" class="px-4 py-3">{{ __('monitoring.index.table.name') }}</th>
-                                    <th scope="col" class="px-4 py-3">{{ __('monitoring.index.table.status') }}</th>
-                                    <th scope="col" class="px-4 py-3">{{ __('maintenance.form.from') }}</th>
-                                    <th scope="col" class="px-4 py-3">{{ __('maintenance.form.until') }}</th>
-                                    <th scope="col" class="px-4 py-3">{{ __('maintenance.table.groups') }}</th>
-                                    @if ($canManageMaintenance)
-                                        <th scope="col" class="px-4 py-3">{{ __('maintenance.table.actions') }}</th>
-                                    @endif
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
-                                @forelse ($monitorings as $monitoring)
-                                    <tr class="align-top hover:bg-gray-50 dark:hover:bg-gray-700/60">
-                                        <td class="px-4 py-3">
-                                            <div class="font-semibold text-gray-900 dark:text-gray-100">{{ $monitoring->name }}</div>
-                                            <div class="mt-1 max-w-md truncate text-xs text-gray-500 dark:text-gray-400" title="{{ $monitoring->target }}">{{ $monitoring->target }}</div>
-                                        </td>
-                                        <td class="px-4 py-3">
-                                            @if ($monitoring->isUnderMaintenance())
-                                                <x-badge type="info">{{ __('maintenance.status.active') }}</x-badge>
-                                            @elseif ($monitoring->maintenance_from && $monitoring->maintenance_from->isFuture())
-                                                <x-badge type="warning">{{ __('maintenance.status.upcoming') }}</x-badge>
-                                            @elseif ($monitoring->maintenance_from)
-                                                <x-badge type="neutral">{{ __('maintenance.status.expired') }}</x-badge>
-                                            @else
-                                                <x-badge type="success">{{ __('maintenance.status.none') }}</x-badge>
-                                            @endif
-                                        </td>
-                                        <td class="whitespace-nowrap px-4 py-3 text-gray-700 dark:text-gray-200">
-                                            {{ $monitoring->maintenance_from?->format('Y-m-d H:i') ?? '-' }}
-                                        </td>
-                                        <td class="whitespace-nowrap px-4 py-3 text-gray-700 dark:text-gray-200">
-                                            {{ $monitoring->maintenance_until?->format('Y-m-d H:i') ?? ($monitoring->maintenance_from ? __('maintenance.status.open_ended') : '-') }}
-                                        </td>
-                                        <td class="px-4 py-3">
-                                            @if ($monitoring->groups->isNotEmpty())
-                                                <div class="flex max-w-sm flex-wrap gap-1.5">
-                                                    @foreach ($monitoring->groups as $group)
-                                                        <x-badge type="neutral">{{ $group->name }}</x-badge>
-                                                    @endforeach
-                                                </div>
-                                            @else
-                                                <span class="text-gray-500 dark:text-gray-400">-</span>
-                                            @endif
-                                        </td>
-                                        @if ($canManageMaintenance)
-                                            <td class="whitespace-nowrap px-4 py-3">
-                                                @if ($monitoring->maintenance_from && in_array($monitoring->id, $manageableMonitoringIds, true))
-                                                    <form method="POST" action="{{ route('maintenance.destroy') }}" class="inline-flex">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <input type="hidden" name="monitoring_id" value="{{ $monitoring->id }}">
-                                                        <button
-                                                            type="submit"
-                                                            class="text-sm font-medium text-purple-600 hover:underline dark:text-purple-300"
-                                                            x-data
-                                                            x-on:click.prevent="if (confirm('{{ __('maintenance.actions.clear_confirmation') }}')) $el.closest('form').submit()">
-                                                            {{ __('maintenance.actions.clear') }}
-                                                        </button>
-                                                    </form>
-                                                @else
-                                                    <span class="text-gray-500 dark:text-gray-400">-</span>
-                                                @endif
-                                            </td>
-                                        @endif
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="{{ $canManageMaintenance ? 6 : 5 }}" class="px-4 py-10 text-center">
-                                            <x-heading type="h3">{{ __('maintenance.empty.title') }}</x-heading>
-                                            <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                                {{ __('maintenance.empty.text') }}
-                                            </x-paragraph>
-                                        </td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
             </x-container>
+
+            <x-async-table id="maintenance-table" :endpoint="route('maintenance.index')" :paginator="$monitorings"
+                :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
+                :initial-direction="$direction"
+                search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('maintenance.title')]) }}">
+                <x-slot name="head">
+                    <x-table.heading sort="name">{{ __('monitoring.index.table.name') }}</x-table.heading>
+                    <x-table.heading sort="maintenance_status">{{ __('monitoring.index.table.status') }}</x-table.heading>
+                    <x-table.heading sort="maintenance_from">{{ __('maintenance.form.from') }}</x-table.heading>
+                    <x-table.heading sort="maintenance_until">{{ __('maintenance.form.until') }}</x-table.heading>
+                    <x-table.heading>{{ __('maintenance.table.groups') }}</x-table.heading>
+                    @if ($canManageMaintenance)
+                        <x-table.heading>{{ __('maintenance.table.actions') }}</x-table.heading>
+                    @endif
+                </x-slot>
+
+                <x-slot name="body">
+                    @include('maintenance.partials.rows', [
+                        'monitorings' => $monitorings,
+                        'canManageMaintenance' => $canManageMaintenance,
+                        'manageableMonitoringIds' => $manageableMonitoringIds,
+                    ])
+                </x-slot>
+            </x-async-table>
         </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/maintenance/partials/rows.blade.php
+++ b/resources/views/maintenance/partials/rows.blade.php
@@ -1,0 +1,62 @@
+@forelse ($monitorings as $monitoring)
+    <x-table.row class="align-top">
+        <x-table.cell>
+            <div class="font-semibold text-gray-900 dark:text-gray-100">{{ $monitoring->name }}</div>
+            <div class="mt-1 max-w-md truncate text-xs text-gray-500 dark:text-gray-400" title="{{ $monitoring->target }}">
+                {{ $monitoring->target }}
+            </div>
+        </x-table.cell>
+        <x-table.cell>
+            @if ($monitoring->isUnderMaintenance())
+                <x-badge type="info">{{ __('maintenance.status.active') }}</x-badge>
+            @elseif ($monitoring->maintenance_from && $monitoring->maintenance_from->isFuture())
+                <x-badge type="warning">{{ __('maintenance.status.upcoming') }}</x-badge>
+            @elseif ($monitoring->maintenance_from)
+                <x-badge type="neutral">{{ __('maintenance.status.expired') }}</x-badge>
+            @else
+                <x-badge type="success">{{ __('maintenance.status.none') }}</x-badge>
+            @endif
+        </x-table.cell>
+        <x-table.cell>{{ $monitoring->maintenance_from?->format('Y-m-d H:i') ?? '-' }}</x-table.cell>
+        <x-table.cell>
+            {{ $monitoring->maintenance_until?->format('Y-m-d H:i') ?? ($monitoring->maintenance_from ? __('maintenance.status.open_ended') : '-') }}
+        </x-table.cell>
+        <x-table.cell>
+            @if ($monitoring->groups->isNotEmpty())
+                <div class="flex max-w-sm flex-wrap gap-1.5">
+                    @foreach ($monitoring->groups as $group)
+                        <x-badge type="neutral">{{ $group->name }}</x-badge>
+                    @endforeach
+                </div>
+            @else
+                <span class="text-gray-500 dark:text-gray-400">-</span>
+            @endif
+        </x-table.cell>
+        @if ($canManageMaintenance)
+            <x-table.cell>
+                @if ($monitoring->maintenance_from && in_array($monitoring->id, $manageableMonitoringIds, true))
+                    <form method="POST" action="{{ route('maintenance.destroy') }}" class="inline-flex">
+                        @csrf
+                        @method('DELETE')
+                        <input type="hidden" name="monitoring_id" value="{{ $monitoring->id }}">
+                        <button
+                            type="submit"
+                            class="inline-flex min-h-10 cursor-pointer items-center text-sm font-medium text-purple-600 hover:underline dark:text-purple-300"
+                            x-data
+                            x-on:click.prevent="if (confirm('{{ __('maintenance.actions.clear_confirmation') }}')) $el.closest('form').submit()">
+                            {{ __('maintenance.actions.clear') }}
+                        </button>
+                    </form>
+                @else
+                    <span class="text-gray-500 dark:text-gray-400">-</span>
+                @endif
+            </x-table.cell>
+        @endif
+    </x-table.row>
+@empty
+    <x-table.row>
+        <x-table.cell colspan="{{ $canManageMaintenance ? 6 : 5 }}" class="text-center text-gray-500">
+            {{ __('maintenance.empty.text') }}
+        </x-table.cell>
+    </x-table.row>
+@endforelse

--- a/tests/Feature/MaintenanceManagementTest.php
+++ b/tests/Feature/MaintenanceManagementTest.php
@@ -14,6 +14,7 @@ use App\Models\Package;
 use App\Models\ServerInstance;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\Date;
 use Tests\TestCase;
 
 class MaintenanceManagementTest extends TestCase
@@ -77,6 +78,54 @@ class MaintenanceManagementTest extends TestCase
             'maintenance_from' => '2026-07-01 10:00:00',
             'maintenance_until' => '2026-07-01 11:00:00',
         ]);
+    }
+
+    public function test_maintenance_table_supports_filtering_search_and_sorting(): void
+    {
+        Date::setTestNow('2026-07-01 10:30:00');
+        $this->beforeApplicationDestroyed(fn (): mixed => Date::setTestNow());
+
+        $group = MonitoringGroup::factory()->for($this->user)->create(['name' => 'Production']);
+        $activeMonitoring = Monitoring::factory()->for($this->user)->create([
+            'name' => 'Alpha Maintenance',
+            'target' => 'https://alpha-maintenance.example.test',
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => '2026-07-01 10:00:00',
+            'maintenance_until' => '2026-07-01 11:00:00',
+        ]);
+        $zuluMonitoring = Monitoring::factory()->for($this->user)->create([
+            'name' => 'Zulu Maintenance',
+            'target' => 'https://zulu-maintenance.example.test',
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => '2026-07-01 09:00:00',
+            'maintenance_until' => '2026-07-01 12:00:00',
+        ]);
+        Monitoring::factory()->for($this->user)->create([
+            'name' => 'Outside Maintenance',
+            'target' => 'https://outside-maintenance.example.test',
+            'preferred_location' => $this->serverInstance->code,
+            'maintenance_from' => null,
+            'maintenance_until' => null,
+        ]);
+        $activeMonitoring->groups()->attach($group);
+        $zuluMonitoring->groups()->attach($group);
+
+        $testResponse = $this->actingAs($this->user)->getJson(route('maintenance.index', [
+            'search' => 'Maintenance',
+            'maintenance_status' => 'active',
+            'monitoring_group_id' => $group->id,
+            'sort' => 'name',
+            'direction' => 'desc',
+            'per_page' => 5,
+        ]));
+
+        $testResponse->assertOk()->assertJsonPath('pagination.total', 2);
+        $html = $testResponse->json('html');
+
+        $this->assertStringContainsString('Zulu Maintenance', $html);
+        $this->assertStringContainsString('Alpha Maintenance', $html);
+        $this->assertStringNotContainsString('Outside Maintenance', $html);
+        $this->assertLessThan(mb_strpos($html, 'Alpha Maintenance'), mb_strpos($html, 'Zulu Maintenance'));
     }
 
     public function test_user_can_schedule_maintenance_for_monitoring_group(): void


### PR DESCRIPTION
## What changed
- Replaced the custom maintenance table with the shared async table component.
- Added backend search, maintenance status filter, monitoring group filter, sortable columns, and pagination.
- Moved maintenance table rows into a reusable partial.
- Added feature coverage for filtering, searching, sorting, and async JSON table responses.

## Why
Maintenance should use the same table controls available elsewhere in the app, especially for accounts with many monitorings.

## Testing
- `git diff --check`
- Attempted targeted Docker Pest run for `tests/Feature/MaintenanceManagementTest.php --filter "maintenance table supports filtering search and sorting"`, but Docker Desktop returned a 500 from the engine API while Compose listed containers.

## Risks
- Runtime verification is pending in CI because local Docker remains unavailable.