### PR TITLE
fix: aggregate monitoring summary across pagination

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Monitoring;
 use App\Services\MonitoringHeatmapService;
 use App\Services\MonitoringStatusPayloadService;
+use BackedEnum;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -29,6 +30,8 @@ class MonitoringCardDataController extends Controller
         $validated = $request->validate([
             'ids' => ['required', 'array', 'min:1'],
             'ids.*' => ['required', 'string'],
+            'summary_ids' => ['nullable', 'array', 'min:1'],
+            'summary_ids.*' => ['required', 'string'],
         ]);
 
         /** @var Collection<int, string> $requestedIds */
@@ -36,21 +39,33 @@ class MonitoringCardDataController extends Controller
             ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
             ->unique()
             ->values();
+        /** @var Collection<int, string> $summaryIds */
+        $summaryIds = collect($validated['summary_ids'] ?? $requestedIds->all())
+            ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->unique()
+            ->values();
+        $allRequestedIds = $requestedIds->merge($summaryIds)->unique()->values();
 
         $monitorings = Monitoring::query()
             ->select([
                 'id',
                 'user_id',
                 'team_id',
+                'status',
                 'name',
                 'target',
                 'type',
                 'created_at',
                 'maintenance_from',
                 'maintenance_until',
+                'preferred_location',
+                'preferred_locations',
+                'heartbeat_interval_minutes',
+                'heartbeat_grace_minutes',
+                'heartbeat_last_ping_at',
             ])
             ->visibleTo($request->user())
