### PR TITLE
feat(ui): convert monitoring forms to modals

### DIFF
--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -38,8 +38,10 @@ class MonitoringController extends Controller
      * @param  Request  $request  The HTTP request instance.
      * @return View The view displaying the list of monitorings.
      */
-    public function index(Request $request): View
-    {
+    public function index(
+        Request $request,
+        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver
+    ): View {
         /** @var User $currentUser */
         $currentUser = $request->user()->loadMissing('package');
 
@@ -182,6 +184,39 @@ class MonitoringController extends Controller
         $maintenanceStatusMap = $lengthAwarePaginator->getCollection()->mapWithKeys(function ($monitoring) {
             return [$monitoring->id => $monitoring->isUnderMaintenance()];
         });
+        $modalForm = $request->string('modal')->toString();
+        $modalMonitoring = null;
+        $modalFormData = [];
+
+        if ($modalForm === 'monitoring-create') {
+            $modalFormData = [
+                'types' => MonitoringType::cases(),
+                'serverInstances' => ServerInstance::query()->active()->orderBy('code')->get(['code']),
+                'enabledNotificationChannels' => $currentUser->enabledNotificationChannelKeys(),
+                'monitoringGroups' => $currentUser->monitoringGroups()->orderBy('name')->get(['id', 'name']),
+                'adminTeams' => $currentUser->administeredTeams()->orderBy('name')->get(['teams.id', 'teams.name']),
+            ];
+        } elseif ($modalForm === 'monitoring-edit' && $request->filled('monitoring')) {
+            $modalMonitoring = Monitoring::query()->findOrFail($request->string('monitoring')->toString());
+            abort_unless($modalMonitoring->isManageableBy($currentUser), 403);
+            $modalMonitoring->loadMissing('groups', 'team');
+            $modalFormData = [
+                'types' => MonitoringType::cases(),
+                'serverInstances' => ServerInstance::query()
+                    ->where(function ($query) use ($modalMonitoring): void {
+                        $query->where('is_active', true)
+                            ->orWhereIn('code', $modalMonitoring->preferredLocationCodes());
+                    })
+                    ->orderBy('code')
+                    ->get(['code']),
+                'enabledNotificationChannels' => $currentUser->enabledNotificationChannelKeys(),
+                'monitoringGroups' => $modalMonitoring->isPrivateOwned()
+                    ? $currentUser->monitoringGroups()->orderBy('name')->get(['id', 'name'])
+                    : collect(),
+                'adminTeams' => $currentUser->administeredTeams()->orderBy('name')->get(['teams.id', 'teams.name']),
+                'notificationPreference' => $monitoringNotificationPreferenceResolver->preferenceFor($modalMonitoring, $currentUser),
+            ];
+        }
 
         return view('monitorings.index', [
             'currentUser' => $currentUser,
@@ -194,6 +229,9 @@ class MonitoringController extends Controller
             'maintenanceStatusMap' => $maintenanceStatusMap,
             'monitoringGroups' => $currentUser->monitoringGroups()->orderBy('name')->get(['id', 'name']),
             'teams' => Team::query()->visibleTo($currentUser)->orderBy('name')->get(['id', 'name']),
+            'modalForm' => $modalForm,
+            'modalMonitoring' => $modalMonitoring,
+            'modalFormData' => $modalFormData,
         ]);
     }
 

--- a/app/Http/Controllers/MonitoringGroupController.php
+++ b/app/Http/Controllers/MonitoringGroupController.php
@@ -23,11 +23,29 @@ class MonitoringGroupController extends Controller
         /** @var User $user */
         $user = Auth::user();
 
+        $modalForm = request()->string('modal')->toString();
+        $modalMonitoringGroup = null;
+        $modalMonitorings = collect();
+
+        if ($modalForm === 'monitoring-group-create') {
+            $modalMonitorings = $this->assignableMonitorings($user);
+        } elseif ($modalForm === 'monitoring-group-edit' && request()->filled('monitoring_group')) {
+            $modalMonitoringGroup = MonitoringGroup::query()->findOrFail(request()->string('monitoring_group')->toString());
+            $this->authorizeOwner($modalMonitoringGroup);
+            $modalMonitoringGroup->load([
+                'monitorings' => fn ($query) => $query->privateOwnedBy($user),
+            ]);
+            $modalMonitorings = $this->assignableMonitorings($user);
+        }
+
         return view('monitoring-groups.index', [
             'monitoringGroups' => $user->monitoringGroups()
                 ->withCount('monitorings')
                 ->orderBy('name')
                 ->paginate(10),
+            'modalForm' => $modalForm,
+            'modalMonitoringGroup' => $modalMonitoringGroup,
+            'modalMonitorings' => $modalMonitorings,
         ]);
     }
 

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -29,12 +29,30 @@ class StatusPageController extends Controller
     {
         /** @var User $user */
         $user = Auth::user();
+        $modalForm = request()->string('modal')->toString();
+        $modalStatusPage = null;
+        $modalMonitorings = collect();
+        $modalDefaultComponents = [];
+
+        if ($modalForm === 'status-page-create') {
+            $modalMonitorings = $this->monitoringOptions();
+            $modalDefaultComponents = $this->defaultComponents();
+        } elseif ($modalForm === 'status-page-edit' && request()->filled('status_page')) {
+            $modalStatusPage = StatusPage::query()->findOrFail(request()->string('status_page')->toString());
+            $this->authorizeOwner($modalStatusPage);
+            $this->loadStatusPageComponents($modalStatusPage);
+            $modalMonitorings = $this->monitoringOptions();
+        }
 
         return view('status-pages.index', [
             'statusPages' => $user->statusPages()
                 ->withCount('components')
                 ->latest()
                 ->paginate(10),
+            'modalForm' => $modalForm,
+            'modalStatusPage' => $modalStatusPage,
+            'modalMonitorings' => $modalMonitorings,
+            'modalDefaultComponents' => $modalDefaultComponents,
         ]);
     }
 

