### PR TITLE
feat(admin): convert resource forms to modals

### DIFF
--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -52,6 +52,11 @@ class PackageController extends Controller
             return AsyncTable::json($lengthAwarePaginator, 'admin.packages.partials.rows', ['packages' => $lengthAwarePaginator]);
         }
 
+        $modalForm = $request->string('modal')->toString();
+        $modalPackage = $modalForm === 'admin-package-edit' && $request->filled('package')
+            ? Package::query()->withoutGlobalScope('selectable')->findOrFail($request->string('package')->toString())
+            : null;
+
         return view('admin.packages.index', [
             'packages' => $lengthAwarePaginator,
             'filters' => [
@@ -70,6 +75,8 @@ class PackageController extends Controller
             ],
             'sort' => $asyncTableOptions->sort,
             'direction' => $asyncTableOptions->direction,
+            'modalForm' => $modalForm,
+            'modalPackage' => $modalPackage,
         ]);
     }
 

--- a/app/Http/Controllers/Admin/ServerInstanceController.php
+++ b/app/Http/Controllers/Admin/ServerInstanceController.php
@@ -71,6 +71,10 @@ class ServerInstanceController extends Controller
         $healthCounts = $summaryInstances
             ->map(fn (ServerInstance $serverInstance): string => $serverInstance->healthStatus())
             ->countBy();
+        $modalForm = $request->string('modal')->toString();
+        $modalInstance = $modalForm === 'admin-server-instance-edit' && $request->filled('server_instance')
+            ? ServerInstance::query()->findOrFail($request->string('server_instance')->toString())
+            : null;
 
         return view('admin.server-instances.index', [
             'instances' => $lengthAwarePaginator,
@@ -110,6 +114,8 @@ class ServerInstanceController extends Controller
                 'stale_instances' => (int) $healthCounts->get('stale', 0),
                 'total_monitorings' => (int) $summaryMonitoringCounts->sum(),
             ],
+            'modalForm' => $modalForm,
+            'modalInstance' => $modalInstance,
         ]);
     }
 

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -81,6 +81,13 @@ class UserController extends Controller
         }
 
         $packages = Package::query()->withoutGlobalScope('selectable')->orderBy('monitoring_limit')->get();
+        $modalForm = $request->string('modal')->toString();
+        $modalUser = null;
+
+        if ($modalForm === 'admin-user-edit' && $request->filled('user')) {
+            $modalUser = User::query()->findOrFail($request->string('user')->toString());
+        }
+
         $filters = [
             [
                 'name' => 'role',
@@ -119,6 +126,9 @@ class UserController extends Controller
             ],
             'sort' => $asyncTableOptions->sort,
             'direction' => $asyncTableOptions->direction,
+            'modalForm' => $modalForm,
+            'modalUser' => $modalUser,
+            'modalPackages' => Package::all(),
         ]);
     }
 
@@ -198,12 +208,19 @@ class UserController extends Controller
      * @param  string  $id  The ID of the user to verify.
      * @return RedirectResponse A redirect response after verifying the user.
      */
