### PR TITLE
fix(ui): keep language menu inside navigation rail

### DIFF
--- a/resources/views/components/language-switch.blade.php
+++ b/resources/views/components/language-switch.blade.php
@@ -2,6 +2,7 @@
     'id' => 'language-switch',
     'class' => '',
     'variant' => 'default',
+    'align' => 'right',
 ])
 
 @php
@@ -33,7 +34,7 @@
 @endphp
 
 <div class="{{ $class }}">
-    <x-dropdown align="right" width="w-40" :content-classes="$menuClasses">
+    <x-dropdown :align="$align" width="w-40" :content-classes="$menuClasses">
         <x-slot name="trigger">
             <button id="{{ $id }}" type="button" aria-label="{{ __('profile.fields.language') }}"
                 title="{{ $languages[$currentLocale]['label'] }}" class="{{ $triggerClasses }}">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -69,7 +69,7 @@
 
         <div data-navigation-utilities class="mt-6 hidden space-y-4 lg:block">
             <div class="flex items-center gap-2">
-                <x-language-switch id="language-switch-desktop" />
+                <x-language-switch id="language-switch-desktop" align="left" />
             </div>
 
             <x-dropdown align="right" width="48" contentClasses="bg-white py-2 dark:bg-slate-900">

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -139,3 +139,43 @@ function () {
 JS, true)
         ->assertNoJavaScriptErrors();
 });
+
+it('keeps the desktop language menu within the navigation rail', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create(['monitoring_limit' => 10]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+
+    $page = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/dashboard')
+        ->resize(1280, 800)
+        ->click('#language-switch-desktop')
+        ->assertScript(<<<'JS'
+function () {
+    const trigger = document.querySelector('#language-switch-desktop');
+    const menu = trigger?.closest('[x-data]')?.querySelector('.absolute');
+    const rail = document.querySelector('nav');
+
+    if (!trigger || !menu || !rail || getComputedStyle(menu).display === 'none') {
+        return false;
+    }
+
+    const menuRect = menu.getBoundingClientRect();
+    const railRect = rail.getBoundingClientRect();
+
+    return menuRect.left >= railRect.left
+        && menuRect.right <= railRect.right;
+}
+JS, true)
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/LocalePreferenceTest.php
+++ b/tests/Feature/LocalePreferenceTest.php
@@ -59,6 +59,7 @@ class LocalePreferenceTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('id="language-switch-desktop"');
         $testResponse->assertSeeHtml('id="language-switch-mobile"');
+        $testResponse->assertSeeHtml('ltr:origin-top-left rtl:origin-top-right start-0');
     }
 
     public function test_authenticated_user_locale_in_database_overrides_cookie_value(): void


### PR DESCRIPTION
## What changed
- pass the dropdown alignment through the language switch component
- align the desktop language menu from the trigger's left edge so it stays inside the fixed rail
- keep mobile language switch alignment unchanged
- add feature and browser regression coverage for the menu position

## Why
The desktop language dropdown was right-aligned inside the narrow navigation rail. Its fixed width therefore extended beyond the rail and was clipped by the rail's overflow container.

## Validation
- Docker Laravel Pint passed for all changed files
- Docker Pest `tests/Feature/LocalePreferenceTest.php` passed (10 tests, 35 assertions)
- Playwright browser fallback `tests/Browser/SignalRoomWorkflowTest.php` passed (3 tests, 16 assertions), including the opened-menu bounds check
- Docker frontend build passed
- The integrated browser could not recover its current tab session; the Playwright fallback verified the rendered behavior.

Closes #507