### PR TITLE
test(ui): cover shared form modal browser flows

### DIFF
--- a/tests/Browser/FormModalInteractionTest.php
+++ b/tests/Browser/FormModalInteractionTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+it('keeps the user monitoring modal usable on desktop and mobile', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create(['monitoring_limit' => 10]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+    $instanceCode = 'browser-' . Str::lower(Str::random(8));
+    ServerInstance::query()->create([
+        'code' => $instanceCode,
+        'api_key_hash' => 'browser-modal-instance-key',
+        'is_active' => true,
+    ]);
+    Monitoring::factory()->for($user)->create([
+        'name' => 'Existing browser monitor',
+        'preferred_location' => $instanceCode,
+    ]);
+
+    $page = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/monitorings');
+
+    foreach ([[1280, 800], [390, 640]] as $iteration => [$width, $height]) {
+        if ($iteration > 0) {
+            $page->navigate('/monitorings');
+        }
+
+        $page->resize($width, $height);
+
+        $trigger = 'header [data-form-modal-name="monitoring-form-modal"]';
+        $modal = '[data-form-modal="monitoring-form-modal"]';
+        $submit = $modal . ' form button[type="submit"]';
+        $nameField = $modal . ' [x-ref="content"] form input[name="name"]';
+        $targetField = $modal . ' [x-ref="content"] form input[name="target"]';
+
+        $page->assertCount($trigger, 1)
+            ->click($trigger);
+        expect($page->script(<<<'JS'
+async function () {
+    const loader = document.querySelector('[x-data="formModalLoader()"]');
+    const startedAt = Date.now();
+
+    while (loader && window.Alpine.$data(loader)?.loading && Date.now() - startedAt < 10000) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    return loader !== null && window.Alpine.$data(loader)?.loading === false;
+}
+JS))->toBeTrue();
+        $page->waitForText(__('monitoring.form.sections.basic'))
+            ->assertVisible($modal)
+            ->assertScript(<<<'JS'
+function () {
+    const modal = document.querySelector('[data-form-modal="monitoring-form-modal"]');
+
+    return modal?.contains(document.activeElement)
+        && document.body.classList.contains('overflow-y-hidden')
+        && document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        && document.body.scrollWidth <= document.body.clientWidth;
+}
+JS, true);
+
+        if ($width === 390) {
+            $page->assertScript(<<<'JS'
+function () {
+    const scrollRegion = document.querySelector('[data-form-modal="monitoring-form-modal"] .min-h-0.overflow-y-auto');
+
+    return scrollRegion !== null
+        && scrollRegion.scrollHeight > scrollRegion.clientHeight
+        && scrollRegion.scrollWidth <= scrollRegion.clientWidth;
+}
+JS, true);
+        }
+
+        $page->clear($nameField)
+            ->press($submit)
+            ->assertVisible($modal);
+        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $page->assertMissing($modal)
+            ->assertScript(<<<'JS'
+function () {
+    return document.activeElement === document.querySelector('header [data-form-modal-name="monitoring-form-modal"]');
+}
+JS, true);
+        $page->navigate('/monitorings?modal=monitoring-create')
+            ->waitForText(__('monitoring.form.sections.basic'))
+            ->assertVisible($modal)
+            ->assertCount($nameField, 1)
+            ->fill($nameField, 'Browser modal ' . Str::lower(Str::random(8)))
+            ->fill($targetField, 'https://example.com');
+        $page->assertScript(<<<'JS'
+function () {
+    const modal = document.querySelector('[data-form-modal="monitoring-form-modal"]');
+    const form = modal?.querySelector('[x-ref="content"] form');
+    const name = form?.querySelector('input[name="name"]')?.value;
+    const type = form?.querySelector('select[name="type"]')?.value;
+    const target = form?.querySelector('input[name="target"]')?.value;
+    return Boolean(name && type === 'http' && target === 'https://example.com' && form?.checkValidity());
+}
+JS, true);
+        $page->press($submit)
+            ->waitForText(__('monitoring.messages.created'))
+            ->assertNoJavaScriptErrors();
+    }
+});
+
+it('opens the admin package edit form in a focused responsive modal', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create([
+        'monitoring_limit' => 25,
+        'is_selectable' => false,
+    ]);
+    $admin = User::factory()->create([
+        'role' => UserRole::ADMIN->value,
+        'password' => Hash::make('password'),
+    ]);
+
+    $page = visit('/login')
+        ->type('email', $admin->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/admin/packages');
+
+    foreach ([[1280, 800], [390, 640]] as $iteration => [$width, $height]) {
+        if ($iteration > 0) {
+            $page->navigate('/admin/packages');
+        }
+
+        $page->resize($width, $height);
+
+        $editTrigger = 'a[data-form-modal-name="admin-package-form-modal"][href$="/packages/' . $package->getRouteKey() . '/edit"]';
+        $modal = '[data-form-modal="admin-package-form-modal"]';
+
+        $page->assertCount($editTrigger, 1)
+            ->click($editTrigger)
+            ->waitForText(__('admin.packages.fields.monitoring_limit'))
+            ->assertVisible($modal)
+            ->assertScript(<<<'JS'
+function () {
+    const modal = document.querySelector('[data-form-modal="admin-package-form-modal"]');
+
+    return modal?.contains(document.activeElement)
+        && document.body.classList.contains('overflow-y-hidden')
+        && document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        && document.body.scrollWidth <= document.body.clientWidth;
+}
+JS, true);
+        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $page->assertMissing($modal)
+            ->assertNoJavaScriptErrors();
+    }
+});


### PR DESCRIPTION
Closes #488

## What changed

- Add browser coverage for the shared monitoring Create modal on desktop and 390px mobile layouts.
- Verify focus capture, body scroll locking, responsive modal scrolling, native validation recovery, Escape close, and focus restoration.
- Cover the admin package Edit modal at desktop and mobile widths.
- Verify successful monitoring creation through the server-rendered modal route.

## Why

The shared Create/Edit modal migration is now used across the dashboard and admin surfaces. These browser checks protect the critical interaction and responsive behavior that unit and feature tests cannot observe.

## Validation

- Browser: `./vendor/bin/pest tests/Browser/FormModalInteractionTest.php` — 2 passed, 41 assertions.
- Docker: `composer analyse` — passed.
- Docker: `./vendor/bin/pest --compact tests/Feature tests/Unit` — 1 passed, 4,063 assertions, 644 pre-existing warnings.
- Docker: Vite production build — passed.
- Docker Pint — passed.
- The PHP container does not include the Playwright runtime in this worktree, so the browser test used the repository's host Playwright installation; no dependency was added or changed.