### PR TITLE
feat(ui): focus incident workbench

### DIFF
--- a/resources/lang/de/status_page.php
+++ b/resources/lang/de/status_page.php
@@ -57,6 +57,11 @@ return [
             'created' => 'Vorfall-Update erfolgreich hinzugefügt.',
         ],
     ],
+    'incident_workbench' => [
+        'heading' => 'Interner Response-Arbeitsbereich',
+        'description' => 'Private Klassifizierung, Auswertungsnotizen, Nachbearbeitung und Untersuchungstimeline.',
+        'public_updates' => 'Öffentliche Updates',
+    ],
     'incident_review' => [
         'heading' => 'Interne Vorfallauswertung',
         'description' => 'Dokumentieren Sie, was den Vorfall verursacht hat und was ihn behoben hat. Diese Notizen bleiben privat und erscheinen nicht auf der öffentlichen Statusseite.',

--- a/resources/lang/en/status_page.php
+++ b/resources/lang/en/status_page.php
@@ -57,6 +57,11 @@ return [
             'created' => 'Incident update added successfully.',
         ],
     ],
+    'incident_workbench' => [
+        'heading' => 'Internal response workbench',
+        'description' => 'Private classification, review notes, follow-ups and investigation timeline.',
+        'public_updates' => 'Public updates',
+    ],
     'incident_review' => [
         'heading' => 'Internal incident review',
         'description' => 'Record what caused the incident and what fixed it. These notes stay private and are not shown on the public status page.',

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -87,7 +87,10 @@
             @endforeach
 
             <x-container>
-                <x-heading type="h2">{{ __('status_page.incident_updates.heading') }}</x-heading>
+                <div class="flex flex-wrap items-center gap-2">
+                    <x-heading type="h2">{{ __('status_page.incident_updates.heading') }}</x-heading>
+                    <x-badge type="info">{{ __('status_page.incident_workbench.public_updates') }}</x-badge>
+                </div>
                 <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
                     {{ __('status_page.incident_updates.description') }}
                 </p>
@@ -122,12 +125,24 @@
                 @else
                     <div class="mt-4 divide-y divide-gray-200 dark:divide-gray-700">
                         @foreach ($incidents as $incident)
-                            <div id="incident-{{ $incident->id }}" class="space-y-4 py-4">
+                                <div id="incident-{{ $incident->id }}" class="space-y-4 py-4">
                                 <div class="flex flex-wrap items-center justify-between gap-2">
                                     <div>
-                                        <p class="font-medium text-gray-900 dark:text-gray-100">
+                                        <div class="flex flex-wrap items-center gap-2">
+                                            <p class="font-medium text-gray-900 dark:text-gray-100">
                                             {{ $incident->monitoring->name }}
-                                        </p>
+                                            </p>
+                                            @if ($incident->severity)
+                                                <x-badge :type="$incident->severity->badgeType()">
+                                                    {{ __('incidents.severities.' . $incident->severity->value) }}
+                                                </x-badge>
+                                            @endif
+                                            @if ($incident->customer_impact)
+                                                <x-badge type="info">
+                                                    {{ __('incidents.customer_impacts.' . $incident->customer_impact->value) }}
+                                                </x-badge>
+                                            @endif
+                                        </div>
                                         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                                             {{ __('monitoring.detail.incidents.incident.down_at') }}:
                                             {{ $incident->down_at->toDayDateTimeString() }}
@@ -161,6 +176,22 @@
                                         @endforeach
                                     </div>
                                 @endif
+
+                                <details class="rounded-lg border border-slate-200 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-950/20">
+                                    <summary class="cursor-pointer list-none">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <div>
+                                                <p class="font-medium text-slate-900 dark:text-slate-100">
+                                                    {{ __('status_page.incident_workbench.heading') }}
+                                                </p>
+                                                <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                                                    {{ __('status_page.incident_workbench.description') }}
+                                                </p>
+                                            </div>
+                                            <span class="text-sm font-medium text-purple-700 dark:text-purple-300">+</span>
+                                        </div>
+                                    </summary>
+                                    <div class="mt-4 space-y-4">
 
                                 @if (!Auth::user()->isDemo())
                                     <form method="POST"
@@ -347,6 +378,9 @@
                                         </form>
                                     </div>
                                 @endif
+
+                                    </div>
+                                </details>
 
                                 @if (!Auth::user()->isDemo())
                                     <form method="POST"

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -90,6 +90,8 @@ class IncidentWorkflowTest extends TestCase
 
         $this->actingAs($user)->get(route('status-pages.show', $statusPage))
             ->assertOk()
+            ->assertSee(__('status_page.incident_workbench.heading'))
+            ->assertSee(__('status_page.incident_workbench.public_updates'))
             ->assertSeeHtml('Checkout API')
             ->assertSeeHtml('Add dependency timeout coverage')
             ->assertSeeHtml('Dependency recovered')


### PR DESCRIPTION
Closes #447

## What changed

- Added a focused internal response workbench for each incident.
- Kept public incident updates visibly separate from private metadata, review notes, follow-ups, and timeline editing.
- Added compact severity and customer-impact badges to the incident header.
- Added localized workbench labels.
- Added coverage confirming the internal/public presentation remains distinct.

## Why

The status-page management view combined public communication with internal response work, making it difficult to identify current impact and next actions. The new structure keeps the public update stream prominent while making internal investigation tools available on demand.

## Validation

- Pest: IncidentWorkflowTest
- Pest: PublicStatusPageTest
- Blade view cache
- git diff --check

Docker validation was unavailable because the local Docker image build ran out of disk space; equivalent host-installed dependencies were used.

## Risks and follow-up

The workbench uses progressive disclosure rather than a full tabbed layout. A later iteration can add direct open-incident and unresolved-follow-up entry points if needed.