### PR TITLE
docs: establish operations-first UX baseline

### DIFF
--- a/docs/ux-baseline.md
+++ b/docs/ux-baseline.md
@@ -1,0 +1,79 @@
+# UX Baseline: Operations-First WebGuard UI
+
+This document records the repository-grounded baseline for issue [#442](https://github.com/marcel-breuer/webguard/issues/442), which is the research prerequisite for the UI epic [#441](https://github.com/marcel-breuer/webguard/issues/441).
+
+## Scope and method
+
+The baseline was completed on 2026-07-17 as a scripted internal walkthrough of the authenticated WebGuard surface. It combines the rendered Blade structure, route definitions, existing feature/browser tests, and the responsive navigation rules. The desktop reference is a viewport at least 640px wide; the mobile reference is the `<640px` responsive branch, represented by a 390px-wide viewport.
+
+This is not user telemetry and does not claim observed behaviour from external participants. Route transitions, visible action counts, and additional disclosure steps below are repeatable source-based measurements. Real-user sessions should be added before committing to a larger visual redesign.
+
+## Task map and baseline measurements
+
+The counts below start on the authenticated dashboard where a dashboard path exists. A route transition means a new page load; an expand action means opening an existing disclosure control. Login and form submission are excluded.
+
+| Task | Desktop journey and baseline | Mobile journey and baseline | Current evidence |
+| --- | --- | --- | --- |
+| Find the current status of a monitored service | `/dashboard` → the relevant attention item → `/monitorings/{monitoring}`: 1 transition when the item is visible; otherwise `/dashboard` → `/monitorings` → detail: 2 transitions. | The dashboard attention link is already direct. From another page, open the menu, then choose Monitoring: 1 menu action plus 1 route transition. | Dashboard attention links and health summaries are rendered in `resources/views/dashboard.blade.php`; authenticated navigation is in `resources/views/layouts/navigation.blade.php`. |
+| Identify what needs attention after a failure | `/dashboard` exposes the recommended action, attention list, health counters, and recent incidents in the first operations view. The next action is normally 1 transition. | The same dashboard links remain available in the single-column layout; the global menu is not required when starting on `/dashboard`. | Covered by `tests/Feature/DashboardOverviewTest.php`. |
+| Open and update an incident | `/dashboard` → `/incidents/analytics` is 1 transition for analysis. Updating public/private incident context requires `/status-pages` → `/status-pages/{statusPage}`, then opening the collapsed Incident Workbench: 2 transitions plus 1 expand action from the status-page index. | From a non-dashboard page, add the menu open action before entering Status Pages. The workbench remains collapsed per incident. | Analytics is linked from the dashboard; update forms and the collapsed workbench are rendered in `resources/views/status-pages/show.blade.php` and covered by `tests/Feature/IncidentWorkflowTest.php`. |
+| Schedule maintenance for one monitor or group | `/dashboard` → `/maintenance`: 1 transition, then submit the central maintenance form on that page. | From another page, open the menu and choose Maintenance; the page then uses its existing single-column form. | `resources/views/maintenance/index.blade.php` and `tests/Feature/MaintenanceManagementTest.php`. |
+| Create a new HTTP monitoring | `/dashboard` → `/monitorings/create`: 1 transition. The form has six visible sections in source order: Basic, Organization, Check, Sharing, Notifications, and Operations. | The route is the same, but the form changes to a single-column flow and requires more vertical scrolling. | `resources/views/monitorings/_form.blade.php` and `tests/Feature/MonitoringFormPresentationTest.php`. |
+| Find and share a public status page | `/dashboard` → `/status-pages` → `/status-pages/{statusPage}`: 2 transitions; the public URL is shown on the detail page only when the page is public. | From another page, open the menu before Status Pages, then use the same two-route journey. | `resources/views/status-pages/show.blade.php` and `tests/Feature/StatusPageManagementTest.php`. |
+
+### View-level measurements
+
+- The desktop primary navigation exposes Monitoring, Incidents, and Status Pages directly. Maintenance, monitoring groups, and teams are behind the **More** dropdown; Dashboard is not a primary navigation item, and the logo links to `/monitorings`.
+- The mobile navigation is closed by default. Operations, collaboration, and administration destinations are only rendered in the expanded menu; the notification bell and language switch remain outside it.
+- The monitoring index offers four preset filters before the advanced filter disclosure, followed by search and type, lifecycle, group, team, ownership, health, maintenance, and sort controls.
+- The monitoring form keeps type-dependent controls in one long form. Advanced request settings are disclosed separately, while sharing, notification, and operational settings remain further down the page.
+- The status-page detail view displays the public URL near the page title, but incident work is placed inside a per-incident `<details>` disclosure after the public incident updates.
+
+## Findings: repository evidence
+
+1. **The default authenticated entry point bypasses the operations overview.** Registration, email verification, and password-related entry points redirect to `monitorings.index`, while `/dashboard` already contains health, attention, maintenance, incident, trend, and quick-action blocks. This makes the current “first screen” different from the documented operations-first intent.
+2. **The dashboard is hard to rediscover.** It is not linked from the primary navigation, and the application logo points to the monitoring list. A user who leaves the dashboard has no visible Dashboard destination in the shared navigation.
+3. **Incident work is split across two mental models.** Incident analytics is a direct navigation destination, while incident updates, metadata, follow-ups, and timeline actions live on a status-page detail screen behind a collapsed workbench. The repository has tests for both behaviours, but the navigation does not explain the relationship.
+4. **The monitoring list has a powerful but dense filter surface.** Presets help with common states, but the advanced disclosure contains many independent dimensions. This is useful for experienced operators and likely costly for first-time task completion, especially on mobile.
+5. **Monitoring creation is complete but vertically expensive.** The form supports many monitoring types and operational controls in one route. The shared form test verifies consistent section order and action placement, but the baseline does not yet show which fields users expect to configure first.
+
+## Findings: hypotheses to validate with participants
+
+- Users will look for Dashboard or Overview in the primary navigation before opening Monitoring.
+- “Incident” and “Status page incident update” may be understood as one workflow rather than two destinations.
+- First-time users will prefer a small set of status presets over opening advanced filters.
+- HTTP monitoring creation can likely be shortened by showing only the fields required for the selected type and moving the rest behind progressive disclosure.
+- On mobile, a persistent or contextual next action may outperform a menu-first workflow for failure response and maintenance scheduling.
+
+These are hypotheses, not observations. They must be tested with participants rather than treated as design requirements.
+
+## Terminology recommendations
+
+| Concept | English recommendation | German recommendation | Current observation |
+| --- | --- | --- | --- |
+| Monitoring resource | Monitoring | Monitoring | The German UI already uses both “Monitoring” and “Überwachung”; the mix is visible across form and navigation copy. |
+| Service disruption record | Incident | Incident | “Incident” is already used in the dashboard, analytics, and status-page workbench. |
+| Customer-facing surface | Status page | Statusseite | The current German navigation and status-page screens use “Statusseite”. |
+| Planned suppression window | Maintenance | Wartung | The current dashboard, navigation, and maintenance screens use “Maintenance” / “Wartung”. |
+| Main daily entry | Overview | Übersicht | The current `/dashboard` is an overview in behaviour, but its label is not exposed in the main navigation. |
+
+Recommended terminology should be confirmed during participant sessions, with one term per concept across navigation, headings, filters, and primary actions.
+
+## Recommendation for #441
+
+Start with work package 2, Navigation and Information Architecture, using the already implemented dashboard as the baseline rather than designing a second overview. The first validation candidate should make the dashboard discoverable and compare two entry flows: dashboard-first versus monitoring-list-first. The next candidate should test a direct path from an attention item to the relevant incident workbench, while preserving the existing public/internal separation.
+
+The follow-up study should recruit representative operators, evaluate at least five tasks on desktop and three on mobile, record success, wrong turns, time to first meaningful action, and terminology, and attach annotated screenshots or session links to #442 before the navigation or detail-page redesign is finalized.
+
+## Repository references
+
+- Dashboard: [`/dashboard`](../resources/views/dashboard.blade.php)
+- Shared navigation: [`resources/views/layouts/navigation.blade.php`](../resources/views/layouts/navigation.blade.php)
+- Monitoring list and filters: [`resources/views/monitorings/index.blade.php`](../resources/views/monitorings/index.blade.php)
+- Monitoring form: [`resources/views/monitorings/_form.blade.php`](../resources/views/monitorings/_form.blade.php)
+- Status-page incident workbench: [`resources/views/status-pages/show.blade.php`](../resources/views/status-pages/show.blade.php)
+- Navigation coverage: [`tests/Feature/AuthenticatedNavigationTest.php`](../tests/Feature/AuthenticatedNavigationTest.php)
+- Dashboard coverage: [`tests/Feature/DashboardOverviewTest.php`](../tests/Feature/DashboardOverviewTest.php)
+- Incident workflow coverage: [`tests/Feature/IncidentWorkflowTest.php`](../tests/Feature/IncidentWorkflowTest.php)
+- Maintenance coverage: [`tests/Feature/MaintenanceManagementTest.php`](../tests/Feature/MaintenanceManagementTest.php)
+- Status-page coverage: [`tests/Feature/StatusPageManagementTest.php`](../tests/Feature/StatusPageManagementTest.php)


### PR DESCRIPTION
Closes #442

## What changed

- Added a repository-grounded UX baseline for the operations-first UI epic.
- Evaluated six core operator tasks across desktop and mobile responsive flows.
- Recorded route transitions, disclosure steps, current evidence, hypotheses, terminology recommendations, and the next recommendation for #441.
- Linked the relevant Blade views and existing feature/browser coverage.

## Why

Issue #441 requires research before larger navigation, overview, and detail-page decisions. The current implementation already has a dashboard overview, but authentication and the logo still lead to the monitoring list, so the baseline documents the actual current state and the highest-value validation candidates.

## Validation

- Docker Compose configuration validation passed with placeholder legal-page environment variables.
- Docker-based `tests/Feature/DocumentationStructureTest.php` passed with 59 assertions; Pest reported four existing warnings.
- `git diff --no-index --check /dev/null docs/ux-baseline.md` passed.

No application code or automated tests were added because this is a documentation-only research deliverable.