### PR TITLE
feat(ui): convert team and profile forms to modals

### DIFF
--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdatePasswordRequest;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules\Password;
 
 /**
  * Class PasswordController
@@ -23,12 +22,9 @@ class PasswordController extends Controller
      * @param  Request  $request  The HTTP request instance containing the new password data.
      * @return RedirectResponse A redirect response after updating the password.
      */
-    public function update(Request $request): RedirectResponse
+    public function update(UpdatePasswordRequest $request): RedirectResponse
     {
-        $validated = $request->validateWithBag('updatePassword', [
-            'current_password' => ['required', 'current_password'],
-            'password' => ['required', Password::defaults(), 'confirmed'],
-        ]);
+        $validated = $request->validated();
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -36,9 +36,13 @@ class ProfileController extends Controller
     public function edit(Request $request): View
     {
         $user = $request->user();
+        $modalForm = $request->input('modal');
+        $isProfileInformationForm = $modalForm === 'profile-information';
+        $isPasswordForm = $modalForm === 'profile-password';
         $showNotificationChannelsHint = false;
 
-        if ($user && ! $user->hasEnabledNotificationChannels() && $user->notification_channels_hint_seen_at === null) {
+        if (($request->boolean('full') || $isProfileInformationForm) && $user
+            && ! $user->hasEnabledNotificationChannels() && $user->notification_channels_hint_seen_at === null) {
             $user->forceFill([
                 'notification_channels_hint_seen_at' => now(),
             ])->save();
@@ -46,10 +50,22 @@ class ProfileController extends Controller
             $showNotificationChannelsHint = true;
         }
 
+        if ($request->ajax() && ($isProfileInformationForm || $isPasswordForm)) {
+            return view($isProfileInformationForm
+                ? 'profile.partials.update-profile-information-form'
+                : 'profile.partials.update-password-form', [
+                    'user' => $user,
+                    'showNotificationChannelsHint' => $showNotificationChannelsHint,
+                    'modal' => true,
+                ]);
+        }
+
         return view('profile.edit', [
             'user' => $user,
             'token' => $user?->currentAccessToken(),
             'showNotificationChannelsHint' => $showNotificationChannelsHint,
+            'fullPage' => $request->boolean('full'),
+            'modalForm' => $modalForm,
         ]);
     }
 

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -14,10 +14,19 @@ use Illuminate\View\View;
 
 class TeamController extends Controller
 {
-    public function index(Request $request): View
+    public function index(Request $request, TeamMembershipService $teamMembershipService): View
     {
         /** @var User $user */
         $user = $request->user();
+        $modalForm = $request->input('modal');
+        $modalTeam = null;
+
+        if ($modalForm === 'team-create') {
+            abort_if($user->isDemo(), 403);
+        } elseif ($modalForm === 'team-edit' && $request->filled('team')) {
+            $modalTeam = Team::query()->findOrFail($request->string('team')->toString());
+            $teamMembershipService->assertAdmin($modalTeam, $user);
+        }
 
         return view('teams.index', [
             'teams' => Team::query()
@@ -25,12 +34,21 @@ class TeamController extends Controller
                 ->withCount(['memberships', 'monitorings'])
                 ->orderBy('name')
                 ->paginate(10),
+            'modalForm' => $modalForm,
+            'modalTeam' => $modalTeam,
         ]);
     }
 
-    public function create(): View
+    public function create(Request $request): View
     {
         abort_if(auth()->user()->isDemo(), 403);
+
+        if ($request->boolean('modal')) {
+            return view('teams._modal-form', [
+                'action' => route('teams.store'),
+                'modalForm' => 'team-create',
+            ]);
+        }
 
         return view('teams.create');
     }
@@ -60,11 +78,19 @@ class TeamController extends Controller
         ]);
     }
 
