### PR TITLE
fix(ui): clarify monitoring form actions

### DIFF
--- a/resources/views/components/multi-select.blade.php
+++ b/resources/views/components/multi-select.blade.php
@@ -26,7 +26,7 @@
     ));
 @endphp
 
-<div {{ $attributes->class('relative') }}
+<div {{ $attributes->class('relative')->merge(['data-select-control' => 'multi']) }}
     x-data="{
         open: false,
         query: '',
@@ -94,12 +94,12 @@
         <input type="hidden" name="{{ $inputName }}" :value="value">
     </template>
 
-    <div class="flex min-h-11 w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition focus-within:border-purple-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-purple-500/30 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+    <div class="flex min-h-11 w-full items-center gap-2 rounded-md border border-purple-200 bg-purple-50/40 px-3 py-2 text-sm shadow-sm transition focus-within:border-purple-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-purple-500/30 dark:border-purple-800 dark:bg-purple-950/30 dark:text-gray-100"
         x-on:click="open = true; $nextTick(() => $refs.search?.focus())"
         x-bind:class="{ 'border-purple-500 ring-2 ring-purple-500/30': open }">
         <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
             <template x-for="option in selectedOptions" :key="option.value">
-                <span class="inline-flex max-w-full items-center gap-1 rounded-md bg-gray-100 px-2 py-1 font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200">
+                <span class="inline-flex max-w-full items-center gap-1 rounded-md bg-purple-100 px-2 py-1 font-medium text-purple-800 dark:bg-purple-900/70 dark:text-purple-100">
                     <span class="truncate" x-text="option.label"></span>
                     <button type="button"
                         class="rounded-sm px-1 text-gray-500 hover:bg-gray-200 hover:text-gray-700 focus:bg-gray-200 focus:outline-none dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100 dark:focus:bg-gray-700"
@@ -119,7 +119,7 @@
                 x-bind:aria-expanded="open.toString()">
         </div>
 
-        <div class="flex shrink-0 items-center gap-2 text-gray-500 dark:text-gray-400">
+        <div class="flex shrink-0 items-center gap-2 text-purple-600 dark:text-purple-300">
             <button type="button" x-cloak x-show="selected.length > 0"
                 class="rounded-sm px-1 text-lg leading-none hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500/30 dark:hover:text-gray-100"
                 x-on:click.stop="clear()"
@@ -138,7 +138,7 @@
     </div>
 
     <div id="{{ $fieldId }}_options" x-cloak x-show="open" x-transition x-on:click.outside="open = false"
-        class="absolute z-20 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-gray-200 bg-white py-1 text-sm shadow-lg dark:border-gray-700 dark:bg-gray-900"
+        class="absolute z-20 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-purple-200 bg-white py-1 text-sm shadow-lg dark:border-purple-800 dark:bg-gray-900"
         role="listbox"
         aria-multiselectable="true">
         <button type="button"

--- a/resources/views/components/select-input.blade.php
+++ b/resources/views/components/select-input.blade.php
@@ -1,6 +1,24 @@
 @props(['disabled' => false, 'multiple' => false])
 
-<select @disabled($disabled) @if ($multiple) multiple @endif
-    {{ $attributes->merge(['class' => 'border-gray-300 focus:border-purple-500 focus:ring-purple-500 rounded-md shadow-xs dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100']) }}>
-    {{ $slot }}
-</select>
+@php
+    $selectClasses = $multiple
+        ? 'border-gray-300 bg-white focus:border-purple-500 focus:ring-purple-500 rounded-md shadow-xs dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+        : 'appearance-none border-purple-200 bg-purple-50/40 pr-10 text-gray-900 focus:border-purple-500 focus:ring-purple-500 rounded-md shadow-xs dark:border-purple-800 dark:bg-purple-950/30 dark:text-gray-100';
+@endphp
+
+<div class="relative">
+    <select @disabled($disabled) @if ($multiple) multiple @endif data-select-control="native"
+        {{ $attributes->class($selectClasses) }}>
+        {{ $slot }}
+    </select>
+    @unless ($multiple)
+        <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-purple-600 dark:text-purple-300"
+            aria-hidden="true">
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd"
+                    d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-.02-1.06z"
+                    clip-rule="evenodd" />
+            </svg>
+        </span>
+    @endunless
+</div>

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -460,14 +460,6 @@
                 <x-heading type="h2">{{ __('monitoring.form.sections.notifications') }}</x-heading>
             </summary>
 
