### PR TITLE
fix(ui): use violet for primary operations accents

### DIFF
--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -630,7 +630,7 @@
 
                     <div class="pt-5 text-center" x-show="recentChecksHasMore">
                         <button type="button" @click="loadMoreChecks()"
-                            class="inline-flex items-center rounded-md border border-emerald-200 bg-white px-4 py-2 text-sm font-semibold uppercase text-emerald-700 shadow-sm transition duration-150 hover:border-emerald-300 hover:bg-emerald-50 focus:outline-hidden focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-800 dark:bg-gray-800 dark:text-emerald-300 dark:hover:bg-emerald-950/40"
+                            class="inline-flex items-center rounded-md border border-purple-200 bg-white px-4 py-2 text-sm font-semibold uppercase text-purple-700 shadow-sm transition duration-150 hover:border-purple-300 hover:bg-purple-50 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-purple-800 dark:bg-gray-800 dark:text-purple-300 dark:hover:bg-purple-950/40"
                             x-bind:disabled="recentChecksLoadingMore"
                             x-bind:class="{ 'opacity-60 cursor-not-allowed': recentChecksLoadingMore }">
                             <span

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -32,7 +32,7 @@
                 'loadMoreContainerId' => 'status-change-load-more-container',
                 'title' => __('notifications.status_change_notifications'),
                 'description' => __('notifications.sections.status_change.description'),