-    public function edit(Team $team, TeamMembershipService $teamMembershipService): View
+    public function edit(Request $request, Team $team, TeamMembershipService $teamMembershipService): View
     {
         /** @var User $user */
         $user = auth()->user();
         $teamMembershipService->assertAdmin($team, $user);
+
+        if ($request->boolean('modal')) {
+            return view('teams._modal-form', [
+                'action' => route('teams.update', $team),
+                'team' => $team,
+                'modalForm' => 'team-edit',
+            ]);
+        }
 
         return view('teams.edit', ['team' => $team]);
     }

--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -109,6 +109,15 @@ class ProfileRequest extends FormRequest
         ]);
     }
 
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'profile-information') {
+            return route('profile.edit', ['modal' => 'profile-information']);
+        }
+
+        return parent::getRedirectUrl();
+    }
+
     private function normalizeNullableFrequency(string $key): ?string
     {
         $value = $this->input($key);

--- a/app/Http/Requests/Teams/TeamRequest.php
+++ b/app/Http/Requests/Teams/TeamRequest.php
@@ -23,4 +23,20 @@ class TeamRequest extends FormRequest
             'description' => ['nullable', 'string', 'max:1000'],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'team-create') {
+            return route('teams.index', ['modal' => 'team-create']);
+        }
+
+        if ($this->input('modal_form') === 'team-edit') {
+            return route('teams.index', [
+                'modal' => 'team-edit',
+                'team' => $this->route('team'),
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/app/Http/Requests/UpdatePasswordRequest.php
+++ b/app/Http/Requests/UpdatePasswordRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class UpdatePasswordRequest extends FormRequest
+{
+    protected $errorBag = 'updatePassword';
+
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'current_password' => ['required', 'current_password'],
+            'password' => ['required', Password::defaults(), 'confirmed'],
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'profile-password') {
+            return route('profile.edit', ['modal' => 'profile-password']);
+        }
+
+        return parent::getRedirectUrl();
+    }
+}

--- a/resources/js/components/form-modal-loader.ts
+++ b/resources/js/components/form-modal-loader.ts
@@ -62,7 +62,7 @@ export default (): FormModalLoader => ({
         }
 
         const requestUrl = new URL(url, window.location.origin);
-        requestUrl.searchParams.set('modal', '1');
+        requestUrl.searchParams.set('modal', trigger.dataset.formModalParam ?? '1');
         this.content = '';
         this.error = '';
         this.loading = true;

--- a/resources/lang/de/profile.php
+++ b/resources/lang/de/profile.php
@@ -141,6 +141,7 @@ return [
     'actions' => [
         'update_password' => 'Passwort aktualisieren',
         'update_profile' => 'Profil aktualisieren',
+        'open_full_page' => 'Editor als vollständige Seite öffnen',
         'delete_account' => 'Konto löschen',
         'send_verification_email' => 'Klicken Sie hier, um die Bestätigungs-E-Mail erneut zu senden',
     ],

--- a/resources/lang/en/profile.php
+++ b/resources/lang/en/profile.php
@@ -141,6 +141,7 @@ return [
     'actions' => [
         'update_password' => 'Update Password',
         'update_profile' => 'Update Profile',
+        'open_full_page' => 'Open full-page editor',
         'delete_account' => 'Delete Account',
         'send_verification_email' => 'Click here to re-send the verification email',
     ],

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,19 +1,86 @@
 <x-app-layout>
     <x-slot name="header">
-        <x-heading type="h1">
-            {{ __('profile.title') }}
-        </x-heading>
+        <x-heading type="h1">{{ __('profile.title') }}</x-heading>
     </x-slot>
 
     <x-main>
-        @include('profile.partials.update-profile-information-form')
+        <div class="space-y-6">
+            @if ($fullPage)
+                @include('profile.partials.update-profile-information-form')
+                @include('profile.partials.update-password-form')
+            @else
+                <x-container>
+                    <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
+                    <x-paragraph>{{ __('profile.information.description') }}</x-paragraph>
 
-        @include('profile.partials.update-password-form')
+                    <div class="mt-4 flex flex-wrap items-center justify-between gap-4">
+                        <div class="text-sm text-gray-600 dark:text-gray-300">
+                            <p class="font-semibold text-gray-950 dark:text-gray-50">{{ $user->name }}</p>
+                            <p>{{ $user->email }}</p>
+                            <p class="mt-2">{{ __('profile.notification_settings.heading') }}: {{ __('profile.notification_settings.description') }}</p>
+                        </div>
 
-        @include('profile.partials.api-configuration')
+                        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}"
+                            class="flex flex-wrap gap-2">
+                            <x-primary-button :href="route('profile.edit', ['modal' => 'profile-information'])"
+                                data-form-modal-trigger data-form-modal-name="profile-information-form-modal"
+                                data-form-modal-param="profile-information">
+                                {{ __('profile.actions.update_profile') }}
+                            </x-primary-button>
 
-        @include('profile.partials.api-docs')
+                            <x-form-modal name="profile-information-form-modal" title="{{ __('profile.information.title') }}"
+                                description="{{ __('profile.notification_settings.description') }}" max-width="6xl"
+                                :show="$modalForm === 'profile-information'">
+                                <div class="p-6" x-ref="content">
+                                    @if ($modalForm === 'profile-information')
+                                        @include('profile.partials.update-profile-information-form', ['modal' => true])
+                                    @else
+                                        <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                                        <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                                        <div x-html="content"></div>
+                                    @endif
+                                </div>
+                            </x-form-modal>
+                        </div>
+                    </div>
+                </x-container>
 
-        @include('profile.partials.delete-user-form')
+                <x-container>
+                    <x-heading type="h2">{{ __('profile.update_password.heading') }}</x-heading>
+                    <x-paragraph>{{ __('profile.update_password.description') }}</x-paragraph>
+
+                    <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}"
+                        class="mt-4">
+                        <x-primary-button :href="route('profile.edit', ['modal' => 'profile-password'])"
+                            data-form-modal-trigger data-form-modal-name="profile-password-form-modal"
+                            data-form-modal-param="profile-password">
+                            {{ __('profile.actions.update_password') }}
+                        </x-primary-button>
+
+                        <x-form-modal name="profile-password-form-modal" title="{{ __('profile.update_password.heading') }}"
+                            description="{{ __('profile.update_password.description') }}" max-width="2xl"
+                            :show="$modalForm === 'profile-password'">
+                            <div class="p-6" x-ref="content">
+                                @if ($modalForm === 'profile-password')
+                                    @include('profile.partials.update-password-form', ['modal' => true])
+                                @else
+                                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                                    <div x-html="content"></div>
+                                @endif
+                            </div>
+                        </x-form-modal>
+                    </div>
+                </x-container>
+
+                <x-secondary-button :href="route('profile.edit', ['full' => 1])">
+                    {{ __('profile.actions.open_full_page') }}
+                </x-secondary-button>
+            @endif
+
+            @include('profile.partials.api-configuration')
+            @include('profile.partials.api-docs')
+            @include('profile.partials.delete-user-form')
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -7,6 +7,9 @@
     <form method="post" action="{{ route('password.update') }}" class="mt-6 space-y-6">
         @csrf
         @method('put')
+        @if (!empty($modal))
+            <input type="hidden" name="modal_form" value="profile-password">
+        @endif
 
         <div>
             <x-input-label for="update_password_current_password" :value="__('profile.form.current_password')" />
@@ -30,6 +33,12 @@
 
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('button.update') }}</x-primary-button>
+
+            @if (!empty($modal))
+                <x-secondary-button type="button" x-on:click="$dispatch('close-form-modal', 'profile-password-form-modal')">
+                    {{ __('button.cancel') }}
+                </x-secondary-button>
+            @endif
         </div>
     </form>
 </x-container>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -16,6 +16,9 @@
     <form method="post" action="{{ route('profile.update') }}" class="mt-6 space-y-6">
         @csrf
         @method('patch')
