### PR TITLE
fix: prevent incident analytics 500 for foreign incidents

### DIFF
--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -57,6 +57,7 @@ class IncidentAnalyticsController extends Controller
     private function incidents(array $filters, int $days): Collection
     {
         $builder = Incident::query()
+            ->whereHas('monitoring')
             ->with('monitoring')
             ->whereBetween('down_at', [Date::now()->subDays($days)->startOfDay(), Date::now()->endOfDay()])
             ->latest('down_at');

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -244,6 +244,32 @@ class IncidentWorkflowTest extends TestCase
             ->assertDontSeeText('Search API');
     }
 
+    public function test_incident_analytics_only_includes_incidents_for_visible_monitorings(): void
+    {
+        Date::setTestNow('2026-07-15 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $otherUser = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+        $otherMonitoring = Monitoring::factory()->for($otherUser)->create(['name' => 'Other API']);
+
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'affected_service' => 'Checkout API',
+            'down_at' => Date::now()->subHour(),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $otherMonitoring->id,
+            'down_at' => Date::now()->subMinutes(30),
+        ]);
+
+        $this->actingAs($user)->get(route('incidents.analytics'))
+            ->assertOk()
+            ->assertSeeText('Checkout API')
+            ->assertDontSeeText('Other API');
+    }
+
     /**
      * @return array{user: User, statusPage: StatusPage, incident: Incident}
      */


### PR DESCRIPTION
Closes #459

## What changed

- Restrict incident analytics to incidents whose monitorings are visible to the authenticated user.
- Add a regression test covering a second user's incident with no affected-service override.

## Why

The analytics query loaded incidents across all users. The monitoring relation's visibility scope then returned no relation for a foreign monitoring, and the analytics aggregation dereferenced `$incident->monitoring->name`, causing HTTP 500.

## Validation

- Docker Pest targeted: 5 passed, 51 assertions.
- Docker Pest full suite: 615 passed, 3 skipped, 3842 assertions.
- Docker PHPStan: no errors.
- Docker Pint: passed for changed files.

The fix also prevents cross-tenant incident aggregation and avoids exposing foreign incident data.