-    public function verify(string $id): RedirectResponse
+    public function verify(Request $request, string $id): RedirectResponse
     {
         $model = User::query()->findOrFail($id);
 
         if (! $model->hasVerifiedEmail()) {
             $model->markEmailAsVerified();
+        }
+
+        if ($request->boolean('modal')) {
+            return to_route('admin.users.index', [
+                'modal' => 'admin-user-edit',
+                'user' => $model->id,
+            ])->with('success', __('user.messages.user_verified'));
         }
 
         return to_route('admin.users.edit', $model->id)->with('success', __('user.messages.user_verified'));

--- a/app/Http/Requests/StorePackageRequest.php
+++ b/app/Http/Requests/StorePackageRequest.php
@@ -31,4 +31,13 @@ class StorePackageRequest extends FormRequest
             'is_selectable' => ['boolean'],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'admin-package-create') {
+            return route('admin.packages.index', ['modal' => 'admin-package-create']);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/app/Http/Requests/StoreServerInstanceRequest.php
+++ b/app/Http/Requests/StoreServerInstanceRequest.php
@@ -27,4 +27,13 @@ class StoreServerInstanceRequest extends FormRequest
             'is_active' => ['boolean'],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'admin-server-instance-create') {
+            return route('admin.server-instances.index', ['modal' => 'admin-server-instance-create']);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/app/Http/Requests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreUserRequest.php
@@ -35,4 +35,13 @@ class StoreUserRequest extends FormRequest
             'role' => ['required', Rule::enum(UserRole::class)],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'admin-user-create') {
+            return route('admin.users.index', ['modal' => 'admin-user-create']);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/app/Http/Requests/UpdatePackageRequest.php
+++ b/app/Http/Requests/UpdatePackageRequest.php
@@ -31,4 +31,18 @@ class UpdatePackageRequest extends FormRequest
             'is_selectable' => ['boolean'],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'admin-package-edit') {
+            $package = $this->route('package');
+
+            return route('admin.packages.index', [
+                'modal' => 'admin-package-edit',
+                'package' => is_object($package) ? $package->getRouteKey() : $package,
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/app/Http/Requests/UpdateServerInstanceRequest.php
+++ b/app/Http/Requests/UpdateServerInstanceRequest.php
@@ -32,4 +32,18 @@ class UpdateServerInstanceRequest extends FormRequest
             'is_active' => ['boolean'],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'admin-server-instance-edit') {
+            $instance = $this->route('server_instance');
+
+            return route('admin.server-instances.index', [
+                'modal' => 'admin-server-instance-edit',
+                'server_instance' => is_object($instance) ? $instance->getRouteKey() : $instance,
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -37,4 +37,18 @@ class UpdateUserRequest extends FormRequest
             'package_id' => ['required', 'exists:packages,id'],
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        if ($this->input('modal_form') === 'admin-user-edit') {
+            $user = $this->route('user');
+
+            return route('admin.users.index', [
+                'modal' => 'admin-user-edit',
+                'user' => is_object($user) ? $user->getRouteKey() : $user,
+            ]);
+        }
+
+        return parent::getRedirectUrl();
+    }
 }

--- a/resources/views/admin/packages/_form.blade.php
+++ b/resources/views/admin/packages/_form.blade.php
@@ -1,4 +1,7 @@
 @csrf
+@if (isset($modalForm))
+    <input type="hidden" name="modal_form" value="{{ $modalForm }}">
+@endif
 
 <div>
     <x-input-label for="monitoring_limit" :value="__('admin.packages.fields.monitoring_limit')" />
@@ -29,4 +32,9 @@
     <x-primary-button class="ms-4">
         {{ isset($package) ? __('button.update') : __('button.create') }}
     </x-primary-button>
+    @if (isset($modalForm))
+        <x-secondary-button type="button" x-on:click="$dispatch('close-form-modal', 'admin-package-form-modal')">
+            {{ __('button.cancel') }}
+        </x-secondary-button>
+    @endif
 </div>

--- a/resources/views/admin/packages/_modal-form.blade.php
+++ b/resources/views/admin/packages/_modal-form.blade.php
@@ -1,0 +1,6 @@
+<form method="POST" action="{{ $action }}">
+    @if (isset($package))
+        @method('PUT')
+    @endif
+    @include('admin.packages._form', ['modalForm' => $modalForm])
+</form>

--- a/resources/views/admin/packages/create.blade.php
+++ b/resources/views/admin/packages/create.blade.php
@@ -1,3 +1,9 @@
+@if (request()->boolean('modal'))
+    @include('admin.packages._modal-form', [
+        'action' => route('admin.packages.store'),
+        'modalForm' => 'admin-package-create',
+    ])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">
@@ -17,3 +23,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/admin/packages/edit.blade.php
+++ b/resources/views/admin/packages/edit.blade.php
@@ -1,3 +1,10 @@
+@if (request()->boolean('modal'))
+    @include('admin.packages._modal-form', [
+        'action' => route('admin.packages.update', $package),
+        'package' => $package,
+        'modalForm' => 'admin-package-edit',
+    ])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">
@@ -14,3 +21,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/admin/packages/index.blade.php
+++ b/resources/views/admin/packages/index.blade.php
@@ -6,12 +6,14 @@
     </x-slot>
 
     <x-main>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
         <x-async-table id="admin-packages-table" :endpoint="route('admin.packages.index')" :paginator="$packages"
             :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
             :initial-direction="$direction"
             search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('admin.packages.title')]) }}">
             <x-slot name="actions">