+        @if (!empty($modal))
+            <input type="hidden" name="modal_form" value="profile-information">
+        @endif
 
         <section class="space-y-4">
             <div>
@@ -261,7 +264,15 @@
             </div>
         </section>
 
-        <x-primary-button>{{ __('button.update') }}</x-primary-button>
+        <div class="flex flex-wrap items-center gap-3">
+            <x-primary-button>{{ __('button.update') }}</x-primary-button>
+
+            @if (!empty($modal))
+                <x-secondary-button type="button" x-on:click="$dispatch('close-form-modal', 'profile-information-form-modal')">
+                    {{ __('button.cancel') }}
+                </x-secondary-button>
+            @endif
+        </div>
     </form>
 
     @foreach ($notificationChannelKeys as $notificationChannelKey)

--- a/resources/views/teams/_form.blade.php
+++ b/resources/views/teams/_form.blade.php
@@ -2,6 +2,9 @@
 @if (isset($team))
     @method('PATCH')
 @endif
+@if (!empty($modal))
+    <input type="hidden" name="modal_form" value="{{ $modalForm }}">
+@endif
 
 <div class="space-y-4">
     <div>
@@ -17,7 +20,15 @@
         <x-input-error :messages="$errors->get('description')" />
     </div>
 
-    <x-primary-button>
-        {{ __('button.save') }}
-    </x-primary-button>
+    <div class="flex flex-wrap items-center gap-3">
+        <x-primary-button>
+            {{ __('button.save') }}
+        </x-primary-button>
+
+        @if (!empty($modal))
+            <x-secondary-button type="button" x-on:click="$dispatch('close-form-modal', 'team-form-modal')">
+                {{ __('button.cancel') }}
+            </x-secondary-button>
+        @endif
+    </div>
 </div>

