### PR TITLE
feat(status-pages): add 30-day aggregate uptime calendar

### DIFF
--- a/app/Http/Controllers/PublicStatusPageController.php
+++ b/app/Http/Controllers/PublicStatusPageController.php
@@ -60,12 +60,17 @@ class PublicStatusPageController extends Controller
         });
 
         $pageStatus = $this->aggregateStatus($components->pluck('status'));
+        $hasAggregateCalendar = $components
+            ->flatMap(fn (array $component): Collection => $component['monitorings']->pluck('model'))
+            ->unique('id')
+            ->count() > 1;
 
         return view('status-pages.public-show', [
             'statusPage' => $statusPage,
             'pageStatus' => $pageStatus,
             'pageStatusBadgeType' => $this->statusBadgeType($pageStatus),
             'components' => $components,
+            'hasAggregateCalendar' => $hasAggregateCalendar,
             'incidents' => $this->recentIncidents($statusPage),
         ]);
     }

--- a/app/Http/Controllers/PublicStatusPageUptimeCalendarController.php
+++ b/app/Http/Controllers/PublicStatusPageUptimeCalendarController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\StatusPage;
+use App\Services\StatusPageUptimeCalendarService;
+use Illuminate\Http\JsonResponse;
+
+final class PublicStatusPageUptimeCalendarController extends Controller
+{
+    public function __invoke(
+        StatusPage $statusPage,
+        StatusPageUptimeCalendarService $statusPageUptimeCalendarService
+    ): JsonResponse {
+        abort_unless($statusPage->is_public, 404);
+
+        return response()->json(
+            $statusPageUptimeCalendarService->getLast30Days($statusPage)->toArray()
+        );
+    }
+}