--- a/app/Http/Requests/MonitoringGroupRequest.php
+++ b/app/Http/Requests/MonitoringGroupRequest.php
@@ -49,6 +49,24 @@ class MonitoringGroupRequest extends FormRequest
         ];
     }
 
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'monitoring-group-create') {
+            return route('monitoring-groups.index', ['modal' => 'monitoring-group-create']);
+        }
+
+        if ($this->input('modal_form') === 'monitoring-group-edit') {
+            $monitoringGroup = $this->route('monitoringGroup');
+
+            return route('monitoring-groups.index', [
+                'modal' => 'monitoring-group-edit',
+                'monitoring_group' => is_object($monitoringGroup) ? $monitoringGroup->getRouteKey() : $monitoringGroup,
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
+
     protected function prepareForValidation(): void
     {
         $description = mb_trim((string) $this->input('description', ''));

--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -253,6 +253,24 @@ class MonitoringRequest extends FormRequest
         return $rules;
     }
 
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'monitoring-create') {
+            return route('monitorings.index', ['modal' => 'monitoring-create']);
+        }
+
+        if ($this->input('modal_form') === 'monitoring-edit') {
+            $monitoring = $this->route('monitoring');
+
+            return route('monitorings.index', [
+                'modal' => 'monitoring-edit',
+                'monitoring' => is_object($monitoring) ? $monitoring->getRouteKey() : $monitoring,
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
+
     protected function notificationChannelUser(): ?User
     {
         return $this->user();

--- a/app/Http/Requests/StatusPages/StatusPageRequest.php
+++ b/app/Http/Requests/StatusPages/StatusPageRequest.php
@@ -77,6 +77,24 @@ class StatusPageRequest extends FormRequest
         });
     }
 
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'status-page-create') {
+            return route('status-pages.index', ['modal' => 'status-page-create']);
+        }
+
+        if ($this->input('modal_form') === 'status-page-edit') {
+            $statusPage = $this->route('statusPage');
+
+            return route('status-pages.index', [
+                'modal' => 'status-page-edit',
+                'status_page' => is_object($statusPage) ? $statusPage->getRouteKey() : $statusPage,
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
+
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -16,6 +16,7 @@ import uptimeCalendar from './components/uptime-calendar';
 import demoLogin from './components/demoLogin';
 import asyncTable from './components/async-table';
 import confirmDialog, { registerConfirmableForms } from './components/confirm-dialog';
+import formModalLoader from './components/form-modal-loader';
 
 const decodeImprintPayload = (payload: string): string => {
     try {
@@ -67,6 +68,7 @@ Alpine.data('uptimeCalendar', uptimeCalendar);
 Alpine.data('demoLogin', demoLogin);
 Alpine.data('asyncTable', asyncTable);
 Alpine.data('confirmDialog', confirmDialog);
+Alpine.data('formModalLoader', formModalLoader);
 
 window.Alpine = Alpine;
 window.Chart = Chart;

--- a/resources/js/components/form-modal-loader.ts
+++ b/resources/js/components/form-modal-loader.ts
@@ -1,0 +1,95 @@
+type FormModalLoader = {
+    content: string;
+    error: string;
+    errorMessage: string;
+    loading: boolean;
+    init(): void;
+    load(trigger: HTMLElement): Promise<void>;
+};
+
+const loaders = new Map<string, FormModalLoader>();
+let globalListenerRegistered = false;
+
+const registerGlobalListener = (): void => {
+    if (globalListenerRegistered) {
+        return;
+    }
+
+    document.addEventListener('click', (event: MouseEvent): void => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+
+        const trigger = target.closest<HTMLElement>('[data-form-modal-trigger]');
+        const modalName = trigger?.dataset.formModalName;
+        const loader = modalName ? loaders.get(modalName) : undefined;
+
+        if (!trigger || !loader) {
+            return;
+        }
+
+        event.preventDefault();
+        void loader.load(trigger);
+    });
+
+    globalListenerRegistered = true;
+};
+
+export default (): FormModalLoader => ({
+    content: '',
+    error: '',
+    errorMessage: '',
+    loading: false,
+
+    init(): void {
+        registerGlobalListener();
+        this.errorMessage = (this as any).$el.dataset.formModalError ?? '';
+
+        const modal = (this as any).$el.querySelector('[data-form-modal]') as HTMLElement | null;
+        const modalName = modal?.dataset.formModal;
+        if (modalName) {
+            loaders.set(modalName, this);
+        }
+    },
+
+    async load(trigger: HTMLElement): Promise<void> {
+        const url = trigger.getAttribute('href') ?? trigger.dataset.formModalUrl;
+        const modalName = trigger.dataset.formModalName;
+
+        if (!url || !modalName) {
+            return;
+        }
+
+        const requestUrl = new URL(url, window.location.origin);
+        requestUrl.searchParams.set('modal', '1');
+        this.content = '';
+        this.error = '';
+        this.loading = true;
+        window.dispatchEvent(new CustomEvent('open-form-modal', { detail: modalName }));
+
+        try {
+            const response = await fetch(requestUrl.toString(), {
+                headers: {
+                    Accept: 'text/html',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`Form modal request failed with status ${response.status}`);
+            }
+
+            this.content = await response.text();
+            await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+            const contentElement = (this as any).$refs.content as HTMLElement | undefined;
+            if (contentElement) {
+                window.Alpine.initTree(contentElement);
+            }
+        } catch {
+            this.error = this.errorMessage;
+        } finally {
+            this.loading = false;
+        }
+    },
+});

--- a/resources/lang/de/app.php
+++ b/resources/lang/de/app.php
@@ -13,6 +13,7 @@ return [
     'messages' => [
         'copied_to_clipboard' => 'In die Zwischenablage kopiert!',
         'loading' => 'Wird geladen...',
+        'form_modal_load_error' => 'Das Formular konnte nicht geladen werden. Bitte verwenden Sie stattdessen den Link zur vollständigen Seite.',
     ],
     'multi_select' => [
         'placeholder' => 'Optionen auswählen',

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -13,6 +13,7 @@ return [
     'messages' => [
         'copied_to_clipboard' => 'Copied to clipboard!',
         'loading' => 'Loading...',
+        'form_modal_load_error' => 'The form could not be loaded. Please use the full-page link instead.',
     ],
     'multi_select' => [
         'placeholder' => 'Select options',

--- a/resources/views/monitoring-groups/_form.blade.php
+++ b/resources/views/monitoring-groups/_form.blade.php
@@ -51,7 +51,11 @@
     </div>
 
     <div class="flex flex-wrap justify-end gap-2">
-        <x-secondary-button :href="route('monitoring-groups.index')">
+        <x-secondary-button
+            :href="isset($modal) && $modal ? null : route('monitoring-groups.index')"
+            type="button"
+            x-on:click="$dispatch('close-form-modal', 'monitoring-group-form-modal')"
+        >
             {{ __('button.cancel') }}
         </x-secondary-button>
         <x-primary-button>

--- a/resources/views/monitoring-groups/_modal-form.blade.php
+++ b/resources/views/monitoring-groups/_modal-form.blade.php
@@ -1,0 +1,6 @@
+<div class="p-6">
+    <form method="POST" action="{{ $action }}">
+        <input type="hidden" name="modal_form" value="monitoring-group-{{ isset($monitoringGroup) ? 'edit' : 'create' }}">
+        @include('monitoring-groups._form', ['modal' => true])
+    </form>
+</div>

--- a/resources/views/monitoring-groups/create.blade.php
+++ b/resources/views/monitoring-groups/create.blade.php
@@ -1,3 +1,6 @@
+@if (request()->boolean('modal'))
+    @include('monitoring-groups._modal-form', ['action' => route('monitoring-groups.store')])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">{{ __('monitoring_group.create.title') }}</x-heading>
@@ -15,3 +18,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/monitoring-groups/edit.blade.php
+++ b/resources/views/monitoring-groups/edit.blade.php
@@ -1,3 +1,6 @@
+@if (request()->boolean('modal'))
+    @include('monitoring-groups._modal-form', ['action' => route('monitoring-groups.update', $monitoringGroup)])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">{{ __('monitoring_group.edit.title', ['group' => $monitoringGroup->name]) }}</x-heading>
@@ -15,3 +18,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/monitoring-groups/index.blade.php
+++ b/resources/views/monitoring-groups/index.blade.php
@@ -3,19 +3,21 @@
         <x-heading type="h1">{{ __('monitoring_group.title') }}</x-heading>
 
         @if (!Auth::user()->isDemo())
-            <x-primary-button :href="route('monitoring-groups.create')" class="sm:ml-auto">
+            <x-primary-button :href="route('monitoring-groups.create')" class="sm:ml-auto"
+                data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
                 {{ __('button.create') }}
             </x-primary-button>
         @endif
     </x-slot>
 
     <x-main>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
         @if ($monitoringGroups->isEmpty())
             <x-container class="text-center">
                 <x-heading type="h2">{{ __('monitoring_group.empty.title') }}</x-heading>
                 <x-paragraph space="true">{{ __('monitoring_group.empty.text') }}</x-paragraph>
                 @if (!Auth::user()->isDemo())
-                    <x-primary-button :href="route('monitoring-groups.create')">
+            <x-primary-button :href="route('monitoring-groups.create')" data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
                         {{ __('button.create') }}
                     </x-primary-button>
                 @endif
@@ -45,7 +47,7 @@
                                             {{ __('monitoring_group.actions.publish_status_page') }}
                                         </x-secondary-button>
                                     </form>
-                                    <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)">
+                                    <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)" data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
                                         {{ __('button.edit') }}
                                     </x-secondary-button>
                                     <form method="POST" action="{{ route('monitoring-groups.destroy', $monitoringGroup) }}"
@@ -67,5 +69,31 @@
                 {{ $monitoringGroups->links() }}
             </div>
         @endif
+
+        <x-form-modal name="monitoring-group-form-modal" title="{{ __('monitoring_group.title') }}"
+            description="{{ __('monitoring_group.form.monitorings') }}" max-width="3xl"
+            :show="in_array($modalForm, ['monitoring-group-create', 'monitoring-group-edit'], true)">
+            <div class="p-6" x-ref="content">
+                @if ($modalForm === 'monitoring-group-create')
+                    @include('monitoring-groups._modal-form', [
+                        'action' => route('monitoring-groups.store'),
+                        'monitorings' => $modalMonitorings,
+                        'modal' => true,
+                    ])
+                @elseif ($modalForm === 'monitoring-group-edit' && $modalMonitoringGroup)
+                    @include('monitoring-groups._modal-form', [
+                        'action' => route('monitoring-groups.update', $modalMonitoringGroup),
+                        'monitoringGroup' => $modalMonitoringGroup,
+                        'monitorings' => $modalMonitorings,
+                        'modal' => true,
+                    ])
+                @else
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                @endif
+            </div>
+        </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -574,7 +574,11 @@
         </details>
 
         <div class="flex flex-wrap justify-end gap-2">
-            <x-secondary-button :href="isset($monitoring) ? route('monitorings.show', $monitoring) : route('monitorings.index')">
+            <x-secondary-button
+                :href="isset($modal) && $modal ? null : (isset($monitoring) ? route('monitorings.show', $monitoring) : route('monitorings.index'))"
+                type="button"
+                x-on:click="$dispatch('close-form-modal', 'monitoring-form-modal')"
+            >
                 {{ __('button.cancel') }}
             </x-secondary-button>
             <x-primary-button>{{ isset($monitoring) ? __('button.update') : __('button.create') }}</x-primary-button>

--- a/resources/views/monitorings/_modal-form.blade.php
+++ b/resources/views/monitorings/_modal-form.blade.php
@@ -1,0 +1,16 @@
+<div class="p-6">
+    @if (isset($monitoring))
+        @include('monitorings._ownership')
+    @endif
+
+    <form method="POST" action="{{ $action }}">
+        <input type="hidden" name="modal_form" value="monitoring-{{ isset($monitoring) ? 'edit' : 'create' }}">
+        @include('monitorings._form', ['modal' => true])
+    </form>
+
+    @if (isset($monitoring))
+        <div class="mt-6">
+            @include('monitorings._notification_preferences', ['fieldIdPrefix' => 'modal_edit_notification_preference'])
+        </div>
+    @endif
+</div>

--- a/resources/views/monitorings/create.blade.php
+++ b/resources/views/monitorings/create.blade.php
@@ -3,6 +3,10 @@
     use App\Enums\MonitoringLifecycleStatus;
 @endphp
 
+@if (request()->boolean('modal'))
+    @include('monitorings._modal-form', ['action' => route('monitorings.store')])
+@else
+
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">
@@ -21,3 +25,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/monitorings/edit.blade.php
+++ b/resources/views/monitorings/edit.blade.php
@@ -4,6 +4,10 @@
     use App\Enums\HttpMethod;
 @endphp
 
+@if (request()->boolean('modal'))
+    @include('monitorings._modal-form', ['action' => route('monitorings.update', $monitoring)])
+@else
+
 <x-app-layout>
     <x-slot name="header">
         <x-heading>
@@ -28,6 +32,7 @@
         @include('monitorings._notification_preferences', ['fieldIdPrefix' => 'edit_notification_preference'])
     </x-main>
 </x-app-layout>
+@endif
 <script>
     function copyToClipboard(elementId) {
         const element = document.getElementById(elementId);

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -22,13 +22,15 @@
         </x-heading>
 
         @if ($canCreateMonitoring)
-            <x-primary-button :href="route('monitorings.create')" class="sm:ml-auto">
+            <x-primary-button :href="route('monitorings.create')" class="sm:ml-auto"
+                data-form-modal-trigger data-form-modal-name="monitoring-form-modal">
                 {{ __('button.create') }}
             </x-primary-button>
         @endif
     </x-slot>
 
     <x-main>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
         <x-container class="sm:flex sm:flex-wrap sm:items-center sm:justify-between sm:gap-4" space="true">
             <x-paragraph>
                 <b>{{ __('monitoring.index.total.current') }}</b>: {{ $monitoringsTotal }}
@@ -394,7 +396,7 @@
                         {{ __('monitoring.no_monitoring.text') }}
                     </x-paragraph>
                     @if ($canCreateMonitoring)
-                        <x-primary-button :href="route('monitorings.create')">
+                        <x-primary-button :href="route('monitorings.create')" data-form-modal-trigger data-form-modal-name="monitoring-form-modal">
                             {{ __('button.create') }}
                         </x-primary-button>
                     @endif
@@ -462,6 +464,11 @@
                                     class="focus:outline-hidden inline-flex w-max cursor-pointer items-center rounded-md border border-purple-500 bg-white px-4 py-2 font-semibold uppercase tracking-widest text-purple-600 transition duration-150 ease-in-out hover:bg-purple-50 focus:bg-purple-50 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 active:bg-purple-100 dark:bg-gray-700 dark:text-purple-300">
                                     {{ __('button.show') }}
                                 </a>
+                                <a href="#" x-bind:href="'/monitorings/' + id + '/edit'"
+                                    data-form-modal-trigger data-form-modal-name="monitoring-form-modal"
+                                    class="focus:outline-hidden inline-flex w-max cursor-pointer items-center rounded-md border border-purple-500 bg-white px-4 py-2 font-semibold uppercase tracking-widest text-purple-600 transition duration-150 ease-in-out hover:bg-purple-50 focus:bg-purple-50 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 active:bg-purple-100 dark:bg-gray-700 dark:text-purple-300">
+                                    {{ __('button.edit') }}
+                                </a>
                             </div>
                         </div>
                     </x-container>
@@ -469,6 +476,29 @@
             </template>
 
             {{ $monitorings->withQueryString()->links() }}
+
+            <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
+                description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl"
+                :show="in_array($modalForm, ['monitoring-create', 'monitoring-edit'], true)">
+                <div class="p-6" x-ref="content">
+                    @if ($modalForm === 'monitoring-create')
+                        @include('monitorings._modal-form', array_merge($modalFormData, [
+                            'action' => route('monitorings.store'),
+                            'modal' => true,
+                        ]))
+                    @elseif ($modalForm === 'monitoring-edit' && $modalMonitoring)
+                        @include('monitorings._modal-form', array_merge($modalFormData, [
+                            'action' => route('monitorings.update', $modalMonitoring),
+                            'monitoring' => $modalMonitoring,
+                            'modal' => true,
+                        ]))
+                    @else
+                        <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                        <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                        <div x-html="content"></div>
+                    @endif
+                </div>
+            </x-form-modal>
         </div>
     </x-main>
 

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -31,7 +31,7 @@
             @endif
         </x-heading>
 
-        <div class="ml-auto flex flex-wrap items-start gap-2 sm:items-center">
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}" class="ml-auto flex flex-wrap items-start gap-2 sm:items-center">
 
             @if ($canManageMonitoring)
                 <div class="relative" x-data="{ open: false }">
@@ -45,6 +45,7 @@
                         x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
                         class="absolute z-10 mt-2 min-w-full rounded-md bg-white shadow-lg" style="display: none">
                         <a href="{{ route('monitorings.edit', ['monitoring' => $monitoring->id]) }}"
+                            data-form-modal-trigger data-form-modal-name="monitoring-form-modal"
                             class="block px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
                             {{ __('monitoring.actions.edit') }}
                         </a>
@@ -73,6 +74,15 @@
             <x-secondary-button :href="route('monitorings.index')">
                 {{ __('button.back') }}
             </x-secondary-button>
+
+            <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
+                description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
         </div>
     </x-slot>
 

--- a/resources/views/status-pages/_form.blade.php
+++ b/resources/views/status-pages/_form.blade.php
@@ -28,6 +28,9 @@
         @isset($method)
             @method($method)
         @endisset
+        @if (isset($modal) && $modal)
+            <input type="hidden" name="modal_form" value="status-page-{{ isset($statusPage) ? 'edit' : 'create' }}">
+        @endif
 
         <div class="space-y-6"
             x-data="{
@@ -128,7 +131,11 @@
                 <x-primary-button>
                     {{ $submitLabel }}
                 </x-primary-button>
-                <x-secondary-button :href="route('status-pages.index')">
+                <x-secondary-button
+                    :href="isset($modal) && $modal ? null : route('status-pages.index')"
+                    type="button"
+                    x-on:click="$dispatch('close-form-modal', 'status-page-form-modal')"
+                >
                     {{ __('button.cancel') }}
                 </x-secondary-button>
             </div>

--- a/resources/views/status-pages/create.blade.php
+++ b/resources/views/status-pages/create.blade.php
@@ -1,3 +1,12 @@
+@if (request()->boolean('modal'))
+    <div class="p-6">
+        @include('status-pages._form', [
+            'action' => route('status-pages.store'),
+            'submitLabel' => __('button.create'),
+            'modal' => true,
+        ])
+    </div>
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">{{ __('status_page.create.title') }}</x-heading>
@@ -10,3 +19,4 @@
         ])
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/status-pages/edit.blade.php
+++ b/resources/views/status-pages/edit.blade.php
@@ -1,3 +1,13 @@
+@if (request()->boolean('modal'))
+    <div class="p-6">
+        @include('status-pages._form', [
+            'action' => route('status-pages.update', $statusPage),
+            'method' => 'PATCH',
+            'submitLabel' => __('button.update'),
+            'modal' => true,
+        ])
+    </div>
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">{{ __('status_page.edit.title', ['statusPage' => $statusPage->name]) }}</x-heading>
@@ -11,3 +21,4 @@
         ])
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -3,19 +3,21 @@
         <x-heading type="h1">{{ __('status_page.title') }}</x-heading>
 
         @if (!Auth::user()->isDemo())
-            <x-primary-button :href="route('status-pages.create')" class="sm:ml-auto">
+            <x-primary-button :href="route('status-pages.create')" class="sm:ml-auto"
+                data-form-modal-trigger data-form-modal-name="status-page-form-modal">
                 {{ __('button.create') }}
             </x-primary-button>
         @endif
     </x-slot>
 
     <x-main>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
         @if ($statusPages->isEmpty())
             <x-container class="text-center">
                 <x-heading type="h2">{{ __('status_page.empty.title') }}</x-heading>
                 <x-paragraph space="true">{{ __('status_page.empty.text') }}</x-paragraph>
                 @if (!Auth::user()->isDemo())
-                    <x-primary-button :href="route('status-pages.create')">
+                    <x-primary-button :href="route('status-pages.create')" data-form-modal-trigger data-form-modal-name="status-page-form-modal">
                         {{ __('button.create') }}
                     </x-primary-button>
                 @endif
@@ -44,6 +46,12 @@
                                 <x-secondary-button :href="route('status-pages.show', $statusPage)">
                                     {{ __('button.show') }}
                                 </x-secondary-button>
+                                @if (!Auth::user()->isDemo())
+                                    <x-secondary-button :href="route('status-pages.edit', $statusPage)"
+                                        data-form-modal-trigger data-form-modal-name="status-page-form-modal">
+                                        {{ __('button.edit') }}
+                                    </x-secondary-button>
+                                @endif
                             </div>
                         </div>
                     </x-container>
@@ -54,5 +62,36 @@
                 {{ $statusPages->links() }}
             </div>
         @endif
+
+        <x-form-modal name="status-page-form-modal" title="{{ __('status_page.title') }}"
+            description="{{ __('status_page.form.components') }}" max-width="5xl"
+            :show="in_array($modalForm, ['status-page-create', 'status-page-edit'], true)">
+            <div class="p-6" x-ref="content">
+                @if ($modalForm === 'status-page-create')
+                    @include('status-pages._form', [
+                        'action' => route('status-pages.store'),
+                        'submitLabel' => __('button.create'),
+                        'monitorings' => $modalMonitorings,
+                        'defaultComponents' => $modalDefaultComponents,
+                        'modal' => true,
+                    ])
+                @elseif ($modalForm === 'status-page-edit' && $modalStatusPage)
+                    @include('status-pages._form', [
+                        'action' => route('status-pages.update', $modalStatusPage),
+                        'method' => 'PATCH',
+                        'submitLabel' => __('button.update'),
+                        'statusPage' => $modalStatusPage,
+                        'monitorings' => $modalMonitorings,
+                        'defaultComponents' => [],
+                        'modal' => true,
+                    ])
+                @else
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                @endif
+            </div>
+        </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -15,12 +15,13 @@
             </div>
         </div>
 
-        <div class="ml-auto flex flex-wrap gap-2">
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}" class="ml-auto flex flex-wrap gap-2">
             <x-secondary-button :href="route('incidents.analytics')">
                 {{ __('incidents.analytics.link') }}
             </x-secondary-button>
             @if (!Auth::user()->isDemo())
-                <x-secondary-button :href="route('status-pages.edit', $statusPage)">
+                <x-secondary-button :href="route('status-pages.edit', $statusPage)"
+                    data-form-modal-trigger data-form-modal-name="status-page-form-modal">
                     {{ __('button.edit') }}
                 </x-secondary-button>
                 <form method="POST" action="{{ route('status-pages.destroy', $statusPage) }}"
@@ -35,6 +36,15 @@
             <x-secondary-button :href="route('status-pages.index')">
                 {{ __('button.back') }}
             </x-secondary-button>
+
+            <x-form-modal name="status-page-form-modal" title="{{ __('status_page.title') }}"
+                description="{{ __('status_page.form.components') }}" max-width="5xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
         </div>
     </x-slot>
 

--- a/tests/Feature/FormModalCrudFlowTest.php
+++ b/tests/Feature/FormModalCrudFlowTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\StatusPage;
+use App\Models\User;
+use Tests\TestCase;
+
+class FormModalCrudFlowTest extends TestCase
+{
+    public function test_monitoring_create_and_edit_endpoints_return_modal_fragments_and_index_exposes_triggers(): void
+    {
+        $user = User::factory()->create([
+            'package_id' => Package::factory()->create(['monitoring_limit' => 10])->id,
+        ]);
+        $serverInstance = ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+        ]);
+
+        $this->actingAs($user)->get(route('monitorings.create', ['modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('action="' . route('monitorings.store') . '"');
+        $this->actingAs($user)->get(route('monitorings.edit', [$monitoring, 'modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('action="' . route('monitorings.update', $monitoring) . '"');
+        $this->actingAs($user)->get(route('monitorings.index'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="monitoring-form-modal"');
+    }
+
+    public function test_monitoring_group_create_and_edit_endpoints_return_modal_fragments(): void
+    {
+        $user = User::factory()->create(['package_id' => Package::factory()->create()->id]);
+        $monitoringGroup = MonitoringGroup::factory()->for($user)->create();
+
+        $this->actingAs($user)->get(route('monitoring-groups.create', ['modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('action="' . route('monitoring-groups.store') . '"');
+        $this->actingAs($user)->get(route('monitoring-groups.edit', [$monitoringGroup, 'modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('action="' . route('monitoring-groups.update', $monitoringGroup) . '"');
+        $this->actingAs($user)->get(route('monitoring-groups.index'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="monitoring-group-form-modal"');
+    }
+
+    public function test_status_page_create_and_edit_endpoints_return_modal_fragments(): void
+    {
+        $user = User::factory()->create(['package_id' => Package::factory()->create()->id]);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'is_public' => true,
+        ]);
+
+        $this->actingAs($user)->get(route('status-pages.create', ['modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('action="' . route('status-pages.store') . '"');
+        $this->actingAs($user)->get(route('status-pages.edit', [$statusPage, 'modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('action="' . route('status-pages.update', $statusPage) . '"');
+        $this->actingAs($user)->get(route('status-pages.index'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="status-page-form-modal"');
+    }
+
+    public function test_validation_redirects_reopen_the_matching_modal_context(): void
+    {
+        $user = User::factory()->create(['package_id' => Package::factory()->create()->id]);
+        $monitoringGroup = MonitoringGroup::factory()->for($user)->create();
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'is_public' => true,
+        ]);
+
+        $monitoringResponse = $this->actingAs($user)
+            ->from(route('monitorings.index'))
+            ->post(route('monitorings.store'), ['modal_form' => 'monitoring-create']);
+        $monitoringResponse->assertRedirect(route('monitorings.index', ['modal' => 'monitoring-create']));
+        $this->get($monitoringResponse->headers->get('Location'))
+            ->assertOk()
+            ->assertSeeText(__('monitoring.form.sections.basic'));
+
+        $groupResponse = $this->actingAs($user)
+            ->from(route('monitoring-groups.index'))
+            ->post(route('monitoring-groups.update', $monitoringGroup), [
+                '_method' => 'PATCH',
+                'modal_form' => 'monitoring-group-edit',
+            ]);
+        $groupResponse->assertRedirect(route('monitoring-groups.index', [
+            'modal' => 'monitoring-group-edit',
+            'monitoring_group' => $monitoringGroup->getRouteKey(),
+        ]));
+
+        $statusResponse = $this->actingAs($user)
+            ->from(route('status-pages.index'))
+            ->patch(route('status-pages.update', $statusPage), [
+                'modal_form' => 'status-page-edit',
+            ]);
+        $statusResponse->assertRedirect(route('status-pages.index', [
+            'modal' => 'status-page-edit',
+            'status_page' => $statusPage->getRouteKey(),
+        ]));
+    }
+}


### PR DESCRIPTION
Closes #479

## What changed

- Added the shared async form-modal loader for CRUD forms.
- Converted Monitoring, Monitoring Groups, and Status Pages create/edit entry points to open in modals.
- Kept direct create/edit URLs working as full-page fallbacks.
- Reopened the matching modal with validation errors and old input after failed submissions.
- Added focused feature coverage for modal fragments, triggers, and validation redirects.

## Why

This is the first implementation slice of the form-modal migration. It gives the three monitoring management areas one consistent create/edit interaction while preserving accessibility and existing full-page behavior.

## Testing

- Docker Pest: targeted and related feature/component tests passed (43 tests, 279 assertions).
- Docker PHPStan: passed.
- Docker Pint check: passed.
- Docker Vite production build: passed.

## Risks and limitations

- Authenticated browser interaction could not be completed locally because the demo-login endpoint returned 404 and no usable local credentials were available. Server-rendered flows and the production frontend build were verified.
- The remaining form areas are tracked separately in #480 and #481, with final QA in #482.