--- a/resources/views/teams/_modal-form.blade.php
+++ b/resources/views/teams/_modal-form.blade.php
@@ -1,0 +1,7 @@
+<form method="POST" action="{{ $action }}" class="p-6">
+    @include('teams._form', [
+        'team' => $team ?? null,
+        'modal' => true,
+        'modalForm' => $modalForm,
+    ])
+</form>

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -3,16 +3,24 @@
         <x-heading type="h1">{{ __('team.title') }}</x-heading>
 
         @if (!Auth::user()->isDemo())
-            <x-primary-button :href="route('teams.create')" class="sm:ml-auto">
+            <x-primary-button :href="route('teams.create')" class="sm:ml-auto"
+                data-form-modal-trigger data-form-modal-name="team-form-modal">
                 {{ __('team.actions.create') }}
             </x-primary-button>
         @endif
     </x-slot>
 
     <x-main>
-        <x-container>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
+            <x-container>
             @if ($teams->count() === 0)
                 <x-paragraph>{{ __('team.empty.teams') }}</x-paragraph>
+                @if (!Auth::user()->isDemo())
+                    <x-primary-button :href="route('teams.create')" class="mt-4"
+                        data-form-modal-trigger data-form-modal-name="team-form-modal">
+                        {{ __('team.actions.create') }}
+                    </x-primary-button>
+                @endif
             @else
                 <div class="space-y-3">
                     @foreach ($teams as $team)
@@ -37,6 +45,30 @@
             @endif
 
             {{ $teams->links() }}
-        </x-container>
+            </x-container>
+
+            <x-form-modal name="team-form-modal" title="{{ __('team.title') }}"
+                description="{{ __('team.create.title') }}" max-width="3xl"
+                :show="in_array($modalForm, ['team-create', 'team-edit'], true)">
+                <div class="p-6" x-ref="content">
+                    @if ($modalForm === 'team-create')
+                        @include('teams._modal-form', [
+                            'action' => route('teams.store'),
+                            'modalForm' => 'team-create',
+                        ])
+                    @elseif ($modalForm === 'team-edit' && $modalTeam)
+                        @include('teams._modal-form', [
+                            'action' => route('teams.update', $modalTeam),
+                            'team' => $modalTeam,
+                            'modalForm' => 'team-edit',
+                        ])
+                    @else
+                        <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                        <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                        <div x-html="content"></div>
+                    @endif
+                </div>
+            </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -11,9 +11,11 @@
             @endif
         </div>
 