--- a/app/Services/StatusPageUptimeCalendarService.php
+++ b/app/Services/StatusPageUptimeCalendarService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Data\MonitoringUptimeCalendarDayPayload;
+use App\Data\MonitoringUptimeCalendarMonthPayload;
+use App\Data\MonitoringUptimeCalendarPayload;
+use App\Enums\StatusPageComponentSource;
+use App\Models\MonitoringDailyResult;
+use App\Models\StatusPage;
+use App\Models\StatusPageComponent;
+use Carbon\CarbonPeriod;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+final class StatusPageUptimeCalendarService
+{
+    public const LOOKBACK_DAYS = 30;
+
+    public function getLast30Days(StatusPage $statusPage): MonitoringUptimeCalendarPayload
+    {
+        $statusPage->loadMissing([
+            'components.monitorings' => fn ($query) => $query->withoutGlobalScope('user'),
+            'components.monitoringGroup.monitorings' => fn ($query) => $query->withoutGlobalScope('user'),
+        ]);
+
+        $monitoringIds = $statusPage->components
+            ->flatMap(fn (StatusPageComponent $component): Collection => $this->componentMonitorings($component)->pluck('id'))
+            ->unique()
+            ->values();
+
+        $endDate = Date::now()->endOfDay();
+        $startDate = $endDate->copy()->subDays(self::LOOKBACK_DAYS - 1)->startOfDay();
+
+        $historicalData = MonitoringDailyResult::query()
+            ->whereIn('monitoring_id', $monitoringIds->all())
+            ->whereBetween('date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->select(['monitoring_id', 'date', 'uptime_minutes', 'downtime_minutes'])
+            ->get()
+            ->groupBy(fn (MonitoringDailyResult $result): string => Date::parse($result->date)->toDateString());
+
+        $dailyUptimeData = [];
+        $monthlyMinutes = [];
+        $carbonPeriod = CarbonPeriod::create($startDate->copy()->startOfMonth(), '1 month', $endDate->copy()->endOfMonth());
+
+        foreach ($carbonPeriod as $monthDate) {
+            $monthYear = $monthDate->format('Y-m');
+            $monthDays = [];
+            $monthlyMinutes[$monthYear] = [
+                'uptime_minutes' => 0,
+                'downtime_minutes' => 0,
+            ];
+
+            for ($day = 1; $day <= $monthDate->daysInMonth; $day++) {
+                $currentDay = $monthDate->copy()->setDay($day)->startOfDay();
+                $dateString = $currentDay->toDateString();
+                $uptimeMinutes = 0;
+                $downtimeMinutes = 0;
+
+                if ($currentDay->between($startDate, $endDate)) {
+                    $results = $historicalData->get($dateString, collect());
+                    $uptimeMinutes = (int) $results->sum('uptime_minutes');
+                    $downtimeMinutes = (int) $results->sum('downtime_minutes');
+                }
+
+                $trackedMinutes = $uptimeMinutes + $downtimeMinutes;
+                $uptimePercentage = $trackedMinutes > 0
+                    ? ($uptimeMinutes / $trackedMinutes) * 100
+                    : null;
+
+                $monthlyMinutes[$monthYear]['uptime_minutes'] += $uptimeMinutes;
+                $monthlyMinutes[$monthYear]['downtime_minutes'] += $downtimeMinutes;
+
+                $monthDays[] = new MonitoringUptimeCalendarDayPayload(
+                    date: $currentDay->toIso8601String(),
+                    uptimePercentage: $uptimePercentage
+                );
+            }
+
+            $dailyUptimeData[$monthYear] = collect($monthDays);
+        }
+
+        $months = collect($dailyUptimeData)
+            ->mapWithKeys(function (Collection $days, string $monthYear) use ($monthlyMinutes): array {
+                $uptimeMinutes = $monthlyMinutes[$monthYear]['uptime_minutes'] ?? 0;
+                $downtimeMinutes = $monthlyMinutes[$monthYear]['downtime_minutes'] ?? 0;
+                $totalTrackedMinutes = $uptimeMinutes + $downtimeMinutes;
+
+                return [
+                    $monthYear => new MonitoringUptimeCalendarMonthPayload(
+                        days: $days,
+                        monthlyAverageUptime: $totalTrackedMinutes > 0
+                            ? ($uptimeMinutes / $totalTrackedMinutes) * 100
+                            : null
+                    ),
+                ];
+            });
+
+        return new MonitoringUptimeCalendarPayload($months);
+    }
+
+    /**
+     * @return Collection<int, \App\Models\Monitoring>
+     */
+    private function componentMonitorings(StatusPageComponent $statusPageComponent): Collection
+    {
+        if ($statusPageComponent->source_type === StatusPageComponentSource::MONITORING_GROUP) {
+            return $statusPageComponent->monitoringGroup?->monitorings ?? collect();
+        }
+
+        return $statusPageComponent->monitorings;
+    }
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,7 +25,7 @@ WebGuard helps teams observe public websites, operational tasks, certificates, d
 - **REST API:** access monitoring data, manage teams, and create or move team monitorings programmatically.
 - **Mobile app:** use the implemented WebGuard mobile app from the separate [WebGuard App Repository](https://github.com/marcel-breuer/webguard-app).
 - **SLA badge:** display website monitoring status on external sites with a compact SLA badge that shows live status, uptime proof, and public trust context.
-- **Public status pages:** publish monitoring status, uptime, recent incidents, and active or upcoming maintenance windows for users and customers. New public status page URLs use ULIDs, while legacy slug URLs remain available through compatibility routes.
+- **Public status pages:** publish monitoring status, uptime, a calculated 30-day aggregate uptime calendar for multi-monitoring pages, recent incidents, and active or upcoming maintenance windows for users and customers. New public status page URLs use ULIDs, while legacy slug URLs remain available through compatibility routes.
 - **Private incident reviews:** record the problem and resolution for each status-page incident in the management interface without exposing internal notes on public status pages.
 - **Incident follow-ups and timelines:** track private preventive actions, owners, due dates, and custom timeline events alongside automatically collected incident activity.
 - **Incident analytics:** classify incidents by type, severity, customer impact, and affected service, then review recurrence and average recovery time for the selected period.

--- a/resources/js/components/uptime-calendar.ts
+++ b/resources/js/components/uptime-calendar.ts
@@ -19,30 +19,38 @@ interface UptimeCalendarComponent {
     calendarData: CalendarData | null;
     monitoringId: string;
     endpoint: string | null;
+    lookbackDays: number | null;
     currentLocale: string;
     fetchUptimeCalendar(this: UptimeCalendarComponent): Promise<void>;
 }
 
-export default (monitoringId: string, endpoint: string | null = null): UptimeCalendarComponent => ({
+export default (monitoringId: string, endpoint: string | null = null, lookbackDays: number | null = null): UptimeCalendarComponent => ({
     isLoading: true,
     calendarData: null,
     monitoringId: monitoringId,
     endpoint: endpoint,
+    lookbackDays: lookbackDays,
     currentLocale: getCurrentDayjsLocale(),
 
     async fetchUptimeCalendar() {
         this.isLoading = true;
         const endDate = new Date();
         const startDate = new Date();
-        startDate.setMonth(startDate.getMonth() - 11);
-        startDate.setDate(1);
+        if (this.lookbackDays !== null) {
+            startDate.setDate(startDate.getDate() - (this.lookbackDays - 1));
+        } else {
+            startDate.setMonth(startDate.getMonth() - 11);
+            startDate.setDate(1);
+        }
 
         const formatDateForApi = (date: Date) => date.toISOString().split('T')[0];
 
         try {
             const url = new URL(this.endpoint ?? `/api/monitorings/${this.monitoringId}/uptime-calendar`, window.location.origin);
-            url.searchParams.set('start_date', formatDateForApi(startDate));
-            url.searchParams.set('end_date', formatDateForApi(endDate));
+            if (this.lookbackDays === null) {
+                url.searchParams.set('start_date', formatDateForApi(startDate));
+                url.searchParams.set('end_date', formatDateForApi(endDate));
+            }
 
             const response = await fetch(url.toString());
             if (!response.ok) {

--- a/resources/lang/de/status_page.php
+++ b/resources/lang/de/status_page.php
@@ -139,6 +139,10 @@ return [
         'title' => ':statusPage - Status',
         'overall_status' => 'Gesamtstatus',
         'recent_incidents' => 'Letzte Vorfälle',
+        'calendar' => [
+            'heading' => 'Aggregierte Verfügbarkeit',
+            'description' => 'Zusammengefasste Verfügbarkeit aller auf dieser Statusseite angezeigten Dienste der letzten 30 Tage.',
+        ],
         'subscribe' => [
             'button' => 'Abonnieren',
             'confirmation_sent' => 'Falls erforderlich, haben wir eine Bestätigungs-E-Mail zum Abschließen des Abonnements gesendet.',

--- a/resources/lang/en/status_page.php
+++ b/resources/lang/en/status_page.php
@@ -139,6 +139,10 @@ return [
         'title' => ':statusPage - Status',
         'overall_status' => 'Overall status',
         'recent_incidents' => 'Recent Incidents',
+        'calendar' => [
+            'heading' => 'Aggregated uptime',
+            'description' => 'Combined uptime for all services shown on this status page over the last 30 days.',
+        ],
         'subscribe' => [
             'button' => 'Subscribe',
             'confirmation_sent' => 'If needed, we sent a confirmation email to finish the subscription.',

--- a/resources/views/status-pages/public-show.blade.php
+++ b/resources/views/status-pages/public-show.blade.php
@@ -73,6 +73,31 @@
                 @endforeach
             </section>
 
+            @if ($hasAggregateCalendar)
+                <section id="status-page-uptime-calendar">
+                    <div class="mb-4">
+                        <x-heading type="h2">{{ __('status_page.public.calendar.heading') }}</x-heading>
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                            {{ __('status_page.public.calendar.description') }}
+                        </p>
+                    </div>
+
+                    <div x-data="uptimeCalendar('{{ $statusPage->id }}', @js(route('public.status-pages.uptime-calendar', $statusPage)), 30)" x-init="fetchUptimeCalendar">
+                        <template x-if="isLoading">
+                            <x-container>
+                                <p>{{ __('calendar.loading') }}</p>
+                            </x-container>
+                        </template>
+
+                        <template x-if="!isLoading && calendarData">
+                            <div x-data="{ data: calendarData }">
+                                @include('components.monitoring-calendar')
+                            </div>
+                        </template>
+                    </div>
+                </section>
+            @endif
+
             <section id="status-page-subscription">
                 <x-container>
                     <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Api\Mobile\MobileAuthController;
 use App\Http\Controllers\Api\ServerHealthReportController;
 use App\Http\Controllers\ApiController;
+use App\Http\Controllers\PublicStatusPageUptimeCalendarController;
 use App\Http\Middleware\TrackApiUsage;
 use Illuminate\Support\Facades\Route;
 
@@ -12,6 +13,8 @@ Route::get('/public/monitorings/{monitoring}/badge', [ApiController::class, 'bad
     ->name('public.monitorings.badge');
 Route::get('/public/monitorings/{monitoring}/uptime-calendar', [ApiController::class, 'uptimeCalendar'])
     ->name('public.monitorings.uptime-calendar');
+Route::get('/public/status-pages/{statusPage}/uptime-calendar', PublicStatusPageUptimeCalendarController::class)
+    ->name('public.status-pages.uptime-calendar');
 
 Route::post('/v1/server-health/{token}', ServerHealthReportController::class)
     ->middleware('throttle:60,1')

--- a/tests/Feature/PublicStatusPageCalendarTest.php
+++ b/tests/Feature/PublicStatusPageCalendarTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\StatusPageComponentSource;
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\StatusPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class PublicStatusPageCalendarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Date::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_public_status_page_calendar_aggregates_unique_monitorings_for_the_last_30_days(): void
+    {
+        Date::setTestNow('2026-07-16 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $firstMonitoring = Monitoring::factory()->for($user)->create();
+        $secondMonitoring = Monitoring::factory()->for($user)->create();
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Customer Status',
+            'slug' => 'customer-status',
+            'is_public' => true,
+        ]);
+
+        $manualComponent = $statusPage->components()->create([
+            'name' => 'API',
+            'position' => 0,
+            'source_type' => StatusPageComponentSource::MANUAL,
+        ]);
+        $manualComponent->monitorings()->attach($firstMonitoring->id, ['position' => 0]);
+
+        $monitoringGroup = MonitoringGroup::factory()->for($user)->create();
+        $monitoringGroup->monitorings()->attach([$firstMonitoring->id, $secondMonitoring->id]);
+        $statusPage->components()->create([
+            'name' => 'Infrastructure',
+            'position' => 1,
+            'source_type' => StatusPageComponentSource::MONITORING_GROUP,
+            'monitoring_group_id' => $monitoringGroup->id,
+        ]);
+
+        $this->createDailyResult($firstMonitoring, '2026-07-15', 60, 120);
+        $this->createDailyResult($secondMonitoring, '2026-07-15', 180, 60);
+        $dailyResultCount = MonitoringDailyResult::query()->count();
+
+        $response = $this->getJson(route('public.status-pages.uptime-calendar', $statusPage));
+
+        $response->assertOk();
+        $calendar = $response->json();
+
+        $this->assertArrayHasKey('2026-06', $calendar);
+        $this->assertArrayHasKey('2026-07', $calendar);
+        $this->assertSame(30, $this->countDaysInRange($calendar));
+        $this->assertEqualsWithDelta(
+            57.142857,
+            $calendar['2026-07']['days'][14]['uptime_percentage'],
+            0.0001
+        );
+        $this->assertEqualsWithDelta(57.142857, $calendar['2026-07']['monthly_average_uptime'], 0.0001);
+        $this->assertSame($dailyResultCount, MonitoringDailyResult::query()->count());
+    }
+
+    public function test_public_status_page_calendar_is_not_available_for_private_status_pages(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Private Status',
+            'slug' => 'private-status',
+            'is_public' => false,
+        ]);
+
+        $this->getJson(route('public.status-pages.uptime-calendar', $statusPage))
+            ->assertNotFound();
+    }
+
+    public function test_public_status_page_renders_aggregate_calendar_for_multiple_monitorings(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $firstMonitoring = Monitoring::factory()->for($user)->create();
+        $secondMonitoring = Monitoring::factory()->for($user)->create();
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Customer Status',
+            'slug' => 'customer-status',
+            'is_public' => true,
+        ]);
+        $component = $statusPage->components()->create([
+            'name' => 'Services',
+            'position' => 0,
+            'source_type' => StatusPageComponentSource::MANUAL,
+        ]);
+        $component->monitorings()->attach([
+            $firstMonitoring->id => ['position' => 0],
+            $secondMonitoring->id => ['position' => 1],
+        ]);
+
+        $this->get(route('public-status-pages.show', $statusPage))
+            ->assertOk()
+            ->assertSeeText(__('status_page.public.calendar.heading'))
+            ->assertSeeHtml('status-page-uptime-calendar');
+    }
+
+    /**
+     * @param  array<string, array{days: list<array{date: string, uptime_percentage: float|null}>}>  $calendar
+     */
+    private function countDaysInRange(array $calendar): int
+    {
+        $startDate = Date::now()->subDays(29)->startOfDay();
+        $endDate = Date::now()->endOfDay();
+
+        return collect($calendar)
+            ->flatMap(fn (array $month): array => $month['days'])
+            ->filter(function (array $day) use ($startDate, $endDate): bool {
+                $date = Date::parse($day['date']);
+
+                return $date->between($startDate, $endDate);
+            })
+            ->count();
+    }
+
+    private function createDailyResult(
+        Monitoring $monitoring,
+        string $date,
+        int $uptimeMinutes,
+        int $downtimeMinutes
+    ): void {
+        $trackedMinutes = $uptimeMinutes + $downtimeMinutes;
+
+        MonitoringDailyResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'date' => $date,
+            'uptime_total' => $uptimeMinutes,
+            'downtime_total' => $downtimeMinutes,
+            'unknown_total' => 0,
+            'uptime_percentage' => ($uptimeMinutes / $trackedMinutes) * 100,
+            'downtime_percentage' => ($downtimeMinutes / $trackedMinutes) * 100,
+            'unknown_percentage' => 0.0,
+            'uptime_minutes' => $uptimeMinutes,
+            'downtime_minutes' => $downtimeMinutes,
+            'unknown_minutes' => 0,
+            'avg_response_time' => 100.0,
+            'min_response_time' => 100,
+            'max_response_time' => 100,
+            'incidents_count' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## What changed

- Added a calculated public status-page uptime calendar for the last 30 days.
- Aggregated existing daily uptime/downtime minutes across unique monitorings shown on the page, including monitoring-group components.
- Reused the existing calendar UI with localized English and German copy.
- Added a public read-only calendar endpoint with private-page protection.
- Added feature coverage for aggregation, deduplication, visibility, no-write behavior, and page rendering.
- Updated the feature documentation.

## Why

Multi-monitoring public status pages previously showed current component status and incidents but had no shared historical availability view. The new board gives visitors one combined reliability calendar without introducing persisted aggregate data.

## Testing

- composer test
- composer analyse
- Laravel Pint on changed PHP files
- bun install --frozen-lockfile && bun run build

## Risks and limitations

- The aggregate is calculated on request from existing daily results and is intentionally limited to the latest 30 calendar days.
- Calendar cells outside the exact 30-day window remain as neutral month-grid context, matching the existing calendar component.

Closes #464