### PR TITLE
test: isolate legal page imprint configuration

### DIFF
--- a/tests/Feature/ImprintPageTest.php
+++ b/tests/Feature/ImprintPageTest.php
@@ -46,6 +46,8 @@ class ImprintPageTest extends TestCase
 
     public function test_footer_contains_imprint_link(): void
     {
+        $this->configureImprint();
+
         $testResponse = $this->get(route('imprint'));
 
         $testResponse->assertOk();

--- a/tests/Feature/TermsOfUsePageTest.php
+++ b/tests/Feature/TermsOfUsePageTest.php
@@ -69,6 +69,8 @@ class TermsOfUsePageTest extends TestCase
 
     public function test_footer_contains_terms_of_use_link(): void
     {
+        $this->configureImprintContact();
+
         $testResponse = $this->get(route('terms-of-use'));
 
         $testResponse->assertOk();


### PR DESCRIPTION
## What changed

- Configured the required imprint contact values inside the terms-of-use footer test.
- Configured the complete required imprint data inside the imprint footer test.

## Why

The tests previously depended on configuration state left behind by earlier tests. Parallel coverage workers execute tests in independent processes and exposed that hidden ordering dependency as HTTP 500 responses from the legal controller.

## Testing

- `TermsOfUsePageTest.php --parallel`: 6 passed
- `ImprintPageTest.php --parallel`: 5 passed
- Full Dockerized parallel suite: 591 passed, 3 skipped, 3,647 assertions
- `./vendor/bin/pint --dirty --test`: passed
- `git diff --check`: passed

The local `composer test:coverage -- --parallel` command was attempted, but the project PHP image has no coverage driver. The command stopped before executing tests; CI remains the coverage-capable validation environment.

## Risks

No production behavior changes. The change only removes test-order dependence from two existing legal-page assertions.

Closes #420