-                'accent' => 'bg-emerald-500',
+                'accent' => 'bg-violet-500',
             ],
             [
                 'type' => 'delivery_history',
@@ -49,7 +49,7 @@
     <x-slot name="header">
         <div id="notification-command-center" class="grid w-full gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,30rem)] lg:items-center">
             <div class="min-w-0">
-                <x-paragraph class="text-sm font-semibold uppercase tracking-[0.08em] text-emerald-700 dark:text-emerald-300">
+                <x-paragraph class="text-sm font-semibold uppercase tracking-[0.08em] text-purple-700 dark:text-purple-300">
                     {{ __('notifications.overview.eyebrow') }}
                 </x-paragraph>
                 <x-heading type="h1" class="mt-1 text-slate-950 dark:text-white">
@@ -68,11 +68,11 @@
                         </x-paragraph>
                         <nav class="mt-2 grid grid-cols-2 rounded-lg bg-slate-100 p-1 text-sm font-semibold dark:bg-slate-800" aria-label="{{ __('notifications.filters.heading') }}">
                             <a href="{{ route('notifications.index', $showReadDisabledQuery) }}" data-notification-filter-link
-                                class="{{ ! $showRead ? 'bg-emerald-500 text-white shadow-sm ring-1 ring-emerald-600/20 dark:bg-emerald-400 dark:text-slate-950 dark:ring-emerald-300/30' : 'text-slate-600 hover:bg-white/70 hover:text-emerald-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-emerald-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
+                                class="{{ ! $showRead ? 'bg-purple-600 text-white shadow-sm ring-1 ring-purple-700/20 dark:bg-purple-500 dark:text-white dark:ring-purple-400/30' : 'text-slate-600 hover:bg-white/70 hover:text-purple-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-purple-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
                                 {{ __('notifications.filters.unread') }}
                             </a>
                             <a href="{{ route('notifications.index', $showReadEnabledQuery) }}" data-notification-filter-link
-                                class="{{ $showRead ? 'bg-emerald-500 text-white shadow-sm ring-1 ring-emerald-600/20 dark:bg-emerald-400 dark:text-slate-950 dark:ring-emerald-300/30' : 'text-slate-600 hover:bg-white/70 hover:text-emerald-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-emerald-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
+                                class="{{ $showRead ? 'bg-purple-600 text-white shadow-sm ring-1 ring-purple-700/20 dark:bg-purple-500 dark:text-white dark:ring-purple-400/30' : 'text-slate-600 hover:bg-white/70 hover:text-purple-700 dark:text-slate-300 dark:hover:bg-slate-950/70 dark:hover:text-purple-300' }} inline-flex min-h-10 items-center justify-center rounded-md px-3 text-center transition">
                                 {{ __('notifications.filters.all') }}
                             </a>
                         </nav>
@@ -80,7 +80,7 @@
 
                     <form method="POST" action="{{ route('notifications.markAllAsRead') }}" class="sm:pb-1">
                         @csrf
-                        <x-secondary-button type="submit" class="!w-full justify-center !border-emerald-500 !bg-emerald-500 px-3 py-2 text-sm !normal-case !tracking-normal !text-white hover:!border-emerald-600 hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!border-emerald-400 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!border-emerald-300 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto">
+                        <x-secondary-button type="submit" class="!w-full justify-center !border-purple-600 !bg-purple-600 px-3 py-2 text-sm !normal-case !tracking-normal !text-white hover:!border-purple-700 hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!border-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!border-purple-400 dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto">
                             <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
                             </svg>
@@ -276,9 +276,9 @@
             </div>
         </x-container>
 
-        <x-container id="notifications-empty-state" x-cloak x-show="!isLoading && isEmpty" class="border border-emerald-200 bg-emerald-50/70 text-center shadow-sm dark:border-emerald-300/20 dark:bg-emerald-300/10">
+        <x-container id="notifications-empty-state" x-cloak x-show="!isLoading && isEmpty" class="border border-purple-200 bg-purple-50/70 text-center shadow-sm dark:border-purple-300/20 dark:bg-purple-300/10">
             <div class="mx-auto flex max-w-2xl flex-col items-center">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-lg bg-white text-emerald-700 shadow-sm ring-1 ring-emerald-200 dark:bg-slate-900 dark:text-emerald-300 dark:ring-emerald-300/20">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-lg bg-white text-purple-700 shadow-sm ring-1 ring-purple-200 dark:bg-slate-900 dark:text-purple-300 dark:ring-purple-300/20">
                     <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
                     </svg>
@@ -336,7 +336,7 @@
                     <div id="{{ $section['containerId'] }}" class="space-y-3"></div>
 
                     <div class="mt-4 text-center" id="{{ $section['loadMoreContainerId'] }}" style="display: none;">
-                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!w-full justify-center !bg-emerald-500 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto">
+                        <x-primary-button @click="loadMoreNotifications('{{ $section['type'] }}')" class="!w-full justify-center !bg-purple-600 px-4 py-2 text-sm !normal-case !tracking-normal hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto">
                             {{ __('notifications.load_more') }}
                         </x-primary-button>
                     </div>

--- a/resources/views/notifications/partials/notification_list.blade.php
+++ b/resources/views/notifications/partials/notification_list.blade.php
@@ -3,7 +3,7 @@
         $isRead = (bool) $notification->read;
         $accentClasses = match ($type) {
             'domain_expiry' => 'bg-sky-500',
-            'status_change' => 'bg-emerald-500',
+            'status_change' => 'bg-violet-500',
             default => 'bg-amber-500',
         };
         $showCardIcon = $type === 'domain_expiry';
@@ -43,7 +43,7 @@
             </div>
 
             @if (! $isRead)
-                <x-primary-button class="mark-as-read-button shrink-0 !w-full justify-center !bg-emerald-500 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto"
+                <x-primary-button class="mark-as-read-button shrink-0 !w-full justify-center !bg-purple-600 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto"
                     aria-label="{{ __('notifications.mark_as_read') }}"
                     @click="markAsRead(event, '{{ $notification->id }}', '{{ route('notifications.markAsRead', $notification) }}', '{{ $type }}')">
                     <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/resources/views/notifications/partials/status_board_list.blade.php
+++ b/resources/views/notifications/partials/status_board_list.blade.php
@@ -75,7 +75,7 @@
                     {{ $statusLabel }}
                 </x-badge>
                 @if (! $isRead)
-                    <x-primary-button class="mark-as-read-button !w-full justify-center !bg-emerald-500 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-emerald-600 focus:!bg-emerald-600 focus:!ring-emerald-500 dark:!bg-emerald-400 dark:!text-slate-950 dark:hover:!bg-emerald-300 dark:focus:!ring-emerald-300 sm:!w-auto"
+                    <x-primary-button class="mark-as-read-button !w-full justify-center !bg-purple-600 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto"
                         aria-label="{{ __('notifications.mark_as_read') }}"
                         @click="markAsRead(event, '{{ $entry['notification_id'] }}', '{{ route('notifications.markAsRead', $entry['notification_id']) }}', 'status_change')">
                         <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
+++ b/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
@@ -36,6 +36,8 @@ class MonitoringDetailRecentChecksSectionTest extends TestCase
         $testResponse->assertSeeHtml('id="response-time-range"');
         $testResponse->assertSeeHtml('id="incidents-range"');
         $testResponse->assertSeeHtml('@click="loadMoreChecks()"');
+        $testResponse->assertSeeHtml('focus:ring-purple-500');
+        $testResponse->assertDontSeeHtml('focus:ring-emerald-500');
         $testResponse->assertDontSeeText(__('monitoring.detail.custom_range.heading'));
         $testResponse->assertDontSeeHtml('id="uptime-card-custom-range"');
         $testResponse->assertSeeHtml('id="recent-checks"');

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -39,9 +39,9 @@ class NotificationPageDesignTest extends TestCase
         $testResponse->assertSeeText(__('notifications.filters.unread'));
         $testResponse->assertSeeText(__('notifications.filters.all'));
         $testResponse->assertSeeText(__('notifications.mark_all_as_read'));
-        $testResponse->assertSeeHtml('bg-emerald-500 text-white');
-        $testResponse->assertSeeHtml('dark:bg-emerald-400 dark:text-slate-950');
-        $testResponse->assertSeeHtml('dark:!bg-emerald-400 dark:!text-slate-950');
+        $testResponse->assertSeeHtml('bg-purple-600 text-white');
+        $testResponse->assertSeeHtml('dark:bg-purple-500 dark:text-white');
+        $testResponse->assertSeeHtml('dark:!bg-purple-500 dark:!text-white');
         $testResponse->assertSeeHtml('sm:grid-cols-[1fr_auto]');
         $testResponse->assertSeeHtml('sm:grid-cols-3');
         $testResponse->assertSeeText(__('notifications.loading.title'));
@@ -80,8 +80,8 @@ class NotificationPageDesignTest extends TestCase
         $this->assertStringContainsString('notification-card-accent', $html);
         $this->assertStringNotContainsString('inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ring-1', $html);
         $this->assertStringContainsString('aria-label="' . __('notifications.mark_as_read') . '"', $html);
-        $this->assertStringContainsString('!bg-emerald-500', $html);
-        $this->assertStringContainsString('dark:!text-slate-950', $html);
+        $this->assertStringContainsString('!bg-purple-600', $html);
+        $this->assertStringContainsString('dark:!text-white', $html);
         $this->assertStringContainsString('id="' . $monitoringNotification->id . '"', $html);
         $this->assertStringContainsString('Checkout API', $html);
     }


### PR DESCRIPTION
## What changed
- Replaced green primary actions in monitoring details and notifications with WebGuard violet.
- Updated notification filter states, mark-as-read actions, load-more actions and neutral empty states to use violet.
- Kept green for genuine positive status semantics such as healthy, operational and successful delivery.
- Updated presentation regression assertions.

## Why
WebGuard violet is the primary corporate accent. Green should communicate system state, not compete with primary navigation, headings or actions.

## Validation
- `./vendor/bin/pint resources/views/monitorings/show.blade.php resources/views/notifications/index.blade.php resources/views/notifications/partials/notification_list.blade.php resources/views/notifications/partials/status_board_list.blade.php tests/Feature/MonitoringDetailRecentChecksSectionTest.php tests/Feature/Notifications/NotificationPageDesignTest.php`
- `./vendor/bin/pest tests/Feature/MonitoringDetailRecentChecksSectionTest.php tests/Feature/Notifications/NotificationPageDesignTest.php tests/Feature/MonitoringIndexEmptyStateTest.php`
- `bun run build`
- Visual QA with local authenticated headless Playwright fallback; Browser connector was unavailable because its Chrome distribution was missing.

The temporary QA account was removed after the screenshot pass.

Closes #521