### PR TITLE
refactor(status-pages): use ULIDs in public URLs

### DIFF
--- a/app/Http/Controllers/LegacyPublicStatusPageController.php
+++ b/app/Http/Controllers/LegacyPublicStatusPageController.php
@@ -12,25 +12,17 @@ class LegacyPublicStatusPageController extends Controller
 {
     public function show(string $statusPageSlug): RedirectResponse
     {
-        return redirect()->route(
-            'public-status-pages.show',
-            $this->resolvePublicStatusPage($statusPageSlug),
-            301
-        );
+        return to_route('public-status-pages.show', $this->resolvePublicStatusPage($statusPageSlug), 301);
     }
 
     public function store(string $statusPageSlug): RedirectResponse
     {
-        return redirect()->route(
-            'public-status-pages.subscribers.store',
-            $this->resolvePublicStatusPage($statusPageSlug),
-            307
-        );
+        return to_route('public-status-pages.subscribers.store', $this->resolvePublicStatusPage($statusPageSlug), 307);
     }
 
     public function confirm(string $statusPageSlug, string $token): RedirectResponse
     {
-        return redirect()->route('public-status-pages.subscribers.confirm', [
+        return to_route('public-status-pages.subscribers.confirm', [
             'statusPage' => $this->resolveConfirmationStatusPage($statusPageSlug, $token),
             'token' => $token,
         ]);
@@ -38,7 +30,7 @@ class LegacyPublicStatusPageController extends Controller
 
     public function unsubscribe(string $statusPageSlug, string $token): RedirectResponse
     {
-        return redirect()->route('public-status-pages.subscribers.unsubscribe', [
+        return to_route('public-status-pages.subscribers.unsubscribe', [
             'statusPage' => $this->resolveUnsubscribeStatusPage($statusPageSlug, $token),
             'token' => $token,
         ]);
@@ -46,7 +38,7 @@ class LegacyPublicStatusPageController extends Controller
 
     public function destroy(string $statusPageSlug, string $token): RedirectResponse
     {
-        return redirect()->route('public-status-pages.subscribers.destroy', [
+        return to_route('public-status-pages.subscribers.destroy', [
             'statusPage' => $this->resolveUnsubscribeStatusPage($statusPageSlug, $token),
             'token' => $token,
         ], 307);

--- a/app/Http/Controllers/LegacyPublicStatusPageController.php
+++ b/app/Http/Controllers/LegacyPublicStatusPageController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\StatusPage;
+use App\Models\StatusPageSubscription;
+use Illuminate\Http\RedirectResponse;
+
+class LegacyPublicStatusPageController extends Controller
+{
+    public function show(string $statusPageSlug): RedirectResponse
+    {
+        return redirect()->route(
+            'public-status-pages.show',
+            $this->resolvePublicStatusPage($statusPageSlug),
+            301
+        );
+    }
+
+    public function store(string $statusPageSlug): RedirectResponse
+    {
+        return redirect()->route(
+            'public-status-pages.subscribers.store',
+            $this->resolvePublicStatusPage($statusPageSlug),
+            307
+        );
+    }
+
+    public function confirm(string $statusPageSlug, string $token): RedirectResponse
+    {
+        return redirect()->route('public-status-pages.subscribers.confirm', [
+            'statusPage' => $this->resolveConfirmationStatusPage($statusPageSlug, $token),
+            'token' => $token,
+        ]);
+    }
+
+    public function unsubscribe(string $statusPageSlug, string $token): RedirectResponse
+    {
+        return redirect()->route('public-status-pages.subscribers.unsubscribe', [
+            'statusPage' => $this->resolveUnsubscribeStatusPage($statusPageSlug, $token),
+            'token' => $token,
+        ]);
+    }
+
+    public function destroy(string $statusPageSlug, string $token): RedirectResponse
+    {
+        return redirect()->route('public-status-pages.subscribers.destroy', [
+            'statusPage' => $this->resolveUnsubscribeStatusPage($statusPageSlug, $token),
+            'token' => $token,
+        ], 307);
+    }
+
+    private function resolvePublicStatusPage(string $statusPageSlug): StatusPage
+    {
+        return StatusPage::query()
+            ->where('slug', $statusPageSlug)
+            ->where('is_public', true)
+            ->firstOrFail();
+    }
+
+    private function resolveConfirmationStatusPage(string $statusPageSlug, string $token): StatusPage
+    {
+        $statusPage = $this->resolvePublicStatusPage($statusPageSlug);
+
+        abort_unless($statusPage->subscriptions()
+            ->where('confirmation_token_hash', StatusPageSubscription::hashToken($token))
+            ->exists(), 404);
+
+        return $statusPage;
+    }
+
+    private function resolveUnsubscribeStatusPage(string $statusPageSlug, string $token): StatusPage
+    {
+        $statusPage = StatusPage::query()->where('slug', $statusPageSlug)->firstOrFail();
+
+        abort_unless($statusPage->subscriptions()->where('unsubscribe_token', $token)->exists(), 404);
+
+        return $statusPage;
+    }
+}

--- a/app/Http/Controllers/MonitoringGroupController.php
+++ b/app/Http/Controllers/MonitoringGroupController.php
@@ -7,11 +7,9 @@ namespace App\Http\Controllers;
 use App\Enums\StatusPageComponentSource;
 use App\Http\Requests\MonitoringGroupRequest;
 use App\Models\MonitoringGroup;
-use App\Models\StatusPage;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 class MonitoringGroupController extends Controller
@@ -90,7 +88,6 @@ class MonitoringGroupController extends Controller
 
         $statusPage = $user->statusPages()->create([
             'name' => $monitoringGroup->name,
-            'slug' => $this->uniqueStatusPageSlug($monitoringGroup->name),
             'description' => $monitoringGroup->description,
             'is_public' => true,
         ]);
@@ -110,24 +107,5 @@ class MonitoringGroupController extends Controller
     private function authorizeOwner(MonitoringGroup $monitoringGroup): void
     {
         abort_unless($monitoringGroup->user_id === Auth::id(), 404);
-    }
-
-    private function uniqueStatusPageSlug(string $name): string
-    {
-        $baseSlug = Str::slug($name);
-
-        if ($baseSlug === '') {
-            $baseSlug = 'status-page';
-        }
-
-        $slug = $baseSlug;
-        $suffix = 2;
-
-        while (StatusPage::query()->where('slug', $slug)->exists()) {
-            $slug = "{$baseSlug}-{$suffix}";
-            $suffix++;
-        }
-
-        return $slug;
     }
 }

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -52,7 +52,6 @@ class StatusPageController extends Controller
 
         $statusPage = $user->statusPages()->create([
             'name' => $validated['name'],
-            'slug' => $validated['slug'],
             'description' => $validated['description'] ?? null,
             'is_public' => $validated['is_public'],
         ]);
@@ -98,7 +97,6 @@ class StatusPageController extends Controller
 
         $statusPage->update([
             'name' => $validated['name'],
-            'slug' => $validated['slug'],
             'description' => $validated['description'] ?? null,
             'is_public' => $validated['is_public'],
         ]);

--- a/app/Http/Controllers/StatusPageSubscriptionController.php
+++ b/app/Http/Controllers/StatusPageSubscriptionController.php
@@ -44,7 +44,7 @@ class StatusPageSubscriptionController extends Controller
             );
         }
 
-        return to_route('public-status-pages.show', $statusPage->slug)
+        return to_route('public-status-pages.show', $statusPage)
             ->with('status_page_subscription_success', __('status_page.public.subscribe.confirmation_sent'));
     }
 
@@ -58,7 +58,7 @@ class StatusPageSubscriptionController extends Controller
 
         $statusPageSubscription->markVerified();
 
-        return to_route('public-status-pages.show', $statusPage->slug)
+        return to_route('public-status-pages.show', $statusPage)
             ->with('status_page_subscription_success', __('status_page.public.subscribe.confirmed'));
     }
 
@@ -98,7 +98,7 @@ class StatusPageSubscriptionController extends Controller
             ->delete();
 
         $redirect = $statusPage->is_public
-            ? to_route('public-status-pages.show', $statusPage->slug)
+            ? to_route('public-status-pages.show', $statusPage)
             : redirect('/');
 
         return $redirect->with('status_page_subscription_success', __('status_page.public.subscribe.unsubscribed'));

--- a/app/Http/Requests/StatusPages/StatusPageRequest.php
+++ b/app/Http/Requests/StatusPages/StatusPageRequest.php
@@ -6,7 +6,6 @@ namespace App\Http\Requests\StatusPages;
 
 use App\Enums\StatusPageComponentSource;
 use App\Models\Monitoring;
-use App\Models\StatusPage;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -23,18 +22,8 @@ class StatusPageRequest extends FormRequest
      */
     public function rules(): array
     {
-        /** @var StatusPage|null $statusPage */
-        $statusPage = $this->route('statusPage');
-
         return [
             'name' => ['required', 'string', 'max:255'],
-            'slug' => [
-                'required',
-                'string',
-                'max:255',
-                'alpha_dash:ascii',
-                Rule::unique('status_pages', 'slug')->ignore($statusPage?->id),
-            ],
             'description' => ['nullable', 'string', 'max:1000'],
             'is_public' => ['boolean'],
             'components' => ['required', 'array', 'min:1'],
@@ -91,7 +80,6 @@ class StatusPageRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         $this->merge([
-            'slug' => str($this->input('slug') ?: $this->input('name'))->slug()->toString(),
             'is_public' => $this->boolean('is_public'),
             'components' => $this->normalizeComponents(),
         ]);

--- a/app/Mail/PublicStatusPageStatusUpdateMail.php
+++ b/app/Mail/PublicStatusPageStatusUpdateMail.php
@@ -47,9 +47,9 @@ class PublicStatusPageStatusUpdateMail extends Mailable
                 'notification' => $this->notification,
                 'status' => $this->status,
                 'statusLabel' => mb_strtoupper($this->status),
-                'statusPageUrl' => route('public-status-pages.show', $this->subscription->statusPage->slug),
+                'statusPageUrl' => route('public-status-pages.show', $this->subscription->statusPage),
                 'unsubscribeUrl' => route('public-status-pages.subscribers.unsubscribe', [
-                    'statusPage' => $this->subscription->statusPage->slug,
+                    'statusPage' => $this->subscription->statusPage,
                     'token' => $this->subscription->unsubscribe_token,
                 ]),
             ],

--- a/app/Mail/PublicStatusPageSubscriptionConfirmationMail.php
+++ b/app/Mail/PublicStatusPageSubscriptionConfirmationMail.php
@@ -36,7 +36,7 @@ class PublicStatusPageSubscriptionConfirmationMail extends Mailable
                 'subscription' => $this->subscription,
                 'statusPage' => $this->subscription->statusPage,
                 'confirmUrl' => route('public-status-pages.subscribers.confirm', [
-                    'statusPage' => $this->subscription->statusPage->slug,
+                    'statusPage' => $this->subscription->statusPage,
                     'token' => $this->token,
                 ]),
             ],

--- a/database/migrations/2026_07_13_120000_make_status_page_slugs_legacy_only.php
+++ b/database/migrations/2026_07_13_120000_make_status_page_slugs_legacy_only.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('status_pages', function (Blueprint $table): void {
+            $table->string('slug')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::table('status_pages')
+            ->whereNull('slug')
+            ->update(['slug' => DB::raw('id')]);
+
+        Schema::table('status_pages', function (Blueprint $table): void {
+            $table->string('slug')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/lang/de/status_page.php
+++ b/resources/lang/de/status_page.php
@@ -21,8 +21,6 @@ return [
     ],
     'form' => [
         'name' => 'Name',
-        'slug' => 'Slug',
-        'slug_placeholder' => 'Wird aus dem Namen erzeugt, wenn leer',
         'description' => 'Beschreibung',
         'is_public' => 'Diese Statusseite veröffentlichen',
         'components' => 'Komponenten',

--- a/resources/lang/en/status_page.php
+++ b/resources/lang/en/status_page.php
@@ -21,8 +21,6 @@ return [
     ],
     'form' => [
         'name' => 'Name',
-        'slug' => 'Slug',
-        'slug_placeholder' => 'Generated from the name when empty',
         'description' => 'Description',
         'is_public' => 'Publish this status page',
         'components' => 'Components',

--- a/resources/views/status-pages/_form.blade.php
+++ b/resources/views/status-pages/_form.blade.php
@@ -39,19 +39,10 @@
                     this.components.splice(index, 1);
                 }
             }">
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                <div>
-                    <x-input-label for="name" :value="__('status_page.form.name')" />
-                    <x-text-input id="name" name="name" type="text" :value="old('name', $statusPage->name ?? '')" required />
-                    <x-input-error :messages="$errors->get('name')" />
-                </div>
-
-                <div>
-                    <x-input-label for="slug" :value="__('status_page.form.slug')" />
-                    <x-text-input id="slug" name="slug" type="text" :value="old('slug', $statusPage->slug ?? '')"
-                        placeholder="{{ __('status_page.form.slug_placeholder') }}" />
-                    <x-input-error :messages="$errors->get('slug')" />
-                </div>
+            <div>
+                <x-input-label for="name" :value="__('status_page.form.name')" />
+                <x-text-input id="name" name="name" type="text" :value="old('name', $statusPage->name ?? '')" required />
+                <x-input-error :messages="$errors->get('name')" />
             </div>
 
             <div>

--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -37,7 +37,7 @@
 
                             <div class="flex flex-wrap gap-2">
                                 @if ($statusPage->is_public)
-                                    <x-secondary-button :href="route('public-status-pages.show', $statusPage->slug)" target="_blank">
+                                    <x-secondary-button :href="route('public-status-pages.show', $statusPage)" target="_blank">
                                         {{ __('status_page.actions.public_page') }}
                                     </x-secondary-button>
                                 @endif

--- a/resources/views/status-pages/public-show.blade.php
+++ b/resources/views/status-pages/public-show.blade.php
@@ -1,6 +1,7 @@
 <x-public-layout>
     <x-slot name="head">
         <meta name="robots" content="noindex">
+        <link rel="canonical" href="{{ route('public-status-pages.show', $statusPage) }}">
         <title>{{ __('status_page.public.title', ['statusPage' => $statusPage->name]) }}</title>
     </x-slot>
 
@@ -82,7 +83,7 @@
                             </p>
                         </div>
 
-                        <form method="POST" action="{{ route('public-status-pages.subscribers.store', $statusPage->slug) }}"
+                        <form method="POST" action="{{ route('public-status-pages.subscribers.store', $statusPage) }}"
                             class="w-full md:max-w-md">
                             @csrf
 

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -7,9 +7,9 @@
                     {{ $statusPage->is_public ? __('status_page.state.public') : __('status_page.state.private') }}
                 </x-badge>
                 @if ($statusPage->is_public)
-                    <a href="{{ route('public-status-pages.show', $statusPage->slug) }}" target="_blank"
+                    <a href="{{ route('public-status-pages.show', $statusPage) }}" target="_blank"
                         class="break-all hover:text-gray-700 dark:hover:text-white">
-                        {{ route('public-status-pages.show', $statusPage->slug) }}
+                        {{ route('public-status-pages.show', $statusPage) }}
                     </a>
                 @endif
             </div>

--- a/resources/views/status-pages/unsubscribe.blade.php
+++ b/resources/views/status-pages/unsubscribe.blade.php
@@ -21,7 +21,7 @@
                 {{ __('status_page.public.subscribe.unsubscribe_description', ['email' => $subscription->email]) }}
             </p>
 
-            <form method="POST" action="{{ route('public-status-pages.subscribers.destroy', ['statusPage' => $statusPage->slug, 'token' => $token]) }}"
+            <form method="POST" action="{{ route('public-status-pages.subscribers.destroy', ['statusPage' => $statusPage, 'token' => $token]) }}"
                 class="mt-6 space-y-4"
                 data-confirm-message="{{ __('status_page.public.subscribe.unsubscribe_confirmation') }}">
                 @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Admin\ServerInstanceController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Auth\SocialiteController;
 use App\Http\Controllers\HeartbeatPingController;
+use App\Http\Controllers\LegacyPublicStatusPageController;
 use App\Http\Controllers\LegalController;
 use App\Http\Controllers\LocaleController;
 use App\Http\Controllers\MaintenanceController;
@@ -87,17 +88,42 @@ Route::get('/label/{monitoring}/subscribers/unsubscribe/{token}', [StatusPageSub
 Route::delete('/label/{monitoring}/subscribers/unsubscribe/{token}', [StatusPageSubscriberController::class, 'destroy'])
     ->name('public-label.subscribers.destroy')
     ->scopeBindings();
-Route::post('/status/{statusPage:slug}/subscribers', [StatusPageSubscriptionController::class, 'store'])
+$statusPageUlidPattern = '(?i:[0-9A-HJKMNP-TV-Z]{26})';
+$legacyStatusPageSlugPattern = '(?!(?i:[0-9A-HJKMNP-TV-Z]{26}))[A-Za-z0-9_-]+';
+
+Route::post('/status/{statusPage}/subscribers', [StatusPageSubscriptionController::class, 'store'])
     ->middleware('throttle:6,1')
-    ->name('public-status-pages.subscribers.store');
-Route::get('/status/{statusPage:slug}/subscribers/confirm/{token}', [StatusPageSubscriptionController::class, 'confirm'])
-    ->name('public-status-pages.subscribers.confirm');
-Route::get('/status/{statusPage:slug}/subscribers/unsubscribe/{token}', [StatusPageSubscriptionController::class, 'unsubscribe'])
-    ->name('public-status-pages.subscribers.unsubscribe');
-Route::delete('/status/{statusPage:slug}/subscribers/unsubscribe/{token}', [StatusPageSubscriptionController::class, 'destroy'])
-    ->name('public-status-pages.subscribers.destroy');
-Route::get('/status/{statusPage:slug}', PublicStatusPageController::class)
-    ->name('public-status-pages.show');
+    ->name('public-status-pages.subscribers.store')
+    ->where('statusPage', $statusPageUlidPattern);
+Route::get('/status/{statusPage}/subscribers/confirm/{token}', [StatusPageSubscriptionController::class, 'confirm'])
+    ->name('public-status-pages.subscribers.confirm')
+    ->where('statusPage', $statusPageUlidPattern);
+Route::get('/status/{statusPage}/subscribers/unsubscribe/{token}', [StatusPageSubscriptionController::class, 'unsubscribe'])
+    ->name('public-status-pages.subscribers.unsubscribe')
+    ->where('statusPage', $statusPageUlidPattern);
+Route::delete('/status/{statusPage}/subscribers/unsubscribe/{token}', [StatusPageSubscriptionController::class, 'destroy'])
+    ->name('public-status-pages.subscribers.destroy')
+    ->where('statusPage', $statusPageUlidPattern);
+Route::get('/status/{statusPage}', PublicStatusPageController::class)
+    ->name('public-status-pages.show')
+    ->where('statusPage', $statusPageUlidPattern);
+
+Route::post('/status/{statusPageSlug}/subscribers', [LegacyPublicStatusPageController::class, 'store'])
+    ->middleware('throttle:6,1')
+    ->name('legacy-public-status-pages.subscribers.store')
+    ->where('statusPageSlug', $legacyStatusPageSlugPattern);
+Route::get('/status/{statusPageSlug}/subscribers/confirm/{token}', [LegacyPublicStatusPageController::class, 'confirm'])
+    ->name('legacy-public-status-pages.subscribers.confirm')
+    ->where('statusPageSlug', $legacyStatusPageSlugPattern);
+Route::get('/status/{statusPageSlug}/subscribers/unsubscribe/{token}', [LegacyPublicStatusPageController::class, 'unsubscribe'])
+    ->name('legacy-public-status-pages.subscribers.unsubscribe')
+    ->where('statusPageSlug', $legacyStatusPageSlugPattern);
+Route::delete('/status/{statusPageSlug}/subscribers/unsubscribe/{token}', [LegacyPublicStatusPageController::class, 'destroy'])
+    ->name('legacy-public-status-pages.subscribers.destroy')
+    ->where('statusPageSlug', $legacyStatusPageSlugPattern);
+Route::get('/status/{statusPageSlug}', [LegacyPublicStatusPageController::class, 'show'])
+    ->name('legacy-public-status-pages.show')
+    ->where('statusPageSlug', $legacyStatusPageSlugPattern);
 
 Route::get('/badge.js', function () {
     return response(file_get_contents(public_path('js/badge.js')))->header('Content-Type', 'application/javascript');

--- a/tests/Feature/ComponentStatusPageTest.php
+++ b/tests/Feature/ComponentStatusPageTest.php
@@ -73,7 +73,7 @@ class ComponentStatusPageTest extends TestCase
         $workerComponent = $statusPage->components()->create(['name' => 'Workers', 'position' => 1]);
         $workerComponent->monitorings()->attach($workerMonitoring->id, ['position' => 0]);
 
-        $testResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $testResponse = $this->get(route('public-status-pages.show', $statusPage));
 
         $testResponse->assertOk();
         $testResponse->assertSeeText('Acme Status');
@@ -97,7 +97,7 @@ class ComponentStatusPageTest extends TestCase
             'is_public' => false,
         ]);
 
-        $testResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $testResponse = $this->get(route('public-status-pages.show', $statusPage));
 
         $testResponse->assertNotFound();
     }

--- a/tests/Feature/Mail/MailableContractTest.php
+++ b/tests/Feature/Mail/MailableContractTest.php
@@ -150,7 +150,7 @@ class MailableContractTest extends TestCase
         $this->assertSame($statusPageSubscription->id, $publicStatusPageSubscriptionConfirmationMail->content()->with['subscription']->id);
         $this->assertSame($statusPage->id, $publicStatusPageSubscriptionConfirmationMail->content()->with['statusPage']->id);
         $this->assertSame(route('public-status-pages.subscribers.confirm', [
-            'statusPage' => 'acme-status',
+            'statusPage' => $statusPage,
             'token' => 'confirm-token',
         ]), $publicStatusPageSubscriptionConfirmationMail->content()->with['confirmUrl']);
         $this->assertSame([], $publicStatusPageSubscriptionConfirmationMail->attachments());
@@ -194,9 +194,9 @@ class MailableContractTest extends TestCase
         $this->assertSame($monitoringNotification->id, $publicStatusPageStatusUpdateMail->content()->with['notification']->id);
         $this->assertSame('down', $publicStatusPageStatusUpdateMail->content()->with['status']);
         $this->assertSame('DOWN', $publicStatusPageStatusUpdateMail->content()->with['statusLabel']);
-        $this->assertSame(route('public-status-pages.show', 'acme-status'), $publicStatusPageStatusUpdateMail->content()->with['statusPageUrl']);
+        $this->assertSame(route('public-status-pages.show', $statusPage), $publicStatusPageStatusUpdateMail->content()->with['statusPageUrl']);
         $this->assertSame(route('public-status-pages.subscribers.unsubscribe', [
-            'statusPage' => 'acme-status',
+            'statusPage' => $statusPage,
             'token' => 'unsubscribe-token',
         ]), $publicStatusPageStatusUpdateMail->content()->with['unsubscribeUrl']);
         $this->assertSame([], $publicStatusPageStatusUpdateMail->attachments());

--- a/tests/Feature/MonitoringGroupTest.php
+++ b/tests/Feature/MonitoringGroupTest.php
@@ -337,7 +337,7 @@ class MonitoringGroupTest extends TestCase
         $this->assertDatabaseHas('status_pages', [
             'id' => $statusPage->id,
             'user_id' => $this->user->id,
-            'slug' => 'public-production',
+            'slug' => null,
             'is_public' => true,
         ]);
         $this->assertDatabaseHas('status_page_components', [
@@ -347,7 +347,7 @@ class MonitoringGroupTest extends TestCase
             'name' => 'Public Production',
         ]);
 
-        $publicResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $publicResponse = $this->get(route('public-status-pages.show', $statusPage));
 
         $publicResponse->assertOk();
         $publicResponse->assertSeeText('Public Production');
@@ -370,11 +370,11 @@ class MonitoringGroupTest extends TestCase
         $monitoringGroup->monitorings()->attach($initialMonitoring->id);
 
         $this->actingAs($this->user)->post(route('monitoring-groups.publish-status-page', $monitoringGroup));
-        $statusPage = StatusPage::query()->where('slug', 'production')->firstOrFail();
+        $statusPage = StatusPage::query()->where('name', 'Production')->firstOrFail();
 
         $monitoringGroup->monitorings()->attach($laterMonitoring->id);
 
-        $testResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $testResponse = $this->get(route('public-status-pages.show', $statusPage));
 
         $testResponse->assertOk();
         $testResponse->assertSeeText('Initial API');

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -44,7 +44,7 @@ class StatusPageManagementTest extends TestCase
         $testResponse->assertSeeHtml('Workers');
         $testResponse->assertSeeHtml('Database');
         $testResponse->assertSeeText('Primary API');
-        $testResponse->assertDontSee('name="slug"', false);
+        $testResponse->assertDontSeeHtml('name="slug"');
     }
 
     public function test_public_status_page_urls_use_ulids_and_legacy_slugs_redirect_to_the_canonical_url(): void
@@ -71,9 +71,7 @@ class StatusPageManagementTest extends TestCase
         $this->assertStringNotContainsString('acme-status', $canonicalUrl);
         $this->assertNotSame($canonicalUrl, $sameNameCanonicalUrl);
 
-        $this->get($canonicalUrl)
-            ->assertOk()
-            ->assertSee('<link rel="canonical" href="' . $canonicalUrl . '">', false);
+        $this->get($canonicalUrl)->assertOk()->assertSeeHtml('<link rel="canonical" href="' . $canonicalUrl . '">');
         $this->get($sameNameCanonicalUrl)->assertOk();
         $this->get(route('legacy-public-status-pages.show', 'acme-status'))
             ->assertRedirect($canonicalUrl)

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -17,6 +17,7 @@ use App\Models\StatusPageSubscription;
 use App\Models\User;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class StatusPageManagementTest extends TestCase
@@ -43,6 +44,102 @@ class StatusPageManagementTest extends TestCase
         $testResponse->assertSeeHtml('Workers');
         $testResponse->assertSeeHtml('Database');
         $testResponse->assertSeeText('Primary API');
+        $testResponse->assertDontSee('name="slug"', false);
+    }
+
+    public function test_public_status_page_urls_use_ulids_and_legacy_slugs_redirect_to_the_canonical_url(): void
+    {
+        $package = Package::factory()->create();
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'slug' => 'acme-status',
+            'is_public' => true,
+        ]);
+        $sameNameStatusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'slug' => null,
+            'is_public' => true,
+        ]);
+
+        $canonicalUrl = route('public-status-pages.show', $statusPage);
+        $sameNameCanonicalUrl = route('public-status-pages.show', $sameNameStatusPage);
+
+        $this->assertStringEndsWith('/status/' . $statusPage->id, $canonicalUrl);
+        $this->assertStringNotContainsString('acme-status', $canonicalUrl);
+        $this->assertNotSame($canonicalUrl, $sameNameCanonicalUrl);
+
+        $this->get($canonicalUrl)
+            ->assertOk()
+            ->assertSee('<link rel="canonical" href="' . $canonicalUrl . '">', false);
+        $this->get($sameNameCanonicalUrl)->assertOk();
+        $this->get(route('legacy-public-status-pages.show', 'acme-status'))
+            ->assertRedirect($canonicalUrl)
+            ->assertStatus(301);
+
+        $statusPage->update(['name' => 'Renamed Status']);
+
+        $this->assertSame($canonicalUrl, route('public-status-pages.show', $statusPage->refresh()));
+        $this->get($canonicalUrl)->assertOk()->assertSeeText('Renamed Status');
+    }
+
+    public function test_unknown_or_private_public_status_page_identifiers_return_not_found(): void
+    {
+        $package = Package::factory()->create();
+        $privateStatusPage = StatusPage::query()->create([
+            'user_id' => User::factory()->create(['package_id' => $package->id])->id,
+            'name' => 'Private Status',
+            'slug' => 'private-status',
+            'is_public' => false,
+        ]);
+
+        $this->get(route('public-status-pages.show', Str::ulid()->toBase32()))->assertNotFound();
+        $this->get(route('legacy-public-status-pages.show', 'unknown-status'))->assertNotFound();
+        $this->get(route('legacy-public-status-pages.show', $privateStatusPage->slug))->assertNotFound();
+    }
+
+    public function test_legacy_subscription_urls_redirect_to_ulid_routes_without_changing_request_methods(): void
+    {
+        $package = Package::factory()->create();
+        $statusPage = StatusPage::query()->create([
+            'user_id' => User::factory()->create(['package_id' => $package->id])->id,
+            'name' => 'Acme Status',
+            'slug' => 'acme-status',
+            'is_public' => true,
+        ]);
+        StatusPageSubscription::query()->create([
+            'status_page_id' => $statusPage->id,
+            'email' => 'customer@example.com',
+            'confirmation_token_hash' => StatusPageSubscription::hashToken('confirm-token'),
+            'unsubscribe_token' => 'unsubscribe-token',
+        ]);
+
+        $this->post(route('legacy-public-status-pages.subscribers.store', $statusPage->slug))
+            ->assertRedirect(route('public-status-pages.subscribers.store', $statusPage))
+            ->assertStatus(307);
+        $this->get(route('legacy-public-status-pages.subscribers.confirm', [
+            'statusPageSlug' => $statusPage->slug,
+            'token' => 'confirm-token',
+        ]))->assertRedirect(route('public-status-pages.subscribers.confirm', [
+            'statusPage' => $statusPage,
+            'token' => 'confirm-token',
+        ]));
+        $this->get(route('legacy-public-status-pages.subscribers.unsubscribe', [
+            'statusPageSlug' => $statusPage->slug,
+            'token' => 'unsubscribe-token',
+        ]))->assertRedirect(route('public-status-pages.subscribers.unsubscribe', [
+            'statusPage' => $statusPage,
+            'token' => 'unsubscribe-token',
+        ]));
+        $this->delete(route('legacy-public-status-pages.subscribers.destroy', [
+            'statusPageSlug' => $statusPage->slug,
+            'token' => 'unsubscribe-token',
+        ]))->assertRedirect(route('public-status-pages.subscribers.destroy', [
+            'statusPage' => $statusPage,
+            'token' => 'unsubscribe-token',
+        ]))->assertStatus(307);
     }
 
     public function test_user_can_create_component_based_status_page(): void
@@ -54,7 +151,6 @@ class StatusPageManagementTest extends TestCase
 
         $testResponse = $this->actingAs($user)->post(route('status-pages.store'), [
             'name' => 'Acme Status',
-            'slug' => 'acme-status',
             'description' => 'Customer-facing status page',
             'is_public' => '1',
             'components' => [
@@ -75,7 +171,7 @@ class StatusPageManagementTest extends TestCase
         $this->assertDatabaseHas('status_pages', [
             'user_id' => $user->id,
             'name' => 'Acme Status',
-            'slug' => 'acme-status',
+            'slug' => null,
             'is_public' => true,
         ]);
         $this->assertDatabaseHas('status_page_components', [
@@ -142,7 +238,6 @@ class StatusPageManagementTest extends TestCase
 
         $this->actingAs($user)->put(route('status-pages.update', $statusPage), [
             'name' => 'Updated Status',
-            'slug' => 'updated-status',
             'description' => 'Updated description',
             'is_public' => '0',
             'components' => [
@@ -163,7 +258,7 @@ class StatusPageManagementTest extends TestCase
         $this->assertDatabaseHas('status_pages', [
             'id' => $statusPage->id,
             'name' => 'Updated Status',
-            'slug' => 'updated-status',
+            'slug' => 'old-status',
             'is_public' => false,
         ]);
         $this->assertDatabaseHas('status_page_components', [
@@ -223,7 +318,10 @@ class StatusPageManagementTest extends TestCase
 
         $testResponse->assertRedirect(route('status-pages.create'));
         $testResponse->assertSessionHasErrors(['components.0.monitoring_group_id']);
-        $this->assertDatabaseMissing('status_pages', ['slug' => 'acme-status']);
+        $this->assertDatabaseMissing('status_pages', [
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+        ]);
     }
 
     public function test_status_page_components_cannot_reference_another_users_monitorings(): void
@@ -249,7 +347,10 @@ class StatusPageManagementTest extends TestCase
 
         $testResponse->assertRedirect(route('status-pages.create'));
         $testResponse->assertSessionHasErrors(['components.0.monitoring_ids.0']);
-        $this->assertDatabaseMissing('status_pages', ['slug' => 'acme-status']);
+        $this->assertDatabaseMissing('status_pages', [
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+        ]);
     }
 
     public function test_user_cannot_view_another_users_status_page_management_screen(): void
@@ -305,7 +406,7 @@ class StatusPageManagementTest extends TestCase
             'message' => 'We found a saturated database connection pool and are applying a fix.',
         ]);
 
-        $publicResponse = $this->get(route('public-status-pages.show', $statusPage->slug));
+        $publicResponse = $this->get(route('public-status-pages.show', $statusPage));
 
         $publicResponse->assertOk();
         $publicResponse->assertSeeText(__('status_page.incident_updates.statuses.identified'));
@@ -325,11 +426,11 @@ class StatusPageManagementTest extends TestCase
             'is_public' => true,
         ]);
 
-        $testResponse = $this->post(route('public-status-pages.subscribers.store', $statusPage->slug), [
+        $testResponse = $this->post(route('public-status-pages.subscribers.store', $statusPage), [
             'email' => 'Customer@Example.com',
         ]);
 
-        $testResponse->assertRedirect(route('public-status-pages.show', $statusPage->slug));
+        $testResponse->assertRedirect(route('public-status-pages.show', $statusPage));
         $testResponse->assertSessionHas('status_page_subscription_success');
 
         $statusPageSubscription = StatusPageSubscription::query()->firstOrFail();
@@ -346,15 +447,15 @@ class StatusPageManagementTest extends TestCase
         });
 
         $this->get(route('public-status-pages.subscribers.confirm', [
-            'statusPage' => $statusPage->slug,
+            'statusPage' => $statusPage,
             'token' => $confirmationToken,
-        ]))->assertRedirect(route('public-status-pages.show', $statusPage->slug));
+        ]))->assertRedirect(route('public-status-pages.show', $statusPage));
 
         $this->assertTrue($statusPageSubscription->refresh()->isVerified());
         $this->assertNull($statusPageSubscription->confirmation_token_hash);
 
         $unsubscribeResponse = $this->get(route('public-status-pages.subscribers.unsubscribe', [
-            'statusPage' => $statusPage->slug,
+            'statusPage' => $statusPage,
             'token' => $statusPageSubscription->unsubscribe_token,
         ]));
 
@@ -362,11 +463,11 @@ class StatusPageManagementTest extends TestCase
         $unsubscribeResponse->assertSeeHtml('data-confirm-message="' . __('status_page.public.subscribe.unsubscribe_confirmation') . '"');
 
         $this->delete(route('public-status-pages.subscribers.destroy', [
-            'statusPage' => $statusPage->slug,
+            'statusPage' => $statusPage,
             'token' => $statusPageSubscription->unsubscribe_token,
         ]), [
             'email' => 'CUSTOMER@example.com',
-        ])->assertRedirect(route('public-status-pages.show', $statusPage->slug));
+        ])->assertRedirect(route('public-status-pages.show', $statusPage));
 
         $this->assertDatabaseMissing('status_page_subscriptions', [
             'id' => $statusPageSubscription->id,


### PR DESCRIPTION
## What changed

- switch public status-page and subscription routes to persisted ULIDs
- remove editable and name-derived slugs from new status pages and group-published pages
- preserve existing slugs as legacy aliases with safe redirects to canonical ULID routes
- update generated links, mail URLs, forms, and canonical metadata
- add regression coverage for ULID routing, rename stability, collisions, legacy URLs, and unknown identifiers

## Why

Name-derived slugs coupled public URLs to editable display names. Renames could break shared links and similar names could create collisions. Persisted ULIDs provide stable routing identities while names remain display-only.

## Testing

- Dockerized targeted Pest suite: 35 passed, 223 assertions
- Dockerized full Pest suite: 594 passed, 3 environment-dependent skips, 3673 assertions
- Dockerized PHPStan: no errors
- Laravel Pint: passed
- MySQL migration: forward, rollback, and forward again passed

## Risks and limitations

Existing slugs remain in the database only for compatibility redirects. New status pages store no slug.

Closes #421