-        <div class="ml-auto flex flex-wrap gap-2">
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}"
+            class="ml-auto flex flex-wrap gap-2">
             @if ($isTeamAdmin)
-                <x-secondary-button :href="route('teams.edit', $team)">
+                <x-secondary-button :href="route('teams.edit', $team)"
+                    data-form-modal-trigger data-form-modal-name="team-form-modal">
                     {{ __('team.actions.edit') }}
                 </x-secondary-button>
                 <form method="POST" action="{{ route('teams.destroy', $team) }}"
@@ -35,6 +37,15 @@
             <x-secondary-button :href="route('teams.index')">
                 {{ __('button.back') }}
             </x-secondary-button>
+
+            <x-form-modal name="team-form-modal" title="{{ __('team.edit.title', ['team' => $team->name]) }}"
+                description="{{ __('team.title') }}" max-width="3xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
         </div>
     </x-slot>
 

--- a/tests/Feature/FormModalTeamsProfileTest.php
+++ b/tests/Feature/FormModalTeamsProfileTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\TeamRole;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class FormModalTeamsProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_team_create_and_edit_modal_fragments_are_available(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+
+        $this->actingAs($admin)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->get(route('teams.create', ['modal' => 1]))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('value="team-create"');
+
+        $this->actingAs($admin)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->get(route('teams.edit', [$team, 'modal' => 1]))
+            ->assertOk()
+            ->assertSee($team->name)
+            ->assertSeeHtml('value="team-edit"');
+    }
+
+    public function test_team_modal_validation_reopens_the_matching_modal_and_update_succeeds(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
+
+        $validationResponse = $this->actingAs($admin)->post(route('teams.store'), [
+            'description' => 'Missing name',
+            'modal_form' => 'team-create',
+        ]);
+
+        $validationResponse
+            ->assertRedirect(route('teams.index', ['modal' => 'team-create']))
+            ->assertSessionHasErrors('name');
+
+        $this->actingAs($admin)
+            ->get(route('teams.index', ['modal' => 'team-create']))
+            ->assertOk()
+            ->assertSeeHtml('value="team-create"')
+            ->assertSeeText(__('validation.required', ['attribute' => 'name']));
+
+        $this->actingAs($admin)->patch(route('teams.update', $team), [
+            'name' => 'Updated team',
+            'description' => 'Updated description',
+            'modal_form' => 'team-edit',
+        ])->assertRedirect(route('teams.show', $team));
+
+        $this->assertDatabaseHas('teams', [
+            'id' => $team->id,
+            'name' => 'Updated team',
+            'description' => 'Updated description',
+        ]);
+    }
+
+    public function test_profile_modal_fragments_and_profile_update_flow_are_available(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create(['theme' => 'system']);
+
+        $this->actingAs($user)
+            ->get(route('profile.edit'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="profile-information-form-modal"')
+            ->assertSeeHtml('data-form-modal-name="profile-password-form-modal"')
+            ->assertSeeText(__('profile.actions.open_full_page'));
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->get(route('profile.edit', ['modal' => 'profile-information']))
+            ->assertOk()
+            ->assertSeeHtml('name="modal_form"')
+            ->assertSeeHtml('value="profile-information"')
+            ->assertSeeText(__('profile.notification_settings.heading'));
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->get(route('profile.edit', ['modal' => 'profile-password']))
+            ->assertOk()
+            ->assertSeeHtml('value="profile-password"')
+            ->assertSeeText(__('profile.update_password.heading'));
+
+        $this->actingAs($user)->patch(route('profile.update'), [
+            'name' => 'Updated profile',
+            'email' => $user->email,
+            'theme' => 'dark',
+            'modal_form' => 'profile-information',
+        ])->assertRedirect(route('profile.edit'));
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'name' => 'Updated profile',
+            'theme' => 'dark',
+        ]);
+    }
+
+    public function test_profile_modal_validation_reopens_the_matching_password_modal_and_update_succeeds(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $validationResponse = $this->actingAs($user)->from(route('profile.edit'))->put(route('password.update'), [
+            'current_password' => 'wrong-password',
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+            'modal_form' => 'profile-password',
+        ]);
+
+        $validationResponse
+            ->assertRedirect(route('profile.edit', ['modal' => 'profile-password']))
+            ->assertSessionHasErrorsIn('updatePassword', 'current_password');
+
+        $this->actingAs($user)
+            ->get(route('profile.edit', ['modal' => 'profile-password']))
+            ->assertOk()
+            ->assertSeeHtml('value="profile-password"')
+            ->assertSeeText(__('profile.update_password.heading'));
+
+        $this->actingAs($user)->from(route('profile.edit'))->put(route('password.update'), [
+            'current_password' => 'password',
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+            'modal_form' => 'profile-password',
+        ])->assertRedirect(route('profile.edit'));
+
+        $this->assertTrue(Hash::check('new-password', (string) $user->fresh()->password));
+    }
+}

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -101,7 +101,7 @@ class ProfileNotificationSettingsTest extends TestCase
             'notification_channels_hint_seen_at' => null,
         ]);
 
