### PR TITLE
feat(dashboard): add operations overview

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Services\MonitoringOverviewService;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class DashboardController extends Controller
+{
+    public function __invoke(Request $request, MonitoringOverviewService $monitoringOverviewService): View
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return view('dashboard', $monitoringOverviewService->overview($user));
+    }
+}

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\NotificationDeliveryStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\NotificationChannelDelivery;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+class MonitoringOverviewService
+{
+    /**
+     * @return array{
+     *     monitorings: EloquentCollection<int, Monitoring>,
+     *     summary: array{total:int,healthy:int,down:int,unknown:int,paused:int,maintenance:int},
+     *     overallState: string,
+     *     attentionItems: Collection<int, array{type:string,monitoring:Monitoring|null,count:int|null}>,
+     *     recentIncidents: EloquentCollection<int, Incident>,
+     *     maintenanceMonitorings: Collection<int, Monitoring>,
+     *     trend: list<array{date:string,label:string,uptime_percentage:float|null,has_data:bool}>,
+     *     failedDeliveryCount: int,
+     *     recommendedAction: string,
+     *     canCreateMonitoring: bool,
+     *     canManageMaintenance: bool
+     * }
+     */
+    public function overview(User $user): array
+    {
+        $user->loadMissing('package');
+
+        $monitorings = Monitoring::query()
+            ->with([
+                'latestResponseResult' => fn ($query) => $query->select([
+                    'monitoring_response_results.id',
+                    'monitoring_response_results.monitoring_id',
+                    'monitoring_response_results.status',
+                    'monitoring_response_results.created_at',
+                    'monitoring_response_results.updated_at',
+                ]),
+                'latestIncident' => fn ($query) => $query->select([
+                    'incidents.id',
+                    'incidents.monitoring_id',
+                    'incidents.down_at',
+                    'incidents.up_at',
+                ]),
+            ])
+            ->orderBy('name')
+            ->get([
+                'id',
+                'name',
+                'target',
+                'type',
+                'status',
+                'maintenance_from',
+                'maintenance_until',
+                'heartbeat_interval_minutes',
+                'heartbeat_grace_minutes',
+            ]);
+
+        $statuses = $monitorings->mapWithKeys(
+            fn (Monitoring $monitoring): array => [$monitoring->id => $this->status($monitoring)]
+        );
+        $summary = [
+            'total' => $monitorings->count(),
+            'healthy' => $statuses->filter(fn (string $status): bool => $status === MonitoringStatus::UP->value)->count(),
+            'down' => $statuses->filter(fn (string $status): bool => $status === MonitoringStatus::DOWN->value)->count(),
+            'unknown' => $statuses->filter(fn (string $status): bool => $status === MonitoringStatus::UNKNOWN->value)->count(),
+            'paused' => $statuses->filter(fn (string $status): bool => $status === MonitoringLifecycleStatus::PAUSED->value)->count(),
+            'maintenance' => $statuses->filter(fn (string $status): bool => $status === 'maintenance')->count(),
+        ];
+
+        $failedDeliveryCount = NotificationChannelDelivery::query()
+            ->where('user_id', $user->id)
+            ->where('status', NotificationDeliveryStatus::FAILED)
+            ->where('created_at', '>=', Date::now()->subDays(7))
+            ->count();
+
+        $maintenanceMonitorings = $monitorings
+            ->filter(fn (Monitoring $monitoring): bool => $monitoring->maintenance_from !== null
+                && ($monitoring->isUnderMaintenance() || $monitoring->maintenance_from->isFuture()))
+            ->sortBy('maintenance_from')
+            ->values();
+
+        $attentionItems = $this->attentionItems($monitorings, $failedDeliveryCount);
+        $overallState = $this->overallState($summary);
+
+        return [
+            'monitorings' => $monitorings,
+            'summary' => $summary,
+            'overallState' => $overallState,
+            'attentionItems' => $attentionItems,
+            'recentIncidents' => Incident::query()
+                ->with('monitoring')
+                ->whereHas('monitoring')
+                ->latest('down_at')
+                ->limit(5)
+                ->get(),
+            'maintenanceMonitorings' => $maintenanceMonitorings,
+            'trend' => $this->trend($monitorings),
+            'failedDeliveryCount' => $failedDeliveryCount,
+            'recommendedAction' => $this->recommendedAction($summary, $failedDeliveryCount, $maintenanceMonitorings->isNotEmpty()),
+            'canCreateMonitoring' => ! $user->isDemo()
+                && (($user->monitorings()->whereNull('team_id')->count() < (int) ($user->package?->monitoring_limit ?? 0))
+                    || $user->administeredTeams()->exists()),
+            'canManageMaintenance' => ! $user->isDemo()
+                && Monitoring::query()->manageableBy($user)->exists(),
+        ];
+    }
+
+    private function status(Monitoring $monitoring): string
+    {
+        if ($monitoring->isPaused()) {
+            return MonitoringLifecycleStatus::PAUSED->value;
+        }
+
+        if ($monitoring->isUnderMaintenance()) {
+            return 'maintenance';
+        }
+
+        $latestIncident = $monitoring->latestIncident;
+        if ($latestIncident && $latestIncident->up_at === null) {
+            return MonitoringStatus::DOWN->value;
+        }
+
+        $latestResponse = $monitoring->latestResponseResult;
+        if ($latestResponse === null || $this->isStale($monitoring)) {
+            return MonitoringStatus::UNKNOWN->value;
+        }
+
+        return $latestResponse->status->value;
+    }
+
+    /**
+     * @param  array{total:int,healthy:int,down:int,unknown:int,paused:int,maintenance:int}  $summary
+     */
+    private function overallState(array $summary): string
+    {
+        if ($summary['total'] === 0) {
+            return 'new';
+        }
+
+        if ($summary['down'] > 0) {
+            return 'degraded';
+        }
+
+        if ($summary['unknown'] > 0) {
+            return 'attention';
+        }
+
+        return 'healthy';
+    }
+
+    /**
+     * @param  array{total:int,healthy:int,down:int,unknown:int,paused:int,maintenance:int}  $summary
+     */
+    private function recommendedAction(array $summary, int $failedDeliveryCount, bool $hasMaintenance): string
+    {
+        if ($summary['total'] === 0) {
+            return 'create';
+        }
+
+        if ($summary['down'] > 0) {
+            return 'incidents';
+        }
+
+        if ($summary['unknown'] > 0) {
+            return 'unknown';
+        }
+
+        if ($failedDeliveryCount > 0) {
+            return 'notifications';
+        }
+
+        if ($hasMaintenance) {
+            return 'maintenance';
+        }
+
+        return 'monitorings';
+    }
+
+    /**
+     * @param  EloquentCollection<int, Monitoring>  $monitorings
+     * @return Collection<int, array{type:string,monitoring:Monitoring|null,count:int|null}>
+     */
+    private function attentionItems(EloquentCollection $monitorings, int $failedDeliveryCount): Collection
+    {
+        $items = collect();
+
+        $monitorings
+            ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::DOWN->value)
+            ->take(5)
+            ->each(function (Monitoring $monitoring) use ($items): void {
+                $items->push([
+                    'type' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null ? 'incident' : 'down',
+                    'monitoring' => $monitoring,
+                    'count' => null,
+                ]);
+            });
+
+        $monitorings
+            ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::UNKNOWN->value
+                && $monitoring->isActive())
+            ->take(5)
+            ->each(fn (Monitoring $monitoring) => $items->push([
+                'type' => $monitoring->latestResponseResult === null ? 'unknown' : 'stale',
+                'monitoring' => $monitoring,
+                'count' => null,
+            ]));
+
+        if ($failedDeliveryCount > 0) {
+            $items->push([
+                'type' => 'delivery',
+                'monitoring' => null,
+                'count' => $failedDeliveryCount,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function isStale(Monitoring $monitoring): bool
+    {
+        $latestResponse = $monitoring->latestResponseResult;
+        if ($latestResponse === null) {
+            return false;
+        }
+
+        $intervalMinutes = $monitoring->isHeartbeat()
+            ? ((int) ($monitoring->heartbeat_interval_minutes ?? 0) + (int) ($monitoring->heartbeat_grace_minutes ?? 0))
+            : (int) config('monitoring.interval', 5);
+
+        return $latestResponse->created_at->lt(Date::now()->subMinutes(max(10, $intervalMinutes * 3)));
+    }
+
+    /**
+     * @param  EloquentCollection<int, Monitoring>  $monitorings
+     * @return list<array{date:string,label:string,uptime_percentage:float|null,has_data:bool}>
+     */
+    private function trend(EloquentCollection $monitorings): array
+    {
+        $dates = collect(range(6, 0))->map(fn (int $days): \Illuminate\Support\Carbon => Date::now()->subDays($days)->startOfDay());
+        $dailyResults = $monitorings->isEmpty()
+            ? collect()
+            : MonitoringDailyResult::query()
+                ->whereIn('monitoring_id', $monitorings->modelKeys())
+                ->whereBetween('date', [$dates->last()->toDateString(), $dates->first()->toDateString()])
+                ->get(['date', 'uptime_minutes', 'downtime_minutes', 'unknown_minutes'])
+                ->groupBy(fn (MonitoringDailyResult $result): string => $result->date->toDateString());
+
+        return $dates->map(function (\Illuminate\Support\Carbon $date) use ($dailyResults): array {
+            $rows = $dailyResults->get($date->toDateString(), collect());
+            $uptimeMinutes = (int) $rows->sum('uptime_minutes');
+            $downtimeMinutes = (int) $rows->sum('downtime_minutes');
+            $unknownMinutes = (int) $rows->sum('unknown_minutes');
+            $trackedMinutes = $uptimeMinutes + $downtimeMinutes + $unknownMinutes;
+
+            return [
+                'date' => $date->toDateString(),
+                'label' => $date->locale(app()->getLocale())->isoFormat('ddd'),
+                'uptime_percentage' => $trackedMinutes > 0 ? round(($uptimeMinutes / $trackedMinutes) * 100, 2) : null,
+                'has_data' => $trackedMinutes > 0,
+            ];
+        })->all();
+    }
+}

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -13,6 +13,7 @@ use App\Models\MonitoringDailyResult;
 use App\Models\NotificationChannelDelivery;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 
@@ -188,14 +189,14 @@ class MonitoringOverviewService
     }
 
     /**
-     * @param  EloquentCollection<int, Monitoring>  $monitorings
+     * @param  EloquentCollection<int, Monitoring>  $eloquentCollection
      * @return Collection<int, array{type:string,monitoring:Monitoring|null,count:int|null}>
      */
-    private function attentionItems(EloquentCollection $monitorings, int $failedDeliveryCount): Collection
+    private function attentionItems(EloquentCollection $eloquentCollection, int $failedDeliveryCount): Collection
     {
         $items = collect();
 
-        $monitorings
+        $eloquentCollection
             ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::DOWN->value)
             ->take(5)
             ->each(function (Monitoring $monitoring) use ($items): void {
@@ -206,7 +207,7 @@ class MonitoringOverviewService
                 ]);
             });
 