-                <x-primary-button :href="route('admin.packages.create')" class="sm:ml-auto">
+                <x-primary-button :href="route('admin.packages.create')" class="sm:ml-auto"
+                    data-form-modal-trigger data-form-modal-name="admin-package-form-modal">
                     {{ __('button.create') }}
                 </x-primary-button>
             </x-slot>
@@ -26,5 +28,28 @@
                 @include('admin.packages.partials.rows', ['packages' => $packages])
             </x-slot>
         </x-async-table>
+
+        <x-form-modal name="admin-package-form-modal" title="{{ __('admin.packages.title') }}"
+            :show="in_array($modalForm, ['admin-package-create', 'admin-package-edit'], true)">
+            <div class="p-6" x-ref="content">
+                @if ($modalForm === 'admin-package-create')
+                    @include('admin.packages._modal-form', [
+                        'action' => route('admin.packages.store'),
+                        'modalForm' => 'admin-package-create',
+                    ])
+                @elseif ($modalForm === 'admin-package-edit' && $modalPackage)
+                    @include('admin.packages._modal-form', [
+                        'action' => route('admin.packages.update', $modalPackage),
+                        'package' => $modalPackage,
+                        'modalForm' => 'admin-package-edit',
+                    ])
+                @else
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                @endif
+            </div>
+        </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/packages/partials/rows.blade.php
+++ b/resources/views/admin/packages/partials/rows.blade.php
@@ -10,7 +10,8 @@
             @endif
         </x-table.cell>
         <x-table.cell>
-            <a href="{{ route('admin.packages.edit', $package) }}" class="text-purple-600 hover:underline">
+            <a href="{{ route('admin.packages.edit', $package) }}" class="text-purple-600 hover:underline"
+                data-form-modal-trigger data-form-modal-name="admin-package-form-modal">
                 {{ __('button.edit') }}
             </a>
             <form action="{{ route('admin.packages.destroy', $package) }}" method="POST" class="inline"

--- a/resources/views/admin/server-instances/_form.blade.php
+++ b/resources/views/admin/server-instances/_form.blade.php
@@ -1,4 +1,7 @@
 @csrf
+@if (isset($modalForm))
+    <input type="hidden" name="modal_form" value="{{ $modalForm }}">
+@endif
 
 <div>
     <x-input-label for="code" :value="__('admin.server_instances.fields.code')" />
@@ -37,4 +40,9 @@
     <x-primary-button class="ms-4">
         {{ isset($instance) ? __('button.update') : __('button.create') }}
     </x-primary-button>
+    @if (isset($modalForm))
+        <x-secondary-button type="button" x-on:click="$dispatch('close-form-modal', 'admin-server-instance-form-modal')">
+            {{ __('button.cancel') }}
+        </x-secondary-button>
+    @endif
 </div>

--- a/resources/views/admin/server-instances/_modal-form.blade.php
+++ b/resources/views/admin/server-instances/_modal-form.blade.php
@@ -1,0 +1,6 @@
+<form method="POST" action="{{ $action }}">
+    @if (isset($instance))
+        @method('PUT')
+    @endif
+    @include('admin.server-instances._form', ['modalForm' => $modalForm])
+</form>

