### PR TITLE
feat(ui): simplify monitoring context navigation

### DIFF
--- a/resources/lang/de/app.php
+++ b/resources/lang/de/app.php
@@ -32,7 +32,7 @@ return [
     'navigation' => [
         'home' => 'Hauptnavigation',
         'signal_room' => 'Signal Room',
-        'monitoring' => 'Monitoring',
+        'monitoring' => 'Überwachung',
         'workspace' => 'Workspace',
         'more' => 'Mehr',
         'sections' => [

--- a/resources/views/components/monitoring-operations-header.blade.php
+++ b/resources/views/components/monitoring-operations-header.blade.php
@@ -1,0 +1,65 @@
+@php
+    $activeTab = match (true) {
+        request()->routeIs('monitoring-groups.*') => 'groups',
+        request()->routeIs('status-pages.*') => 'status_pages',
+        request()->routeIs('incidents.analytics') => 'analytics',
+        default => 'overview',
+    };
+
+    $tabs = [
+        [
+            'key' => 'overview',
+            'label' => __('incidents.analytics.overview.tabs.overview'),
+            'href' => route('monitorings.index'),
+        ],
+        [
+            'key' => 'groups',
+            'label' => __('incidents.analytics.overview.tabs.groups'),
+            'href' => route('monitoring-groups.index'),
+        ],
+        [
+            'key' => 'status_pages',
+            'label' => __('incidents.analytics.overview.tabs.status_pages'),
+            'href' => route('status-pages.index'),
+        ],
+        [
+            'key' => 'analytics',
+            'label' => __('incidents.analytics.overview.tabs.analytics'),
+            'href' => route('incidents.analytics'),
+        ],
+    ];
+@endphp
+
+<div class="w-full" data-monitoring-context>
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+            <x-heading type="h1">{{ __('incidents.analytics.title') }}</x-heading>
+            <p class="mt-2 max-w-3xl text-sm text-gray-500 dark:text-gray-400">
+                {{ __('incidents.analytics.description') }}
+            </p>
+        </div>
+
+        @isset($actions)
+            <div class="shrink-0 sm:ml-auto">
+                {{ $actions }}
+            </div>
+        @endisset
+    </div>
+
+    <nav class="mt-6 -mb-6 overflow-x-auto" aria-label="{{ __('incidents.analytics.title') }}">
+        <div class="flex min-w-max items-center gap-1 border-b border-gray-200 dark:border-gray-700">
+            @foreach ($tabs as $tab)
+                @php($isActive = $activeTab === $tab['key'])
+                <a href="{{ $tab['href'] }}"
+                    @class([
+                        'border-b-2 px-3 py-3 text-sm transition focus:outline-hidden focus:ring-2 focus:ring-purple-400',
+                        'border-purple-500 font-semibold text-purple-700 dark:text-purple-300' => $isActive,
+                        'border-transparent font-medium text-gray-500 hover:border-purple-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200' => ! $isActive,
+                    ])
+                    @if ($isActive) aria-current="page" @endif>
+                    {{ $tab['label'] }}
+                </a>
+            @endforeach
+        </div>
+    </nav>
+</div>

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -19,12 +19,7 @@
 
 <x-app-layout>
     <x-slot name="header">
-        <div>
-            <x-heading type="h1">{{ __('incidents.analytics.title') }}</x-heading>
-            <p class="mt-2 max-w-3xl text-sm text-gray-500 dark:text-gray-400">
-                {{ __('incidents.analytics.description') }}
-            </p>
-        </div>
+        <x-monitoring-operations-header />
     </x-slot>
 
     <x-main>
@@ -40,28 +35,6 @@
         </div>
 
         <div id="service-operations" class="space-y-6">
-            <nav aria-label="{{ __('incidents.analytics.overview.tabs.overview') }}" class="overflow-x-auto">
-                <div class="flex min-w-max items-center gap-1 border-b border-gray-200 dark:border-gray-700">
-                    <a href="{{ route('incidents.analytics') }}#overview"
-                        class="border-b-2 border-purple-500 px-3 py-3 text-sm font-semibold text-purple-700 dark:text-purple-300"
-                        aria-current="page">
-                        {{ __('incidents.analytics.overview.tabs.overview') }}
-                    </a>
-                    <a href="{{ route('monitoring-groups.index') }}"
-                        class="border-b-2 border-transparent px-3 py-3 text-sm font-medium text-gray-500 transition hover:border-purple-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
-                        {{ __('incidents.analytics.overview.tabs.groups') }}
-                    </a>
-                    <a href="{{ route('status-pages.index') }}"
-                        class="border-b-2 border-transparent px-3 py-3 text-sm font-medium text-gray-500 transition hover:border-purple-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
-                        {{ __('incidents.analytics.overview.tabs.status_pages') }}
-                    </a>
-                    <a href="#incident-analytics"
-                        class="border-b-2 border-transparent px-3 py-3 text-sm font-medium text-gray-500 transition hover:border-purple-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
-                        {{ __('incidents.analytics.overview.tabs.analytics') }}
-                    </a>
-                </div>
-            </nav>
-
             <section id="overview" aria-labelledby="service-health-heading">
                 <x-container class="overflow-hidden">
                     <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,13 +1,11 @@
 @php
-    $workspaceNavActive = request()->routeIs('monitorings.*')
+    $monitoringNavActive = request()->routeIs('monitorings.*')
         || request()->routeIs('incidents.*')
-        || request()->routeIs('maintenance.*')
         || request()->routeIs('monitoring-groups.*')
-        || request()->routeIs('status-pages.*')
-        || request()->routeIs('teams.*');
+        || request()->routeIs('status-pages.*');
 @endphp
 
-<nav x-data="{ open: false, workspaceOpen: false }"
+<nav x-data="{ open: false }"
     class="relative z-40 border-b border-purple-900/40 bg-purple-950 text-white lg:fixed lg:inset-y-0 lg:left-0 lg:w-64 lg:overflow-y-auto lg:border-b-0">
     <div class="flex min-h-16 items-center justify-between px-4 lg:min-h-screen lg:h-auto lg:flex-col lg:items-stretch lg:px-3 lg:py-5">
         <a href="{{ route('dashboard') }}" class="flex items-center gap-3 rounded-xl px-2 py-1.5 focus:outline-hidden focus:ring-2 focus:ring-purple-300">
@@ -17,7 +15,7 @@
             <span class="text-lg font-bold tracking-tight text-white">{{ __('app.name') }}</span>
         </a>
 
-        <div class="hidden flex-1 pt-12 lg:block">
+        <div data-primary-navigation class="hidden flex-1 pt-12 lg:block">
             <a href="{{ route('dashboard') }}"
                 @class([
                     'flex items-center gap-3 rounded-xl border px-4 py-3 text-sm font-semibold transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
@@ -30,44 +28,24 @@
                 <span>{{ __('app.navigation.signal_room') }}</span>
             </a>
 
-            <div data-workspace-navigation class="mt-5">
-                <button type="button" @click="workspaceOpen = ! workspaceOpen"
+            <div class="mt-5">
+                <a href="{{ route('monitorings.index') }}"
                     @class([
-                        'flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left text-sm font-semibold transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
-                        'border-purple-700 bg-purple-900/70 text-white' => $workspaceNavActive,
-                        'border-transparent text-purple-100 hover:border-purple-700 hover:bg-purple-900/70 hover:text-white' => ! $workspaceNavActive,
+                        'flex w-full items-center gap-3 rounded-xl border px-4 py-3 text-left text-sm font-semibold transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
+                        'border-purple-400/50 bg-purple-700 text-white shadow-lg shadow-purple-950/20' => $monitoringNavActive,
+                        'border-transparent text-purple-100 hover:border-purple-700 hover:bg-purple-900/70 hover:text-white' => ! $monitoringNavActive,
                     ])>
                     <span class="flex items-center gap-3">
                         <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6.5A2.5 2.5 0 0 1 6.5 4h4A2.5 2.5 0 0 1 13 6.5v4a2.5 2.5 0 0 1-2.5 2.5h-4A2.5 2.5 0 0 1 4 10.5v-4Zm7 7A2.5 2.5 0 0 1 13.5 11h4a2.5 2.5 0 0 1 2.5 2.5v4a2.5 2.5 0 0 1-2.5 2.5h-4a2.5 2.5 0 0 1-2.5-2.5v-4Z" />
                         </svg>
-                        <span>{{ __('app.navigation.workspace') }}</span>
+                        <span>{{ __('app.navigation.monitoring') }}</span>
                     </span>
-                    <svg class="h-4 w-4 transition" :class="{ 'rotate-180': workspaceOpen }" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <svg class="hidden" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                         <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
                     </svg>
-                </button>
+                </a>
 
-                <div x-cloak x-show="workspaceOpen || {{ $workspaceNavActive ? 'true' : 'false' }}" x-transition class="mt-3 space-y-2 border-s border-purple-800 ps-3">
-                    <a href="{{ route('monitorings.index') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('monitorings.*')])>
-                        {{ __('monitoring.title') }}
-                    </a>
-                    <a href="{{ route('incidents.analytics') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('incidents.*')])>
-                        {{ __('incidents.analytics.title') }}
-                    </a>
-                    <a href="{{ route('maintenance.index') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('maintenance.*')])>
-                        {{ __('maintenance.title') }}
-                    </a>
-                    <a href="{{ route('monitoring-groups.index') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('monitoring-groups.*')])>
-                        {{ __('monitoring_group.title') }}
-                    </a>
-                    <a href="{{ route('status-pages.index') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('status-pages.*')])>
-                        {{ __('status_page.title') }}
-                    </a>
-                    <a href="{{ route('teams.index') }}" @class(['block rounded-lg px-3 py-2 text-sm text-purple-100 transition hover:bg-purple-900/70 hover:text-white' => true, 'bg-purple-800 text-white' => request()->routeIs('teams.*')])>
-                        {{ __('team.title') }}
-                    </a>
-                </div>
             </div>
         </div>
 
@@ -142,13 +120,8 @@
         <p class="px-3 pb-2 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.signal_room') }}</p>
         <a href="{{ route('dashboard') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('dashboard'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('dashboard')])>{{ __('app.navigation.signal_room') }}</a>
 
-        <p class="px-3 pb-2 pt-4 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.workspace') }}</p>
-        <a href="{{ route('monitorings.index') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('monitorings.*'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('monitorings.*')])>{{ __('monitoring.title') }}</a>
-        <a href="{{ route('incidents.analytics') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('incidents.*'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('incidents.*')])>{{ __('incidents.analytics.title') }}</a>
-        <a href="{{ route('maintenance.index') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('maintenance.*'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('maintenance.*')])>{{ __('maintenance.title') }}</a>
-        <a href="{{ route('monitoring-groups.index') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('monitoring-groups.*'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('monitoring-groups.*')])>{{ __('monitoring_group.title') }}</a>
-        <a href="{{ route('status-pages.index') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('status-pages.*'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('status-pages.*')])>{{ __('status_page.title') }}</a>
-        <a href="{{ route('teams.index') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('teams.*'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('teams.*')])>{{ __('team.title') }}</a>
+        <p class="px-3 pb-2 pt-4 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.monitoring') }}</p>
+        <a href="{{ route('monitorings.index') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => $monitoringNavActive, 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! $monitoringNavActive])>{{ __('app.navigation.monitoring') }}</a>
 
         @if (Auth::user()->isAdmin())
             <p class="px-3 pb-2 pt-4 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.sections.administration') }}</p>

--- a/resources/views/monitoring-groups/index.blade.php
+++ b/resources/views/monitoring-groups/index.blade.php
@@ -1,13 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <x-heading type="h1">{{ __('monitoring_group.title') }}</x-heading>
-
-        @if (!Auth::user()->isDemo())
-            <x-primary-button :href="route('monitoring-groups.create')" class="sm:ml-auto"
-                data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
-                {{ __('button.create') }}
-            </x-primary-button>
-        @endif
+        <x-monitoring-operations-header>
+            @if (!Auth::user()->isDemo())
+                <x-slot name="actions">
+                    <x-primary-button :href="route('monitoring-groups.create')"
+                        data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
+                        {{ __('button.create') }}
+                    </x-primary-button>
+                </x-slot>
+            @endif
+        </x-monitoring-operations-header>
     </x-slot>
 
     <x-main>

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -17,16 +17,16 @@
 
 <x-app-layout>
     <x-slot name="header">
-        <x-heading type="h1">
-            {{ __('monitoring.title') }}
-        </x-heading>
-
-        @if ($canCreateMonitoring)
-            <x-primary-button :href="route('monitorings.create')" class="sm:ml-auto"
-                data-form-modal-trigger data-form-modal-name="monitoring-form-modal">
-                {{ __('button.create') }}
-            </x-primary-button>
-        @endif
+        <x-monitoring-operations-header>
+            @if ($canCreateMonitoring)
+                <x-slot name="actions">
+                    <x-primary-button :href="route('monitorings.create')"
+                        data-form-modal-trigger data-form-modal-name="monitoring-form-modal">
+                        {{ __('button.create') }}
+                    </x-primary-button>
+                </x-slot>
+            @endif
+        </x-monitoring-operations-header>
     </x-slot>
 
     <x-main>

--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -1,13 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <x-heading type="h1">{{ __('status_page.title') }}</x-heading>
-
-        @if (!Auth::user()->isDemo())
-            <x-primary-button :href="route('status-pages.create')" class="sm:ml-auto"
-                data-form-modal-trigger data-form-modal-name="status-page-form-modal">
-                {{ __('button.create') }}
-            </x-primary-button>
-        @endif
+        <x-monitoring-operations-header>
+            @if (!Auth::user()->isDemo())
+                <x-slot name="actions">
+                    <x-primary-button :href="route('status-pages.create')"
+                        data-form-modal-trigger data-form-modal-name="status-page-form-modal">
+                        {{ __('button.create') }}
+                    </x-primary-button>
+                </x-slot>
+            @endif
+        </x-monitoring-operations-header>
     </x-slot>
 
     <x-main>

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -43,13 +43,12 @@ it('supports desktop service selection and keeps the Signal Room inside the view
         ->assertVisible('aside [data-signal-detail]')
         ->assertScript(<<<'JS'
 function () {
-    const workspace = document.querySelector('[data-workspace-navigation]');
-    const utilities = document.querySelector('[data-navigation-utilities]');
-    if (!workspace || !utilities) {
+    const primaryNavigation = document.querySelector('[data-primary-navigation]');
+    if (!primaryNavigation) {
         return false;
     }
 
-    return utilities.getBoundingClientRect().top - workspace.getBoundingClientRect().bottom >= 24;
+    return primaryNavigation.querySelectorAll('a').length === 2;
 }
 JS, true)
         ->assertScript(<<<'JS'

--- a/tests/Feature/AuthenticatedNavigationTest.php
+++ b/tests/Feature/AuthenticatedNavigationTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 
 class AuthenticatedNavigationTest extends TestCase
 {
-    public function test_member_navigation_exposes_signal_room_and_secondary_workspace_destinations_without_admin_links(): void
+    public function test_member_navigation_exposes_only_signal_room_and_monitoring_as_primary_destinations(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);
         $user = User::factory()->create(['package_id' => $package->id]);
@@ -20,15 +20,11 @@ class AuthenticatedNavigationTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeText(__('app.navigation.signal_room'));
-        $testResponse->assertSeeText(__('monitoring.title'));
-        $testResponse->assertSeeText(__('incidents.analytics.title'));
-        $testResponse->assertSeeText(__('status_page.title'));
-        $testResponse->assertSeeText(__('maintenance.title'));
-        $testResponse->assertSeeText(__('monitoring_group.title'));
-        $testResponse->assertSeeText(__('team.title'));
-        $testResponse->assertSeeHtml('href="' . route('incidents.analytics') . '"');
-        $testResponse->assertSeeHtml('href="' . route('status-pages.index') . '"');
+        $testResponse->assertSeeText(__('app.navigation.monitoring'));
         $testResponse->assertSeeHtml('href="' . route('dashboard') . '"');
+        $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
+        $testResponse->assertDontSeeText(__('app.navigation.workspace'));
+        $testResponse->assertDontSeeHtml('data-workspace-navigation');
         $testResponse->assertDontSeeText(__('app.navigation.sections.administration'));
         $testResponse->assertDontSeeText(__('admin.dashboard.users.heading'));
     }

--- a/tests/Feature/MonitoringContextNavigationTest.php
+++ b/tests/Feature/MonitoringContextNavigationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\User;
+use Tests\TestCase;
+
+class MonitoringContextNavigationTest extends TestCase
+{
+    public function test_monitoring_pages_share_the_same_context_navigation_with_one_active_tab(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $tabs = [
+            __('incidents.analytics.overview.tabs.overview'),
+            __('incidents.analytics.overview.tabs.groups'),
+            __('incidents.analytics.overview.tabs.status_pages'),
+            __('incidents.analytics.overview.tabs.analytics'),
+        ];
+
+        foreach ([
+            'monitorings.index',
+            'monitoring-groups.index',
+            'status-pages.index',
+            'incidents.analytics',
+        ] as $routeName) {
+            $testResponse = $this->actingAs($user)->get(route($routeName));
+
+            $testResponse->assertOk()
+                ->assertSeeHtml('data-monitoring-context')
+                ->assertSeeText(__('incidents.analytics.title'))
+                ->assertSeeText(__('incidents.analytics.description'))
+                ->assertSeeTextInOrder($tabs)
+                ->assertSeeHtml('aria-current="page"');
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- reduce the authenticated primary navigation to Signal Room and Monitoring
- add a shared Service-Betrieb header with Overview, Monitoring Groups, Status Pages, and Incident Analytics tabs
- keep the header structure stable while the active tab follows the current route
- preserve create actions in the shared header and remove the duplicate Analytics tab bar

## Why
The monitoring workspace should feel like one coherent surface instead of a collection of sidebar destinations. This also keeps the navigation visible at the point where users switch between the operational views.

## Validation
- Docker frontend build: `bun run build`
- Docker Pest feature coverage: 370 assertions across the affected monitoring, incident, status-page, modal, and navigation tests
- Browser fallback coverage: `tests/Browser/SignalRoomWorkflowTest.php` (2 passed, 14 assertions)
- Laravel Pint passed for all changed PHP/Blade/test files
- In-app Browser could not start because the expected Chrome binary is unavailable in the environment; the Playwright browser fallback passed.

Closes #503