### PR TITLE
fix(ui): compact monitoring ownership status

### DIFF
--- a/resources/views/monitorings/_ownership.blade.php
+++ b/resources/views/monitorings/_ownership.blade.php
@@ -1,34 +1,34 @@
-<x-container>
-    <div class="space-y-4">
-        <div>
-            <x-heading type="h2">{{ __('team.ownership.select_label') }}</x-heading>
-            <x-paragraph class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                {{ $monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private') }}
-            </x-paragraph>
-        </div>
-
-        @if (! $monitoring->isTeamOwned() && $adminTeams->isNotEmpty())
-            <form method="POST" action="{{ route('monitorings.team-ownership.store', $monitoring) }}"
-                class="flex flex-col gap-2 sm:flex-row sm:items-end">
-                @csrf
-                <div class="min-w-0 flex-1">
-                    <x-input-label for="move-team-{{ $monitoring->id }}" :value="__('team.ownership.move_to_team')" />
-                    <x-select-input id="move-team-{{ $monitoring->id }}" name="team_id" class="mt-1 block w-full">
-                        @foreach ($adminTeams as $team)
-                            <option value="{{ $team->id }}">{{ $team->name }}</option>
-                        @endforeach
-                    </x-select-input>
-                </div>
-                <x-secondary-button type="submit">{{ __('team.ownership.move_to_team') }}</x-secondary-button>
-            </form>
-        @endif
-
-        @if ($monitoring->isTeamOwned())
-            <form method="POST" action="{{ route('monitorings.team-ownership.destroy', $monitoring) }}">
-                @csrf
-                @method('DELETE')
-                <x-secondary-button type="submit">{{ __('team.ownership.move_to_private') }}</x-secondary-button>
-            </form>
-        @endif
+<div class="space-y-4" data-monitoring-ownership-status>
+    <div class="flex flex-wrap items-center gap-3 border-b border-gray-200 pb-4 dark:border-gray-700">
+        <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">
+            {{ __('team.ownership.select_label') }}
+        </span>
+        <x-badge type="info" class="rounded-full px-3 py-1" data-monitoring-ownership-badge>
+            {{ $monitoring->team ? __('team.ownership.team') . ': ' . $monitoring->team->name : __('team.ownership.private') }}
+        </x-badge>
     </div>
-</x-container>
+
+    @if (! $monitoring->isTeamOwned() && $adminTeams->isNotEmpty())
+        <form method="POST" action="{{ route('monitorings.team-ownership.store', $monitoring) }}"
+            class="flex flex-col gap-2 sm:flex-row sm:items-end">
+            @csrf
+            <div class="min-w-0 flex-1">
+                <x-input-label for="move-team-{{ $monitoring->id }}" :value="__('team.ownership.move_to_team')" />
+                <x-select-input id="move-team-{{ $monitoring->id }}" name="team_id" class="mt-1 block w-full">
+                    @foreach ($adminTeams as $team)
+                        <option value="{{ $team->id }}">{{ $team->name }}</option>
+                    @endforeach
+                </x-select-input>
+            </div>
+            <x-secondary-button type="submit">{{ __('team.ownership.move_to_team') }}</x-secondary-button>
+        </form>
+    @endif
+
+    @if ($monitoring->isTeamOwned())
+        <form method="POST" action="{{ route('monitorings.team-ownership.destroy', $monitoring) }}">
+            @csrf
+            @method('DELETE')
+            <x-secondary-button type="submit">{{ __('team.ownership.move_to_private') }}</x-secondary-button>
+        </form>
+    @endif
+</div>

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -74,5 +74,7 @@ class MonitoringFormPresentationTest extends TestCase
         $editResponse->assertOk();
         $editResponse->assertSeeText(__('team.ownership.private'));
         $editResponse->assertSeeText('Production');
+        $editResponse->assertSeeHtml('data-monitoring-ownership-status');
+        $editResponse->assertSeeHtml('data-monitoring-ownership-badge');
     }
 }


### PR DESCRIPTION
Closes #509

## What changed

- Replaced the oversized ownership card on monitoring detail/edit forms with a compact status row.
- Rendered the current private/team ownership as a rounded badge.
- Kept the existing team assignment and move-to-private actions unchanged.
- Added feature assertions for the ownership status and badge markup.

## Why

The ownership state looked like a large primary form section and consumed unnecessary vertical space at the top of the detail form.

## Validation

- Docker Pest: `tests/Feature/MonitoringFormPresentationTest.php`, `tests/Feature/FormModalCrudFlowTest.php`
- Browser: `tests/Browser/DashboardServiceOperationsModalTest.php`
- Docker Vite production build
- Laravel Pint and `git diff --check`

The direct Playwright connector could not start because Chromium is not installed in its configured path; the repository browser test passed as the interaction fallback.