### PR TITLE
feat(navigation): make dashboard the authenticated entry point

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -47,7 +47,7 @@ class AuthenticatedSessionController extends Controller
             $userLocale = SupportedLanguage::default()->value;
         }
 
-        return redirect()->intended(route('monitorings.index', absolute: false))
+        return redirect()->intended(route('dashboard', absolute: false))
             ->withCookie(
                 cookie(
                     SupportedLanguage::cookieName(),

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -50,6 +50,6 @@ class ConfirmablePasswordController extends Controller
 
         $request->session()->put('auth.password_confirmed_at', Date::now()->getTimestamp());
 
-        return redirect()->intended(route('monitorings.index', absolute: false));
+        return redirect()->intended(route('dashboard', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -24,7 +24,7 @@ class EmailVerificationNotificationController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('monitorings.index', absolute: false));
+            return redirect()->intended(route('dashboard', absolute: false));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -17,7 +17,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request): RedirectResponse|View
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(route('monitorings.index', absolute: false))
+                    ? redirect()->intended(route('dashboard', absolute: false))
                     : view('auth.verify-email');
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -69,6 +69,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($model);
 
-        return redirect()->intended(route('monitorings.index', absolute: false));
+        return redirect()->intended(route('dashboard', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/SocialiteConsentController.php
+++ b/app/Http/Controllers/Auth/SocialiteConsentController.php
@@ -51,7 +51,7 @@ class SocialiteConsentController extends Controller
 
         Auth::login($user);
 
-        return to_route('monitorings.index');
+        return to_route('dashboard');
     }
 
     private function hasPendingConsent(Request $request): bool

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -57,7 +57,7 @@ class SocialiteController extends Controller
                 $this->clearPendingConsentState($request);
                 Auth::login($user);
 
-                return to_route('monitorings.index');
+                return to_route('dashboard');
             }
 
             $request->session()->put(self::SESSION_PENDING_EXISTING_USER_ID, $user->id);

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -25,13 +25,13 @@ class VerifyEmailController extends Controller
     public function __invoke(EmailVerificationRequest $emailVerificationRequest): RedirectResponse
     {
         if ($emailVerificationRequest->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('monitorings.index', absolute: false) . '?verified=1');
+            return redirect()->intended(route('dashboard', absolute: false) . '?verified=1');
         }
 
         if ($emailVerificationRequest->user()->markEmailAsVerified()) {
             event(new Verified($emailVerificationRequest->user()));
         }
 
-        return redirect()->intended(route('monitorings.index', absolute: false) . '?verified=1');
+        return redirect()->intended(route('dashboard', absolute: false) . '?verified=1');
     }
 }

--- a/docs/ux-baseline.md
+++ b/docs/ux-baseline.md
@@ -1,6 +1,6 @@
 # UX Baseline: Operations-First WebGuard UI
 
-This document records the repository-grounded baseline for issue [#442](https://github.com/marcel-breuer/webguard/issues/442), which is the research prerequisite for the UI epic [#441](https://github.com/marcel-breuer/webguard/issues/441).
+This document records the repository-grounded baseline for issue [#442](https://github.com/marcel-breuer/webguard/issues/442), which is the research prerequisite for the UI epic [#441](https://github.com/marcel-breuer/webguard/issues/441). The measurements capture the pre-change state used to choose the first #441 implementation slice; subsequent implementation PRs may reduce the friction described here.
 
 ## Scope and method
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -12,7 +12,7 @@
         <div class="flex h-16 justify-between">
             <div class="flex">
                 <div class="flex shrink-0 items-center">
-                    <a href="{{ route('monitorings.index') }}" class="flex items-center">
+                    <a href="{{ route('dashboard') }}" class="flex items-center">
                         <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="Logo" class="h-8 w-8">
                         <x-span class="ms-2 text-xl font-bold text-gray-800 dark:text-gray-100">
                             {{ __('app.name') }}
@@ -21,6 +21,10 @@
                 </div>
 
                 <div class="hidden sm:-my-px sm:ms-10 sm:flex sm:items-center sm:gap-2">
+                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+                        {{ __('dashboard.title') }}
+                    </x-nav-link>
+
                     <x-nav-link :href="route('monitorings.index')" :active="request()->routeIs('monitorings.*')">
                         {{ __('monitoring.title') }}
                     </x-nav-link>
@@ -209,6 +213,9 @@
             <div class="px-4 pb-1 pt-2 text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
                 {{ __('app.navigation.sections.operations') }}
             </div>
+            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+                {{ __('dashboard.title') }}
+            </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('monitorings.index')" :active="request()->routeIs('monitorings.*')">
                 {{ __('monitoring.title') }}
             </x-responsive-nav-link>

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -32,7 +32,7 @@ class AuditLogTest extends TestCase
             'captcha' => $this->validCaptchaValue(),
         ]);
 
