### PR TITLE
docs: refresh feature and release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 
 WebGuard is an open-source monitoring core built with Laravel 13. It provides the management UI, REST API, public status pages, notification workflows, and package administration for monitoring websites, DNS records, domains, SSL certificates, and background jobs.
 
-> **System architecture note:** this repository contains the Management Core & API. Distributed scanning nodes live in the [WebGuard Instance Repository](https://github.com/marcel-breuer/webguard-instance).
+> **System architecture note:** this repository contains the Management Core & API. Distributed scanning nodes live in the [WebGuard Instance Repository](https://github.com/marcel-breuer/webguard-instance), while the mobile client is maintained in the [WebGuard App Repository](https://github.com/marcel-breuer/webguard-app).
 
 ## What It Does
 
 - Tracks uptime, response times, expected HTTP status ranges, expected DNS records, SSL expiry, and domain expiry.
 - Monitors heartbeats and cron jobs through private ping URLs.
+- Classifies multi-location incidents as localized, regional, or global based on selected monitoring locations.
+- Supports team-owned monitorings with group assignment and admin-controlled ownership changes.
 - Sends in-app, configurable, expiry, status-change, and weekly digest notifications.
 - Provides dashboards, public status pages, SLA badges, and a REST API.
 - Supports a global language switch across public and authenticated navigation.
@@ -41,6 +43,7 @@ php artisan test
 - [Installation, Docker, and operations](docs/installation.md)
 - [Test concept](docs/test-concept.md)
 - [Contributing](docs/contributing.md)
+- [Releases and changelog](docs/releases.md)
 
 ## License
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,12 +19,13 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 ## Product Surface
 
 - **Real-time dashboard:** visualize monitoring data with statistics and charts.
+- **Monitoring management:** create and edit monitorings through structured forms, assign them to monitoring groups, and manage ownership with team-admin controls.
 - **Team collaboration:** create teams, invite registered or new users by email, assign admin/member roles, and share team-owned monitorings with read-only members.
 - **Admin panel:** manage users, subscription packages, and API usage logs.
 - **REST API:** access monitoring data, manage teams, and create or move team monitorings programmatically.
 - **Mobile app:** use the implemented WebGuard mobile app from the separate [WebGuard App Repository](https://github.com/marcel-breuer/webguard-app).
 - **SLA badge:** display website monitoring status on external sites with a compact SLA badge that shows live status, uptime proof, and public trust context.
-- **Public status pages:** publish monitoring status, uptime, recent incidents, and active or upcoming maintenance windows for users and customers.
+- **Public status pages:** publish monitoring status, uptime, recent incidents, and active or upcoming maintenance windows for users and customers. New public status page URLs use ULIDs, while legacy slug URLs remain available through compatibility routes.
 - **Global language switch:** switch between supported languages from both public and authenticated top navigation.
 
 ## Notifications

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,15 @@
+# Releases and Changelog
+
+WebGuard publishes release notes automatically through GitHub Actions. A successful CI run for a push to `main` triggers the `Tag` workflow, which creates a release tag, generates notes from the commits since the previous tag, and publishes or updates the corresponding GitHub release.
+
+The generator groups Conventional Commits into feature, fix, performance, refactoring, documentation, test, CI/build, maintenance, breaking-change, and other-change sections. It also includes merged pull request branches when the repository name is provided.
+
+The workflow can be started manually to regenerate notes for one tag or backfill all existing tags. For local previews, run:
+
+```bash
+php .github/scripts/generate-changelog.php \
+  --tag=v0.82.1 \
+  --repository=marcel-breuer/webguard
+```
+
+Release notes are maintained on the [GitHub Releases page](https://github.com/marcel-breuer/webguard/releases); the repository does not keep a separate generated `CHANGELOG.md` file.

--- a/tests/Feature/DocumentationStructureTest.php
+++ b/tests/Feature/DocumentationStructureTest.php
@@ -58,6 +58,11 @@ class DocumentationStructureTest extends TestCase
                 'Write tests',
                 'pull request',
             ],
+            'docs/releases.md' => [
+                'GitHub Actions',
+                'Conventional Commits',
+                'GitHub Releases page',
+            ],
         ];
 
         foreach ($topicsByDocument as $document => $topics) {
@@ -106,6 +111,7 @@ class DocumentationStructureTest extends TestCase
             'docs/installation.md',
             'docs/test-concept.md',
             'docs/contributing.md',
+            'docs/releases.md',
         ];
     }
 }


### PR DESCRIPTION
## What changed
- Update the README with the current mobile app, regional incident classification, and team monitoring/group assignment capabilities.
- Update the feature documentation with structured monitoring management and ULID-based public status page URLs.
- Add release documentation for the existing CI-driven GitHub release notes workflow.
- Extend the documentation structure test to cover the new release document.

## Why
Keep the repository documentation aligned with the features already implemented and make the release-note process discoverable.

## Validation
- `git diff --check` passed.
- `DocumentationStructureTest` passed in Docker (4 tests, 53 assertions).
- The local changelog generator produced valid release notes for `v0.82.1`.
- `TagChangelogGenerationTest` was skipped in Docker because the PHP test container does not include `git`.

## Risk
Documentation and documentation-test changes only; runtime behavior and CI workflow logic are unchanged.

Closes #434