### PR TITLE
fix(ui): increase Signal Room navigation spacing

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -8,8 +8,8 @@
 @endphp
 
 <nav x-data="{ open: false, workspaceOpen: false }"
-    class="relative z-40 border-b border-purple-900/40 bg-purple-950 text-white lg:fixed lg:inset-y-0 lg:left-0 lg:w-64 lg:border-b-0">
-    <div class="flex h-16 items-center justify-between px-4 lg:flex-col lg:items-stretch lg:px-3 lg:py-5">
+    class="relative z-40 border-b border-purple-900/40 bg-purple-950 text-white lg:fixed lg:inset-y-0 lg:left-0 lg:w-64 lg:overflow-y-auto lg:border-b-0">
+    <div class="flex min-h-16 items-center justify-between px-4 lg:min-h-screen lg:h-auto lg:flex-col lg:items-stretch lg:px-3 lg:py-5">
         <a href="{{ route('dashboard') }}" class="flex items-center gap-3 rounded-xl px-2 py-1.5 focus:outline-hidden focus:ring-2 focus:ring-purple-300">
             <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-white p-1.5 shadow-sm">
                 <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="{{ __('app.logo_alt') }}" class="h-full w-full object-contain">
@@ -30,7 +30,7 @@
                 <span>{{ __('app.navigation.signal_room') }}</span>
             </a>
 
-            <div class="mt-5">
+            <div data-workspace-navigation class="mt-5">
                 <button type="button" @click="workspaceOpen = ! workspaceOpen"
                     @class([
                         'flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left text-sm font-semibold transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
@@ -48,7 +48,7 @@
                     </svg>
                 </button>
 
-                <div x-cloak x-show="workspaceOpen || {{ $workspaceNavActive ? 'true' : 'false' }}" x-transition class="mt-2 space-y-1 border-s border-purple-800 ps-3">
+                <div x-cloak x-show="workspaceOpen || {{ $workspaceNavActive ? 'true' : 'false' }}" x-transition class="mt-3 space-y-2 border-s border-purple-800 ps-3">
                     <a href="{{ route('monitorings.index') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('monitorings.*')])>
                         {{ __('monitoring.title') }}
                     </a>
@@ -71,7 +71,7 @@
             </div>
         </div>
 
-        <div class="hidden space-y-3 lg:block">
+        <div data-navigation-utilities class="mt-6 hidden space-y-4 lg:block">
             <div class="flex items-center gap-2">
                 <a id="notifications-bell-desktop" href="{{ route('notifications.index') }}"
                     aria-label="{{ __('notifications.title') }}" title="{{ __('notifications.title') }}"

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -43,6 +43,17 @@ it('supports desktop service selection and keeps the Signal Room inside the view
         ->assertVisible('aside [data-signal-detail]')
         ->assertScript(<<<'JS'
 function () {
+    const workspace = document.querySelector('[data-workspace-navigation]');
+    const utilities = document.querySelector('[data-navigation-utilities]');
+    if (!workspace || !utilities) {
+        return false;
+    }
+
+    return utilities.getBoundingClientRect().top - workspace.getBoundingClientRect().bottom >= 24;
+}
+JS, true)
+        ->assertScript(<<<'JS'
+function () {
     const detail = document.querySelector('aside [data-signal-detail]');
     return detail !== null
         && detail.textContent.includes('Payments API')


### PR DESCRIPTION
## What changed

- give the desktop navigation rail the full viewport height with overflow protection
- increase the spacing between Workspace links
- separate the notification and account controls from the Workspace navigation
- add a browser regression check that verifies the navigation gap

## Why

The Workspace navigation and lower utility controls appeared too compressed in the current rail, especially at shorter desktop viewport heights.

## Testing

- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T php php artisan view:cache`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T php ./vendor/bin/pest tests/Feature/AuthenticatedNavigationTest.php`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec -T php ./vendor/bin/pint --dirty`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps --entrypoint bun node run build`
- `./vendor/bin/pest tests/Browser/SignalRoomWorkflowTest.php tests/Browser/DashboardServiceOperationsModalTest.php`
- `git diff --check`

The in-app Browser could not resolve the local `webguard.test` domain, so the repository's browser-test fallback was used for rendered validation.

Closes #501