-            ->whereIn('id', $requestedIds)
+            ->whereIn('id', $allRequestedIds)
             ->with([
                 'latestIncident',
                 'latestResponseResult',
@@ -58,13 +73,18 @@ class MonitoringCardDataController extends Controller
             ->get()
             ->keyBy('id');
 
+        $cardMonitorings = $monitorings->only($requestedIds->all());
         $heatmaps = $monitoringHeatmapService->getHeatmapsForMonitorings(
-            $monitorings->values(),
+            $cardMonitorings->values(),
             Date::now()->subHours(23)->startOfHour(),
             Date::now()->endOfHour()
         );
 
-        $data = $requestedIds->mapWithKeys(function (string $monitoringId) use ($monitorings, $heatmaps, $monitoringStatusPayloadService): array {
+        $statusPayloads = $monitorings->mapWithKeys(function (Monitoring $monitoring) use ($monitoringStatusPayloadService): array {
+            return [$monitoring->id => $monitoringStatusPayloadService->getPayload($monitoring, includeMonitoring: false)];
+        });
+
+        $data = $requestedIds->mapWithKeys(function (string $monitoringId) use ($monitorings, $heatmaps, $statusPayloads): array {
             /** @var Monitoring|null $monitoring */
             $monitoring = $monitorings->get($monitoringId);
 
@@ -74,14 +94,49 @@ class MonitoringCardDataController extends Controller
 
             return [
                 $monitoringId => array_merge(
-                    $monitoringStatusPayloadService->getPayload($monitoring, includeMonitoring: false)->toArray(),
+                    $statusPayloads->get($monitoringId)->toArray(),
                     ['heatmap' => $heatmaps[$monitoringId] ?? []]
                 ),
             ];
         });
 
-        return response()->json([
+        $summary = [
+            'attention' => 0,
+            'healthy' => 0,
+            'paused' => 0,
+            'maintenance' => 0,
+        ];
+
+        foreach ($summaryIds as $summaryId) {
+            $monitoring = $monitorings->get($summaryId);
+
+            if (! $monitoring) {
+                continue;
+            }
+
+            $status = $statusPayloads->get($summaryId)->status;
+            $statusValue = $status instanceof BackedEnum ? $status->value : $status;
+
+            if (in_array($statusValue, ['down', 'unknown'], true)) {
+                $summary['attention']++;
+            }
+
+            if ($statusValue === 'up') {
+                $summary['healthy']++;
+            }
+
+            if ($monitoring->isPaused()) {
+                $summary['paused']++;
+            }
+
+            if ($monitoring->isUnderMaintenance()) {
+                $summary['maintenance']++;
+            }
+        }
+
+        return response()->json(array_filter([
             'data' => $data,
-        ]);
+            'summary' => array_key_exists('summary_ids', $validated) ? $summary : null,
+        ], static fn (mixed $value): bool => $value !== null));
     }
 }

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -157,6 +157,7 @@ class MonitoringController extends Controller
             default => $query->orderBy('name'),
         };
 
+        $summaryMonitoringIds = (clone $query)->pluck('id')->values();
         $lengthAwarePaginator = $query->paginate(5);
         $hasActiveFilters = $request->filled('search')
             || $request->filled('types')
@@ -185,6 +186,7 @@ class MonitoringController extends Controller
         return view('monitorings.index', [
             'currentUser' => $currentUser,
             'monitorings' => $lengthAwarePaginator,
+            'summaryMonitoringIds' => $summaryMonitoringIds,
             'monitoringsTotal' => $monitoringsTotal,
             'monitoringLimit' => $monitoringLimit,
             'privateMonitoringsTotal' => $privateMonitoringsTotal,

--- a/resources/js/components/monitoring-cards.ts
+++ b/resources/js/components/monitoring-cards.ts
@@ -9,6 +9,7 @@ interface MonitoringCardLoaderComponent {
     monitoringStatusMap: Record<string, string>;
     monitoringPublicLabelMap: Record<string, boolean>;
     maintenanceStatusMap: Record<string, boolean>;
+    summaryMonitoringIds: string[];
     hasMonitorings: boolean;
     statusMap: Record<string, string>;
     sinceMap: Record<string, string>;
@@ -33,7 +34,8 @@ export default (
     monitoringTypes: Record<string, string>,
     monitoringStatusMap: Record<string, string>,
     monitoringPublicLabelMap: Record<string, boolean>,
-    maintenanceStatusMap: Record<string, boolean>
+    maintenanceStatusMap: Record<string, boolean>,
+    summaryMonitoringIds: string[]
 ): MonitoringCardLoaderComponent => ({
     monitoringIds: monitoringIds,
     monitoringNames: monitoringNames,
@@ -42,6 +44,7 @@ export default (
     monitoringStatusMap: monitoringStatusMap,
     monitoringPublicLabelMap: monitoringPublicLabelMap,
     maintenanceStatusMap: maintenanceStatusMap,
+    summaryMonitoringIds: summaryMonitoringIds,
     hasMonitorings: monitoringIds.length > 0,
     statusMap: {} as Record<string, string>,
     sinceMap: {} as Record<string, string>,
@@ -62,13 +65,22 @@ export default (
         const query = new URLSearchParams();
 
         this.monitoringIds.forEach((id: string) => query.append('ids[]', id));
+        this.summaryMonitoringIds.forEach((id: string) => query.append('summary_ids[]', id));
 
         const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
         if (!response?.ok) {
             return;
         }
 
-        const payload = await response.json() as { data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }> };
+        const payload = await response.json() as {
+            data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }>;
+            summary?: {
+                attention: number;
+                healthy: number;
+                paused: number;
+                maintenance: number;
+            };
+        };
         const cardData = payload.data ?? {};
 
         for (const monitoringId of this.monitoringIds) {
@@ -90,7 +102,15 @@ export default (
             }
         }
 
-        this.updateSummary();
+        if (payload.summary) {
+            this.attentionCount = payload.summary.attention;
+            this.healthyCount = payload.summary.healthy;
+            this.pausedCount = payload.summary.paused;
+            this.maintenanceCount = payload.summary.maintenance;
+            this.summaryReady = true;
+        } else {
+            this.updateSummary();
+        }
     },
 
     updateSummary(this: MonitoringCardLoaderComponent): void {

--- a/resources/lang/de/monitoring.php
+++ b/resources/lang/de/monitoring.php
@@ -51,7 +51,7 @@ return [
         ],
         'table' => [
             'summary' => 'Betriebsübersicht',
-            'summary_scope' => 'Aktuelle Ergebnisseite',
+            'summary_scope' => 'Alle Ergebnisse der aktuellen Filter',
             'summary_loading' => 'Live-Status wird geladen ...',
             'attention' => 'Aufmerksamkeit nötig',
             'healthy' => 'Verfügbar',

--- a/resources/lang/en/monitoring.php
+++ b/resources/lang/en/monitoring.php
@@ -51,7 +51,7 @@ return [
         ],
         'table' => [
             'summary' => 'Operational summary',
-            'summary_scope' => 'Current result page',
+            'summary_scope' => 'All results matching the current filters',
             'summary_loading' => 'Loading live status...',
             'attention' => 'Needs attention',
             'healthy' => 'Healthy',

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -4,6 +4,7 @@
     use App\Enums\MonitoringStatus;
 
     $monitoringIds = json_encode(collect($monitorings->items())->pluck('id'));
+    $summaryMonitoringIds = json_encode($summaryMonitoringIds);
     $monitoringNames = json_encode($monitorings->pluck('name', 'id'));
     $monitoringTargets = json_encode($monitorings->pluck('target', 'id'));
     $monitoringTypes = json_encode($monitorings->getCollection()->mapWithKeys(fn ($monitoring) => [
@@ -352,7 +353,7 @@
             </x-container>
         @endif
 
-        <div x-data="monitoringCardLoader({{ $monitoringIds }}, {{ $monitoringNames }}, {{ $monitoringTargets }}, {{ $monitoringTypes }}, {{ $monitoringStatusMap }}, {{ $monitoringPublicLabelMap }}, {{ $maintenanceStatusMap }})">
+        <div x-data="monitoringCardLoader({{ $monitoringIds }}, {{ $monitoringNames }}, {{ $monitoringTargets }}, {{ $monitoringTypes }}, {{ $monitoringStatusMap }}, {{ $monitoringPublicLabelMap }}, {{ $maintenanceStatusMap }}, {{ $summaryMonitoringIds }})">
             <x-container x-show="monitoringIds.length > 0" space="true" class="border-l-4 border-purple-500">
                 <div class="flex flex-wrap items-start justify-between gap-2">
                     <div>

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -120,6 +120,44 @@ class MonitoringIndexEmptyStateTest extends TestCase
         $testResponse->assertSee(__('monitoring.index.filters.clear'));
     }
 
+    public function test_operational_summary_includes_monitorings_from_all_result_pages(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitorings = Monitoring::factory()->count(6)->for($user)->sequence(
+            ['name' => 'Monitoring 1'],
+            ['name' => 'Monitoring 2'],
+            ['name' => 'Monitoring 3'],
+            ['name' => 'Monitoring 4'],
+            ['name' => 'Monitoring 5'],
+            ['name' => 'Monitoring 6'],
+        )->create();
+
+        foreach ($monitorings as $monitoring) {
+            MonitoringResponse::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'status' => $monitoring->name === 'Monitoring 6' ? MonitoringStatus::DOWN : MonitoringStatus::UP,
+                'created_at' => now()->subMinute(),
+                'updated_at' => now()->subMinute(),
+            ]);
+        }
+
+        $indexResponse = $this->actingAs($user)->get(route('monitorings.index'));
+        $summaryMonitoringIds = $indexResponse->viewData('summaryMonitoringIds');
+        $pageMonitoringIds = $indexResponse->viewData('monitorings')->getCollection()->pluck('id')->all();
+
+        $this->assertCount(6, $summaryMonitoringIds);
+        $this->assertCount(5, $pageMonitoringIds);
+
+        $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'ids' => $pageMonitoringIds,
+            'summary_ids' => $summaryMonitoringIds->all(),
+        ]))
+            ->assertOk()
+            ->assertJsonPath('summary.attention', 1)
+            ->assertJsonPath('summary.healthy', 5);
+    }
+
     public function test_monitoring_index_supports_active_maintenance_preset(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -142,9 +142,9 @@ class MonitoringIndexEmptyStateTest extends TestCase
             ]);
         }
 
-        $indexResponse = $this->actingAs($user)->get(route('monitorings.index'));
-        $summaryMonitoringIds = $indexResponse->viewData('summaryMonitoringIds');
-        $pageMonitoringIds = $indexResponse->viewData('monitorings')->getCollection()->pluck('id')->all();
+        $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
+        $summaryMonitoringIds = $testResponse->viewData('summaryMonitoringIds');
+        $pageMonitoringIds = $testResponse->viewData('monitorings')->getCollection()->pluck('id')->all();
 
         $this->assertCount(6, $summaryMonitoringIds);
         $this->assertCount(5, $pageMonitoringIds);


### PR DESCRIPTION
Closes #461

## What changed

- Aggregate the monitoring operational summary across all monitorings matching the active filters, not only the current pagination page.
- Keep card and heatmap loading limited to the current page.
- Add a regression test covering six monitorings across two result pages.

## Why

A healthy first page could incorrectly make the full monitoring set appear available when a later page contained an unavailable monitoring.

## Validation

- Targeted Pest tests: 13 passed, 50 assertions
- Full Pest suite: successful, 3844 assertions
- PHPStan: no errors
- Laravel Pint: passed
- Vite production build: passed

The Docker test environment emitted existing file lookup warnings because this one-off container has no local `.env`; the test process exited successfully.