### PR TITLE
test(ui): add responsive quality smoke coverage

### DIFF
--- a/tests/Browser/UiQualityBarSmokeTest.php
+++ b/tests/Browser/UiQualityBarSmokeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+it('keeps the public shell responsive and keyboard reachable', function () {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    foreach ([[1280, 800], [390, 844]] as [$width, $height]) {
+        visit('/login')
+            ->resize($width, $height)
+            ->assertScript(<<<'JS'
+function () {
+    const documentWidth = document.documentElement.clientWidth;
+    const firstFocusable = document.querySelector('a, button, input, select, textarea');
+    const submitButton = document.querySelector('button[type="submit"]');
+
+    firstFocusable?.focus();
+
+    return document.body.scrollWidth <= documentWidth
+        && firstFocusable !== null
+        && document.activeElement === firstFocusable
+        && firstFocusable.matches(':focus')
+        && submitButton !== null
+        && (submitButton.textContent?.trim() || submitButton.getAttribute('aria-label'));
+}
+JS, true);
+    }
+});


### PR DESCRIPTION
Closes #455

## What changed

- Added a Pest Browser smoke test for the public login shell at 1280px and 390px.
- Checks horizontal overflow, keyboard focus reachability, and the accessible primary submit action.
- Reuses the existing Vite asset guard and Browser test conventions.

## Why

The UI quality checklist now has a deterministic smoke test for the most important responsive shell guarantees.

## Validation

- PHP syntax check for the new Browser test
- git diff --check

The Browser runtime itself was not executed locally because the Docker stack could not be rebuilt after the local Docker environment ran out of disk space; CI will execute the repository test workflow.

## Risks and follow-up

The smoke test covers the public login shell. Navigation, authenticated monitoring, and incident workbench interaction remain covered by their focused tests and the manual checklist.