### PR TITLE
fix(seo): advertise sitemap in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://webguard.marcel-breuer.dev/sitemap.xml

--- a/tests/Feature/PublicIndexingTest.php
+++ b/tests/Feature/PublicIndexingTest.php
@@ -77,13 +77,14 @@ class PublicIndexingTest extends TestCase
         unlink($sitemapPath);
     }
 
-    public function test_application_robots_file_does_not_advertise_a_marketing_sitemap(): void
+    public function test_application_robots_file_advertises_its_sitemap_without_marketing_sitemap(): void
     {
         $robotsContent = file_get_contents(public_path('robots.txt'));
 
         $this->assertIsString($robotsContent);
         $this->assertStringContainsString('User-agent: *', $robotsContent);
-        $this->assertStringNotContainsString('Sitemap:', $robotsContent);
+        $this->assertStringContainsString('Sitemap: https://webguard.marcel-breuer.dev/sitemap.xml', $robotsContent);
+        $this->assertStringNotContainsString('webguard.m-breuer.dev', $robotsContent);
     }
 
     public function test_removed_marketing_routes_are_not_served_by_core(): void


### PR DESCRIPTION
## What changed
- add the core sitemap URL to `public/robots.txt`
- update the indexing regression test to require the sitemap and reject the former marketing host

## Why
Search engine crawlers can discover the core application's public sitemap again after the marketing routes were moved out of this repository.

## Validation
- Docker Pest: `tests/Feature/PublicIndexingTest.php` — 5 passed, 36 assertions
- Docker Pint: passed
- Docker PHPStan: passed

Closes #472