-        $monitorings
+        $eloquentCollection
             ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::UNKNOWN->value
                 && $monitoring->isActive())
             ->take(5)
@@ -242,21 +243,21 @@ class MonitoringOverviewService
     }
 
     /**
-     * @param  EloquentCollection<int, Monitoring>  $monitorings
+     * @param  EloquentCollection<int, Monitoring>  $eloquentCollection
      * @return list<array{date:string,label:string,uptime_percentage:float|null,has_data:bool}>
      */
-    private function trend(EloquentCollection $monitorings): array
+    private function trend(EloquentCollection $eloquentCollection): array
     {
-        $dates = collect(range(6, 0))->map(fn (int $days): \Illuminate\Support\Carbon => Date::now()->subDays($days)->startOfDay());
-        $dailyResults = $monitorings->isEmpty()
+        $dates = collect(range(6, 0))->map(fn (int $days): Carbon => Date::now()->subDays($days)->startOfDay());
+        $dailyResults = $eloquentCollection->isEmpty()
             ? collect()
             : MonitoringDailyResult::query()
-                ->whereIn('monitoring_id', $monitorings->modelKeys())
+                ->whereIn('monitoring_id', $eloquentCollection->modelKeys())
                 ->whereBetween('date', [$dates->last()->toDateString(), $dates->first()->toDateString()])
                 ->get(['date', 'uptime_minutes', 'downtime_minutes', 'unknown_minutes'])
-                ->groupBy(fn (MonitoringDailyResult $result): string => $result->date->toDateString());
+                ->groupBy(fn (MonitoringDailyResult $monitoringDailyResult): string => $monitoringDailyResult->date->toDateString());
 
-        return $dates->map(function (\Illuminate\Support\Carbon $date) use ($dailyResults): array {
+        return $dates->map(function (Carbon $date) use ($dailyResults): array {
             $rows = $dailyResults->get($date->toDateString(), collect());
             $uptimeMinutes = (int) $rows->sum('uptime_minutes');
             $downtimeMinutes = (int) $rows->sum('downtime_minutes');

--- a/resources/lang/de/dashboard.php
+++ b/resources/lang/de/dashboard.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Betriebsübersicht',
+    'description' => 'Sieh sofort, was Aufmerksamkeit braucht, und öffne direkt die nächste sinnvolle Aktion.',
+    'open_monitorings' => 'Alle Monitorings anzeigen',
+    'state' => [
+        'new' => [
+            'title' => 'Überwache deine Services',
+            'description' => 'Erstelle dein erstes Monitoring, um diese Seite als tägliche Betriebsübersicht zu nutzen.',
+        ],
+        'healthy' => [
+            'title' => 'Alles ist gesund',
+            'description' => 'Deine aktiven Monitorings melden normale Zustände.',
+        ],
+        'degraded' => [
+            'title' => 'Aktion erforderlich',
+            'description' => ':count Monitoring meldet aktuell ein Problem.|:count Monitorings melden aktuell ein Problem.',
+        ],
+        'attention' => [
+            'title' => 'Einige Checks brauchen Aufmerksamkeit',
+            'description' => 'Bei :count Monitoring fehlt ein aktuelles verwertbares Ergebnis.|Bei :count Monitorings fehlen aktuelle verwertbare Ergebnisse.',
+        ],
+    ],
+    'summary' => [
+        'total' => 'Alle Monitorings',
+        'healthy' => 'Gesund',
+        'down' => 'Ausgefallen',
+        'unknown' => 'Unbekannt oder veraltet',
+        'paused' => 'Pausiert',
+        'maintenance' => 'Wartung aktiv',
+    ],
+    'attention' => [
+        'heading' => 'Braucht Aufmerksamkeit',
+        'description' => 'Priorisierte Hinweise aus den Monitorings, auf die du Zugriff hast.',
+        'incident' => ':name hat einen offenen Incident.',
+        'down' => ':name meldet aktuell einen Ausfall.',
+        'unknown' => ':name hat noch kein verwertbares Ergebnis gemeldet.',
+        'stale' => ':name hat kürzlich kein Ergebnis gemeldet.',
+        'delivery' => ':count fehlgeschlagene Benachrichtigungszustellungen in den letzten 7 Tagen.',
+        'open' => 'Details öffnen',
+        'empty' => 'Keine aktiven Aufmerksamkeitspunkte. Behalte die Übersicht oben im Blick.',
+    ],
+    'quick_actions' => [
+        'heading' => 'Schnellaktionen',
+        'create' => 'Monitoring erstellen',
+        'maintenance' => 'Wartung planen',
+        'incidents' => 'Incidents prüfen',
+        'notifications' => 'Benachrichtigungen öffnen',
+        'status_pages' => 'Statusseiten verwalten',
+    ],
+    'maintenance' => [
+        'heading' => 'Wartungsfenster',
+        'description' => 'Aktive und bevorstehende Fenster deiner Monitorings.',
+        'active' => 'Aktiv',
+        'upcoming' => 'Bevorstehend',
+        'open' => 'Wartung öffnen',
+        'empty' => 'Keine aktiven oder bevorstehenden Wartungsfenster.',
+    ],
+    'incidents' => [
+        'heading' => 'Letzte Incidents',
+        'description' => 'Die neuesten Incidents aus deinen zugänglichen Monitorings.',
+        'ongoing' => 'Laufend',
+        'resolved' => 'Behoben',
+        'open' => 'Monitoring-Details öffnen',
+        'empty' => 'Es wurden noch keine Incidents aufgezeichnet.',
+    ],
+    'trend' => [
+        'heading' => 'Zuverlässigkeitstrend',
+        'description' => 'Aggregierte Verfügbarkeit der letzten sieben Tage.',
+        'no_data' => 'Der Trend erscheint, sobald tägliche Monitoringdaten vorhanden sind.',
+        'uptime' => ':value % Verfügbarkeit',
+    ],
+    'recommended' => [
+        'label' => 'Nächste empfohlene Aktion',
+        'create' => 'Erstes Monitoring erstellen',
+        'incidents' => 'Offene Incidents prüfen',
+        'unknown' => 'Unbekannte oder veraltete Checks untersuchen',
+        'notifications' => 'Fehlgeschlagene Zustellungen prüfen',
+        'maintenance' => 'Wartungsfenster prüfen',
+        'monitorings' => 'Monitoring-Liste prüfen',
+    ],
+    'empty' => [
+        'title' => 'Deine Betriebsübersicht beginnt hier',
+        'description' => 'Sobald du ein Monitoring hinzufügst, fasst diese Seite Gesundheit, Incidents, Wartung und die nächste Aktion zusammen.',
+    ],
+];

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Operations overview',
+    'description' => 'See what needs attention and move directly to the next useful action.',
+    'open_monitorings' => 'View all monitorings',
+    'state' => [
+        'new' => [
+            'title' => 'Start monitoring your services',
+            'description' => 'Create your first monitoring to turn this page into your daily operations overview.',
+        ],
+        'healthy' => [
+            'title' => 'Everything is healthy',
+            'description' => 'Your active monitorings are reporting normally.',
+        ],
+        'degraded' => [
+            'title' => 'Action required',
+            'description' => ':count monitoring|:count monitorings currently report a problem.',
+        ],
+        'attention' => [
+            'title' => 'Some checks need attention',
+            'description' => ':count monitoring|:count monitorings have no recent usable result.',
+        ],
+    ],
+    'summary' => [
+        'total' => 'All monitorings',
+        'healthy' => 'Healthy',
+        'down' => 'Down',
+        'unknown' => 'Unknown or stale',
+        'paused' => 'Paused',
+        'maintenance' => 'In maintenance',
+    ],
+    'attention' => [
+        'heading' => 'Needs attention',
+        'description' => 'Prioritized signals from the monitorings you can access.',
+        'incident' => ':name has an open incident.',
+        'down' => ':name is currently reporting down.',
+        'unknown' => ':name has not reported a usable result yet.',
+        'stale' => ':name has not reported recently.',
+        'delivery' => ':count failed notification deliveries in the last 7 days.',
+        'open' => 'Open details',
+        'empty' => 'No active attention items. Keep an eye on the summary above.',
+    ],
+    'quick_actions' => [
+        'heading' => 'Quick actions',
+        'create' => 'Create monitoring',
+        'maintenance' => 'Schedule maintenance',
+        'incidents' => 'Review incidents',
+        'notifications' => 'Open notifications',
+        'status_pages' => 'Manage status pages',
+    ],
+    'maintenance' => [
+        'heading' => 'Maintenance windows',
+        'description' => 'Active and upcoming windows across your monitorings.',
+        'active' => 'Active',
+        'upcoming' => 'Upcoming',
+        'open' => 'Open maintenance',
+        'empty' => 'No active or upcoming maintenance windows.',
+    ],
+    'incidents' => [
+        'heading' => 'Recent incidents',
+        'description' => 'The latest incidents from monitorings you can access.',
+        'ongoing' => 'Ongoing',
+        'resolved' => 'Resolved',
+        'open' => 'Open monitoring details',
+        'empty' => 'No incidents have been recorded yet.',
+    ],
+    'trend' => [
+        'heading' => 'Reliability trend',
+        'description' => 'Aggregated uptime for the last seven days.',
+        'no_data' => 'A trend will appear after daily monitoring data is available.',
+        'uptime' => ':value% uptime',
+    ],
+    'recommended' => [
+        'label' => 'Recommended next action',
+        'create' => 'Create your first monitoring',
+        'incidents' => 'Review the open incidents',
+        'unknown' => 'Investigate unknown or stale checks',
+        'notifications' => 'Review failed notification deliveries',
+        'maintenance' => 'Review maintenance windows',
+        'monitorings' => 'Review the monitoring list',
+    ],
+    'empty' => [
+        'title' => 'Your operations overview starts here',
+        'description' => 'Once you add a monitoring, this page will summarize health, incidents, maintenance and the next action in one place.',
+    ],
+];

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,239 @@
+@php
+    $stateType = match ($overallState) {
+        'degraded' => 'danger',
+        'attention' => 'warning',
+        'healthy' => 'success',
+        default => 'info',
+    };
+
+    $recommendedHref = match ($recommendedAction) {
+        'create' => route('monitorings.create'),
+        'incidents' => route('incidents.analytics'),
+        'unknown' => route('monitorings.index', ['lifecycle' => 'active']),
+        'notifications' => route('notifications.index'),
+        'maintenance' => route('maintenance.index', ['maintenance_status' => 'upcoming']),
+        default => route('monitorings.index'),
+    };
+
+    $quickActions = [
+        ['key' => 'create', 'href' => route('monitorings.create'), 'visible' => $canCreateMonitoring, 'primary' => true],
+        ['key' => 'maintenance', 'href' => route('maintenance.index'), 'visible' => $canManageMaintenance, 'primary' => false],
+        ['key' => 'incidents', 'href' => route('incidents.analytics'), 'visible' => true, 'primary' => false],
+        ['key' => 'notifications', 'href' => route('notifications.index'), 'visible' => true, 'primary' => false],
+        ['key' => 'status_pages', 'href' => route('status-pages.index'), 'visible' => true, 'primary' => false],
+    ];
+@endphp
+
+<x-app-layout>
+    <x-slot name="header">
+        <div>
+            <x-heading type="h1">{{ __('dashboard.title') }}</x-heading>
+            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.description') }}</p>
+        </div>
+
+        <x-secondary-button :href="route('monitorings.index')" class="sm:ml-auto">
+            {{ __('dashboard.open_monitorings') }}
+        </x-secondary-button>
+    </x-slot>
+
+    <x-main>
+        @if ($summary['total'] === 0)
+            <x-container class="mx-auto max-w-3xl text-center" space="true">
+                <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-purple-100 text-2xl dark:bg-purple-400/10" aria-hidden="true">
+                    <span>+</span>
+                </div>
+                <x-heading type="h2" class="mt-4">{{ __('dashboard.empty.title') }}</x-heading>
+                <p class="mx-auto mt-3 max-w-xl text-sm text-gray-600 dark:text-gray-300">{{ __('dashboard.empty.description') }}</p>
+                @if ($canCreateMonitoring)
+                    <x-primary-button :href="route('monitorings.create')" class="mx-auto mt-6">
+                        {{ __('dashboard.quick_actions.create') }}
+                    </x-primary-button>
+                @endif
+            </x-container>
+        @else
+            <div class="space-y-4">
+                <x-container space="true" class="border-l-4 {{ $stateType === 'danger' ? 'border-red-500' : ($stateType === 'warning' ? 'border-amber-500' : ($stateType === 'success' ? 'border-emerald-500' : 'border-purple-500')) }}">
+                    <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+                        <div>
+                            <div class="flex flex-wrap items-center gap-2">
+                                <x-badge :type="$stateType">{{ __('dashboard.recommended.label') }}</x-badge>
+                                <span class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('dashboard.summary.total') }}: {{ $summary['total'] }}</span>
+                            </div>
+                            <x-heading type="h2" class="mt-3">
+                                {{ __('dashboard.state.' . $overallState . '.title') }}
+                            </x-heading>
+                            <p class="mt-2 max-w-2xl text-sm text-gray-600 dark:text-gray-300">
+                                @if ($overallState === 'degraded')
+                                    {{ trans_choice('dashboard.state.degraded.description', $summary['down'], ['count' => $summary['down']]) }}
+                                @elseif ($overallState === 'attention')
+                                    {{ trans_choice('dashboard.state.attention.description', $summary['unknown'], ['count' => $summary['unknown']]) }}
+                                @else
+                                    {{ __('dashboard.state.' . $overallState . '.description') }}
+                                @endif
+                            </p>
+                        </div>
+
+                        <a href="{{ $recommendedHref }}" class="inline-flex shrink-0 items-center justify-center rounded-md bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2">
+                            {{ __('dashboard.recommended.' . $recommendedAction) }}
+                        </a>
+                    </div>
+
+                    <div class="mt-6 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+                        @foreach ([
+                            ['key' => 'healthy', 'value' => $summary['healthy'], 'href' => route('monitorings.index')],
+                            ['key' => 'down', 'value' => $summary['down'], 'href' => route('incidents.analytics')],
+                            ['key' => 'unknown', 'value' => $summary['unknown'], 'href' => route('monitorings.index', ['lifecycle' => 'active'])],
+                            ['key' => 'paused', 'value' => $summary['paused'], 'href' => route('monitorings.index', ['lifecycle' => 'paused'])],
+                            ['key' => 'maintenance', 'value' => $summary['maintenance'], 'href' => route('maintenance.index', ['maintenance_status' => 'active'])],
+                            ['key' => 'total', 'value' => $summary['total'], 'href' => route('monitorings.index')],
+                        ] as $metric)
+                            <a href="{{ $metric['href'] }}" class="rounded-lg border border-gray-200 bg-gray-50 p-3 transition hover:border-purple-300 hover:bg-purple-50 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:border-gray-700 dark:bg-gray-900/50 dark:hover:border-purple-500 dark:hover:bg-gray-900">
+                                <span class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('dashboard.summary.' . $metric['key']) }}</span>
+                                <span class="mt-1 block text-2xl font-bold text-gray-900 dark:text-gray-100">{{ $metric['value'] }}</span>
+                            </a>
+                        @endforeach
+                    </div>
+                </x-container>
+
+                <x-container space="true">
+                    <x-heading type="h2" class="mb-4">{{ __('dashboard.quick_actions.heading') }}</x-heading>
+                    <div class="flex flex-wrap gap-2">
+                        @foreach ($quickActions as $action)
+                            @if ($action['visible'])
+                                @if ($action['primary'])
+                                    <x-primary-button :href="$action['href']">{{ __('dashboard.quick_actions.' . $action['key']) }}</x-primary-button>
+                                @else
+                                    <x-secondary-button :href="$action['href']">{{ __('dashboard.quick_actions.' . $action['key']) }}</x-secondary-button>
+                                @endif
+                            @endif
+                        @endforeach
+                    </div>
+                </x-container>
+
+                <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                    <x-container space="true">
+                        <x-heading type="h2">{{ __('dashboard.attention.heading') }}</x-heading>
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.attention.description') }}</p>
+
+                        @if ($attentionItems->isEmpty())
+                            <p class="mt-5 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">{{ __('dashboard.attention.empty') }}</p>
+                        @else
+                            <div class="mt-5 divide-y divide-gray-200 dark:divide-gray-700">
+                                @foreach ($attentionItems as $item)
+                                    @php
+                                        $itemHref = $item['type'] === 'delivery'
+                                            ? route('notifications.index')
+                                            : route('monitorings.show', $item['monitoring']);
+                                        $itemText = match ($item['type']) {
+                                            'incident' => __('dashboard.attention.incident', ['name' => $item['monitoring']->name]),
+                                            'down' => __('dashboard.attention.down', ['name' => $item['monitoring']->name]),
+                                            'unknown' => __('dashboard.attention.unknown', ['name' => $item['monitoring']->name]),
+                                            'stale' => __('dashboard.attention.stale', ['name' => $item['monitoring']->name]),
+                                            default => __('dashboard.attention.delivery', ['count' => $item['count']]),
+                                        };
+                                        $itemBadge = match ($item['type']) {
+                                            'incident' => 'danger',
+                                            'down' => 'danger',
+                                            'delivery' => 'danger',
+                                            'stale' => 'warning',
+                                            default => 'info',
+                                        };
+                                    @endphp
+                                    <div class="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+                                        <div class="flex min-w-0 items-start gap-3">
+                                            <span class="mt-1 h-2.5 w-2.5 shrink-0 rounded-full {{ $itemBadge === 'danger' ? 'bg-red-500' : ($itemBadge === 'warning' ? 'bg-amber-500' : 'bg-blue-500') }}" aria-hidden="true"></span>
+                                            <div class="min-w-0">
+                                                <div class="flex flex-wrap items-center gap-2">
+                                                    <p class="font-medium text-gray-900 dark:text-gray-100">{{ $itemText }}</p>
+                                                    <x-badge :type="$itemBadge">{{ __('dashboard.summary.' . (in_array($item['type'], ['incident', 'down', 'delivery'], true) ? 'down' : 'unknown')) }}</x-badge>
+                                                </div>
+                                                @if ($item['monitoring'])
+                                                    <p class="mt-1 break-all text-sm text-gray-500 dark:text-gray-400">{{ $item['monitoring']->target }}</p>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        <a href="{{ $itemHref }}" class="shrink-0 text-sm font-semibold text-purple-600 hover:text-purple-800 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:text-purple-200">
+                                            {{ __('dashboard.attention.open') }}
+                                        </a>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </x-container>
+
+                    <x-container space="true">
+                        <div class="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <x-heading type="h2">{{ __('dashboard.maintenance.heading') }}</x-heading>
+                                <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.maintenance.description') }}</p>
+                            </div>
+                            <a href="{{ route('maintenance.index') }}" class="text-sm font-semibold text-purple-600 hover:text-purple-800 dark:text-purple-300 dark:hover:text-purple-200">{{ __('dashboard.maintenance.open') }}</a>
+                        </div>
+
+                        @if ($maintenanceMonitorings->isEmpty())
+                            <p class="mt-5 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">{{ __('dashboard.maintenance.empty') }}</p>
+                        @else
+                            <div class="mt-5 divide-y divide-gray-200 dark:divide-gray-700">
+                                @foreach ($maintenanceMonitorings as $monitoring)
+                                    @php $isActiveMaintenance = $monitoring->isUnderMaintenance(); @endphp
+                                    <div class="flex items-center justify-between gap-3 py-4">
+                                        <div class="min-w-0">
+                                            <a href="{{ route('monitorings.show', $monitoring) }}" class="font-medium text-gray-900 hover:text-purple-600 dark:text-gray-100 dark:hover:text-purple-300">{{ $monitoring->name }}</a>
+                                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $monitoring->maintenance_from->locale(app()->getLocale())->isoFormat('L LT') }}</p>
+                                        </div>
+                                        <x-badge :type="$isActiveMaintenance ? 'warning' : 'info'">{{ $isActiveMaintenance ? __('dashboard.maintenance.active') : __('dashboard.maintenance.upcoming') }}</x-badge>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </x-container>
+                </div>
+
+                <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                    <x-container space="true">
+                        <x-heading type="h2">{{ __('dashboard.incidents.heading') }}</x-heading>
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.incidents.description') }}</p>
+
+                        @if ($recentIncidents->isEmpty())
+                            <p class="mt-5 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">{{ __('dashboard.incidents.empty') }}</p>
+                        @else
+                            <div class="mt-5 divide-y divide-gray-200 dark:divide-gray-700">
+                                @foreach ($recentIncidents as $incident)
+                                    <div class="flex items-center justify-between gap-3 py-4" id="incident-{{ $incident->id }}">
+                                        <div class="min-w-0">
+                                            <a href="{{ route('monitorings.show', $incident->monitoring) }}" class="font-medium text-gray-900 hover:text-purple-600 dark:text-gray-100 dark:hover:text-purple-300">{{ $incident->monitoring->name }}</a>
+                                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $incident->down_at->locale(app()->getLocale())->isoFormat('L LT') }}</p>
+                                        </div>
+                                        <x-badge :type="$incident->up_at ? 'success' : 'danger'">{{ $incident->up_at ? __('dashboard.incidents.resolved') : __('dashboard.incidents.ongoing') }}</x-badge>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </x-container>
+
+                    <x-container space="true">
+                        <x-heading type="h2">{{ __('dashboard.trend.heading') }}</x-heading>
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.trend.description') }}</p>
+
+                        @if (collect($trend)->contains('has_data', true))
+                            <div class="mt-5 grid grid-cols-7 items-end gap-2" aria-label="{{ __('dashboard.trend.heading') }}">
+                                @foreach ($trend as $point)
+                                    @php $barHeight = $point['has_data'] ? max(8, min(100, (float) $point['uptime_percentage'])) : 4; @endphp
+                                    <div class="flex min-w-0 flex-col items-center gap-2">
+                                        <span class="text-center text-xs font-medium text-gray-600 dark:text-gray-300">{{ $point['has_data'] ? __('dashboard.trend.uptime', ['value' => number_format($point['uptime_percentage'], 2)]) : '–' }}</span>
+                                        <div class="flex h-32 w-full items-end rounded-md bg-gray-100 p-1 dark:bg-gray-900" title="{{ $point['date'] }}">
+                                            <div class="w-full rounded-sm {{ $point['has_data'] && $point['uptime_percentage'] < 99 ? 'bg-amber-500' : 'bg-emerald-500' }}" style="height: {{ $barHeight }}%" aria-hidden="true"></div>
+                                        </div>
+                                        <span class="text-xs text-gray-500 dark:text-gray-400">{{ $point['label'] }}</span>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="mt-5 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">{{ __('dashboard.trend.no_data') }}</p>
+                        @endif
+                    </x-container>
+                </div>
+            </div>
+        @endif
+    </x-main>
+</x-app-layout>

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -122,7 +122,7 @@
                 @else
                     <div class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
                         @foreach ($incidents as $incident)
