### PR TITLE
feat(ui): complete cross-surface modal entry points

### DIFF
--- a/resources/views/components/dashboard/action-link.blade.php
+++ b/resources/views/components/dashboard/action-link.blade.php
@@ -2,6 +2,7 @@
     'href',
     'variant' => 'quiet',
     'label' => null,
+    'modalName' => null,
 ])
 
 @php
@@ -12,7 +13,17 @@
     };
 @endphp
 
-<a href="{{ $href }}" {{ $attributes->class($classes) }}>
+@php
+    $attributes = $attributes->class($classes);
+    if ($modalName !== null) {
+        $attributes = $attributes->merge([
+            'data-form-modal-trigger' => true,
+            'data-form-modal-name' => $modalName,
+        ]);
+    }
+@endphp
+
+<a href="{{ $href }}" {{ $attributes }}>
     <span>{{ $slot->isNotEmpty() ? $slot : $label }}</span>
     <x-dashboard.chevron class="h-4 w-4 shrink-0 {{ $variant === 'list' ? 'text-gray-400 transition group-hover:translate-x-0.5 group-hover:text-purple-600' : '' }}" />
 </a>

--- a/resources/views/components/dashboard/empty-state.blade.php
+++ b/resources/views/components/dashboard/empty-state.blade.php
@@ -1,5 +1,6 @@
 @props([
     'canCreateMonitoring',
+    'modal' => false,
 ])
 
 <section class="overflow-hidden rounded-3xl border border-purple-200 bg-white shadow-sm dark:border-purple-900/60 dark:bg-gray-800">
@@ -9,7 +10,8 @@
             <x-heading type="h2">{{ __('dashboard.empty.title') }}</x-heading>
             <p class="mt-4 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">{{ __('dashboard.empty.description') }}</p>
             @if ($canCreateMonitoring)
-                <x-dashboard.action-link href="{{ route('monitorings.create') }}" variant="solid" class="mt-7 w-max">
+                <x-dashboard.action-link href="{{ route('monitorings.create') }}" variant="solid" class="mt-7 w-max"
+                    :modal-name="$modal ? 'monitoring-form-modal' : null">
                     {{ __('dashboard.quick_actions.create') }}
                 </x-dashboard.action-link>
             @endif

--- a/resources/views/components/dashboard/next-action.blade.php
+++ b/resources/views/components/dashboard/next-action.blade.php
@@ -19,7 +19,8 @@
     </div>
 
     <p class="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">{{ __('dashboard.next_action.description') }}</p>
-    <x-dashboard.action-link :href="$recommendedHref" variant="solid" class="mt-6">
+    <x-dashboard.action-link :href="$recommendedHref" variant="solid" class="mt-6"
+        :modal-name="$recommendedAction === 'create' ? 'monitoring-form-modal' : null">
         {{ __('dashboard.recommended.label') }}
     </x-dashboard.action-link>
 
@@ -28,7 +29,8 @@
         <div class="mt-3 grid gap-1 sm:grid-cols-2 xl:grid-cols-1">
             @foreach ($quickActions as $action)
                 @if ($action['visible'])
-                    <x-dashboard.action-link :href="$action['href']" variant="list">
+                    <x-dashboard.action-link :href="$action['href']" variant="list"
+                        :modal-name="$action['key'] === 'create' ? 'monitoring-form-modal' : null">
                         {{ __('dashboard.quick_actions.' . $action['key']) }}
                     </x-dashboard.action-link>
                 @endif

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -57,7 +57,7 @@
 
     <x-main>
         @if ($summary['total'] === 0)
-            <x-dashboard.empty-state :can-create-monitoring="$canCreateMonitoring" />
+            <x-dashboard.empty-state :can-create-monitoring="$canCreateMonitoring" modal />
         @else
             <div class="space-y-6">
                 <section class="grid gap-5 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.75fr)]">
@@ -211,5 +211,15 @@
                 </div>
             </div>
         @endif
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
+            <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
+                description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
+        </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -28,6 +28,17 @@
     </x-slot>
 
     <x-main>
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
+            <x-form-modal name="status-page-form-modal" title="{{ __('status_page.title') }}"
+                description="{{ __('status_page.form.components') }}" max-width="5xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
+        </div>
+
         <div id="service-operations" class="space-y-6">
             <nav aria-label="{{ __('incidents.analytics.overview.tabs.overview') }}" class="overflow-x-auto">
                 <div class="flex min-w-max items-center gap-1 border-b border-gray-200 dark:border-gray-700">
