### PR TITLE
fix: translate unclassified incident analytics values

### DIFF
--- a/resources/lang/de/incidents.php
+++ b/resources/lang/de/incidents.php
@@ -46,18 +46,21 @@ return [
         'dependency' => 'Abhängigkeit',
         'configuration' => 'Konfiguration',
         'other' => 'Sonstiges',
+        'unclassified' => 'Nicht klassifiziert',
     ],
     'severities' => [
         'low' => 'Niedrig',
         'medium' => 'Mittel',
         'high' => 'Hoch',
         'critical' => 'Kritisch',
+        'unclassified' => 'Nicht klassifiziert',
     ],
     'customer_impacts' => [
         'none' => 'Keine',
         'degraded' => 'Beeinträchtigt',
         'outage' => 'Ausfall',
         'unknown' => 'Unbekannt',
+        'unclassified' => 'Nicht klassifiziert',
     ],
     'contributing_categories' => [
         'code' => 'Code',

--- a/resources/lang/en/incidents.php
+++ b/resources/lang/en/incidents.php
@@ -46,18 +46,21 @@ return [
         'dependency' => 'Dependency',
         'configuration' => 'Configuration',
         'other' => 'Other',
+        'unclassified' => 'Unclassified',
     ],
     'severities' => [
         'low' => 'Low',
         'medium' => 'Medium',
         'high' => 'High',
         'critical' => 'Critical',
+        'unclassified' => 'Unclassified',
     ],
     'customer_impacts' => [
         'none' => 'None',
         'degraded' => 'Degraded',
         'outage' => 'Outage',
         'unknown' => 'Unknown',
+        'unclassified' => 'Unclassified',
     ],
     'contributing_categories' => [
         'code' => 'Code',

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -270,6 +270,37 @@ class IncidentWorkflowTest extends TestCase
             ->assertDontSeeText('Other API');
     }
 
+    public function test_incident_analytics_translates_unclassified_values_for_each_locale(): void
+    {
+        Date::setTestNow('2026-07-15 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+
+        foreach ([
+            ['locale' => 'en', 'label' => 'Unclassified'],
+            ['locale' => 'de', 'label' => 'Nicht klassifiziert'],
+        ] as $localizedExpectation) {
+            $user = User::factory()->create([
+                'locale' => $localizedExpectation['locale'],
+                'package_id' => $package->id,
+            ]);
+            $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+
+            Incident::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'down_at' => Date::now()->subHour(),
+                'up_at' => Date::now()->subMinutes(30),
+            ]);
+
+            $this->actingAs($user)->get(route('incidents.analytics'))
+                ->assertOk()
+                ->assertSeeText($localizedExpectation['label'])
+                ->assertDontSeeText('incidents.types.unclassified')
+                ->assertDontSeeText('incidents.severities.unclassified')
+                ->assertDontSeeText('incidents.customer_impacts.unclassified');
+        }
+    }
+
     /**
      * @return array{user: User, statusPage: StatusPage, incident: Incident}
      */


### PR DESCRIPTION
## What changed
- Added English and German translations for unclassified incident types, severities, and customer impacts.
- Added a regression test covering the analytics page in both locales when incident metadata is missing.

## Why
Incident analytics rendered raw keys such as `incidents.types.unclassified` instead of user-facing labels for incidents without classification metadata.

## Testing
- `docker exec webguard-php ./vendor/bin/pest tests/Feature/IncidentWorkflowTest.php --compact`
- `docker exec webguard-php ./vendor/bin/pest tests/Feature/LocalePreferenceTest.php --compact`
- `docker exec webguard-php composer test`
- `docker exec webguard-php composer analyse -- --debug`
- `docker exec webguard-php ./vendor/bin/pint resources/lang/en/incidents.php resources/lang/de/incidents.php tests/Feature/IncidentWorkflowTest.php --test`

## Risks / follow-up
No schema, route, or API changes. The remote page should show localized labels after deployment of this branch.

Closes #465