-                            <div class="space-y-4 py-4">
+                            <div id="incident-{{ $incident->id }}" class="space-y-4 py-4">
                                 <div class="flex flex-wrap items-center justify-between gap-2">
                                     <div>
                                         <p class="font-medium text-gray-900 dark:text-gray-100">

--- a/routes/web.php
+++ b/routes/web.php
@@ -193,15 +193,15 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         ->name('status-pages.incident-metadata.update');
     Route::post('/status-pages/{statusPage}/incidents/{incident}/follow-ups', [StatusPageIncidentFollowUpController::class, 'store'])
         ->name('status-pages.incident-follow-ups.store');
-    Route::patch('/status-pages/{statusPage}/incidents/{incident}/follow-ups/{followUp}', [StatusPageIncidentFollowUpController::class, 'update'])
+    Route::patch('/status-pages/{statusPage}/incidents/{incident}/follow-ups/{incidentFollowUp}', [StatusPageIncidentFollowUpController::class, 'update'])
         ->name('status-pages.incident-follow-ups.update');
-    Route::delete('/status-pages/{statusPage}/incidents/{incident}/follow-ups/{followUp}', [StatusPageIncidentFollowUpController::class, 'destroy'])
+    Route::delete('/status-pages/{statusPage}/incidents/{incident}/follow-ups/{incidentFollowUp}', [StatusPageIncidentFollowUpController::class, 'destroy'])
         ->name('status-pages.incident-follow-ups.destroy');
     Route::post('/status-pages/{statusPage}/incidents/{incident}/timeline', [StatusPageIncidentTimelineController::class, 'store'])
         ->name('status-pages.incident-timeline.store');
