### PR TITLE
feat(ui): simplify monitoring overview

### DIFF
--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
 use App\Enums\MonitoringType;
 use App\Http\Requests\MonitoringRequest;
 use App\Jobs\DeleteMonitoringResults;
@@ -52,6 +53,13 @@ class MonitoringController extends Controller
                     }
                 }
             }],
+            'health' => ['nullable', 'string', function ($attribute, $value, $fail) {
+                foreach (explode(',', $value) as $status) {
+                    if (! MonitoringStatus::tryFrom($status)) {
+                        $fail(__('monitoring.validation.invalid_status', ['status' => $status]));
+                    }
+                }
+            }],
             'lifecycle' => ['nullable', 'string', Rule::enum(MonitoringLifecycleStatus::class)],
             'group_id' => [
                 'nullable',
@@ -72,6 +80,7 @@ class MonitoringController extends Controller
                 },
             ],
             'ownership' => ['nullable', 'string', Rule::in(['all', 'private', 'team'])],
+            'maintenance' => ['nullable', 'string', Rule::in(['active'])],
         ]);
 
         $query = Monitoring::query();
@@ -111,6 +120,34 @@ class MonitoringController extends Controller
             $query->whereNotNull('team_id');
         }
 
+        if ($request->filled('health')) {
+            $healthStatuses = explode(',', (string) $request->input('health'));
+
+            $query->where(function (Builder $builder) use ($healthStatuses): void {
+                if (in_array(MonitoringStatus::UP->value, $healthStatuses, true)) {
+                    $builder->orWhereHas('latestResponseResult', fn ($query) => $query->where('status', MonitoringStatus::UP));
+                }
+
+                if (in_array(MonitoringStatus::DOWN->value, $healthStatuses, true)) {
+                    $builder->orWhereHas('latestResponseResult', fn ($query) => $query->where('status', MonitoringStatus::DOWN));
+                }
+
+                if (in_array(MonitoringStatus::UNKNOWN->value, $healthStatuses, true)) {
+                    $builder->orWhereDoesntHave('latestResponseResult')
+                        ->orWhereHas('latestResponseResult', fn ($query) => $query->where('status', MonitoringStatus::UNKNOWN));
+                }
+            });
+        }
+
+        if ($request->input('maintenance') === 'active') {
+            $query->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '<=', now())
+                ->where(function (Builder $builder): void {
+                    $builder->whereNull('maintenance_until')
+                        ->orWhere('maintenance_until', '>=', now());
+                });
+        }
+
         $query->orderBy('status');
 
         match ($request->input('sort')) {
@@ -126,7 +163,9 @@ class MonitoringController extends Controller
             || $request->filled('lifecycle')
             || $request->filled('group_id')
             || $request->filled('team_id')
-            || $request->filled('ownership');
+            || $request->filled('ownership')
+            || $request->filled('health')
+            || $request->filled('maintenance');
         $privateMonitoringsTotal = $currentUser->monitorings()->whereNull('team_id')->count();
         $monitoringsTotal = $hasActiveFilters
             ? Monitoring::query()->count()

--- a/resources/js/components/monitoring-cards.ts
+++ b/resources/js/components/monitoring-cards.ts
@@ -14,7 +14,13 @@ interface MonitoringCardLoaderComponent {
     sinceMap: Record<string, string>;
     sinceDateMap: Record<string, string | null>;
     lastCheckMap: Record<string, string>;
+    summaryReady: boolean;
+    healthyCount: number;
+    attentionCount: number;
+    pausedCount: number;
+    maintenanceCount: number;
     currentLocale: string;
+    updateSummary(this: MonitoringCardLoaderComponent): void;
     updateSince(this: MonitoringCardLoaderComponent): void;
     loadAll(this: MonitoringCardLoaderComponent): Promise<void>;
     init(this: MonitoringCardLoaderComponent): void;
@@ -41,6 +47,11 @@ export default (
     sinceMap: {} as Record<string, string>,
     sinceDateMap: {} as Record<string, string | null>,
     lastCheckMap: {} as Record<string, string>,
+    summaryReady: false,
+    healthyCount: 0,
+    attentionCount: 0,
+    pausedCount: 0,
+    maintenanceCount: 0,
 
     currentLocale: getCurrentDayjsLocale(),
 
@@ -78,6 +89,16 @@ export default (
                 renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
             }
         }
+
+        this.updateSummary();
+    },
+
+    updateSummary(this: MonitoringCardLoaderComponent): void {
+        this.healthyCount = this.monitoringIds.filter((id) => this.statusMap[id] === 'up').length;
+        this.attentionCount = this.monitoringIds.filter((id) => ['down', 'unknown'].includes(this.statusMap[id])).length;
+        this.pausedCount = this.monitoringIds.filter((id) => this.monitoringStatusMap[id] === 'paused').length;
+        this.maintenanceCount = this.monitoringIds.filter((id) => this.maintenanceStatusMap[id]).length;
+        this.summaryReady = true;
     },
 
     updateSince(this: MonitoringCardLoaderComponent): void {

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -29,6 +29,19 @@ return [
         ],
 
         'filters' => [
+            'advanced' => 'Erweiterte Filter',
+            'presets' => 'Schnellansichten',
+            'all' => 'Alle',
+            'attention' => 'Aufmerksamkeit nötig',
+            'paused' => 'Pausiert',
+            'maintenance' => 'In Wartung',
+            'active' => 'Aktive Filter',
+            'clear' => 'Alle löschen',
+            'health' => 'Gesundheit',
+            'health_up' => 'Verfügbar',
+            'health_down' => 'Nicht verfügbar',
+            'health_unknown' => 'Unbekannt',
+            'maintenance_active' => 'Wartung',
             'sort' => [
                 'name_asc' => 'Name (A-Z)',
                 'name_desc' => 'Name (Z-A)',
@@ -37,6 +50,13 @@ return [
             ],
         ],
         'table' => [
+            'summary' => 'Betriebsübersicht',
+            'summary_scope' => 'Aktuelle Ergebnisseite',
+            'summary_loading' => 'Live-Status wird geladen ...',
+            'attention' => 'Aufmerksamkeit nötig',
+            'healthy' => 'Verfügbar',
+            'paused_count' => 'Pausiert',
+            'maintenance_count' => 'In Wartung',
             'name' => 'Name',
             'target' => 'Ziel',
             'type' => 'Typ',
@@ -363,6 +383,7 @@ return [
         ],
     ],
     'validation' => [
+        'invalid_status' => 'Der ausgewählte Status ist ungültig.',
         'invalid_type' => 'Der ausgewählte Typ \':type\' ist ungültig.',
         'target_invalid_url' => 'Das :attribute muss eine gültige URL für den Typ :type sein.',
         'target_invalid_ip' => 'Das :attribute muss eine gültige IP-Adresse für den Typ :type sein.',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -29,6 +29,19 @@ return [
         ],
 
         'filters' => [
+            'advanced' => 'Advanced filters',
+            'presets' => 'Quick views',
+            'all' => 'All',
+            'attention' => 'Needs attention',
+            'paused' => 'Paused',
+            'maintenance' => 'In maintenance',
+            'active' => 'Active filters',
+            'clear' => 'Clear all',
+            'health' => 'Health',
+            'health_up' => 'Healthy',
+            'health_down' => 'Down',
+            'health_unknown' => 'Unknown',
+            'maintenance_active' => 'Maintenance',
             'sort' => [
                 'name_asc' => 'Name (A-Z)',
                 'name_desc' => 'Name (Z-A)',
@@ -37,6 +50,13 @@ return [
             ],
         ],
         'table' => [
+            'summary' => 'Operational summary',
+            'summary_scope' => 'Current result page',
+            'summary_loading' => 'Loading live status...',
+            'attention' => 'Needs attention',
+            'healthy' => 'Healthy',
+            'paused_count' => 'Paused',
+            'maintenance_count' => 'In maintenance',
             'name' => 'Name',
             'target' => 'Target',
             'type' => 'Type',
@@ -363,6 +383,7 @@ return [
         ],
     ],
     'validation' => [
+        'invalid_status' => 'The selected health status is invalid.',
         'invalid_type' => 'The selected type \':type\' is invalid.',
         'target_invalid_url' => 'The :attribute must be a valid URL for type :type.',
         'target_invalid_ip' => 'The :attribute must be a valid IP address for type :type.',

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -39,6 +39,29 @@
         </x-container>
 
         <x-container class="ml-auto mr-auto" space="true">
+            <div class="mb-4">
+                <p class="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+                    {{ __('monitoring.index.filters.presets') }}
+                </p>
+                <nav class="flex flex-wrap gap-2" aria-label="{{ __('monitoring.index.filters.presets') }}">
+                    @foreach ([
+                        ['label' => __('monitoring.index.filters.all'), 'query' => [], 'active' => ! request()->hasAny(['search', 'types', 'lifecycle', 'group_id', 'team_id', 'ownership', 'health', 'maintenance'])],
+                        ['label' => __('monitoring.index.filters.attention'), 'query' => ['health' => 'down,unknown'], 'active' => request('health') === 'down,unknown'],
+                        ['label' => __('monitoring.index.filters.paused'), 'query' => ['lifecycle' => 'paused'], 'active' => request('lifecycle') === 'paused'],
+                        ['label' => __('monitoring.index.filters.maintenance'), 'query' => ['maintenance' => 'active'], 'active' => request('maintenance') === 'active'],
+                    ] as $preset)
+                        <a href="{{ route('monitorings.index', $preset['query']) }}"
+                            @class([
+                                'rounded-full px-3 py-1.5 text-sm font-medium transition',
+                                'bg-purple-600 text-white' => $preset['active'],
+                                'bg-gray-100 text-gray-700 hover:bg-purple-100 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600' => ! $preset['active'],
+                            ])>
+                            {{ $preset['label'] }}
+                        </a>
+                    @endforeach
+                </nav>
+            </div>
+
             <form method="GET" action="{{ route('monitorings.index') }}"
                 class="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:justify-start sm:gap-4">
 
@@ -60,6 +83,12 @@
                     @if (request('ownership'))
                         <x-text-input type="hidden" name="ownership" :value="request('ownership')" />
                     @endif
+                    @if (request('health'))
+                        <x-text-input type="hidden" name="health" :value="request('health')" />
+                    @endif
+                    @if (request('maintenance'))
+                        <x-text-input type="hidden" name="maintenance" :value="request('maintenance')" />
+                    @endif
                     @if (request('sort'))
                         <x-text-input type="hidden" name="sort" :value="request('sort')" />
                     @endif
@@ -71,6 +100,13 @@
                     @endif
                 </div>
 
+                <details @if (request('types') || request('lifecycle') || request('group_id') || request('team_id') || request('ownership') || request('health') || request('maintenance') || request('sort')) open @endif
+                    class="w-full rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+                    <summary class="cursor-pointer font-semibold text-gray-700 dark:text-gray-200">
+                        {{ __('monitoring.index.filters.advanced') }}
+                    </summary>
+
+                    <div class="mt-3 space-y-3">
                 <div x-data="{
                     selectedTypes: [],
                     init() {
@@ -256,7 +292,58 @@
                         </div>
                     </div>
                 </div>
+                    </div>
+                </details>
             </form>
+
+            @if (request()->hasAny(['search', 'types', 'lifecycle', 'group_id', 'team_id', 'ownership', 'health', 'maintenance']))
+                <div class="mt-4 flex flex-wrap items-center gap-2" aria-label="{{ __('monitoring.index.filters.active') }}">
+                    <span class="text-sm font-semibold text-gray-700 dark:text-gray-200">{{ __('monitoring.index.filters.active') }}:</span>
+                    @if (request('search'))
+                        <a href="{{ request()->fullUrlWithQuery(['search' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ request('search') }} &times;
+                        </a>
+                    @endif
+                    @if (request('health'))
+                        <a href="{{ request()->fullUrlWithQuery(['health' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ __('monitoring.index.filters.health') }}: {{ request('health') }} &times;
+                        </a>
+                    @endif
+                    @if (request('lifecycle'))
+                        <a href="{{ request()->fullUrlWithQuery(['lifecycle' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ ucfirst(request('lifecycle')) }} &times;
+                        </a>
+                    @endif
+                    @if (request('maintenance'))
+                        <a href="{{ request()->fullUrlWithQuery(['maintenance' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ __('monitoring.index.filters.maintenance_active') }} &times;
+                        </a>
+                    @endif
+                    @if (request('types'))
+                        <a href="{{ request()->fullUrlWithQuery(['types' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ __('monitoring.index.table.type') }}: {{ request('types') }} &times;
+                        </a>
+                    @endif
+                    @if (request('group_id'))
+                        <a href="{{ request()->fullUrlWithQuery(['group_id' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ __('monitoring_group.filter.label') }} &times;
+                        </a>
+                    @endif
+                    @if (request('team_id'))
+                        <a href="{{ request()->fullUrlWithQuery(['team_id' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ __('team.title') }} &times;
+                        </a>
+                    @endif
+                    @if (request('ownership'))
+                        <a href="{{ request()->fullUrlWithQuery(['ownership' => null]) }}" class="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-800 dark:bg-purple-900 dark:text-purple-100">
+                            {{ __('team.ownership.select_label') }} &times;
+                        </a>
+                    @endif
+                    <a href="{{ route('monitorings.index') }}" class="ml-auto text-sm font-semibold text-purple-700 underline dark:text-purple-300">
+                        {{ __('monitoring.index.filters.clear') }}
+                    </a>
+                </div>
+            @endif
         </x-container>
 
         @if ($errors->has('limit'))
@@ -266,6 +353,37 @@
         @endif
 
         <div x-data="monitoringCardLoader({{ $monitoringIds }}, {{ $monitoringNames }}, {{ $monitoringTargets }}, {{ $monitoringTypes }}, {{ $monitoringStatusMap }}, {{ $monitoringPublicLabelMap }}, {{ $maintenanceStatusMap }})">
+            <x-container x-show="monitoringIds.length > 0" space="true" class="border-l-4 border-purple-500">
+                <div class="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                        <x-heading type="h2">{{ __('monitoring.index.table.summary') }}</x-heading>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('monitoring.index.table.summary_scope') }}</p>
+                    </div>
+                    <p x-show="!summaryReady" class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('monitoring.index.table.summary_loading') }}
+                    </p>
+                </div>
+
+                <div class="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
+                    <div class="rounded-lg bg-red-50 p-3 dark:bg-red-950/30">
+                        <p class="text-sm text-red-700 dark:text-red-300">{{ __('monitoring.index.table.attention') }}</p>
+                        <p class="mt-1 text-2xl font-bold text-red-800 dark:text-red-200" x-text="summaryReady ? attentionCount : '—'"></p>
+                    </div>
+                    <div class="rounded-lg bg-green-50 p-3 dark:bg-green-950/30">
+                        <p class="text-sm text-green-700 dark:text-green-300">{{ __('monitoring.index.table.healthy') }}</p>
+                        <p class="mt-1 text-2xl font-bold text-green-800 dark:text-green-200" x-text="summaryReady ? healthyCount : '—'"></p>
+                    </div>
+                    <div class="rounded-lg bg-yellow-50 p-3 dark:bg-yellow-950/30">
+                        <p class="text-sm text-yellow-700 dark:text-yellow-300">{{ __('monitoring.index.table.paused_count') }}</p>
+                        <p class="mt-1 text-2xl font-bold text-yellow-800 dark:text-yellow-200" x-text="summaryReady ? pausedCount : '—'"></p>
+                    </div>
+                    <div class="rounded-lg bg-blue-50 p-3 dark:bg-blue-950/30">
+                        <p class="text-sm text-blue-700 dark:text-blue-300">{{ __('monitoring.index.table.maintenance_count') }}</p>
+                        <p class="mt-1 text-2xl font-bold text-blue-800 dark:text-blue-200" x-text="summaryReady ? maintenanceCount : '—'"></p>
+                    </div>
+                </div>
+            </x-container>
+
             <div x-show="monitoringIds.length === 0">
                 <x-container class="text-center">
                     <x-heading type="h2">

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\MonitoringStatus;
 use App\Enums\UserRole;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -86,5 +89,52 @@ class MonitoringIndexEmptyStateTest extends TestCase
         $testResponse = $this->actingAs($demoUser)->get(route('monitorings.create'));
 
         $testResponse->assertForbidden();
+    }
+
+    public function test_monitoring_index_supports_health_preset_and_exposes_operational_summary(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $downMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Down service']);
+        $healthyMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Healthy service']);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $downMonitoring->id,
+            'status' => MonitoringStatus::DOWN,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $healthyMonitoring->id,
+            'status' => MonitoringStatus::UP,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.index', ['health' => 'down']));
+
+        $testResponse->assertOk();
+        $testResponse->assertSee('Down service');
+        $testResponse->assertDontSee('Healthy service');
+        $testResponse->assertSee(__('monitoring.index.table.summary'));
+        $testResponse->assertSee(__('monitoring.index.filters.clear'));
+    }
+
+    public function test_monitoring_index_supports_active_maintenance_preset(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $maintenanceMonitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Maintenance service',
+            'maintenance_from' => now()->subMinute(),
+            'maintenance_until' => now()->addMinute(),
+        ]);
+        Monitoring::factory()->for($user)->create(['name' => 'Regular service']);
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.index', ['maintenance' => 'active']));
+
+        $testResponse->assertOk();
+        $testResponse->assertSee($maintenanceMonitoring->name);
+        $testResponse->assertDontSee('Regular service');
     }
 }


### PR DESCRIPTION
Closes #445

## What changed

- Added quick views for all monitors, monitors needing attention, paused monitors, and active maintenance.
- Moved secondary filters into an explicit advanced-filter disclosure.
- Added removable active-filter chips and a clear-all action.
- Added health and maintenance URL filters while preserving existing filter and sort parameters.
- Added a live operational summary for the current result page.
- Added localized English and German labels.
- Added feature coverage for health and maintenance presets.

## Why

The monitoring overview exposed too many controls and metadata at once, making unhealthy or operationally relevant monitors harder to find. The new hierarchy keeps the primary search visible and makes operational state scannable before deeper configuration details.

## Validation

- Pest: MonitoringIndexEmptyStateTest
- Pest: MonitoringGroupTest and TeamMonitoringTest
- PHPStan
- Laravel Pint
- Blade view cache
- Bun frontend production build

Docker validation was unavailable because the local Docker image build ran out of disk space; equivalent host-installed dependencies were used.

## Risks and follow-up

The operational summary is scoped to the current paginated result page. A later iteration can add an aggregate endpoint for account-wide totals.