### PR TITLE
feat(ux): connect incident attention items to response workspaces

### DIFF
--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -86,9 +86,15 @@ class StatusPageController extends Controller
             });
         }
 
+        $openIncidentId = request()->string('incident_id')->toString();
+        if (! $incidents->contains(fn (Incident $incident): bool => $incident->id === $openIncidentId)) {
+            $openIncidentId = null;
+        }
+
         return view('status-pages.show', [
             'statusPage' => $statusPage,
             'incidents' => $incidents,
+            'openIncidentId' => $openIncidentId,
             'incidentTimelines' => $incidents->mapWithKeys(
                 fn (Incident $incident) => [$incident->id => $this->incidentTimelineService->events($incident)]
             ),

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -7,10 +7,12 @@ namespace App\Services;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringStatus;
 use App\Enums\NotificationDeliveryStatus;
+use App\Enums\StatusPageComponentSource;
 use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringDailyResult;
 use App\Models\NotificationChannelDelivery;
+use App\Models\StatusPage;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Carbon;
@@ -91,7 +93,11 @@ class MonitoringOverviewService
             ->sortBy('maintenance_from')
             ->values();
 
-        $attentionItems = $this->attentionItems($monitorings, $failedDeliveryCount);
+        $attentionItems = $this->attentionItems(
+            $monitorings,
+            $failedDeliveryCount,
+            $this->statusPagesByMonitoringId($user)
+        );
         $overallState = $this->overallState($summary);
 
         return [
@@ -190,20 +196,28 @@ class MonitoringOverviewService
 
     /**
      * @param  EloquentCollection<int, Monitoring>  $eloquentCollection
-     * @return Collection<int, array{type:string,monitoring:Monitoring|null,count:int|null}>
+     * @param  Collection<string, StatusPage>  $statusPagesByMonitoringId
+     * @return Collection<int, array{type:string,monitoring:Monitoring|null,count:int|null,statusPage:StatusPage|null}>
      */
-    private function attentionItems(EloquentCollection $eloquentCollection, int $failedDeliveryCount): Collection
-    {
+    private function attentionItems(
+        EloquentCollection $eloquentCollection,
+        int $failedDeliveryCount,
+        Collection $statusPagesByMonitoringId
+    ): Collection {
         $items = collect();
 
         $eloquentCollection
             ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::DOWN->value)
             ->take(5)
-            ->each(function (Monitoring $monitoring) use ($items): void {
+            ->each(function (Monitoring $monitoring) use ($items, $statusPagesByMonitoringId): void {
+                $isOpenIncident = $monitoring->latestIncident?->up_at === null
+                    && $monitoring->latestIncident !== null;
+
                 $items->push([
-                    'type' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null ? 'incident' : 'down',
+                    'type' => $isOpenIncident ? 'incident' : 'down',
                     'monitoring' => $monitoring,
                     'count' => null,
+                    'statusPage' => $isOpenIncident ? $statusPagesByMonitoringId->get($monitoring->id) : null,
                 ]);
             });
 
@@ -215,6 +229,7 @@ class MonitoringOverviewService
                 'type' => $monitoring->latestResponseResult === null ? 'unknown' : 'stale',
                 'monitoring' => $monitoring,
                 'count' => null,
+                'statusPage' => null,
             ]));
 
         if ($failedDeliveryCount > 0) {
@@ -222,10 +237,37 @@ class MonitoringOverviewService
                 'type' => 'delivery',
                 'monitoring' => null,
                 'count' => $failedDeliveryCount,
+                'statusPage' => null,
             ]);
         }
 
         return $items;
+    }
+
+    /**
+     * @return Collection<string, StatusPage>
+     */
+    private function statusPagesByMonitoringId(User $user): Collection
+    {
+        $statusPages = $user->statusPages()->with([
+            'components.monitorings',
+            'components.monitoringGroup.monitorings',
+        ])->get();
+        $statusPagesByMonitoringId = collect();
+
+        foreach ($statusPages as $statusPage) {
+            foreach ($statusPage->components as $component) {
+                $monitorings = $component->source_type === StatusPageComponentSource::MONITORING_GROUP
+                    ? $component->monitoringGroup?->monitorings ?? new EloquentCollection()
+                    : $component->monitorings;
+
+                foreach ($monitorings as $monitoring) {
+                    $statusPagesByMonitoringId->put($monitoring->id, $statusPage);
+                }
+            }
+        }
+
+        return $statusPagesByMonitoringId;
     }
 
     private function isStale(Monitoring $monitoring): bool