-        $testResponse->assertRedirect(route('monitorings.index', absolute: false));
+        $testResponse->assertRedirect(route('dashboard', absolute: false));
 
         $model = User::query()->where('email', 'audit-registration@example.test')->firstOrFail();
         $activity = Activity::query()

--- a/tests/Feature/Auth/EmailVerificationSignatureTest.php
+++ b/tests/Feature/Auth/EmailVerificationSignatureTest.php
@@ -32,7 +32,7 @@ class EmailVerificationSignatureTest extends TestCase
         $testResponse = $this->actingAs($user)
             ->get('https://www.webguard.m-breuer.dev' . $relativeSignedPath);
 
-        $testResponse->assertRedirect(route('monitorings.index', absolute: false) . '?verified=1');
+        $testResponse->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
         $this->assertNotNull($user->fresh()->email_verified_at);
     }
 }

--- a/tests/Feature/Auth/RegistrationPrivacyConsentTest.php
+++ b/tests/Feature/Auth/RegistrationPrivacyConsentTest.php
@@ -50,7 +50,7 @@ class RegistrationPrivacyConsentTest extends TestCase
             'captcha' => $this->validCaptchaValue(),
         ]);
 
-        $testResponse->assertRedirect('/monitorings');
+        $testResponse->assertRedirect('/dashboard');
         $this->assertAuthenticated();
 
         $user = User::query()->where('email', 'jane@example.test')->first();

--- a/tests/Feature/Auth/RegistrationTermsAcceptanceTest.php
+++ b/tests/Feature/Auth/RegistrationTermsAcceptanceTest.php
@@ -73,7 +73,7 @@ class RegistrationTermsAcceptanceTest extends TestCase
 
         $testResponse = $this->post('/register', $registrationData);
 
-        $testResponse->assertRedirect(route('monitorings.index', absolute: false));
+        $testResponse->assertRedirect(route('dashboard', absolute: false));
         $this->assertAuthenticated();
 
         $user = User::query()->where('email', $registrationData['email'])->first();

--- a/tests/Feature/Auth/SocialiteControllerTest.php
+++ b/tests/Feature/Auth/SocialiteControllerTest.php
@@ -53,7 +53,7 @@ class SocialiteControllerTest extends TestCase
             'terms' => '1',
         ]);
 
-        $consentResponse->assertRedirect(route('monitorings.index'));
+        $consentResponse->assertRedirect(route('dashboard'));
         $this->assertAuthenticated();
         $this->assertDatabaseHas('users', [
             'email' => 'test@webguard.io',
@@ -88,7 +88,7 @@ class SocialiteControllerTest extends TestCase
 
         $this->assertDatabaseCount('users', 1);
         $this->assertAuthenticatedAs($user);
-        $testResponse->assertRedirect(route('monitorings.index'));
+        $testResponse->assertRedirect(route('dashboard'));
     }
 
     public function test_handle_github_callback_for_existing_socialite_user_without_consent_redirects_to_consent(): void
@@ -136,7 +136,7 @@ class SocialiteControllerTest extends TestCase
             'terms' => '1',
         ]);
 
-        $consentResponse->assertRedirect(route('monitorings.index'));
+        $consentResponse->assertRedirect(route('dashboard'));
         $user->refresh();
         $this->assertAuthenticatedAs($user);
         $this->assertSame('12345', $user->github_id);

--- a/tests/Feature/Auth/UnderCoveredAuthControllerTest.php
+++ b/tests/Feature/Auth/UnderCoveredAuthControllerTest.php
@@ -39,7 +39,7 @@ class UnderCoveredAuthControllerTest extends TestCase
 
         $this->actingAs($user)->post(route('password.confirm'), [
             'password' => 'secret-password',
-        ])->assertRedirect(route('monitorings.index', absolute: false));
+        ])->assertRedirect(route('dashboard', absolute: false));
 
         $this->assertNotNull(session('auth.password_confirmed_at'));
     }
