### PR TITLE
fix(ui): align monitoring edit panel spacing

### DIFF
--- a/resources/views/monitorings/_notification_preferences.blade.php
+++ b/resources/views/monitorings/_notification_preferences.blade.php
@@ -5,7 +5,7 @@
     $fieldIdPrefix = $fieldIdPrefix ?? 'monitoring_notification_preference';
 @endphp
 
-<x-container class="mb-4">
+<x-container>
     <x-heading type="h2">{{ __('team.sections.notification_preferences') }}</x-heading>
     <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
         class="mt-4 space-y-4">

--- a/resources/views/monitorings/_ownership.blade.php
+++ b/resources/views/monitorings/_ownership.blade.php
@@ -1,4 +1,4 @@
-<x-container class="mb-4">
+<x-container>
     <div class="space-y-4">
         <div>
             <x-heading type="h2">{{ __('team.ownership.select_label') }}</x-heading>

--- a/resources/views/monitorings/create.blade.php
+++ b/resources/views/monitorings/create.blade.php
@@ -13,8 +13,7 @@
         </x-secondary-button>
     </x-slot>
 
-    <x-main>
-
+    <x-main class="space-y-4">
         <x-container>
             <form method="POST" action="{{ route('monitorings.store') }}">
                 @include('monitorings._form')

--- a/resources/views/monitorings/edit.blade.php
+++ b/resources/views/monitorings/edit.blade.php
@@ -16,7 +16,7 @@
         </x-secondary-button>
     </x-slot>
 
-    <x-main>
+    <x-main class="space-y-4">
         @include('monitorings._ownership')
 
         <x-container>

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -39,6 +39,8 @@ class MonitoringFormPresentationTest extends TestCase
 
         $testResponse->assertOk()->assertSeeInOrder($sections);
         $editResponse->assertOk()->assertSeeInOrder($sections);
+        $testResponse->assertSeeHtml('class="mx-auto max-w-7xl space-y-4 px-4 sm:px-6 lg:px-8"');
+        $editResponse->assertSeeHtml('class="mx-auto max-w-7xl space-y-4 px-4 sm:px-6 lg:px-8"');
         $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
         $editResponse->assertSeeHtml('href="' . route('monitorings.show', $monitoring) . '"');
     }


### PR DESCRIPTION
## What changed
- Apply the same vertical panel spacing to Monitoring Create and Edit pages.
- Remove the old per-panel bottom margins so the Edit page does not render inconsistent or doubled gaps.
- Add a presentation regression assertion for the shared layout class.

## Why
The Monitoring Edit page rendered the main form and notification preferences directly adjacent, unlike the consistent section spacing used by the form layout.

## Validation
- Docker Pest: `tests/Feature/MonitoringFormPresentationTest.php` (2 tests, 15 assertions)
- Docker Bun/Vite production build
- Docker Pint check
- `git diff --check`

## Risks / follow-up
No behavior or API changes; this is limited to Blade layout spacing and its presentation test.

Closes #429