-    Route::patch('/status-pages/{statusPage}/incidents/{incident}/timeline/{timelineEvent}', [StatusPageIncidentTimelineController::class, 'update'])
+    Route::patch('/status-pages/{statusPage}/incidents/{incident}/timeline/{incidentTimelineEvent}', [StatusPageIncidentTimelineController::class, 'update'])
         ->name('status-pages.incident-timeline.update');
-    Route::delete('/status-pages/{statusPage}/incidents/{incident}/timeline/{timelineEvent}', [StatusPageIncidentTimelineController::class, 'destroy'])
+    Route::delete('/status-pages/{statusPage}/incidents/{incident}/timeline/{incidentTimelineEvent}', [StatusPageIncidentTimelineController::class, 'destroy'])
         ->name('status-pages.incident-timeline.destroy');
     Route::get('/incidents/analytics', [IncidentAnalyticsController::class, 'index'])
         ->name('incidents.analytics');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Admin\PackageController;
 use App\Http\Controllers\Admin\ServerInstanceController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Auth\SocialiteController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\HeartbeatPingController;
 use App\Http\Controllers\IncidentAnalyticsController;
 use App\Http\Controllers\LegacyPublicStatusPageController;
@@ -145,7 +146,7 @@ Route::middleware(['auth', 'role:member,admin'])
 
 Route::middleware(['auth', 'verified'])->group(function (): void {
 
-    Route::get('/dashboard', fn () => to_route('monitorings.index'))->name('dashboard');
+    Route::get('/dashboard', DashboardController::class)->name('dashboard');
 
     Route::group(['prefix' => 'profile', 'as' => 'profile.', 'middleware' => 'role:member,admin'], function (): void {
         Route::post('/api-generate-token', [ProfileController::class, 'apiGenerateToken'])->name('api-generate-token');

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -57,9 +57,9 @@ class DashboardOverviewTest extends TestCase
         Monitoring::factory()->for($user)->create(['name' => 'Unknown API']);
         Monitoring::factory()->for($otherUser)->create(['name' => 'Private API']);
 
-        $response = $this->actingAs($user)->get(route('dashboard'));
+        $testResponse = $this->actingAs($user)->get(route('dashboard'));
 
-        $response->assertOk()
+        $testResponse->assertOk()
             ->assertSeeText(__('dashboard.state.degraded.title'))
             ->assertSeeText(__('dashboard.summary.healthy'))
             ->assertSeeText(__('dashboard.summary.down'))

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Enums\NotificationDeliveryStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringResponse;
+use App\Models\NotificationChannelDelivery;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class DashboardOverviewTest extends TestCase
+{
+    public function test_new_user_sees_a_clear_dashboard_empty_state(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+
+        $this->actingAs($user)->get(route('dashboard'))
+            ->assertOk()
+            ->assertSeeText(__('dashboard.empty.title'))
+            ->assertSeeText(__('dashboard.empty.description'))
+            ->assertSeeHtml('href="' . route('monitorings.create') . '"');
+    }
+
+    public function test_dashboard_summarizes_health_attention_and_recent_incidents_for_visible_monitorings(): void
+    {
+        Date::setTestNow('2026-07-15 12:00:00');
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $otherUser = User::factory()->create(['package_id' => $package->id]);
+
+        $healthy = Monitoring::factory()->for($user)->create(['name' => 'Healthy API']);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $healthy->id,
+            'status' => MonitoringStatus::UP,
+        ]);
+
+        $down = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+        Incident::query()->create([
+            'monitoring_id' => $down->id,
+            'down_at' => Date::now()->subMinutes(20),
+        ]);
+
+        Monitoring::factory()->for($user)->create([
+            'name' => 'Paused API',
+            'status' => MonitoringLifecycleStatus::PAUSED,
+        ]);
+        Monitoring::factory()->for($user)->create(['name' => 'Unknown API']);
+        Monitoring::factory()->for($otherUser)->create(['name' => 'Private API']);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk()
+            ->assertSeeText(__('dashboard.state.degraded.title'))
+            ->assertSeeText(__('dashboard.summary.healthy'))
+            ->assertSeeText(__('dashboard.summary.down'))
+            ->assertSeeText(__('dashboard.summary.unknown'))
+            ->assertSeeText(__('dashboard.summary.paused'))
+            ->assertSeeText('Checkout API')
+            ->assertSeeText('Unknown API')
+            ->assertDontSeeText('Private API')
+            ->assertSeeHtml('href="' . route('monitorings.show', $down) . '"')
+            ->assertSeeHtml('href="' . route('incidents.analytics') . '"');
+    }
+
+    public function test_all_healthy_dashboard_has_a_reassuring_empty_attention_state(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Healthy API']);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+        ]);
+
+        $this->actingAs($user)->get(route('dashboard'))
+            ->assertOk()
+            ->assertSeeText(__('dashboard.state.healthy.title'))
+            ->assertSeeText(__('dashboard.attention.empty'))
+            ->assertDontSeeText(__('dashboard.attention.incident', ['name' => $monitoring->name]));
+    }
+
+    public function test_dashboard_includes_maintenance_delivery_and_reliability_context(): void
+    {
+        Date::setTestNow('2026-07-15 12:00:00');
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Scheduled API',
+            'maintenance_from' => Date::now()->addHour(),
+        ]);
+
+        MonitoringDailyResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'date' => Date::today(),
+            'uptime_total' => 99,
+            'downtime_total' => 1,
+            'unknown_total' => 0,
+            'uptime_percentage' => 99,
+            'downtime_percentage' => 1,
+            'unknown_percentage' => 0,
+            'uptime_minutes' => 99,
+            'downtime_minutes' => 1,
+            'unknown_minutes' => 0,
+            'incidents_count' => 1,
+        ]);
+
+        NotificationChannelDelivery::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'webhook',
+            'event_type' => 'incident',
+            'status' => NotificationDeliveryStatus::FAILED,
+            'error_message' => 'Webhook unavailable',
+        ]);
+
+        $this->actingAs($user)->get(route('dashboard'))
+            ->assertOk()
+            ->assertSeeText(__('dashboard.maintenance.heading'))
+            ->assertSeeText(__('dashboard.maintenance.upcoming'))
+            ->assertSeeText(__('dashboard.attention.delivery', ['count' => 1]))
+            ->assertSeeText(__('dashboard.trend.heading'))
+            ->assertSeeHtml('href="' . route('maintenance.index') . '"')
+            ->assertSeeHtml('href="' . route('notifications.index') . '"');
+    }
+}

