### PR TITLE
feat(ui): make core operations visible in navigation

### DIFF
--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -15,9 +15,9 @@ use Illuminate\View\View;
 
 class IncidentAnalyticsController extends Controller
 {
-    public function index(IncidentAnalyticsRequest $request): View
+    public function index(IncidentAnalyticsRequest $incidentAnalyticsRequest): View
     {
-        $filters = $request->validated();
+        $filters = $incidentAnalyticsRequest->validated();
         $days = (int) ($filters['days'] ?? 90);
         $incidents = $this->incidents($filters, $days);
         $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
@@ -56,22 +56,22 @@ class IncidentAnalyticsController extends Controller
      */
     private function incidents(array $filters, int $days): Collection
     {
-        $query = Incident::query()
+        $builder = Incident::query()
             ->with('monitoring')
             ->whereBetween('down_at', [Date::now()->subDays($days)->startOfDay(), Date::now()->endOfDay()])
             ->latest('down_at');
 
         foreach (['incident_type', 'severity', 'customer_impact'] as $filter) {
             if (! empty($filters[$filter])) {
-                $query->where($filter, $filters[$filter]);
+                $builder->where($filter, $filters[$filter]);
             }
         }
 
         if (! empty($filters['affected_service'])) {
-            $query->where('affected_service', 'like', '%' . $filters['affected_service'] . '%');
+            $builder->where('affected_service', 'like', '%' . $filters['affected_service'] . '%');
         }
 
-        return $query->get();
+        return $builder->get();
     }
 
     /**

--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -15,9 +15,9 @@ use Illuminate\View\View;
 
 class IncidentAnalyticsController extends Controller
 {
-    public function index(IncidentAnalyticsRequest $incidentAnalyticsRequest): View
+    public function index(IncidentAnalyticsRequest $request): View
     {
-        $filters = $incidentAnalyticsRequest->validated();
+        $filters = $request->validated();
         $days = (int) ($filters['days'] ?? 90);
         $incidents = $this->incidents($filters, $days);
         $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
@@ -56,22 +56,22 @@ class IncidentAnalyticsController extends Controller
      */
     private function incidents(array $filters, int $days): Collection
     {
-        $builder = Incident::query()
+        $query = Incident::query()
             ->with('monitoring')
             ->whereBetween('down_at', [Date::now()->subDays($days)->startOfDay(), Date::now()->endOfDay()])
             ->latest('down_at');
 
         foreach (['incident_type', 'severity', 'customer_impact'] as $filter) {
             if (! empty($filters[$filter])) {
-                $builder->where($filter, $filters[$filter]);
+                $query->where($filter, $filters[$filter]);
             }
         }
 
         if (! empty($filters['affected_service'])) {
-            $builder->where('affected_service', 'like', '%' . $filters['affected_service'] . '%');
+            $query->where('affected_service', 'like', '%' . $filters['affected_service'] . '%');
         }
 
-        return $builder->get();
+        return $query->get();
     }
 
     /**

--- a/app/Http/Controllers/StatusPageIncidentFollowUpController.php
+++ b/app/Http/Controllers/StatusPageIncidentFollowUpController.php
@@ -19,12 +19,12 @@ class StatusPageIncidentFollowUpController extends Controller
     use InteractsWithStatusPageIncidents;
 
     public function store(
-        StoreIncidentFollowUpRequest $storeIncidentFollowUpRequest,
+        StoreIncidentFollowUpRequest $request,
         StatusPage $statusPage,
         Incident $incident
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        $validated = $storeIncidentFollowUpRequest->validated();
+        $validated = $request->validated();
         $this->assertAssignedUserIsStatusPageOwner($statusPage, $validated['assigned_user_id'] ?? null);
 
         $incident->followUps()->create([
@@ -37,21 +37,21 @@ class StatusPageIncidentFollowUpController extends Controller
     }
 
     public function update(
-        UpdateIncidentFollowUpRequest $updateIncidentFollowUpRequest,
+        UpdateIncidentFollowUpRequest $request,
         StatusPage $statusPage,
         Incident $incident,
-        IncidentFollowUp $incidentFollowUp
+        IncidentFollowUp $followUp
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($incidentFollowUp->incident_id === $incident->id, 404);
+        abort_unless($followUp->incident_id === $incident->id, 404);
 
-        $validated = $updateIncidentFollowUpRequest->validated();
+        $validated = $request->validated();
         $this->assertAssignedUserIsStatusPageOwner($statusPage, $validated['assigned_user_id'] ?? null);
         $validated['completed_at'] = $validated['status'] === IncidentFollowUpStatus::COMPLETED->value
-            ? ($incidentFollowUp->completed_at ?? Date::now())
+            ? ($followUp->completed_at ?? Date::now())
             : null;
 
-        $incidentFollowUp->update($validated);
+        $followUp->update($validated);
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_follow_ups.messages.updated'));
@@ -60,12 +60,12 @@ class StatusPageIncidentFollowUpController extends Controller
     public function destroy(
         StatusPage $statusPage,
         Incident $incident,
-        IncidentFollowUp $incidentFollowUp
+        IncidentFollowUp $followUp
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($incidentFollowUp->incident_id === $incident->id, 404);
+        abort_unless($followUp->incident_id === $incident->id, 404);
 
-        $incidentFollowUp->delete();
+        $followUp->delete();
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_follow_ups.messages.deleted'));

--- a/app/Http/Controllers/StatusPageIncidentFollowUpController.php
+++ b/app/Http/Controllers/StatusPageIncidentFollowUpController.php
@@ -19,12 +19,12 @@ class StatusPageIncidentFollowUpController extends Controller
     use InteractsWithStatusPageIncidents;
 
     public function store(
-        StoreIncidentFollowUpRequest $request,
+        StoreIncidentFollowUpRequest $storeIncidentFollowUpRequest,
         StatusPage $statusPage,
         Incident $incident
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        $validated = $request->validated();
+        $validated = $storeIncidentFollowUpRequest->validated();
         $this->assertAssignedUserIsStatusPageOwner($statusPage, $validated['assigned_user_id'] ?? null);
 
         $incident->followUps()->create([
@@ -37,21 +37,21 @@ class StatusPageIncidentFollowUpController extends Controller
     }
 
     public function update(
-        UpdateIncidentFollowUpRequest $request,
+        UpdateIncidentFollowUpRequest $updateIncidentFollowUpRequest,
         StatusPage $statusPage,
         Incident $incident,
-        IncidentFollowUp $followUp
+        IncidentFollowUp $incidentFollowUp
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($followUp->incident_id === $incident->id, 404);
+        abort_unless($incidentFollowUp->incident_id === $incident->id, 404);
 
-        $validated = $request->validated();
+        $validated = $updateIncidentFollowUpRequest->validated();
         $this->assertAssignedUserIsStatusPageOwner($statusPage, $validated['assigned_user_id'] ?? null);
         $validated['completed_at'] = $validated['status'] === IncidentFollowUpStatus::COMPLETED->value
-            ? ($followUp->completed_at ?? Date::now())
+            ? ($incidentFollowUp->completed_at ?? Date::now())
             : null;
 
-        $followUp->update($validated);
+        $incidentFollowUp->update($validated);
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_follow_ups.messages.updated'));
@@ -60,12 +60,12 @@ class StatusPageIncidentFollowUpController extends Controller
     public function destroy(
         StatusPage $statusPage,
         Incident $incident,
-        IncidentFollowUp $followUp
+        IncidentFollowUp $incidentFollowUp
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($followUp->incident_id === $incident->id, 404);
+        abort_unless($incidentFollowUp->incident_id === $incident->id, 404);
 
-        $followUp->delete();
+        $incidentFollowUp->delete();
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_follow_ups.messages.deleted'));

--- a/app/Http/Controllers/StatusPageIncidentMetadataController.php
+++ b/app/Http/Controllers/StatusPageIncidentMetadataController.php
@@ -15,13 +15,13 @@ class StatusPageIncidentMetadataController extends Controller
     use InteractsWithStatusPageIncidents;
 
     public function update(
-        UpdateIncidentMetadataRequest $request,
+        UpdateIncidentMetadataRequest $updateIncidentMetadataRequest,
         StatusPage $statusPage,
         Incident $incident
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
 
-        $incident->update($request->validated());
+        $incident->update($updateIncidentMetadataRequest->validated());
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_metadata.messages.updated'));

--- a/app/Http/Controllers/StatusPageIncidentMetadataController.php
+++ b/app/Http/Controllers/StatusPageIncidentMetadataController.php
@@ -15,13 +15,13 @@ class StatusPageIncidentMetadataController extends Controller
     use InteractsWithStatusPageIncidents;
 
     public function update(
-        UpdateIncidentMetadataRequest $updateIncidentMetadataRequest,
+        UpdateIncidentMetadataRequest $request,
         StatusPage $statusPage,
         Incident $incident
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
 
-        $incident->update($updateIncidentMetadataRequest->validated());
+        $incident->update($request->validated());
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_metadata.messages.updated'));

--- a/app/Http/Controllers/StatusPageIncidentTimelineController.php
+++ b/app/Http/Controllers/StatusPageIncidentTimelineController.php
@@ -17,14 +17,14 @@ class StatusPageIncidentTimelineController extends Controller
     use InteractsWithStatusPageIncidents;
 
     public function store(
-        StoreIncidentTimelineEventRequest $storeIncidentTimelineEventRequest,
+        StoreIncidentTimelineEventRequest $request,
         StatusPage $statusPage,
         Incident $incident
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
 
         $incident->timelineEvents()->create([
-            ...$storeIncidentTimelineEventRequest->validated(),
+            ...$request->validated(),
             'source_type' => 'custom',
         ]);
 
@@ -33,15 +33,15 @@ class StatusPageIncidentTimelineController extends Controller
     }
 
     public function update(
-        UpdateIncidentTimelineEventRequest $updateIncidentTimelineEventRequest,
+        UpdateIncidentTimelineEventRequest $request,
         StatusPage $statusPage,
         Incident $incident,
-        IncidentTimelineEvent $incidentTimelineEvent
+        IncidentTimelineEvent $timelineEvent
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($incidentTimelineEvent->incident_id === $incident->id, 404);
+        abort_unless($timelineEvent->incident_id === $incident->id, 404);
 
-        $incidentTimelineEvent->update($updateIncidentTimelineEventRequest->validated());
+        $timelineEvent->update($request->validated());
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_timeline.messages.updated'));
@@ -50,12 +50,12 @@ class StatusPageIncidentTimelineController extends Controller
     public function destroy(
         StatusPage $statusPage,
         Incident $incident,
-        IncidentTimelineEvent $incidentTimelineEvent
+        IncidentTimelineEvent $timelineEvent
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($incidentTimelineEvent->incident_id === $incident->id, 404);
+        abort_unless($timelineEvent->incident_id === $incident->id, 404);
 
-        $incidentTimelineEvent->delete();
+        $timelineEvent->delete();
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_timeline.messages.deleted'));

--- a/app/Http/Controllers/StatusPageIncidentTimelineController.php
+++ b/app/Http/Controllers/StatusPageIncidentTimelineController.php
@@ -17,14 +17,14 @@ class StatusPageIncidentTimelineController extends Controller
     use InteractsWithStatusPageIncidents;
 
     public function store(
-        StoreIncidentTimelineEventRequest $request,
+        StoreIncidentTimelineEventRequest $storeIncidentTimelineEventRequest,
         StatusPage $statusPage,
         Incident $incident
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
 
         $incident->timelineEvents()->create([
-            ...$request->validated(),
+            ...$storeIncidentTimelineEventRequest->validated(),
             'source_type' => 'custom',
         ]);
 
@@ -33,15 +33,15 @@ class StatusPageIncidentTimelineController extends Controller
     }
 
     public function update(
-        UpdateIncidentTimelineEventRequest $request,
+        UpdateIncidentTimelineEventRequest $updateIncidentTimelineEventRequest,
         StatusPage $statusPage,
         Incident $incident,
-        IncidentTimelineEvent $timelineEvent
+        IncidentTimelineEvent $incidentTimelineEvent
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($timelineEvent->incident_id === $incident->id, 404);
+        abort_unless($incidentTimelineEvent->incident_id === $incident->id, 404);
 
-        $timelineEvent->update($request->validated());
+        $incidentTimelineEvent->update($updateIncidentTimelineEventRequest->validated());
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_timeline.messages.updated'));
@@ -50,12 +50,12 @@ class StatusPageIncidentTimelineController extends Controller
     public function destroy(
         StatusPage $statusPage,
         Incident $incident,
-        IncidentTimelineEvent $timelineEvent
+        IncidentTimelineEvent $incidentTimelineEvent
     ): RedirectResponse {
         $this->authorizeIncident($statusPage, $incident);
-        abort_unless($timelineEvent->incident_id === $incident->id, 404);
+        abort_unless($incidentTimelineEvent->incident_id === $incident->id, 404);
 
-        $timelineEvent->delete();
+        $incidentTimelineEvent->delete();
 
         return to_route('status-pages.show', $statusPage)
             ->with('success', __('status_page.incident_timeline.messages.deleted'));

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use App\Enums\IncidentContributingCategory;
-use App\Enums\IncidentCustomerImpact;
-use App\Enums\IncidentSeverity;
-use App\Enums\IncidentType;
 use App\Enums\RegionalConsensusStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -81,7 +77,7 @@ class Incident extends Model
      */
     public function timelineEvents(): HasMany
     {
-        return $this->hasMany(IncidentTimelineEvent::class)->oldest('occurred_at');
+        return $this->hasMany(IncidentTimelineEvent::class)->orderBy('occurred_at');
     }
 
     /**
@@ -96,10 +92,10 @@ class Incident extends Model
             'affected_locations' => 'array',
             'problem_description' => 'string',
             'resolution_description' => 'string',
-            'incident_type' => IncidentType::class,
-            'severity' => IncidentSeverity::class,
-            'customer_impact' => IncidentCustomerImpact::class,
-            'contributing_category' => IncidentContributingCategory::class,
+            'incident_type' => \App\Enums\IncidentType::class,
+            'severity' => \App\Enums\IncidentSeverity::class,
+            'customer_impact' => \App\Enums\IncidentCustomerImpact::class,
+            'contributing_category' => \App\Enums\IncidentContributingCategory::class,
             'down_at' => 'datetime',
             'up_at' => 'datetime',
             'created_at' => 'datetime',

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\IncidentContributingCategory;
+use App\Enums\IncidentCustomerImpact;
+use App\Enums\IncidentSeverity;
+use App\Enums\IncidentType;
 use App\Enums\RegionalConsensusStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -77,7 +81,7 @@ class Incident extends Model
      */
     public function timelineEvents(): HasMany
     {
-        return $this->hasMany(IncidentTimelineEvent::class)->orderBy('occurred_at');
+        return $this->hasMany(IncidentTimelineEvent::class)->oldest('occurred_at');
     }
 
     /**
@@ -92,10 +96,10 @@ class Incident extends Model
             'affected_locations' => 'array',
             'problem_description' => 'string',
             'resolution_description' => 'string',
-            'incident_type' => \App\Enums\IncidentType::class,
-            'severity' => \App\Enums\IncidentSeverity::class,
-            'customer_impact' => \App\Enums\IncidentCustomerImpact::class,
-            'contributing_category' => \App\Enums\IncidentContributingCategory::class,
+            'incident_type' => IncidentType::class,
+            'severity' => IncidentSeverity::class,
+            'customer_impact' => IncidentCustomerImpact::class,
+            'contributing_category' => IncidentContributingCategory::class,
             'down_at' => 'datetime',
             'up_at' => 'datetime',
             'created_at' => 'datetime',

--- a/app/Services/IncidentTimelineService.php
+++ b/app/Services/IncidentTimelineService.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Incident;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class IncidentTimelineService
 {
     /**
-     * @return Collection<int, array{id: string|null, title: string, description: string|null, occurred_at: \Illuminate\Support\Carbon, source_type: string}>
+     * @return Collection<int, array{id: string|null, title: string, description: string|null, occurred_at: Carbon, source_type: string}>
      */
     public function events(Incident $incident): Collection
     {

--- a/app/Services/IncidentTimelineService.php
+++ b/app/Services/IncidentTimelineService.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Incident;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class IncidentTimelineService
 {
     /**
-     * @return Collection<int, array{id: string|null, title: string, description: string|null, occurred_at: Carbon, source_type: string}>
+     * @return Collection<int, array{id: string|null, title: string, description: string|null, occurred_at: \Illuminate\Support\Carbon, source_type: string}>
      */
     public function events(Incident $incident): Collection
     {

--- a/database/migrations/2026_07_15_140100_create_incident_follow_ups_table.php
+++ b/database/migrations/2026_07_15_140100_create_incident_follow_ups_table.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Models\Incident;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_07_15_140100_create_incident_follow_ups_table.php
+++ b/database/migrations/2026_07_15_140100_create_incident_follow_ups_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Incident;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_07_15_140200_create_incident_timeline_events_table.php
+++ b/database/migrations/2026_07_15_140200_create_incident_timeline_events_table.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Models\Incident;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_07_15_140200_create_incident_timeline_events_table.php
+++ b/database/migrations/2026_07_15_140200_create_incident_timeline_events_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Incident;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/resources/lang/de/app.php
+++ b/resources/lang/de/app.php
@@ -32,6 +32,7 @@ return [
         'home' => 'Hauptnavigation',
         'monitoring' => 'Monitoring',
         'workspace' => 'Workspace',
+        'more' => 'Mehr',
         'sections' => [
             'operations' => 'Betrieb',
             'collaboration' => 'Zusammenarbeit',

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -32,6 +32,7 @@ return [
         'home' => 'Main navigation',
         'monitoring' => 'Monitoring',
         'workspace' => 'Workspace',
+        'more' => 'More',
         'sections' => [
             'operations' => 'Operations',
             'collaboration' => 'Collaboration',

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,8 +1,9 @@
 @php
-    $monitoringNavActive = request()->routeIs('monitorings.*')
-        || request()->routeIs('maintenance.*')
-        || request()->routeIs('monitoring-groups.*');
-    $workspaceNavActive = request()->routeIs('teams.*') || request()->routeIs('status-pages.*');
+    $incidentsNavActive = request()->routeIs('incidents.*');
+    $statusPagesNavActive = request()->routeIs('status-pages.*');
+    $moreNavActive = request()->routeIs('maintenance.*')
+        || request()->routeIs('monitoring-groups.*')
+        || request()->routeIs('teams.*');
     $adminNavActive = request()->routeIs('admin.*');
 @endphp
 
@@ -20,15 +21,27 @@
                 </div>
 
                 <div class="hidden sm:-my-px sm:ms-10 sm:flex sm:items-center sm:gap-2">
+                    <x-nav-link :href="route('monitorings.index')" :active="request()->routeIs('monitorings.*')">
+                        {{ __('monitoring.title') }}
+                    </x-nav-link>
+
+                    <x-nav-link :href="route('incidents.analytics')" :active="$incidentsNavActive">
+                        {{ __('incidents.analytics.title') }}
+                    </x-nav-link>
+
+                    <x-nav-link :href="route('status-pages.index')" :active="$statusPagesNavActive">
+                        {{ __('status_page.title') }}
+                    </x-nav-link>
+
                     <x-dropdown align="left" width="w-72" contentClasses="bg-white py-2 dark:bg-gray-800">
                         <x-slot name="trigger">
                             <button type="button"
                                 @class([
                                     'inline-flex h-16 items-center gap-1 border-b-2 px-2 pt-1 text-sm font-medium leading-5 transition focus:outline-hidden',
-                                    'border-purple-500 text-gray-900 dark:text-gray-100' => $monitoringNavActive,
-                                    'border-transparent text-gray-500 hover:border-purple-500 hover:text-gray-700 focus:border-gray-300 focus:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100' => ! $monitoringNavActive,
+                                    'border-purple-500 text-gray-900 dark:text-gray-100' => $moreNavActive,
+                                    'border-transparent text-gray-500 hover:border-purple-500 hover:text-gray-700 focus:border-gray-300 focus:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100' => ! $moreNavActive,
                                 ])>
-                                {{ __('app.navigation.monitoring') }}
+                                {{ __('app.navigation.more') }}
                                 <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                     <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
                                 </svg>
@@ -39,42 +52,17 @@
                             <div class="px-4 pb-2 pt-1 text-xs font-semibold uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
                                 {{ __('app.navigation.sections.operations') }}
                             </div>
-                            <x-dropdown-link :href="route('monitorings.index')" @class(['bg-purple-50 text-purple-700 dark:bg-gray-700 dark:text-purple-300' => request()->routeIs('monitorings.*')])>
-                                {{ __('monitoring.title') }}
-                            </x-dropdown-link>
                             <x-dropdown-link :href="route('maintenance.index')" @class(['bg-purple-50 text-purple-700 dark:bg-gray-700 dark:text-purple-300' => request()->routeIs('maintenance.*')])>
                                 {{ __('maintenance.title') }}
                             </x-dropdown-link>
                             <x-dropdown-link :href="route('monitoring-groups.index')" @class(['bg-purple-50 text-purple-700 dark:bg-gray-700 dark:text-purple-300' => request()->routeIs('monitoring-groups.*')])>
                                 {{ __('monitoring_group.title') }}
                             </x-dropdown-link>
-                        </x-slot>
-                    </x-dropdown>
-
-                    <x-dropdown align="left" width="w-72" contentClasses="bg-white py-2 dark:bg-gray-800">
-                        <x-slot name="trigger">
-                            <button type="button"
-                                @class([
-                                    'inline-flex h-16 items-center gap-1 border-b-2 px-2 pt-1 text-sm font-medium leading-5 transition focus:outline-hidden',
-                                    'border-purple-500 text-gray-900 dark:text-gray-100' => $workspaceNavActive,
-                                    'border-transparent text-gray-500 hover:border-purple-500 hover:text-gray-700 focus:border-gray-300 focus:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100' => ! $workspaceNavActive,
-                                ])>
-                                {{ __('app.navigation.workspace') }}
-                                <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
-                                </svg>
-                            </button>
-                        </x-slot>
-
-                        <x-slot name="content">
-                            <div class="px-4 pb-2 pt-1 text-xs font-semibold uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
+                            <div class="px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
                                 {{ __('app.navigation.sections.collaboration') }}
                             </div>
                             <x-dropdown-link :href="route('teams.index')" @class(['bg-purple-50 text-purple-700 dark:bg-gray-700 dark:text-purple-300' => request()->routeIs('teams.*')])>
                                 {{ __('team.title') }}
-                            </x-dropdown-link>
-                            <x-dropdown-link :href="route('status-pages.index')" @class(['bg-purple-50 text-purple-700 dark:bg-gray-700 dark:text-purple-300' => request()->routeIs('status-pages.*')])>
-                                {{ __('status_page.title') }}
                             </x-dropdown-link>
                         </x-slot>
                     </x-dropdown>
@@ -223,6 +211,10 @@
             </div>
             <x-responsive-nav-link :href="route('monitorings.index')" :active="request()->routeIs('monitorings.*')">
                 {{ __('monitoring.title') }}
+            </x-responsive-nav-link>
+
+            <x-responsive-nav-link :href="route('incidents.analytics')" :active="$incidentsNavActive">
+                {{ __('incidents.analytics.title') }}
             </x-responsive-nav-link>
 
             <x-responsive-nav-link :href="route('maintenance.index')" :active="request()->routeIs('maintenance.*')">

--- a/tests/Feature/AuthenticatedNavigationTest.php
+++ b/tests/Feature/AuthenticatedNavigationTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 
 class AuthenticatedNavigationTest extends TestCase
 {
-    public function test_member_navigation_is_grouped_without_admin_links(): void
+    public function test_member_navigation_exposes_primary_destinations_without_admin_links(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);
         $user = User::factory()->create(['package_id' => $package->id]);
@@ -19,15 +19,17 @@ class AuthenticatedNavigationTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeText(__('app.navigation.monitoring'));
-        $testResponse->assertSeeText(__('app.navigation.workspace'));
+        $testResponse->assertSeeText(__('monitoring.title'));
+        $testResponse->assertSeeText(__('incidents.analytics.title'));
+        $testResponse->assertSeeText(__('status_page.title'));
+        $testResponse->assertSeeText(__('app.navigation.more'));
         $testResponse->assertSeeText(__('app.navigation.sections.operations'));
         $testResponse->assertSeeText(__('app.navigation.sections.collaboration'));
-        $testResponse->assertSeeText(__('monitoring.title'));
         $testResponse->assertSeeText(__('maintenance.title'));
         $testResponse->assertSeeText(__('monitoring_group.title'));
         $testResponse->assertSeeText(__('team.title'));
-        $testResponse->assertSeeText(__('status_page.title'));
+        $testResponse->assertSeeHtml('href="' . route('incidents.analytics') . '"');
+        $testResponse->assertSeeHtml('href="' . route('status-pages.index') . '"');
         $testResponse->assertDontSeeText(__('app.navigation.sections.administration'));
         $testResponse->assertDontSeeText(__('admin.dashboard.users.heading'));
     }

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -44,7 +44,7 @@ class IncidentWorkflowTest extends TestCase
             ]
         )->assertRedirect(route('status-pages.show', $statusPage));
 
-        $followUp = IncidentFollowUp::query()->firstOrFail();
+        $incidentFollowUp = IncidentFollowUp::query()->firstOrFail();
         $incident->followUps()->create([
             'title' => 'Completed historical task',
             'status' => IncidentFollowUpStatus::COMPLETED,
@@ -78,7 +78,7 @@ class IncidentWorkflowTest extends TestCase
             'contributing_category' => 'dependency',
         ]);
         $this->assertDatabaseHas('incident_follow_ups', [
-            'id' => $followUp->id,
+            'id' => $incidentFollowUp->id,
             'assigned_user_id' => $user->id,
             'status' => IncidentFollowUpStatus::OPEN->value,
         ]);
@@ -105,11 +105,11 @@ class IncidentWorkflowTest extends TestCase
     public function test_owner_can_complete_reopen_and_delete_follow_ups_and_edit_timeline_events(): void
     {
         ['user' => $user, 'statusPage' => $statusPage, 'incident' => $incident] = $this->incidentWorkspace();
-        $followUp = $incident->followUps()->create([
+        $incidentFollowUp = $incident->followUps()->create([
             'title' => 'Review timeout policy',
             'status' => IncidentFollowUpStatus::OPEN,
         ]);
-        $timelineEvent = $incident->timelineEvents()->create([
+        $incidentTimelineEvent = $incident->timelineEvents()->create([
             'title' => 'Initial mitigation',
             'description' => 'Restarted the worker.',
             'occurred_at' => now()->subMinutes(10),
@@ -117,7 +117,7 @@ class IncidentWorkflowTest extends TestCase
         ]);
 
         $this->actingAs($user)->patch(
-            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $followUp]),
+            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $incidentFollowUp]),
             [
                 'title' => 'Review timeout policy',
                 'status' => IncidentFollowUpStatus::COMPLETED->value,
@@ -125,13 +125,13 @@ class IncidentWorkflowTest extends TestCase
         )->assertRedirect(route('status-pages.show', $statusPage));
 
         $this->assertDatabaseHas('incident_follow_ups', [
-            'id' => $followUp->id,
+            'id' => $incidentFollowUp->id,
             'status' => IncidentFollowUpStatus::COMPLETED->value,
         ]);
-        $this->assertNotNull($followUp->refresh()->completed_at);
+        $this->assertNotNull($incidentFollowUp->refresh()->completed_at);
 
         $this->actingAs($user)->patch(
-            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $followUp]),
+            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $incidentFollowUp]),
             [
                 'title' => 'Review timeout policy',
                 'status' => IncidentFollowUpStatus::IN_PROGRESS->value,
@@ -139,13 +139,13 @@ class IncidentWorkflowTest extends TestCase
         )->assertRedirect(route('status-pages.show', $statusPage));
 
         $this->assertDatabaseHas('incident_follow_ups', [
-            'id' => $followUp->id,
+            'id' => $incidentFollowUp->id,
             'status' => IncidentFollowUpStatus::IN_PROGRESS->value,
             'completed_at' => null,
         ]);
 
         $this->actingAs($user)->patch(
-            route('status-pages.incident-timeline.update', [$statusPage, $incident, $timelineEvent]),
+            route('status-pages.incident-timeline.update', [$statusPage, $incident, $incidentTimelineEvent]),
             [
                 'title' => 'Worker restarted',
                 'description' => 'Restarted the affected worker and verified recovery.',
@@ -154,19 +154,19 @@ class IncidentWorkflowTest extends TestCase
         )->assertRedirect(route('status-pages.show', $statusPage));
 
         $this->assertDatabaseHas('incident_timeline_events', [
-            'id' => $timelineEvent->id,
+            'id' => $incidentTimelineEvent->id,
             'title' => 'Worker restarted',
         ]);
 
         $this->actingAs($user)->delete(
-            route('status-pages.incident-follow-ups.destroy', [$statusPage, $incident, $followUp])
+            route('status-pages.incident-follow-ups.destroy', [$statusPage, $incident, $incidentFollowUp])
         )->assertRedirect(route('status-pages.show', $statusPage));
         $this->actingAs($user)->delete(
-            route('status-pages.incident-timeline.destroy', [$statusPage, $incident, $timelineEvent])
+            route('status-pages.incident-timeline.destroy', [$statusPage, $incident, $incidentTimelineEvent])
         )->assertRedirect(route('status-pages.show', $statusPage));
 
-        $this->assertDatabaseMissing('incident_follow_ups', ['id' => $followUp->id]);
-        $this->assertDatabaseMissing('incident_timeline_events', ['id' => $timelineEvent->id]);
+        $this->assertDatabaseMissing('incident_follow_ups', ['id' => $incidentFollowUp->id]);
+        $this->assertDatabaseMissing('incident_timeline_events', ['id' => $incidentTimelineEvent->id]);
     }
 
     public function test_incident_workspace_rejects_incidents_outside_status_page(): void

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -44,7 +44,7 @@ class IncidentWorkflowTest extends TestCase
             ]
         )->assertRedirect(route('status-pages.show', $statusPage));
 
-        $incidentFollowUp = IncidentFollowUp::query()->firstOrFail();
+        $followUp = IncidentFollowUp::query()->firstOrFail();
         $incident->followUps()->create([
             'title' => 'Completed historical task',
             'status' => IncidentFollowUpStatus::COMPLETED,
@@ -78,7 +78,7 @@ class IncidentWorkflowTest extends TestCase
             'contributing_category' => 'dependency',
         ]);
         $this->assertDatabaseHas('incident_follow_ups', [
-            'id' => $incidentFollowUp->id,
+            'id' => $followUp->id,
             'assigned_user_id' => $user->id,
             'status' => IncidentFollowUpStatus::OPEN->value,
         ]);
@@ -105,11 +105,11 @@ class IncidentWorkflowTest extends TestCase
     public function test_owner_can_complete_reopen_and_delete_follow_ups_and_edit_timeline_events(): void
     {
         ['user' => $user, 'statusPage' => $statusPage, 'incident' => $incident] = $this->incidentWorkspace();
-        $incidentFollowUp = $incident->followUps()->create([
+        $followUp = $incident->followUps()->create([
             'title' => 'Review timeout policy',
             'status' => IncidentFollowUpStatus::OPEN,
         ]);
-        $incidentTimelineEvent = $incident->timelineEvents()->create([
+        $timelineEvent = $incident->timelineEvents()->create([
             'title' => 'Initial mitigation',
             'description' => 'Restarted the worker.',
             'occurred_at' => now()->subMinutes(10),
@@ -117,7 +117,7 @@ class IncidentWorkflowTest extends TestCase
         ]);
 
         $this->actingAs($user)->patch(
-            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $incidentFollowUp]),
+            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $followUp]),
             [
                 'title' => 'Review timeout policy',
                 'status' => IncidentFollowUpStatus::COMPLETED->value,
@@ -125,13 +125,13 @@ class IncidentWorkflowTest extends TestCase
         )->assertRedirect(route('status-pages.show', $statusPage));
 
         $this->assertDatabaseHas('incident_follow_ups', [
-            'id' => $incidentFollowUp->id,
+            'id' => $followUp->id,
             'status' => IncidentFollowUpStatus::COMPLETED->value,
         ]);
-        $this->assertNotNull($incidentFollowUp->refresh()->completed_at);
+        $this->assertNotNull($followUp->refresh()->completed_at);
 
         $this->actingAs($user)->patch(
-            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $incidentFollowUp]),
+            route('status-pages.incident-follow-ups.update', [$statusPage, $incident, $followUp]),
             [
                 'title' => 'Review timeout policy',
                 'status' => IncidentFollowUpStatus::IN_PROGRESS->value,
@@ -139,13 +139,13 @@ class IncidentWorkflowTest extends TestCase
         )->assertRedirect(route('status-pages.show', $statusPage));
 
         $this->assertDatabaseHas('incident_follow_ups', [
-            'id' => $incidentFollowUp->id,
+            'id' => $followUp->id,
             'status' => IncidentFollowUpStatus::IN_PROGRESS->value,
             'completed_at' => null,
         ]);
 
         $this->actingAs($user)->patch(
-            route('status-pages.incident-timeline.update', [$statusPage, $incident, $incidentTimelineEvent]),
+            route('status-pages.incident-timeline.update', [$statusPage, $incident, $timelineEvent]),
             [
                 'title' => 'Worker restarted',
                 'description' => 'Restarted the affected worker and verified recovery.',
@@ -154,19 +154,19 @@ class IncidentWorkflowTest extends TestCase
         )->assertRedirect(route('status-pages.show', $statusPage));
 
         $this->assertDatabaseHas('incident_timeline_events', [
-            'id' => $incidentTimelineEvent->id,
+            'id' => $timelineEvent->id,
             'title' => 'Worker restarted',
         ]);
 
         $this->actingAs($user)->delete(
-            route('status-pages.incident-follow-ups.destroy', [$statusPage, $incident, $incidentFollowUp])
+            route('status-pages.incident-follow-ups.destroy', [$statusPage, $incident, $followUp])
         )->assertRedirect(route('status-pages.show', $statusPage));
         $this->actingAs($user)->delete(
-            route('status-pages.incident-timeline.destroy', [$statusPage, $incident, $incidentTimelineEvent])
+            route('status-pages.incident-timeline.destroy', [$statusPage, $incident, $timelineEvent])
         )->assertRedirect(route('status-pages.show', $statusPage));
 
-        $this->assertDatabaseMissing('incident_follow_ups', ['id' => $incidentFollowUp->id]);
-        $this->assertDatabaseMissing('incident_timeline_events', ['id' => $incidentTimelineEvent->id]);
+        $this->assertDatabaseMissing('incident_follow_ups', ['id' => $followUp->id]);
+        $this->assertDatabaseMissing('incident_timeline_events', ['id' => $timelineEvent->id]);
     }
 
     public function test_incident_workspace_rejects_incidents_outside_status_page(): void


### PR DESCRIPTION
Closes #443

## What changed

- Expose Monitoring, Incident analytics, and Status Pages as direct desktop navigation links.
- Consolidate Maintenance, Monitoring Groups, and Teams under a localized “More” menu.
- Add Incident analytics to the mobile navigation while preserving the existing responsive sections.
- Keep Admin navigation role-restricted and preserve existing named routes.
- Add English and German translations for the new navigation label.
- Update authenticated navigation regression coverage for the new primary destinations.

## Why

The previous navigation hid core operational destinations behind two broad dropdowns. This made incident analysis and status-page management harder to discover and required users to remember which group contained each workflow.

## Validation

- Dockerized Laravel Pint on the changed test file.
- Dockerized tests/Feature/AuthenticatedNavigationTest.php — passed, 23 assertions.
- Dockerized php artisan view:cache — passed.
- git diff --check — passed.

The Pest run reports two existing warnings from the test setup around file_get_contents; there are no test failures.

## Risks and limitations

- This is a presentation and navigation change only; no API, authorization, database, or public URL contract changes.
- The full Overview/dashboard work remains tracked separately in #444.