--- a/resources/views/admin/server-instances/create.blade.php
+++ b/resources/views/admin/server-instances/create.blade.php
@@ -1,3 +1,9 @@
+@if (request()->boolean('modal'))
+    @include('admin.server-instances._modal-form', [
+        'action' => route('admin.server-instances.store'),
+        'modalForm' => 'admin-server-instance-create',
+    ])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">
@@ -17,3 +23,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/admin/server-instances/edit.blade.php
+++ b/resources/views/admin/server-instances/edit.blade.php
@@ -1,3 +1,10 @@
+@if (request()->boolean('modal'))
+    @include('admin.server-instances._modal-form', [
+        'action' => route('admin.server-instances.update', $instance),
+        'instance' => $instance,
+        'modalForm' => 'admin-server-instance-edit',
+    ])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading type="h1">
@@ -18,3 +25,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/admin/server-instances/index.blade.php
+++ b/resources/views/admin/server-instances/index.blade.php
@@ -37,12 +37,14 @@
             </x-container>
         </div>
 
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
         <x-async-table id="admin-server-instances-table" :endpoint="route('admin.server-instances.index')"
             :paginator="$instances" :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
             :initial-direction="$direction"
             search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('admin.server_instances.title')]) }}">
             <x-slot name="actions">
-                <x-primary-button :href="route('admin.server-instances.create')" class="sm:ml-auto">
+                <x-primary-button :href="route('admin.server-instances.create')" class="sm:ml-auto"
+                    data-form-modal-trigger data-form-modal-name="admin-server-instance-form-modal">
                     {{ __('button.create') }}
                 </x-primary-button>
             </x-slot>
@@ -66,5 +68,28 @@
                 ])
             </x-slot>
         </x-async-table>
