### PR TITLE
feat(ui): modernize profile and settings surfaces

### DIFF
--- a/resources/lang/de/profile.php
+++ b/resources/lang/de/profile.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 return [
     'title' => 'Profil',
+    'navigation' => [
+        'heading' => 'Kontoeinstellungen',
+        'account' => 'Konto und Darstellung',
+        'security' => 'Sicherheit',
+        'api' => 'API und Dokumentation',
+        'danger_zone' => 'Konto löschen',
+    ],
     'delete_account' => [
         'heading' => 'Konto löschen',
         'description' => 'Sobald Ihr Konto gelöscht wurde, werden alle zugehörigen Ressourcen und Daten dauerhaft gelöscht.',

--- a/resources/lang/en/profile.php
+++ b/resources/lang/en/profile.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 return [
     'title' => 'Profile',
+    'navigation' => [
+        'heading' => 'Account settings',
+        'account' => 'Account and appearance',
+        'security' => 'Security',
+        'api' => 'API and documentation',
+        'danger_zone' => 'Delete account',
+    ],
     'delete_account' => [
         'heading' => 'Delete Account',
         'description' => 'Once your account is deleted, all of its resources and data will be permanently deleted.',

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,14 +1,47 @@
 <x-app-layout>
     <x-slot name="header">
-        <x-heading type="h1">{{ __('profile.title') }}</x-heading>
+        <div>
+            <x-heading type="h1">{{ __('profile.title') }}</x-heading>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('profile.information.description') }}</p>
+        </div>
     </x-slot>
 
     <x-main>
-        <div class="space-y-6">
+        <div data-profile-settings class="space-y-6">
             @if ($fullPage)
-                @include('profile.partials.update-profile-information-form')
-                @include('profile.partials.update-password-form')
+                <div class="grid gap-6 lg:grid-cols-[13rem_minmax(0,1fr)] lg:items-start">
+                    <nav aria-label="{{ __('profile.navigation.heading') }}" class="lg:sticky lg:top-6">
+                        <p class="px-3 text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">{{ __('profile.navigation.heading') }}</p>
+                        <div class="mt-3 space-y-1 text-sm font-semibold">
+                            <a href="#profile-information" class="block rounded-lg px-3 py-2 text-purple-700 hover:bg-purple-50 dark:text-purple-300 dark:hover:bg-purple-950/30">{{ __('profile.navigation.account') }}</a>
+                            <a href="#profile-password" class="block rounded-lg px-3 py-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">{{ __('profile.navigation.security') }}</a>
+                            <a href="#profile-api" class="block rounded-lg px-3 py-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">{{ __('profile.navigation.api') }}</a>
+                            <a href="#profile-delete" class="block rounded-lg px-3 py-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">{{ __('profile.navigation.danger_zone') }}</a>
+                        </div>
+                    </nav>
+
+                    <div class="min-w-0 space-y-6">
+                        <section id="profile-information" class="scroll-mt-6">
+                            <x-container>
+                                @include('profile.partials.update-profile-information-form')
+                            </x-container>
+                        </section>
+                        <section id="profile-password" class="scroll-mt-6">
+                            <x-container>
+                                @include('profile.partials.update-password-form')
+                            </x-container>
+                        </section>
+                        <section id="profile-api" class="scroll-mt-6">
+                            @include('profile.partials.api-configuration')
+                            @include('profile.partials.api-docs')
+                        </section>
+                        <section id="profile-delete" class="scroll-mt-6">
+                            @include('profile.partials.delete-user-form')
+                        </section>
+                    </div>
+                </div>
             @else
+                <section data-profile-section="account">
                 <x-container>
                     <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
                     <x-paragraph>{{ __('profile.information.description') }}</x-paragraph>
@@ -44,7 +77,9 @@
                         </div>
                     </div>
                 </x-container>
+                </section>
 
+                <section data-profile-section="security">
                 <x-container>
                     <x-heading type="h2">{{ __('profile.update_password.heading') }}</x-heading>
                     <x-paragraph>{{ __('profile.update_password.description') }}</x-paragraph>
@@ -72,15 +107,20 @@
                         </x-form-modal>
                     </div>
                 </x-container>
+                </section>
 
                 <x-secondary-button :href="route('profile.edit', ['full' => 1])">
                     {{ __('profile.actions.open_full_page') }}
                 </x-secondary-button>
             @endif
 
-            @include('profile.partials.api-configuration')
-            @include('profile.partials.api-docs')
-            @include('profile.partials.delete-user-form')
+            <section data-profile-section="api">
+                @include('profile.partials.api-configuration')
+                @include('profile.partials.api-docs')
+            </section>
+            <section data-profile-section="danger-zone">
+                @include('profile.partials.delete-user-form')
+            </section>
         </div>
     </x-main>
 </x-app-layout>

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -103,6 +103,11 @@ class ProfileNotificationSettingsTest extends TestCase
 
         $testResponse = $this->actingAs($user)->get(route('profile.edit', ['full' => 1]));
         $testResponse->assertOk();
+        $testResponse->assertSeeHtml('data-profile-settings')
+            ->assertSeeHtml('id="profile-information"')
+            ->assertSeeHtml('id="profile-password"')
+            ->assertSeeHtml('id="profile-api"')
+            ->assertSeeHtml('id="profile-delete"');
         $testResponse->assertSeeText(__('profile.sections.account'));
         $testResponse->assertSeeText(__('profile.sections.preferences'));
         $testResponse->assertSeeText(__('profile.notification_settings.heading'));


### PR DESCRIPTION
Closes #519

## What changed

- Added a clear profile/settings information architecture with grouped account, security, API and danger-zone sections.
- Added responsive in-page navigation for the full profile view.
- Kept existing profile modal flows, API configuration, password changes, notification settings and account deletion behavior intact.
- Added localized navigation labels in German and English.

## Testing

- Docker Blade view cache
- Focused Pest coverage for profile and team modal flows
- Docker Vite production build
- Authenticated browser checks at desktop and 390px mobile width, including overflow verification

## Risks and follow-up

- The existing modal-based profile flows remain unchanged for modal entry points; the grouped navigation applies to the full settings view.
- A pre-existing local demo-credentials request still reports a 404 in the browser console and is unrelated to this UI change.