### PR TITLE
refactor(ui): align monitoring forms

### DIFF
--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -238,12 +238,11 @@ class MonitoringController extends Controller
     {
         /** @var User $user */
         $user = Auth::user();
-        $monitoring->loadMissing('domainResult', 'team');
+        $monitoring->loadMissing('domainResult');
 
         return view('monitorings.show', [
             'monitoring' => $monitoring,
             'canManageMonitoring' => $monitoring->isManageableBy($user) && ! $user->isDemo(),
-            'adminTeams' => Team::query()->administeredBy($user)->orderBy('name')->get(['teams.id', 'teams.name']),
             'regionalConsensus' => count($monitoring->preferredLocationCodes()) > 1
                 ? $regionalConsensusService->snapshot($monitoring)
                 : null,

--- a/app/Http/Controllers/MonitoringOwnershipController.php
+++ b/app/Http/Controllers/MonitoringOwnershipController.php
@@ -39,7 +39,7 @@ class MonitoringOwnershipController extends Controller
         $team = Team::query()->findOrFail($validated['team_id']);
         $monitoringOwnershipService->moveToTeam($monitoring, $team, $user);
 
-        return to_route('monitorings.show', $monitoring)
+        return to_route('monitorings.edit', $monitoring)
             ->with('success', __('team.ownership.moved_to_team'));
     }
 
@@ -54,7 +54,7 @@ class MonitoringOwnershipController extends Controller
 
         $monitoringOwnershipService->moveToPrivate($monitoring, $user);
 
-        return to_route('monitorings.show', $monitoring)
+        return to_route('monitorings.edit', $monitoring)
             ->with('success', __('team.ownership.moved_to_private'));
     }
 }

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -213,6 +213,7 @@ return [
     'form' => [
         'sections' => [
             'basic' => 'Basisdaten',
+            'organization' => 'Eigentümerschaft und Gruppen',
             'check' => 'Prüfkonfiguration',
             'sharing' => 'Öffentliche Anzeige',
             'notifications' => 'Benachrichtigungen',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -213,6 +213,7 @@ return [
     'form' => [
         'sections' => [
             'basic' => 'Basics',
+            'organization' => 'Ownership and groups',
             'check' => 'Check configuration',
             'sharing' => 'Public display',
             'notifications' => 'Notifications',

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -117,56 +117,6 @@
     </div>
 
     <div class="mt-4">
-        <x-input-label for="team_id" :value="__('team.ownership.select_label')" />
-        @if (isset($monitoring))
-            <x-text-input id="team_id" class="cursor-not-allowed" :value="$monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private')" readonly />
-        @else
-            <x-select-input id="team_id" name="team_id" class="mt-1 block w-full">
-                <option value="">{{ __('team.ownership.private') }}</option>
-                @foreach ($adminTeams as $team)
-                    <option value="{{ $team->id }}" @selected($selectedTeamId === $team->id)>
-                        {{ __('team.ownership.team') }}: {{ $team->name }}
-                    </option>
-                @endforeach
-            </x-select-input>
-            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                {{ __('team.ownership.private_help') }}
-                @if ($adminTeams->isNotEmpty())
-                    {{ __('team.ownership.team_help') }}
-                @endif
-            </p>
-        @endif
-        <x-input-error :messages="$errors->get('team_id')" />
-    </div>
-
-    <div class="mt-4">
-        <x-input-label for="group_ids" :value="__('monitoring.form.groups')" />
-        <x-multi-select
-            id="group_ids"
-            name="group_ids"
-            :options="$groupOptions"
-            :selected="$selectedGroupIds"
-            :placeholder="__('monitoring.form.no_group')"
-            :search-placeholder="__('monitoring.form.search_groups')"
-            :select-all-label="__('monitoring.form.select_all_groups')"
-            :all-selected-label="__('monitoring.form.all_groups_selected')"
-            :no-options-label="__('monitoring.form.no_groups_available')"
-            :no-results-label="__('monitoring.form.no_groups_found')"
-            :remove-label="__('monitoring.form.remove_group')"
-            :clear-label="__('monitoring.form.clear_groups')" />
-        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            {{ __('monitoring.form.groups_help') }}
-            @if (!Auth::user()->isDemo())
-                <a href="{{ route('monitoring-groups.index') }}" class="text-purple-700 underline dark:text-purple-300">
-                    {{ __('monitoring_group.title') }}
-                </a>
-            @endif
-        </p>
-        <x-input-error :messages="$errors->get('group_ids')" />
-        <x-input-error :messages="$errors->get('group_ids.*')" />
-    </div>
-
-    <div class="mt-4">
         <x-input-label for="target" :value="__('monitoring.form.target')" />
         @if (isset($monitoring))
             @if ($monitoring->type === MonitoringType::HEARTBEAT || $monitoring->type === MonitoringType::SERVER_HEALTH)
@@ -221,6 +171,62 @@
         <x-input-error :messages="$errors->get('target')" />
     </div>
 
+        </section>
+
+        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div>
+                <x-heading type="h2">{{ __('monitoring.form.sections.organization') }}</x-heading>
+            </div>
+
+            <div>
+                <x-input-label for="team_id" :value="__('team.ownership.select_label')" />
+                @if (isset($monitoring))
+                    <x-text-input id="team_id" class="cursor-not-allowed" :value="$monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private')" readonly />
+                @else
+                    <x-select-input id="team_id" name="team_id" class="mt-1 block w-full">
+                        <option value="">{{ __('team.ownership.private') }}</option>
+                        @foreach ($adminTeams as $team)
+                            <option value="{{ $team->id }}" @selected($selectedTeamId === $team->id)>
+                                {{ __('team.ownership.team') }}: {{ $team->name }}
+                            </option>
+                        @endforeach
+                    </x-select-input>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        {{ __('team.ownership.private_help') }}
+                        @if ($adminTeams->isNotEmpty())
+                            {{ __('team.ownership.team_help') }}
+                        @endif
+                    </p>
+                @endif
+                <x-input-error :messages="$errors->get('team_id')" />
+            </div>
+
+            <div>
+                <x-input-label for="group_ids" :value="__('monitoring.form.groups')" />
+                <x-multi-select
+                    id="group_ids"
+                    name="group_ids"
+                    :options="$groupOptions"
+                    :selected="$selectedGroupIds"
+                    :placeholder="__('monitoring.form.no_group')"
+                    :search-placeholder="__('monitoring.form.search_groups')"
+                    :select-all-label="__('monitoring.form.select_all_groups')"
+                    :all-selected-label="__('monitoring.form.all_groups_selected')"
+                    :no-options-label="__('monitoring.form.no_groups_available')"
+                    :no-results-label="__('monitoring.form.no_groups_found')"
+                    :remove-label="__('monitoring.form.remove_group')"
+                    :clear-label="__('monitoring.form.clear_groups')" />
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                    {{ __('monitoring.form.groups_help') }}
+                    @if (!Auth::user()->isDemo())
+                        <a href="{{ route('monitoring-groups.index') }}" class="text-purple-700 underline dark:text-purple-300">
+                            {{ __('monitoring_group.title') }}
+                        </a>
+                    @endif
+                </p>
+                <x-input-error :messages="$errors->get('group_ids')" />
+                <x-input-error :messages="$errors->get('group_ids.*')" />
+            </div>
         </section>
 
         <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
@@ -559,6 +565,11 @@
 
         </section>
 
-        <x-primary-button>{{ isset($monitoring) ? __('button.update') : __('button.create') }}</x-primary-button>
+        <div class="flex flex-wrap justify-end gap-2">
+            <x-secondary-button :href="isset($monitoring) ? route('monitorings.show', $monitoring) : route('monitorings.index')">
+                {{ __('button.cancel') }}
+            </x-secondary-button>
+            <x-primary-button>{{ isset($monitoring) ? __('button.update') : __('button.create') }}</x-primary-button>
+        </div>
     </div>
 </div>

--- a/resources/views/monitorings/_ownership.blade.php
+++ b/resources/views/monitorings/_ownership.blade.php
@@ -1,0 +1,34 @@
+<x-container class="mb-4">
+    <div class="space-y-4">
+        <div>
+            <x-heading type="h2">{{ __('team.ownership.select_label') }}</x-heading>
+            <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                {{ $monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private') }}
+            </x-paragraph>
+        </div>
+
+        @if (! $monitoring->isTeamOwned() && $adminTeams->isNotEmpty())
+            <form method="POST" action="{{ route('monitorings.team-ownership.store', $monitoring) }}"
+                class="flex flex-col gap-2 sm:flex-row sm:items-end">
+                @csrf
+                <div class="min-w-0 flex-1">
+                    <x-input-label for="move-team-{{ $monitoring->id }}" :value="__('team.ownership.move_to_team')" />
+                    <x-select-input id="move-team-{{ $monitoring->id }}" name="team_id" class="mt-1 block w-full">
+                        @foreach ($adminTeams as $team)
+                            <option value="{{ $team->id }}">{{ $team->name }}</option>
+                        @endforeach
+                    </x-select-input>
+                </div>
+                <x-secondary-button type="submit">{{ __('team.ownership.move_to_team') }}</x-secondary-button>
+            </form>
+        @endif
+
+        @if ($monitoring->isTeamOwned())
+            <form method="POST" action="{{ route('monitorings.team-ownership.destroy', $monitoring) }}">
+                @csrf
+                @method('DELETE')
+                <x-secondary-button type="submit">{{ __('team.ownership.move_to_private') }}</x-secondary-button>
+            </form>
+        @endif
+    </div>
+</x-container>

--- a/resources/views/monitorings/edit.blade.php
+++ b/resources/views/monitorings/edit.blade.php
@@ -17,6 +17,8 @@
     </x-slot>
 
     <x-main>
+        @include('monitorings._ownership')
+
         <x-container>
             <form method="POST" action="{{ route('monitorings.update', $monitoring) }}">
                 @include('monitorings._form')

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -29,9 +29,6 @@
                     {{ __('monitoring.index.table.maintenance') }}
                 </x-badge>
             @endif
-            <x-badge type="{{ $monitoring->isTeamOwned() ? 'info' : 'success' }}">
-                {{ $monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private') }}
-            </x-badge>
         </x-heading>
 
         <div class="ml-auto flex flex-wrap items-start gap-2 sm:items-center">
@@ -51,32 +48,6 @@
                             class="block px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
                             {{ __('monitoring.actions.edit') }}
                         </a>
-                        @if (!$monitoring->isTeamOwned() && $adminTeams->isNotEmpty())
-                            <form method="POST" action="{{ route('monitorings.team-ownership.store', $monitoring) }}"
-                                class="px-4 py-2">
-                                @csrf
-                                <label for="move-team-{{ $monitoring->id }}" class="sr-only">{{ __('team.ownership.move_to_team') }}</label>
-                                <select id="move-team-{{ $monitoring->id }}" name="team_id"
-                                    class="mb-2 w-full rounded-md border border-gray-300 p-2 text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                                    @foreach ($adminTeams as $team)
-                                        <option value="{{ $team->id }}">{{ $team->name }}</option>
-                                    @endforeach
-                                </select>
-                                <button type="submit" class="block w-full text-left text-gray-700 hover:bg-gray-100 sm:text-right">
-                                    {{ __('team.ownership.move_to_team') }}
-                                </button>
-                            </form>
-                        @endif
-                        @if ($monitoring->isTeamOwned())
-                            <form method="POST" action="{{ route('monitorings.team-ownership.destroy', $monitoring) }}">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit"
-                                    class="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
-                                    {{ __('team.ownership.move_to_private') }}
-                                </button>
-                            </form>
-                        @endif
                         <form method="POST" action="{{ route('monitorings.destroyResults', $monitoring) }}"
                             data-confirm-message="{{ __('monitoring.actions.reset.confirmation') }}">
                             @csrf

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Tests\TestCase;
+
+class MonitoringFormPresentationTest extends TestCase
+{
+    public function test_create_and_edit_forms_share_section_order_and_action_placement(): void
+    {
+        $user = User::factory()->create([
+            'package_id' => Package::factory()->create(['monitoring_limit' => 10])->id,
+        ]);
+        $serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+        ]);
+        $sections = [
+            __('monitoring.form.sections.basic'),
+            __('monitoring.form.sections.organization'),
+            __('monitoring.form.sections.check'),
+            __('monitoring.form.sections.sharing'),
+            __('monitoring.form.sections.notifications'),
+            __('monitoring.form.sections.operations'),
+        ];
+
+        $createResponse = $this->actingAs($user)->get(route('monitorings.create'));
+        $editResponse = $this->actingAs($user)->get(route('monitorings.edit', $monitoring));
+
+        $createResponse->assertOk()->assertSeeInOrder($sections);
+        $editResponse->assertOk()->assertSeeInOrder($sections);
+        $createResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
+        $editResponse->assertSeeHtml('href="' . route('monitorings.show', $monitoring) . '"');
+    }
+
+    public function test_assignment_indicators_and_ownership_actions_only_appear_on_edit_page(): void
+    {
+        $user = User::factory()->create([
+            'package_id' => Package::factory()->create(['monitoring_limit' => 10])->id,
+        ]);
+        $serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Checkout API',
+            'preferred_location' => $serverInstance->code,
+        ]);
+        $monitoringGroup = MonitoringGroup::factory()->for($user)->create(['name' => 'Production']);
+        $monitoring->groups()->attach($monitoringGroup);
+
+        $showResponse = $this->actingAs($user)->get(route('monitorings.show', $monitoring));
+        $editResponse = $this->actingAs($user)->get(route('monitorings.edit', $monitoring));
+
+        $showResponse->assertOk();
+        $showResponse->assertDontSeeText(__('team.ownership.private'));
+        $showResponse->assertDontSeeText('Production');
+        $showResponse->assertDontSeeHtml('action="' . route('monitorings.team-ownership.store', $monitoring) . '"');
+
+        $editResponse->assertOk();
+        $editResponse->assertSeeText(__('team.ownership.private'));
+        $editResponse->assertSeeText('Production');
+    }
+}

--- a/tests/Feature/TeamMonitoringTest.php
+++ b/tests/Feature/TeamMonitoringTest.php
@@ -168,14 +168,14 @@ class TeamMonitoringTest extends TestCase
 
         $this->actingAs($admin)->post(route('monitorings.team-ownership.store', $monitoring), [
             'team_id' => $team->id,
-        ])->assertRedirect(route('monitorings.show', $monitoring));
+        ])->assertRedirect(route('monitorings.edit', $monitoring));
 
         $monitoring->refresh();
         $this->assertNull($monitoring->user_id);
         $this->assertSame($team->id, $monitoring->team_id);
 
         $this->actingAs($admin)->delete(route('monitorings.team-ownership.destroy', $monitoring))
-            ->assertRedirect(route('monitorings.show', $monitoring));
+            ->assertRedirect(route('monitorings.edit', $monitoring));
 
         $monitoring->refresh();
         $this->assertSame($admin->id, $monitoring->user_id);


### PR DESCRIPTION
Closes #418

## What changed

- Added a shared organization section to the monitoring form so create and edit use the same section order and hierarchy.
- Standardized form cancellation and primary action placement.
- Kept creation-only controls available during creation while showing edit-only ownership actions in a dedicated edit section.
- Moved monitoring ownership controls out of the detail action menu and routed ownership changes back to the edit workflow.
- Added English/German section labels and feature coverage for create/edit presentation and ownership visibility.

## Why

Monitoring creation and editing should present shared configuration consistently while keeping workflow-specific controls clear and discoverable.

## Validation

- Dockerized Pest: 30 passed, 179 assertions across monitoring form, notification, team, and group coverage.
- Dockerized Pint check passed.
- Dockerized PHPStan: no errors.
- Dockerized Vite production build passed.
- `git diff --check` passed.