--- a/resources/lang/de/dashboard.php
+++ b/resources/lang/de/dashboard.php
@@ -41,6 +41,8 @@ return [
         'stale' => ':name hat kürzlich kein Ergebnis gemeldet.',
         'delivery' => ':count fehlgeschlagene Benachrichtigungszustellungen in den letzten 7 Tagen.',
         'open' => 'Details öffnen',
+        'open_incident' => 'Incident-Arbeitsbereich öffnen',
+        'status_page' => 'Response-Arbeitsbereich: :name',
         'empty' => 'Keine aktiven Aufmerksamkeitspunkte. Behalte die Übersicht oben im Blick.',
     ],
     'quick_actions' => [

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -41,6 +41,8 @@ return [
         'stale' => ':name has not reported recently.',
         'delivery' => ':count failed notification deliveries in the last 7 days.',
         'open' => 'Open details',
+        'open_incident' => 'Open incident workspace',
+        'status_page' => 'Response workspace: :name',
         'empty' => 'No active attention items. Keep an eye on the summary above.',
     ],
     'quick_actions' => [

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -121,9 +121,16 @@
                             <div class="mt-5 divide-y divide-gray-200 dark:divide-gray-700">
                                 @foreach ($attentionItems as $item)
                                     @php
+                                        $itemStatusPage = $item['statusPage'] ?? null;
+                                        $itemIncident = $item['monitoring']?->latestIncident;
                                         $itemHref = $item['type'] === 'delivery'
                                             ? route('notifications.index')
-                                            : route('monitorings.show', $item['monitoring']);
+                                            : ($itemStatusPage && $itemIncident
+                                                ? route('status-pages.show', [
+                                                    'statusPage' => $itemStatusPage,
+                                                    'incident_id' => $itemIncident->id,
+                                                ]) . '#incident-workbench-' . $itemIncident->id
+                                                : route('monitorings.show', $item['monitoring']));
                                         $itemText = match ($item['type']) {
                                             'incident' => __('dashboard.attention.incident', ['name' => $item['monitoring']->name]),
                                             'down' => __('dashboard.attention.down', ['name' => $item['monitoring']->name]),
@@ -138,6 +145,9 @@
                                             'stale' => 'warning',
                                             default => 'info',
                                         };
+                                        $itemAction = $itemStatusPage && $itemIncident
+                                            ? __('dashboard.attention.open_incident')
+                                            : __('dashboard.attention.open');
                                     @endphp
                                     <a href="{{ $itemHref }}" class="group -mx-2 flex flex-col gap-3 rounded-md px-2 py-4 transition hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:hover:bg-gray-900 sm:flex-row sm:items-center sm:justify-between">
                                         <div class="flex min-w-0 items-start gap-3">
@@ -150,10 +160,15 @@
                                                 @if ($item['monitoring'])
                                                     <p class="mt-1 break-all text-sm text-gray-500 dark:text-gray-400">{{ $item['monitoring']->target }}</p>
                                                 @endif
+                                                @if ($itemStatusPage && $itemIncident)
+                                                    <p class="mt-1 text-sm text-purple-700 dark:text-purple-300">
+                                                        {{ __('dashboard.attention.status_page', ['name' => $itemStatusPage->name]) }}
+                                                    </p>
+                                                @endif
                                             </div>
                                         </div>
                                         <span class="shrink-0 text-sm font-semibold text-purple-600 group-hover:text-purple-800 dark:text-purple-300 dark:group-hover:text-purple-200">
-                                            {{ __('dashboard.attention.open') }}
+                                            {{ $itemAction }}
                                         </span>
                                     </a>
                                 @endforeach

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -177,7 +177,7 @@
                                     </div>
                                 @endif
 
-                                <details class="rounded-lg border border-slate-200 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-950/20">
+                                <details id="incident-workbench-{{ $incident->id }}" @if ($openIncidentId === $incident->id || $incident->up_at === null) open @endif class="rounded-lg border border-slate-200 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-950/20">
                                     <summary class="cursor-pointer list-none">
                                         <div class="flex flex-wrap items-center justify-between gap-2">
                                             <div>

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -7,12 +7,14 @@ namespace Tests\Feature;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringStatus;
 use App\Enums\NotificationDeliveryStatus;
+use App\Enums\StatusPageComponentSource;
 use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\MonitoringDailyResult;
 use App\Models\MonitoringResponse;
 use App\Models\NotificationChannelDelivery;
 use App\Models\Package;
+use App\Models\StatusPage;
 use App\Models\User;
 use Illuminate\Support\Facades\Date;
 use Tests\TestCase;
@@ -89,6 +91,39 @@ class DashboardOverviewTest extends TestCase
             ->assertSeeText(__('dashboard.state.healthy.title'))
             ->assertSeeText(__('dashboard.attention.empty'))
             ->assertDontSeeText(__('dashboard.attention.incident', ['name' => $monitoring->name]));
+    }
+
+    public function test_open_incident_attention_item_links_to_the_matching_status_page_workbench(): void
+    {
+        Date::setTestNow('2026-07-15 12:00:00');
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+        $incident = Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subMinutes(20),
+        ]);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Customer Status',
+            'is_public' => true,
+        ]);
+        $statusPage->components()->create([
+            'name' => 'API',
+            'position' => 0,
+            'source_type' => StatusPageComponentSource::MANUAL,
+        ])->monitorings()->attach($monitoring->id, ['position' => 0]);
+
+        $incidentWorkspaceUrl = route('status-pages.show', [
+            'statusPage' => $statusPage,
+            'incident_id' => $incident->id,
+        ]) . '#incident-workbench-' . $incident->id;
+
+        $this->actingAs($user)->get(route('dashboard'))
+            ->assertOk()
+            ->assertSeeHtml('href="' . $incidentWorkspaceUrl . '"')
+            ->assertSeeText(__('dashboard.attention.open_incident'))
+            ->assertSeeText(__('dashboard.attention.status_page', ['name' => $statusPage->name]));
     }
 
     public function test_dashboard_includes_maintenance_delivery_and_reliability_context(): void

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -368,6 +368,38 @@ class StatusPageManagementTest extends TestCase
         $testResponse->assertNotFound();
     }
 