@@ -51,7 +51,7 @@ class UnderCoveredAuthControllerTest extends TestCase
         $verifiedUser = User::factory()->create();
         $this->actingAs($verifiedUser)
             ->post(route('verification.send'))
-            ->assertRedirect(route('monitorings.index', absolute: false));
+            ->assertRedirect(route('dashboard', absolute: false));
 
         $unverifiedUser = User::factory()->unverified()->create();
         $this->actingAs($unverifiedUser)
@@ -68,7 +68,7 @@ class UnderCoveredAuthControllerTest extends TestCase
         $verifiedUser = User::factory()->create();
         $this->actingAs($verifiedUser)
             ->get(route('verification.notice'))
-            ->assertRedirect(route('monitorings.index', absolute: false));
+            ->assertRedirect(route('dashboard', absolute: false));
 
         $unverifiedUser = User::factory()->unverified()->create();
         $this->actingAs($unverifiedUser)
@@ -84,7 +84,7 @@ class UnderCoveredAuthControllerTest extends TestCase
 
         $this->actingAs($unverifiedUser)
             ->get($verificationUrl)
-            ->assertRedirect(route('monitorings.index', absolute: false) . '?verified=1');
+            ->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
 
         $this->assertTrue($unverifiedUser->refresh()->hasVerifiedEmail());
         Event::assertDispatched(Verified::class);
@@ -98,7 +98,7 @@ class UnderCoveredAuthControllerTest extends TestCase
 
         $this->actingAs($verifiedUser)
             ->get($alreadyVerifiedUrl)
-            ->assertRedirect(route('monitorings.index', absolute: false) . '?verified=1');
+            ->assertRedirect(route('dashboard', absolute: false) . '?verified=1');
     }
 
     public function test_demo_login_credentials_returns_not_found_without_demo_user(): void

--- a/tests/Feature/AuthenticatedNavigationTest.php
+++ b/tests/Feature/AuthenticatedNavigationTest.php
@@ -19,6 +19,7 @@ class AuthenticatedNavigationTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
 
         $testResponse->assertOk();
+        $testResponse->assertSeeText(__('dashboard.title'));
         $testResponse->assertSeeText(__('monitoring.title'));
         $testResponse->assertSeeText(__('incidents.analytics.title'));
         $testResponse->assertSeeText(__('status_page.title'));
@@ -30,6 +31,7 @@ class AuthenticatedNavigationTest extends TestCase
         $testResponse->assertSeeText(__('team.title'));
         $testResponse->assertSeeHtml('href="' . route('incidents.analytics') . '"');
         $testResponse->assertSeeHtml('href="' . route('status-pages.index') . '"');
+        $testResponse->assertSeeHtml('<a href="' . route('dashboard') . '" class="flex items-center">');
         $testResponse->assertDontSeeText(__('app.navigation.sections.administration'));
         $testResponse->assertDontSeeText(__('admin.dashboard.users.heading'));
     }

--- a/tests/Feature/LocalePreferenceTest.php
+++ b/tests/Feature/LocalePreferenceTest.php
@@ -125,7 +125,7 @@ class LocalePreferenceTest extends TestCase
                 'password' => 'password',
             ]);
 
-        $testResponse->assertRedirect('/monitorings');
+        $testResponse->assertRedirect('/dashboard');
         $testResponse->assertCookie(SupportedLanguage::cookieName(), SupportedLanguage::EN->value);
     }
 


### PR DESCRIPTION
Part of #441

## What changed
- Make the dashboard the default authenticated entry point while preserving intended redirects.
- Add Dashboard to the shared desktop and mobile operations navigation.
- Point the WebGuard logo to the dashboard.
- Update auth, navigation, locale, audit-log, registration, verification, and Socialite regression assertions.
- Mark the UX baseline as the pre-change reference for this implementation slice.

## Why
The UX baseline identified the post-login monitoring list as a narrow entry point. The dashboard is now the first operational overview while monitoring remains directly available in the primary navigation.

## Validation
- Docker: `composer test` (passes; existing test warnings remain)
- Docker: `composer analyse` (passes)
- Docker: `./vendor/bin/pint --test` (passes)

No new standalone tests were added; existing feature coverage was updated to lock the new entry-point and navigation behavior.