-    @if (isset($monitoring))
-        <input type="hidden" name="notification_on_failure" value="{{ old('notification_on_failure', $monitoring->notification_on_failure ?? true) ? '1' : '0' }}">
-        @foreach ($selectedNotificationChannels as $channel)
-            <input type="hidden" name="notification_channels[]" value="{{ $channel }}">
-        @endforeach
-        <input type="hidden" name="ssl_expiry_warning_days" value="{{ old('ssl_expiry_warning_days', $monitoring->ssl_expiry_warning_days ?? 7) }}">
-    @endif
-
     @unless (isset($monitoring))
     <div class="mt-4">
         <x-input-label for="notification_on_failure" :value="__('monitoring.form.notification_on_failure')" />
@@ -497,14 +489,14 @@
     <div class="mt-4">
         <x-input-label for="notification_channels" :value="__('monitoring.form.notification_channels')" />
         @if (count($enabledNotificationChannels) > 0)
-            <select id="notification_channels" name="notification_channels[]" multiple size="{{ min(4, count($enabledNotificationChannels)) }}"
-                class="mt-1 block w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+            <x-select-input id="notification_channels" name="notification_channels[]" multiple
+                size="{{ min(4, count($enabledNotificationChannels)) }}" class="mt-1 block w-full">
                 @foreach ($enabledNotificationChannels as $channel)
                     <option value="{{ $channel }}" @selected(in_array($channel, $selectedNotificationChannels, true))>
                         {{ __('profile.notification_settings.channels.' . $channel . '.title') }}
                     </option>
                 @endforeach
-            </select>
+            </x-select-input>
             <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
                 {{ __('monitoring.form.notification_channels_help') }}
             </p>
@@ -573,7 +565,8 @@
 
         </details>
 
-        <div class="flex flex-wrap justify-end gap-2">
+        <div class="flex flex-wrap justify-end gap-2 border-t border-gray-200 pt-6 dark:border-gray-700"
+            data-monitoring-form-actions>
             <x-secondary-button
                 :href="isset($modal) && $modal ? null : (isset($monitoring) ? route('monitorings.show', $monitoring) : route('monitorings.index'))"
                 type="button"

--- a/resources/views/monitorings/_notification_preferences.blade.php
+++ b/resources/views/monitorings/_notification_preferences.blade.php
@@ -5,8 +5,9 @@
     $fieldIdPrefix = $fieldIdPrefix ?? 'monitoring_notification_preference';
 @endphp
 
-<x-container>
-    <x-heading type="h2">{{ __('team.sections.notification_preferences') }}</x-heading>
+<section class="rounded-lg border border-gray-200 bg-gray-50/70 p-4 shadow-none dark:border-gray-700 dark:bg-gray-900/30 sm:p-5"
+    data-monitoring-notification-preferences>
+    <x-heading type="h3">{{ __('team.sections.notification_preferences') }}</x-heading>
     <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
         class="mt-4 space-y-4">
         @csrf
@@ -45,8 +46,8 @@
             <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
         </div>
 
-        <x-primary-button>
+        <x-secondary-button>
             {{ __('button.save') }}
-        </x-primary-button>
+        </x-secondary-button>
     </form>
-</x-container>
+</section>

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -76,5 +76,9 @@ class MonitoringFormPresentationTest extends TestCase
         $editResponse->assertSeeText('Production');
         $editResponse->assertSeeHtml('data-monitoring-ownership-status');
         $editResponse->assertSeeHtml('data-monitoring-ownership-badge');
+        $editResponse->assertSeeHtml('data-monitoring-form-actions');
+        $editResponse->assertSeeHtml('data-monitoring-notification-preferences');
+        $editResponse->assertSeeHtml('data-select-control="native"');
+        $editResponse->assertSeeHtml('data-select-control="multi"');
     }
 }


### PR DESCRIPTION
Closes #511

## What changed

- Reduced the visual emphasis of the per-monitoring notification preferences section.
- Changed its save action to the secondary button style so the monitoring update remains the primary action.
- Removed duplicated notification preference values from the edit form; they are now submitted only by the dedicated preference form.
- Added a consistent colored native select treatment with a chevron affordance.
- Applied the same visual treatment to custom multi-select controls.
- Added presentation regression assertions.

## Why

The monitoring form presented two adjacent save/update flows with overlapping notification data, and select controls did not consistently communicate that they were interactive.

## Validation

- Docker Pest: MonitoringFormPresentationTest, MonitoringNotificationSettingsTest, FormModalCrudFlowTest
- Browser fallback: FormModalInteractionTest, DashboardServiceOperationsModalTest
- Docker Vite production build
- Laravel Pint and git diff --check

The in-app Browser could not reach the local route in this environment; the repository's Playwright/Pest browser fallback passed the responsive modal flows.