+
+        <x-form-modal name="admin-server-instance-form-modal" title="{{ __('admin.server_instances.title') }}"
+            :show="in_array($modalForm, ['admin-server-instance-create', 'admin-server-instance-edit'], true)">
+            <div class="p-6" x-ref="content">
+                @if ($modalForm === 'admin-server-instance-create')
+                    @include('admin.server-instances._modal-form', [
+                        'action' => route('admin.server-instances.store'),
+                        'modalForm' => 'admin-server-instance-create',
+                    ])
+                @elseif ($modalForm === 'admin-server-instance-edit' && $modalInstance)
+                    @include('admin.server-instances._modal-form', [
+                        'action' => route('admin.server-instances.update', $modalInstance),
+                        'instance' => $modalInstance,
+                        'modalForm' => 'admin-server-instance-edit',
+                    ])
+                @else
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                @endif
+            </div>
+        </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/server-instances/partials/rows.blade.php
+++ b/resources/views/admin/server-instances/partials/rows.blade.php
@@ -61,7 +61,8 @@
         <x-table.cell>{{ $instance->created_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>{{ $instance->updated_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>
-            <a href="{{ route('admin.server-instances.edit', $instance) }}" class="text-purple-600 hover:underline">
+            <a href="{{ route('admin.server-instances.edit', $instance) }}" class="text-purple-600 hover:underline"
+                data-form-modal-trigger data-form-modal-name="admin-server-instance-form-modal">
                 {{ __('button.edit') }}
             </a>
             <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST" class="inline"

--- a/resources/views/admin/users/_form.blade.php
+++ b/resources/views/admin/users/_form.blade.php
@@ -1,4 +1,7 @@
 @csrf
+@if (isset($modalForm))
+    <input type="hidden" name="modal_form" value="{{ $modalForm }}">
+@endif
 
 <div class="mb-4">
     <x-input-label for="name" :value="__('user.fields.name')" />
@@ -49,3 +52,9 @@
 <x-primary-button>
     {{ isset($user) ? __('button.update') : __('button.create') }}
 </x-primary-button>
+
+@if (isset($modalForm))
+    <x-secondary-button type="button" x-on:click="$dispatch('close-form-modal', 'admin-user-form-modal')">
+        {{ __('button.cancel') }}
+    </x-secondary-button>
+@endif

--- a/resources/views/admin/users/_modal-form.blade.php
+++ b/resources/views/admin/users/_modal-form.blade.php
@@ -1,0 +1,24 @@
+<div class="space-y-6">
+    @if (isset($user) && $user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail)
+        <div class="flex flex-wrap items-center gap-3 rounded-md border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900">
+            @if ($user->hasVerifiedEmail())
+                <p class="text-sm text-green-600">{{ __('user.messages.email_verified') }}</p>
+            @else
+                <p class="text-sm text-red-600">{{ __('user.messages.email_unverified') }}</p>
+                <form method="POST" action="{{ route('admin.users.verify', [$user, 'modal' => 1]) }}" class="sm:ml-auto">
+                    @csrf
+                    <x-secondary-button type="submit">
+                        {{ __('user.actions.verify_email') }}
+                    </x-secondary-button>
+                </form>
+            @endif
+        </div>
+    @endif
+
+    <form method="POST" action="{{ $action }}">
+        @if (isset($user))
+            @method('PUT')
+        @endif
+        @include('admin.users._form', ['modalForm' => $modalForm])
+    </form>
+</div>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,3 +1,9 @@
+@if (request()->boolean('modal'))
+    @include('admin.users._modal-form', [
+        'action' => route('admin.users.store'),
+        'modalForm' => 'admin-user-create',
+    ])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading>{{ __('user.actions.create') }}</x-heading>
@@ -15,3 +21,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,3 +1,11 @@
+@if (request()->boolean('modal'))
+    @include('admin.users._modal-form', [
+        'action' => route('admin.users.update', $user),
+        'user' => $user,
+        'packages' => $packages,
+        'modalForm' => 'admin-user-edit',
+    ])
+@else
 <x-app-layout>
     <x-slot name="header">
         <x-heading>{{ __('user.actions.edit') . ': ' . $user->name }}</x-heading>
@@ -37,3 +45,4 @@
         </x-container>
     </x-main>
 </x-app-layout>
+@endif

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -10,12 +10,14 @@
     </x-slot>
 
     <x-main>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
         <x-async-table id="admin-users-table" :endpoint="route('admin.users.index')" :paginator="$users"
             :filters="$filters" :initial-filters="$activeFilters" :initial-sort="$sort"
             :initial-direction="$direction"
             search-placeholder="{{ __('search.fields.placeholder', ['attribute' => __('user.title')]) }}">
             <x-slot name="actions">
-                <x-primary-button :href="route('admin.users.create')" class="sm:ml-auto">
+                <x-primary-button :href="route('admin.users.create')" class="sm:ml-auto"
+                    data-form-modal-trigger data-form-modal-name="admin-user-form-modal">
                     {{ __('button.create') }}
                 </x-primary-button>
             </x-slot>
@@ -35,5 +37,29 @@
                 @include('admin.users.partials.rows', ['users' => $users])
             </x-slot>
         </x-async-table>
+
+        <x-form-modal name="admin-user-form-modal" title="{{ __('user.title') }}"
+            :show="in_array($modalForm, ['admin-user-create', 'admin-user-edit'], true)">
+            <div class="p-6" x-ref="content">
+                @if ($modalForm === 'admin-user-create')
+                    @include('admin.users._modal-form', [
+                        'action' => route('admin.users.store'),
+                        'modalForm' => 'admin-user-create',
+                    ])
+                @elseif ($modalForm === 'admin-user-edit' && $modalUser)
+                    @include('admin.users._modal-form', [
+                        'action' => route('admin.users.update', $modalUser),
+                        'user' => $modalUser,
+                        'packages' => $modalPackages,
+                        'modalForm' => 'admin-user-edit',
+                    ])
+                @else
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                @endif
+            </div>
+        </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/admin/users/partials/rows.blade.php
+++ b/resources/views/admin/users/partials/rows.blade.php
@@ -18,7 +18,8 @@
         <x-table.cell>
             <div class="flex items-center gap-3">
                 <a href="{{ route('admin.users.edit', $user) }}"
-                    class="inline-flex min-h-10 items-center text-purple-600 hover:underline">
+                    class="inline-flex min-h-10 items-center text-purple-600 hover:underline"
+                    data-form-modal-trigger data-form-modal-name="admin-user-form-modal">
                     {{ __('button.edit') }}
                 </a>
                 @if ($user->id !== auth()->id())

--- a/tests/Feature/Admin/AdminFormModalTest.php
+++ b/tests/Feature/Admin/AdminFormModalTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\UserRole;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Tests\TestCase;
+
+class AdminFormModalTest extends TestCase
+{
+    public function test_admin_resource_indexes_expose_modal_entry_points(): void
+    {
+        $admin = $this->adminUser();
+        $user = User::factory()->create();
+        $package = Package::factory()->create(['is_selectable' => false]);
+        $instance = ServerInstance::query()->create([
+            'code' => 'modal-instance',
+            'ip_address' => '10.0.0.10',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.users.index'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="admin-user-form-modal"')
+            ->assertSeeHtml('href="' . route('admin.users.edit', $user) . '"');
+
+        $this->actingAs($admin)
+            ->get(route('admin.packages.index'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="admin-package-form-modal"')
+            ->assertSeeHtml('href="' . route('admin.packages.edit', $package) . '"');
+
+        $this->actingAs($admin)
+            ->get(route('admin.server-instances.index'))
+            ->assertOk()
+            ->assertSeeHtml('data-form-modal-name="admin-server-instance-form-modal"')
+            ->assertSeeHtml('href="' . route('admin.server-instances.edit', $instance) . '"');
+    }
+
+    public function test_admin_can_load_create_and_edit_forms_as_modal_fragments(): void
+    {
+        $admin = $this->adminUser();
+        $user = User::factory()->unverified()->create();
+        $package = Package::factory()->create(['is_selectable' => false]);
+        $instance = ServerInstance::query()->create([
+            'code' => 'modal-fragment-instance',
+            'ip_address' => '10.0.0.11',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $modalRoutes = [
+            [route('admin.users.create', ['modal' => 1]), 'admin-user-create'],
+            [route('admin.users.edit', ['user' => $user, 'modal' => 1]), 'admin-user-edit'],
+            [route('admin.packages.create', ['modal' => 1]), 'admin-package-create'],
+            [route('admin.packages.edit', ['package' => $package, 'modal' => 1]), 'admin-package-edit'],
+            [route('admin.server-instances.create', ['modal' => 1]), 'admin-server-instance-create'],
+            [route('admin.server-instances.edit', ['server_instance' => $instance, 'modal' => 1]), 'admin-server-instance-edit'],
+        ];
+
+        foreach ($modalRoutes as [$route, $modalForm]) {
+            $this->actingAs($admin)
+                ->get($route)
+                ->assertOk()
+                ->assertDontSee('<html')
+                ->assertSeeHtml('name="modal_form" value="' . $modalForm . '"');
+        }
+
+        $this->actingAs($admin)
+            ->get(route('admin.users.edit', ['user' => $user, 'modal' => 1]))
+            ->assertSeeHtml('action="' . route('admin.users.verify', [$user, 'modal' => 1]) . '"');
+    }
+
+    public function test_modal_validation_reopens_the_matching_admin_form(): void
+    {
+        $admin = $this->adminUser();
+        $user = User::factory()->create();
+        $package = Package::factory()->create(['is_selectable' => false]);
+        $instance = ServerInstance::query()->create([
+            'code' => 'modal-validation-instance',
+            'ip_address' => '10.0.0.12',
+            'api_key_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($admin)
+            ->post(route('admin.users.store'), [
+                'name' => 'Modal User',
+                'email' => 'modal-user@example.test',
+                'password' => 'short',
+                'role' => UserRole::REGULAR->value,
+                'modal_form' => 'admin-user-create',
+            ])
+            ->assertRedirect(route('admin.users.index', ['modal' => 'admin-user-create']))
+            ->assertSessionHasErrors('password');
+
+        $this->actingAs($admin)
+            ->put(route('admin.users.update', $user), [
+                'name' => $user->name,
+                'email' => $user->email,
+                'password' => '',
+                'role' => UserRole::REGULAR->value,
+                'package_id' => 'missing-package',
+                'modal_form' => 'admin-user-edit',
+            ])
+            ->assertRedirect(route('admin.users.index', ['modal' => 'admin-user-edit', 'user' => $user]))
+            ->assertSessionHasErrors('package_id');
+
+        $this->actingAs($admin)
+            ->post(route('admin.packages.store'), [
+                'monitoring_limit' => 0,
+                'price' => '-1',
+                'modal_form' => 'admin-package-create',
+            ])
+            ->assertRedirect(route('admin.packages.index', ['modal' => 'admin-package-create']))
+            ->assertSessionHasErrors(['monitoring_limit', 'price']);
+
+        $this->actingAs($admin)
+            ->put(route('admin.packages.update', $package), [
+                'monitoring_limit' => 0,
+                'price' => '-1',
+                'modal_form' => 'admin-package-edit',
+            ])
+            ->assertRedirect(route('admin.packages.index', ['modal' => 'admin-package-edit', 'package' => $package]));
+
+        $this->actingAs($admin)
+            ->post(route('admin.server-instances.store'), [
+                'code' => 'modal-invalid-instance',
+                'ip_address' => 'not-an-ip',
+                'api_key' => '1234567890abcdef',
+                'modal_form' => 'admin-server-instance-create',
+            ])
+            ->assertRedirect(route('admin.server-instances.index', ['modal' => 'admin-server-instance-create']))
+            ->assertSessionHasErrors('ip_address');
+
+        $this->actingAs($admin)
+            ->put(route('admin.server-instances.update', $instance), [
+                'code' => $instance->code,
+                'ip_address' => 'not-an-ip',
+                'api_key' => '',
+                'modal_form' => 'admin-server-instance-edit',
+            ])
+            ->assertRedirect(route('admin.server-instances.index', [
+                'modal' => 'admin-server-instance-edit',
+                'server_instance' => $instance,
+            ]));
+    }
+
+    public function test_admin_can_verify_email_from_the_user_modal(): void
+    {
+        $admin = $this->adminUser();
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($admin)
+            ->post(route('admin.users.verify', [$user, 'modal' => 1]))
+            ->assertRedirect(route('admin.users.index', [
+                'modal' => 'admin-user-edit',
+                'user' => $user,
+            ]))
+            ->assertSessionHas('success', __('user.messages.user_verified'));
+
+        $this->assertNotNull($user->fresh()->email_verified_at);
+    }
+
+    public function test_non_admin_users_cannot_open_admin_form_modals(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('admin.users.create', ['modal' => 1]))
+            ->assertForbidden();
+    }
+
+    private function adminUser(): User
+    {
+        Package::factory()->create();
+
+        return User::factory()->create(['role' => UserRole::ADMIN]);
+    }
+}


### PR DESCRIPTION
Closes #481

## What changed
- Added modal Create/Edit entry points for admin users, packages, and server instances.
- Kept the existing standalone pages available as direct-link fallbacks.
- Preserved authorization, validation, destructive confirmations, and role/package rules.
- Kept user email verification as a separate action inside the user edit modal.
- Reopen the matching modal with validation errors after failed submissions.

## Why
Admin resource management now follows the same modal-first interaction pattern as the rest of the dashboard, reducing navigation away from the overview tables while retaining a safe direct-page fallback.

## Testing
- `composer test` in Docker: 642 passed, 3 skipped (4057 assertions)
- `composer analyse` in Docker: passed
- Vite production build in Docker: passed
- Focused admin modal and regression tests: 28 passed
- In-app browser navigation was attempted, but the local Traefik domain was blocked by the browser session's untrusted local certificate; server-rendered modal fragments and interactions are covered by the feature tests.

## Risks / follow-up
- No schema or API contract changes.
- The final cross-feature modal QA remains tracked in issue #482.