--- a/tests/Feature/VerifiedEmailRequiredTest.php
+++ b/tests/Feature/VerifiedEmailRequiredTest.php
@@ -71,13 +71,14 @@ class VerifiedEmailRequiredTest extends TestCase
         $this->assertTrue(Hash::check('new-password', (string) $user->fresh()->password));
     }
 
-    public function test_verified_user_can_access_protected_routes(): void
+    public function test_verified_user_can_access_dashboard_and_protected_routes(): void
     {
         Package::factory()->create();
         $user = User::factory()->create();
 
         $testResponse = $this->actingAs($user)->get(route('dashboard'));
-        $testResponse->assertRedirect(route('monitorings.index'));
+        $testResponse->assertOk();
+        $testResponse->assertSeeText(__('dashboard.title'));
 
         $monitoringsResponse = $this->actingAs($user)->get(route('monitorings.index'));
         $monitoringsResponse->assertOk();


### PR DESCRIPTION
Closes #444

## What changed

- Replace the authenticated dashboard redirect with an operations overview.
- Add permission-aware health summary for healthy, down, unknown/stale, paused, and maintenance states.
- Add prioritized attention items for incidents, down checks, stale/unknown checks, and failed notification deliveries.
- Add quick actions, maintenance windows, recent incidents, and a seven-day reliability trend.
- Add clear new-account and all-healthy empty states.
- Add English and German dashboard translations.
- Add incident anchors and update dashboard/verification feature coverage.

## Why

The previous dashboard sent users directly to the monitoring list, which made it difficult to answer whether anything was broken or what to do next. The overview puts the most important operational signals and next actions into the first screen while keeping detailed workflows on their existing routes.

## Validation

- Dockerized Laravel Pint on changed PHP/test files.
- Dockerized targeted Pest coverage: 12 tests, 66 assertions passed.
- Dockerized PHPStan: no errors.
- Dockerized Blade view cache: passed.
- git diff --check: passed.

Rendered browser QA could not run because the existing local PHP container was mounted to a different worktree and blocked a clean local stack start.

## Risks and limitations

- No API, database schema, authorization, or existing workflow route contracts changed.
- The overview uses existing monitoring responses, incidents, maintenance fields, notification delivery history, and daily results.
- Browser-level desktop/mobile validation remains a follow-up because of the local Docker container collision.