### PR TITLE
test(ui): cover Signal Room responsive workflows

### DIFF
--- a/resources/js/components/signal-room.ts
+++ b/resources/js/components/signal-room.ts
@@ -53,8 +53,19 @@ export default (config: SignalRoomConfig): SignalRoomComponent => ({
         updateViewport();
         mediaQuery.addEventListener('change', this.resizeHandler);
 
+        const keydownHandler = (event: KeyboardEvent): void => {
+            if (event.key === 'Escape') {
+                this.closeDetail();
+            }
+        };
+
+        window.addEventListener('keydown', keydownHandler);
+        document.addEventListener('keydown', keydownHandler);
+
         (this as any).$el.addEventListener('alpine:destroy', () => {
             mediaQuery.removeEventListener('change', this.resizeHandler);
+            window.removeEventListener('keydown', keydownHandler);
+            document.removeEventListener('keydown', keydownHandler);
         });
     },
 

--- a/resources/views/components/dashboard/signal-room-context.blade.php
+++ b/resources/views/components/dashboard/signal-room-context.blade.php
@@ -15,8 +15,8 @@
         <a href="{{ route('incidents.analytics') }}" class="text-sm font-bold text-purple-700 hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-200">{{ __('dashboard.signal_room.context.open_workspace') }}</a>
     </div>
 
-    <div class="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)_minmax(18rem,0.85fr)]">
-        <article class="rounded-3xl border border-red-100 bg-white p-5 shadow-sm dark:border-red-900/50 dark:bg-gray-800 sm:p-6">
+    <div class="grid min-w-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)_minmax(18rem,0.85fr)]">
+        <article class="min-w-0 rounded-3xl border border-red-100 bg-white p-5 shadow-sm dark:border-red-900/50 dark:bg-gray-800 sm:p-6">
             <div class="flex items-start justify-between gap-4">
                 <div>
                     <p class="text-sm font-extrabold text-gray-950 dark:text-white">{{ __('dashboard.signal_room.context.attention_heading') }}</p>
@@ -55,7 +55,7 @@
             @endif
         </article>
 
-        <article class="rounded-3xl border border-amber-100 bg-white p-5 shadow-sm dark:border-amber-900/50 dark:bg-gray-800 sm:p-6">
+        <article class="min-w-0 rounded-3xl border border-amber-100 bg-white p-5 shadow-sm dark:border-amber-900/50 dark:bg-gray-800 sm:p-6">
             <div class="flex items-start justify-between gap-4">
                 <div>
                     <p class="text-sm font-extrabold text-gray-950 dark:text-white">{{ __('dashboard.signal_room.context.maintenance_heading') }}</p>
@@ -78,7 +78,7 @@
             <a href="{{ route('maintenance.index') }}" class="mt-4 inline-flex text-sm font-bold text-purple-700 hover:text-purple-900 dark:text-purple-300">{{ $canManageMaintenance ? __('dashboard.signal_room.context.open_maintenance') : __('dashboard.signal_room.context.view_maintenance') }}</a>
         </article>
 
-        <article class="rounded-3xl border border-blue-100 bg-white p-5 shadow-sm dark:border-blue-900/50 dark:bg-gray-800 sm:p-6">
+        <article class="min-w-0 rounded-3xl border border-blue-100 bg-white p-5 shadow-sm dark:border-blue-900/50 dark:bg-gray-800 sm:p-6">
             <div class="flex items-start justify-between gap-4">
                 <div>
                     <p class="text-sm font-extrabold text-gray-950 dark:text-white">{{ __('dashboard.signal_room.context.surfaces_heading') }}</p>

--- a/resources/views/components/dashboard/signal-room-detail.blade.php
+++ b/resources/views/components/dashboard/signal-room-detail.blade.php
@@ -1,7 +1,7 @@
 @props(['mobile' => false])
 
 <template x-for="service in services" :key="service.id">
-    <div x-show="selectedServiceId === service.id" x-cloak class="p-5 sm:p-6">
+    <div data-signal-detail x-show="selectedServiceId === service.id" x-cloak class="p-5 sm:p-6">
         <div class="flex items-start justify-between gap-4">
             <div class="min-w-0">
                 <p class="text-[11px] font-black uppercase tracking-[0.18em] text-purple-600 dark:text-purple-300">{{ __('dashboard.signal_room.tabs.signal') }}</p>

--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -18,6 +18,7 @@
 
 <section
     x-data="signalRoom({ services: @js($services), initialServiceId: @js($initialServiceId) })"
+    data-signal-room
     class="space-y-5"
 >
     <div class="flex flex-col gap-5 rounded-3xl border border-purple-100 bg-white p-6 shadow-sm dark:border-purple-900/50 dark:bg-gray-800 sm:p-7 lg:flex-row lg:items-end lg:justify-between">
@@ -63,6 +64,7 @@
             @foreach (['all', 'attention', 'maintenance', 'paused'] as $filter)
                 <button
                     type="button"
+                    data-signal-filter="{{ $filter }}"
                     role="tab"
                     :aria-selected="activeFilter === '{{ $filter }}'"
                     @click="activeFilter = '{{ $filter }}'"
@@ -100,6 +102,7 @@
                                 @endphp
                                 <button
                                     type="button"
+                                    data-signal-service="{{ $service['id'] }}"
                                     @click="selectService(@js($service['id']))"
                                     @class([
                                         'group flex w-full items-center gap-3 rounded-2xl border px-3.5 py-3 text-start transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800',
@@ -134,9 +137,9 @@
         </aside>
     </div>
 
-    <div x-show="mobileDetailOpen" x-cloak class="lg:hidden">
+    <div data-signal-mobile-sheet x-show="mobileDetailOpen" x-cloak class="lg:hidden">
         <div class="fixed inset-0 z-40 bg-gray-950/35" aria-hidden="true" @click="closeDetail()"></div>
-        <div class="fixed inset-x-0 bottom-0 z-50 max-h-[88vh] overflow-y-auto rounded-t-3xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-800" role="dialog" aria-modal="true" aria-label="{{ __('dashboard.signal_room.heading') }}">
+        <div data-signal-mobile-detail class="fixed inset-x-0 bottom-0 z-50 max-h-[88vh] overflow-y-auto rounded-t-3xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-800" role="dialog" aria-modal="true" aria-label="{{ __('dashboard.signal_room.heading') }}">
             <x-dashboard.signal-room-detail mobile />
         </div>
     </div>

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MonitoringStatus;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+it('supports desktop service selection and keeps the Signal Room inside the viewport', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create(['monitoring_limit' => 10]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+    $monitoring = Monitoring::factory()->for($user)->create([
+        'name' => 'Payments API',
+        'target' => 'https://payments.example.test/health',
+    ]);
+    MonitoringResponse::query()->create([
+        'monitoring_id' => $monitoring->id,
+        'status' => MonitoringStatus::UP,
+        'response_time' => 128,
+    ]);
+
+    $page = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/dashboard')
+        ->resize(1280, 800);
+
+    $page->assertVisible('[data-signal-room]')
+        ->assertVisible('[data-signal-service="' . $monitoring->id . '"]')
+        ->assertVisible('aside [data-signal-detail]')
+        ->assertScript(<<<'JS'
+function () {
+    const detail = document.querySelector('aside [data-signal-detail]');
+    return detail !== null
+        && detail.textContent.includes('Payments API')
+        && detail.textContent.includes('128 ms');
+}
+JS, true)
+        ->assertScript(<<<'JS'
+function () {
+    return document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        && document.body.scrollWidth <= document.body.clientWidth;
+}
+JS, true)
+        ->assertNoJavaScriptErrors();
+});
+
+it('supports mobile filtering, service details and Escape to close the detail sheet', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create(['monitoring_limit' => 10]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+    $healthy = Monitoring::factory()->for($user)->create(['name' => 'Healthy Payments API']);
+    MonitoringResponse::query()->create([
+        'monitoring_id' => $healthy->id,
+        'status' => MonitoringStatus::UP,
+    ]);
+    $unknown = Monitoring::factory()->for($user)->create(['name' => 'Unknown Search Service']);
+
+    $page = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/dashboard')
+        ->resize(390, 640);
+
+    $page->click('[data-signal-filter="attention"]')
+        ->assertScript(<<<JS
+function () {
+    const service = document.querySelector('[data-signal-service="{$healthy->id}"]');
+    return service !== null && getComputedStyle(service).display === 'none';
+}
+JS, true)
+        ->click('[data-signal-filter="all"]')
+        ->click('[data-signal-service="' . $healthy->id . '"]')
+        ->assertVisible('[data-signal-mobile-detail]')
+        ->assertScript(<<<'JS'
+function () {
+    const detail = document.querySelector('[data-signal-mobile-detail]');
+    return detail !== null && detail.textContent.includes('Healthy Payments API');
+}
+JS, true)
+        ->assertScript(<<<'JS'
+function () {
+    return document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        && document.body.scrollWidth <= document.body.clientWidth;
+}
+JS, true);
+    $page->keys('input[type="search"]', 'Escape');
+    $page->wait(0.2);
+
+    $page->assertScript(<<<'JS'
+function () {
+    const sheet = document.querySelector('[data-signal-mobile-sheet]');
+    return sheet !== null && getComputedStyle(sheet).display === 'none';
+}
+JS, true)
+        ->type('input[type="search"]', 'Unknown Search')
+        ->assertScript(<<<JS
+function () {
+    const unknown = document.querySelector('[data-signal-service="{$unknown->id}"]');
+    const healthy = document.querySelector('[data-signal-service="{$healthy->id}"]');
+    return unknown !== null
+        && healthy !== null
+        && getComputedStyle(unknown).display !== 'none'
+        && getComputedStyle(healthy).display === 'none';
+}
+JS, true)
+        ->assertNoJavaScriptErrors();
+});


### PR DESCRIPTION
## What changed

- add responsive browser coverage for the Signal Room at desktop and 390px widths
- cover service selection, grouped detail rendering and response-time display
- cover attention filtering and service search
- cover mobile detail sheet open/close behavior and Escape handling
- assert no horizontal overflow and no JavaScript errors
- add stable data attributes for the responsive workflow selectors
- fix the mobile operational-context grid so it cannot widen the viewport

## Why

The Signal Room is the primary dashboard surface, so its core scan-and-drill workflow needs explicit responsive regression coverage before further dashboard consolidation.

## Testing

- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T php ./vendor/bin/pest tests/Feature/DashboardOverviewTest.php tests/Feature/AuthenticatedNavigationTest.php`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T php composer analyse`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T php ./vendor/bin/pint --dirty`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --entrypoint bun node run build`
- `./vendor/bin/pest tests/Browser/SignalRoomWorkflowTest.php tests/Browser/DashboardServiceOperationsModalTest.php`
- `git diff --check`

The in-app Browser could not resolve the local `webguard.test` domain in this environment, so repository browser coverage was run through the host fallback instead.

## Risks and follow-up

- This PR adds regression coverage and the responsive hardening needed for the current Signal Room surface.
- The existing detailed analytics view remains available for deeper analysis; future cleanup can now proceed with browser guardrails in place.

Closes #495