+    public function test_open_incident_context_expands_the_internal_response_workbench(): void
+    {
+        Date::setTestNow('2026-05-14 14:30:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'is_public' => true,
+        ]);
+        $statusPageComponent = $statusPage->components()->create(['name' => 'API', 'position' => 0]);
+        $statusPageComponent->monitorings()->attach($monitoring->id, ['position' => 0]);
+        $incident = Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subMinutes(20),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('status-pages.show', [
+                'statusPage' => $statusPage,
+                'incident_id' => $incident->id,
+            ]));
+
+        $this->assertMatchesRegularExpression(
+            '/<details id="incident-workbench-' . $incident->id . '"\s+open\s+class=/',
+            $response->getContent()
+        );
+        $response->assertOk()->assertSeeText(__('status_page.incident_workbench.heading'));
+    }
+
     public function test_user_can_add_manual_incident_update_to_status_page_incident(): void
     {
         Date::setTestNow('2026-05-14 14:30:00');


### PR DESCRIPTION
Closes #441

## What changed
- link open incident attention items on the dashboard to the matching private response workspace
- resolve status pages through both direct monitoring components and monitoring-group components
- preserve the public status page boundary while opening the selected incident workbench in context
- add English/German copy and feature coverage for the dashboard handoff and workbench state

## Why
The operations-first UX epic already established the dashboard entry point and documentation baseline. This completes the incident handoff so an operator can move from an active incident directly into the response workspace instead of stopping at the monitoring detail page.

## Validation
- Docker Pest focused tests: `tests/Feature/DashboardOverviewTest.php` and `tests/Feature/StatusPageManagementTest.php`
- Docker full test suite: 1 passed, 3,879 assertions; 624 existing environment warnings
- Docker PHPStan analysis
- Docker Pint check
- Docker Bun/Vite production build

## Risks and follow-up
The dashboard shows the first matching owned status page when a monitoring appears on multiple pages. No schema or public API changes are introduced.