@@ -86,7 +97,8 @@
                             </div>
                         </div>
 
-                        <x-primary-button :href="route('status-pages.create')">
+                        <x-primary-button :href="route('status-pages.create')"
+                            data-form-modal-trigger data-form-modal-name="status-page-form-modal">
                             {{ __('incidents.analytics.overview.create_status_page') }}
                         </x-primary-button>
                     </div>
@@ -109,7 +121,8 @@
                         <div class="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
                             <p>{{ __('incidents.analytics.overview.empty_groups') }}</p>
                             @if (!Auth::user()->isDemo())
-                                <x-secondary-button :href="route('monitoring-groups.create')" class="mt-4">
+                                <x-secondary-button :href="route('monitoring-groups.create')" class="mt-4"
+                                    data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
                                     {{ __('button.create') }}
                                 </x-secondary-button>
                             @endif
@@ -143,7 +156,8 @@
                                     </div>
                                     <div class="flex flex-wrap items-center gap-2 sm:justify-end">
                                         @if (!Auth::user()->isDemo())
-                                            <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)">
+                                            <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)"
+                                                data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
                                                 {{ __('button.edit') }}
                                             </x-secondary-button>
                                         @endif
@@ -172,7 +186,8 @@
                         <div class="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
                             <p>{{ __('incidents.analytics.overview.empty_status_pages') }}</p>
                             @if (!Auth::user()->isDemo())
-                                <x-secondary-button :href="route('status-pages.create')" class="mt-4">
+                                <x-secondary-button :href="route('status-pages.create')" class="mt-4"
+                                    data-form-modal-trigger data-form-modal-name="status-page-form-modal">
                                     {{ __('button.create') }}
                                 </x-secondary-button>
                             @endif
@@ -406,6 +421,17 @@
                     <p class="mt-3">{{ __('incidents.analytics.definitions') }}</p>
                 </details>
             </section>
+        </div>
+
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
+            <x-form-modal name="monitoring-group-form-modal" title="{{ __('monitoring_group.title') }}"
+                description="{{ __('monitoring_group.form.monitorings') }}" max-width="3xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
         </div>
     </x-main>
 </x-app-layout>

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -30,6 +30,8 @@ class DashboardOverviewTest extends TestCase
             ->assertOk()
             ->assertSeeText(__('dashboard.empty.title'))
             ->assertSeeText(__('dashboard.empty.description'))
+            ->assertSeeHtml('data-form-modal-name="monitoring-form-modal"')
+            ->assertSeeHtml('data-form-modal="monitoring-form-modal"')
             ->assertSeeHtml('href="' . route('monitorings.create') . '"');
     }
 

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -273,6 +273,10 @@ class IncidentWorkflowTest extends TestCase
             ->assertSeeText(__('incidents.analytics.overview.status_pages'))
             ->assertSeeText('Customer-facing')
             ->assertSeeText('Customer Status')
+            ->assertSeeHtml('data-form-modal-name="monitoring-group-form-modal"')
+            ->assertSeeHtml('data-form-modal-name="status-page-form-modal"')
+            ->assertSeeHtml('data-form-modal="monitoring-group-form-modal"')
+            ->assertSeeHtml('data-form-modal="status-page-form-modal"')
             ->assertSeeHtml('href="' . route('monitorings.index', ['group_id' => $monitoringGroup->id]) . '"')
             ->assertSeeHtml('href="' . route('status-pages.show', $statusPage) . '"');
     }


### PR DESCRIPTION
Closes #482

## What changed

- Added shared modal entry points for the dashboard's monitoring creation actions.
- Added shared modal entry points for monitoring group and status page creation/editing actions on incident analytics.
- Preserved direct Create/Edit routes as safe fallbacks.
- Added rendered-markup assertions for the new dashboard and analytics entry points.

## Why

The remaining authenticated Create/Edit actions should consistently open the shared modal flow instead of navigating to separate pages, including the combined monitoring groups/status pages analytics surface.

## Validation

- Docker Pest suite passed.
- Targeted modal/dashboard/analytics feature tests passed.
- PHPStan passed with no errors.
- Pint passed for the changed PHP tests.
- Vite production build passed.
- Static audit confirms all authenticated Create/Edit links in resources/views use modal triggers where applicable.

## Notes

The integrated browser currently blocks the local Docker hostname before the application loads, so interactive desktop/mobile visual QA could not be completed in this environment. Server-rendered markup, modal roots, fallback routes, and the frontend production build were validated instead.