-        $testResponse = $this->actingAs($user)->get(route('profile.edit'));
+        $testResponse = $this->actingAs($user)->get(route('profile.edit', ['full' => 1]));
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('profile.sections.account'));
         $testResponse->assertSeeText(__('profile.sections.preferences'));
@@ -113,7 +113,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse->assertSeeText(__('profile.notification_settings.hint_banner'));
         $testResponse->assertSeeHtml('data-confirm-message="' . __('api.configuration.messages.confirm_revoke_token') . '"');
 
-        $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit'));
+        $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit', ['full' => 1]));
         $secondResponse->assertOk();
         $secondResponse->assertDontSeeText(__('profile.notification_settings.hint_banner'));
     }
@@ -407,7 +407,7 @@ class ProfileNotificationSettingsTest extends TestCase
         Package::factory()->create();
         $user = User::factory()->create();
 
-        $testResponse = $this->actingAs($user)->get(route('profile.edit'));
+        $testResponse = $this->actingAs($user)->get(route('profile.edit', ['modal' => 'profile-information']));
 
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('profile.notification_settings.test.action'));


### PR DESCRIPTION
Closes #480

## What changed

- Added modal create/edit entry points for Teams, including create and admin edit flows.
- Added profile information and password modals using the shared form-modal loader.
- Kept direct team create/edit routes and a full-page profile editor fallback available.
- Preserved profile notification channel actions, API token actions, and account deletion confirmation.
- Added modal-aware validation redirects for team, profile, and password requests.
- Added feature coverage for fragments, successful submissions, validation reopening, and fallback rendering.

## Why

This is the second implementation slice of the repository-wide CRUD modal migration. It brings team management and account editing into the same interaction model while retaining authorization, existing destructive flows, and a deliberate full-page fallback for the profile surface.

## Testing

- Docker Pest full suite: 637 passed, 4,000 assertions, 3 skipped.
- Docker PHPStan: passed.
- Docker Pint check: passed.
- Docker Vite production build: passed.
- Local browser QA: profile information, password, and team create modals opened and loaded their controls; browser console was clean.

## Risks and limitations

- Profile information remains a large, scrollable modal because notification settings and their test actions are part of the existing profile form.
- The full-page profile editor is available through the explicit fallback link and `?full=1`.