### PR TITLE
feat(ui): streamline monitoring form

### DIFF
--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -231,6 +231,7 @@ return [
         ],
     ],
     'form' => [
+        'advanced_request_settings' => 'Erweiterte Anfrageeinstellungen',
         'sections' => [
             'basic' => 'Basisdaten',
             'organization' => 'Eigentümerschaft und Gruppen',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -231,6 +231,7 @@ return [
         ],
     ],
     'form' => [
+        'advanced_request_settings' => 'Advanced request settings',
         'sections' => [
             'basic' => 'Basics',
             'organization' => 'Ownership and groups',

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -173,10 +173,10 @@
 
         </section>
 
-        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <div>
+        <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <summary class="cursor-pointer list-none">
                 <x-heading type="h2">{{ __('monitoring.form.sections.organization') }}</x-heading>
-            </div>
+            </summary>
 
             <div>
                 <x-input-label for="team_id" :value="__('team.ownership.select_label')" />
@@ -227,7 +227,7 @@
                 <x-input-error :messages="$errors->get('group_ids')" />
                 <x-input-error :messages="$errors->get('group_ids.*')" />
             </div>
-        </section>
+        </details>
 
         <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
             <div>
@@ -374,6 +374,12 @@
         </div>
     </template>
 
+    <details x-show="type === '{{ MonitoringType::HTTP->value }}' || type === '{{ MonitoringType::KEYWORD->value }}'"
+        class="mt-4 rounded-md border border-gray-200 p-4 dark:border-gray-700">
+        <summary class="cursor-pointer font-semibold text-gray-800 dark:text-gray-100">
+            {{ __('monitoring.form.advanced_request_settings') }}
+        </summary>
+
     <template x-if="type === '{{ MonitoringType::HTTP->value }}' || type === '{{ MonitoringType::KEYWORD->value }}'">
         <div class="mt-4">
             <x-input-label for="auth_username" :value="__('monitoring.form.auth_username')" />
@@ -404,12 +410,14 @@
         </div>
     </template>
 
+    </details>
+
         </section>
 
-        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <div>
+        <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <summary class="cursor-pointer list-none">
                 <x-heading type="h2">{{ __('monitoring.form.sections.sharing') }}</x-heading>
-            </div>
+            </summary>
 
     <div class="mt-4">
         <x-input-label for="public_label_enabled" :value="__('monitoring.form.public_label')" />
@@ -445,12 +453,12 @@
         @endif
     </div>
 
-        </section>
+        </details>
 
-        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <div>
+        <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <summary class="cursor-pointer list-none">
                 <x-heading type="h2">{{ __('monitoring.form.sections.notifications') }}</x-heading>
-            </div>
+            </summary>
 
     @if (isset($monitoring))
         <input type="hidden" name="notification_on_failure" value="{{ old('notification_on_failure', $monitoring->notification_on_failure ?? true) ? '1' : '0' }}">
@@ -520,12 +528,12 @@
     </div>
     @endunless
 
-        </section>
+        </details>
 
-        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <div>
+        <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <summary class="cursor-pointer list-none">
                 <x-heading type="h2">{{ __('monitoring.form.sections.operations') }}</x-heading>
-            </div>
+            </summary>
 
     <div class="mt-4">
         <x-input-label for="preferred_locations" :value="__('monitoring.form.preferred_location')" />
@@ -563,7 +571,7 @@
         <x-input-error :messages="$errors->get('status')" />
     </div>
 
-        </section>
+        </details>
 
         <div class="flex flex-wrap justify-end gap-2">
             <x-secondary-button :href="isset($monitoring) ? route('monitorings.show', $monitoring) : route('monitorings.index')">

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -43,6 +43,8 @@ class MonitoringFormPresentationTest extends TestCase
         $editResponse->assertSeeHtml('class="mx-auto max-w-7xl space-y-4 px-4 sm:px-6 lg:px-8"');
         $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
         $editResponse->assertSeeHtml('href="' . route('monitorings.show', $monitoring) . '"');
+        $testResponse->assertSeeHtml('<details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">');
+        $testResponse->assertSee(__('monitoring.form.advanced_request_settings'));
     }
 
     public function test_assignment_indicators_and_ownership_actions_only_appear_on_edit_page(): void


### PR DESCRIPTION
Closes #446

## What changed

- Kept the basic monitoring setup path visible.
- Added progressive disclosure for organization, public sharing, notifications, and operations.
- Grouped HTTP and keyword request/auth/header/body settings under an accessible advanced section.
- Preserved all existing fields, values, validation, and edit/create behavior.
- Added localized copy and presentation coverage.

## Why

The shared monitoring form supports many monitoring types and operational settings. Collapsing secondary configuration reduces cognitive load for first-time users while keeping every existing capability discoverable.

## Validation

- Pest: MonitoringFormPresentationTest
- Laravel Pint
- Blade view cache
- Bun frontend production build

Docker validation was unavailable because the local Docker image build ran out of disk space; equivalent host-installed dependencies were used.

## Risks and follow-up

The form still contains all existing fields and server-side validation. A later iteration can add section-specific error auto-expansion and a sticky progress summary.