### PR TITLE
fix(ui): left-align monitoring filter dropdowns

### DIFF
--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -150,7 +150,7 @@
                     @endforeach
                 </div>
 
-                <div class="grid w-full grid-cols-1 gap-2 sm:ml-auto sm:grid-cols-2 md:flex md:w-auto md:flex-wrap md:justify-end md:gap-3">
+                <div class="grid w-full grid-cols-1 gap-2 sm:grid-cols-2 md:flex md:w-auto md:flex-wrap md:gap-3">
                     <div class="min-w-0">
                         <div x-data="{
                             selectedStatus: '{{ request('lifecycle') ?? '' }}',

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -52,7 +52,7 @@ class MonitoringIndexEmptyStateTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeHtml('class="grid w-full grid-cols-1 gap-2 sm:ml-auto sm:grid-cols-2 md:flex md:w-auto md:flex-wrap md:justify-end md:gap-3"');
+        $testResponse->assertSeeHtml('class="grid w-full grid-cols-1 gap-2 sm:grid-cols-2 md:flex md:w-auto md:flex-wrap md:gap-3"');
         $testResponse->assertSeeHtml('class="w-full rounded-md border border-gray-300 p-2 pr-8 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 md:w-auto"');
     }
 


### PR DESCRIPTION
Closes #513

## What changed

- Removed the auto-margin that pushed the advanced filter dropdown group to the right.
- Removed the desktop end-justification so the dropdowns begin at the same left edge as the filter chips.
- Updated the mobile-friendly presentation regression assertion.

## Why

The filter controls were visually detached from the filter chips by a large empty gap.

## Validation

- Docker Pest: MonitoringIndexEmptyStateTest
- Laravel Pint and git diff --check
- Docker Vite production build

An existing unrelated browser test remains broken because its browser API calls the unavailable actingAs() method; the filter change itself does not alter browser behavior or filter logic.