### PR TITLE
fix(ui): simplify operations navigation and incident filters

### DIFF
--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -19,14 +19,14 @@ class PasswordController extends Controller
     /**
      * Update the user's password.
      *
-     * @param  Request  $request  The HTTP request instance containing the new password data.
+     * @param  Request  $updatePasswordRequest  The HTTP request instance containing the new password data.
      * @return RedirectResponse A redirect response after updating the password.
      */
-    public function update(UpdatePasswordRequest $request): RedirectResponse
+    public function update(UpdatePasswordRequest $updatePasswordRequest): RedirectResponse
     {
-        $validated = $request->validated();
+        $validated = $updatePasswordRequest->validated();
 
-        $request->user()->update([
+        $updatePasswordRequest->user()->update([
             'password' => Hash::make($validated['password']),
         ]);
 

--- a/app/Http/Requests/UpdatePasswordRequest.php
+++ b/app/Http/Requests/UpdatePasswordRequest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Foundation\Http\Attributes\ErrorBag;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Password;
 
+#[ErrorBag('updatePassword')]
 class UpdatePasswordRequest extends FormRequest
 {
-    protected $errorBag = 'updatePassword';
-
     public function authorize(): bool
     {
         return $this->user() !== null;

--- a/resources/views/components/monitoring-operations-header.blade.php
+++ b/resources/views/components/monitoring-operations-header.blade.php
@@ -1,35 +1,3 @@
-@php
-    $activeTab = match (true) {
-        request()->routeIs('monitoring-groups.*') => 'groups',
-        request()->routeIs('status-pages.*') => 'status_pages',
-        request()->routeIs('incidents.analytics') => 'analytics',
-        default => 'overview',
-    };
-
-    $tabs = [
-        [
-            'key' => 'overview',
-            'label' => __('incidents.analytics.overview.tabs.overview'),
-            'href' => route('monitorings.index'),
-        ],
-        [
-            'key' => 'groups',
-            'label' => __('incidents.analytics.overview.tabs.groups'),
-            'href' => route('monitoring-groups.index'),
-        ],
-        [
-            'key' => 'status_pages',
-            'label' => __('incidents.analytics.overview.tabs.status_pages'),
-            'href' => route('status-pages.index'),
-        ],
-        [
-            'key' => 'analytics',
-            'label' => __('incidents.analytics.overview.tabs.analytics'),
-            'href' => route('incidents.analytics'),
-        ],
-    ];
-@endphp
-
 <div class="w-full" data-monitoring-context>
     <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
@@ -46,20 +14,4 @@
         @endisset
     </div>
 
-    <nav class="mt-6 -mb-6 overflow-x-auto" aria-label="{{ __('incidents.analytics.title') }}">
-        <div class="flex min-w-max items-center gap-1 border-b border-gray-200 dark:border-gray-700">
-            @foreach ($tabs as $tab)
-                @php($isActive = $activeTab === $tab['key'])
-                <a href="{{ $tab['href'] }}"
-                    @class([
-                        'border-b-2 px-3 py-3 text-sm transition focus:outline-hidden focus:ring-2 focus:ring-purple-400',
-                        'border-purple-500 font-semibold text-purple-700 dark:text-purple-300' => $isActive,
-                        'border-transparent font-medium text-gray-500 hover:border-purple-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200' => ! $isActive,
-                    ])
-                    @if ($isActive) aria-current="page" @endif>
-                    {{ $tab['label'] }}
-                </a>
-            @endforeach
-        </div>
-    </nav>
 </div>

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -209,14 +209,14 @@
 
             <section id="incident-analytics" aria-labelledby="incident-analytics-heading" class="scroll-mt-6 space-y-4">
                 <x-container>
-                    <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                    <div class="space-y-5">
                         <div>
                             <x-heading type="h2" id="incident-analytics-heading">{{ __('incidents.analytics.sections.recent') }}</x-heading>
                             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.definitions') }}</p>
                         </div>
-                        <form method="GET" action="{{ route('incidents.analytics') }}" class="grid w-full gap-3 sm:grid-cols-2 lg:max-w-4xl lg:grid-cols-5">
-                            <div>
-                                <x-input-label for="days" :value="__('incidents.analytics.filters.period')" />
+                        <form method="GET" action="{{ route('incidents.analytics') }}" class="grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
+                            <div class="min-w-0">
+                                <x-input-label for="days" class="leading-5" :value="__('incidents.analytics.filters.period')" />
                                 <x-select-input id="days" name="days" class="mt-1 w-full">
                                     @foreach ([30, 90, 365] as $daysOption)
                                         <option value="{{ $daysOption }}" @selected($filters['days'] === $daysOption)>
@@ -225,8 +225,8 @@
                                     @endforeach
                                 </x-select-input>
                             </div>
-                            <div>
-                                <x-input-label for="incident_type" :value="__('incidents.analytics.filters.type')" />
+                            <div class="min-w-0">
+                                <x-input-label for="incident_type" class="leading-5" :value="__('incidents.analytics.filters.type')" />
                                 <x-select-input id="incident_type" name="incident_type" class="mt-1 w-full">
                                     <option value="">{{ __('incidents.analytics.filters.all') }}</option>
                                     @foreach ($incidentTypes as $type)
@@ -236,8 +236,8 @@
                                     @endforeach
                                 </x-select-input>
                             </div>
-                            <div>
-                                <x-input-label for="severity" :value="__('incidents.analytics.filters.severity')" />
+                            <div class="min-w-0">
+                                <x-input-label for="severity" class="leading-5" :value="__('incidents.analytics.filters.severity')" />
                                 <x-select-input id="severity" name="severity" class="mt-1 w-full">
                                     <option value="">{{ __('incidents.analytics.filters.all') }}</option>
                                     @foreach ($severities as $severity)
@@ -247,8 +247,8 @@
                                     @endforeach
                                 </x-select-input>
                             </div>
-                            <div>
-                                <x-input-label for="customer_impact" :value="__('incidents.analytics.filters.customer_impact')" />
+                            <div class="min-w-0">
+                                <x-input-label for="customer_impact" class="leading-5" :value="__('incidents.analytics.filters.customer_impact')" />
                                 <x-select-input id="customer_impact" name="customer_impact" class="mt-1 w-full">
                                     <option value="">{{ __('incidents.analytics.filters.all') }}</option>
                                     @foreach ($customerImpacts as $impact)
@@ -258,8 +258,8 @@
                                     @endforeach
                                 </x-select-input>
                             </div>
-                            <div class="flex items-end">
-                                <x-primary-button class="w-full justify-center">{{ __('incidents.analytics.filters.apply') }}</x-primary-button>
+                            <div class="flex items-end sm:col-span-2 sm:justify-end">
+                                <x-primary-button class="w-full justify-center whitespace-nowrap sm:w-auto">{{ __('incidents.analytics.filters.apply') }}</x-primary-button>
                             </div>
                             <div class="sm:col-span-2 lg:col-span-5">
                                 <x-input-label for="affected_service" :value="__('incidents.analytics.filters.affected_service')" />

--- a/tests/Browser/DashboardServiceOperationsModalTest.php
+++ b/tests/Browser/DashboardServiceOperationsModalTest.php
@@ -22,19 +22,19 @@ it('opens the dashboard monitoring create actions in a responsive modal', functi
         'password' => Hash::make('password'),
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]');
 
     foreach ([[1280, 800], [390, 640]] as $widthHeight) {
         [$width, $height] = $widthHeight;
-        $page->navigate('/dashboard')->resize($width, $height);
+        $webpage->navigate('/dashboard')->resize($width, $height);
 
         $trigger = 'a[data-form-modal-name="monitoring-form-modal"][href$="/monitorings/create"]';
         $modal = '[data-form-modal="monitoring-form-modal"]';
 
-        $page->assertCount($trigger, 1)
+        $webpage->assertCount($trigger, 1)
             ->click($trigger)
             ->wait(1)
             ->waitForText(__('monitoring.form.sections.basic'))
@@ -52,7 +52,7 @@ JS, true)
             ->assertNoJavaScriptErrors();
 
         if ($width === 390) {
-            $page->assertScript(<<<'JS'
+            $webpage->assertScript(<<<'JS'
 function () {
     const scrollRegion = document.querySelector('[data-form-modal="monitoring-form-modal"] .min-h-0.overflow-y-auto');
 
@@ -62,8 +62,8 @@ function () {
 JS, true);
         }
 
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($modal);
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($modal);
     }
 });
 
@@ -89,21 +89,21 @@ it('opens service operations status page and monitoring group modals responsivel
         'is_public' => true,
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]');
 
     foreach ([[1280, 800], [390, 640]] as $widthHeight) {
         [$width, $height] = $widthHeight;
-        $page->navigate('/incidents/analytics')->resize($width, $height);
+        $webpage->navigate('/incidents/analytics')->resize($width, $height);
 
         $statusTrigger = 'a[data-form-modal-name="status-page-form-modal"][href$="/status-pages/create"]';
         $statusModal = '[data-form-modal="status-page-form-modal"]';
         $groupTrigger = 'a[data-form-modal-name="monitoring-group-form-modal"][href$="/monitoring-groups/' . $group->getRouteKey() . '/edit"]';
         $groupModal = '[data-form-modal="monitoring-group-form-modal"]';
 
-        $page->assertCount($statusTrigger, 1)
+        $webpage->assertCount($statusTrigger, 1)
             ->click($statusTrigger)
             ->wait(1)
             ->waitForText(__('status_page.form.name'))
@@ -117,8 +117,8 @@ function () {
         && document.body.scrollWidth <= document.body.clientWidth;
 }
 JS, true);
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($statusModal)
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($statusModal)
             ->click($groupTrigger)
             ->wait(1)
             ->waitForText(__('monitoring_group.form.name'))
@@ -134,7 +134,7 @@ function () {
 JS, true)
             ->assertNoJavaScriptErrors();
 
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($groupModal);
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($groupModal);
     }
 });

--- a/tests/Browser/FormModalInteractionTest.php
+++ b/tests/Browser/FormModalInteractionTest.php
@@ -33,7 +33,7 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
         'preferred_location' => $instanceCode,
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
@@ -41,10 +41,10 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
 
     foreach ([[1280, 800], [390, 640]] as $iteration => [$width, $height]) {
         if ($iteration > 0) {
-            $page->navigate('/monitorings');
+            $webpage->navigate('/monitorings');
         }
 
-        $page->resize($width, $height);
+        $webpage->resize($width, $height);
 
         $trigger = 'header [data-form-modal-name="monitoring-form-modal"]';
         $modal = '[data-form-modal="monitoring-form-modal"]';
@@ -52,9 +52,9 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
         $nameField = $modal . ' [x-ref="content"] form input[name="name"]';
         $targetField = $modal . ' [x-ref="content"] form input[name="target"]';
 
-        $page->assertCount($trigger, 1)
+        $webpage->assertCount($trigger, 1)
             ->click($trigger);
-        expect($page->script(<<<'JS'
+        expect($webpage->script(<<<'JS'
 async function () {
     const loader = document.querySelector('[x-data="formModalLoader()"]');
     const startedAt = Date.now();
@@ -66,7 +66,7 @@ async function () {
     return loader !== null && window.Alpine.$data(loader)?.loading === false;
 }
 JS))->toBeTrue();
-        $page->waitForText(__('monitoring.form.sections.basic'))
+        $webpage->waitForText(__('monitoring.form.sections.basic'))
             ->assertVisible($modal)
             ->assertScript(<<<'JS'
 function () {
@@ -80,7 +80,7 @@ function () {
 JS, true);
 
         if ($width === 390) {
-            $page->assertScript(<<<'JS'
+            $webpage->assertScript(<<<'JS'
 function () {
     const scrollRegion = document.querySelector('[data-form-modal="monitoring-form-modal"] .min-h-0.overflow-y-auto');
 
@@ -91,23 +91,23 @@ function () {
 JS, true);
         }
 
-        $page->clear($nameField)
+        $webpage->clear($nameField)
             ->press($submit)
             ->assertVisible($modal);
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($modal)
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($modal)
             ->assertScript(<<<'JS'
 function () {
     return document.activeElement === document.querySelector('header [data-form-modal-name="monitoring-form-modal"]');
 }
 JS, true);
-        $page->navigate('/monitorings?modal=monitoring-create')
+        $webpage->navigate('/monitorings?modal=monitoring-create')
             ->waitForText(__('monitoring.form.sections.basic'))
             ->assertVisible($modal)
             ->assertCount($nameField, 1)
             ->fill($nameField, 'Browser modal ' . Str::lower(Str::random(8)))
             ->fill($targetField, 'https://example.com');
-        $page->assertScript(<<<'JS'
+        $webpage->assertScript(<<<'JS'
 function () {
     const modal = document.querySelector('[data-form-modal="monitoring-form-modal"]');
     const form = modal?.querySelector('[x-ref="content"] form');
@@ -117,7 +117,7 @@ function () {
     return Boolean(name && type === 'http' && target === 'https://example.com' && form?.checkValidity());
 }
 JS, true);
-        $page->press($submit)
+        $webpage->press($submit)
             ->waitForText(__('monitoring.messages.created'))
             ->assertNoJavaScriptErrors();
     }
@@ -139,7 +139,7 @@ it('opens the admin package edit form in a focused responsive modal', function (
         'password' => Hash::make('password'),
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $admin->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
@@ -147,15 +147,15 @@ it('opens the admin package edit form in a focused responsive modal', function (
 
     foreach ([[1280, 800], [390, 640]] as $iteration => [$width, $height]) {
         if ($iteration > 0) {
-            $page->navigate('/admin/packages');
+            $webpage->navigate('/admin/packages');
         }
 
-        $page->resize($width, $height);
+        $webpage->resize($width, $height);
 
         $editTrigger = 'a[data-form-modal-name="admin-package-form-modal"][href$="/packages/' . $package->getRouteKey() . '/edit"]';
         $modal = '[data-form-modal="admin-package-form-modal"]';
 
-        $page->assertCount($editTrigger, 1)
+        $webpage->assertCount($editTrigger, 1)
             ->click($editTrigger)
             ->waitForText(__('admin.packages.fields.monitoring_limit'))
             ->assertVisible($modal)
@@ -169,8 +169,8 @@ function () {
         && document.body.scrollWidth <= document.body.clientWidth;
 }
 JS, true);
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($modal)
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($modal)
             ->assertNoJavaScriptErrors();
     }
 });

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -31,14 +31,14 @@ it('supports desktop service selection and keeps the Signal Room inside the view
         'response_time' => 128,
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
         ->resize(1280, 800);
 
-    $page->assertVisible('[data-signal-room]')
+    $webpage->assertVisible('[data-signal-room]')
         ->assertVisible('[data-signal-service="' . $monitoring->id . '"]')
         ->assertVisible('aside [data-signal-detail]')
         ->assertScript(<<<'JS'
@@ -114,14 +114,14 @@ it('supports mobile filtering, service details and Escape to close the detail sh
     ]);
     $unknown = Monitoring::factory()->for($user)->create(['name' => 'Unknown Search Service']);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
         ->resize(390, 640);
 
-    $page->click('[data-signal-filter="attention"]')
+    $webpage->click('[data-signal-filter="attention"]')
         ->assertScript(<<<JS
 function () {
     const service = document.querySelector('[data-signal-service="{$healthy->id}"]');
@@ -143,10 +143,10 @@ function () {
         && document.body.scrollWidth <= document.body.clientWidth;
 }
 JS, true);
-    $page->keys('input[type="search"]', 'Escape');
-    $page->wait(0.2);
+    $webpage->keys('input[type="search"]', 'Escape');
+    $webpage->wait(0.2);
 
-    $page->assertScript(<<<'JS'
+    $webpage->assertScript(<<<'JS'
 function () {
     const sheet = document.querySelector('[data-signal-mobile-sheet]');
     return sheet !== null && getComputedStyle(sheet).display === 'none';
@@ -179,7 +179,7 @@ it('keeps the desktop language menu within the navigation rail', function (): vo
         'password' => Hash::make('password'),
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')

--- a/tests/Feature/Admin/AdminFormModalTest.php
+++ b/tests/Feature/Admin/AdminFormModalTest.php
@@ -17,7 +17,7 @@ class AdminFormModalTest extends TestCase
         $admin = $this->adminUser();
         $user = User::factory()->create();
         $package = Package::factory()->create(['is_selectable' => false]);
-        $instance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'modal-instance',
             'ip_address' => '10.0.0.10',
             'api_key_hash' => 'secret',
@@ -40,7 +40,7 @@ class AdminFormModalTest extends TestCase
             ->get(route('admin.server-instances.index'))
             ->assertOk()
             ->assertSeeHtml('data-form-modal-name="admin-server-instance-form-modal"')
-            ->assertSeeHtml('href="' . route('admin.server-instances.edit', $instance) . '"');
+            ->assertSeeHtml('href="' . route('admin.server-instances.edit', $serverInstance) . '"');
     }
 
     public function test_admin_can_load_create_and_edit_forms_as_modal_fragments(): void
@@ -48,7 +48,7 @@ class AdminFormModalTest extends TestCase
         $admin = $this->adminUser();
         $user = User::factory()->unverified()->create();
         $package = Package::factory()->create(['is_selectable' => false]);
-        $instance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'modal-fragment-instance',
             'ip_address' => '10.0.0.11',
             'api_key_hash' => 'secret',
@@ -61,7 +61,7 @@ class AdminFormModalTest extends TestCase
             [route('admin.packages.create', ['modal' => 1]), 'admin-package-create'],
             [route('admin.packages.edit', ['package' => $package, 'modal' => 1]), 'admin-package-edit'],
             [route('admin.server-instances.create', ['modal' => 1]), 'admin-server-instance-create'],
-            [route('admin.server-instances.edit', ['server_instance' => $instance, 'modal' => 1]), 'admin-server-instance-edit'],
+            [route('admin.server-instances.edit', ['server_instance' => $serverInstance, 'modal' => 1]), 'admin-server-instance-edit'],
         ];
 
         foreach ($modalRoutes as [$route, $modalForm]) {
@@ -82,7 +82,7 @@ class AdminFormModalTest extends TestCase
         $admin = $this->adminUser();
         $user = User::factory()->create();
         $package = Package::factory()->create(['is_selectable' => false]);
-        $instance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'modal-validation-instance',
             'ip_address' => '10.0.0.12',
             'api_key_hash' => 'secret',
@@ -140,15 +140,15 @@ class AdminFormModalTest extends TestCase
             ->assertSessionHasErrors('ip_address');
 
         $this->actingAs($admin)
-            ->put(route('admin.server-instances.update', $instance), [
-                'code' => $instance->code,
+            ->put(route('admin.server-instances.update', $serverInstance), [
+                'code' => $serverInstance->code,
                 'ip_address' => 'not-an-ip',
                 'api_key' => '',
                 'modal_form' => 'admin-server-instance-edit',
             ])
             ->assertRedirect(route('admin.server-instances.index', [
                 'modal' => 'admin-server-instance-edit',
-                'server_instance' => $instance,
+                'server_instance' => $serverInstance,
             ]));
     }
 

--- a/tests/Feature/AuthenticatedNavigationTest.php
+++ b/tests/Feature/AuthenticatedNavigationTest.php
@@ -29,7 +29,7 @@ class AuthenticatedNavigationTest extends TestCase
         $testResponse->assertSeeHtml('href="' . route('dashboard') . '"');
         $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
         $testResponse->assertSeeHtml('data-secondary-navigation');
-        $this->assertSame(1, substr_count($testResponse->getContent() ?? '', 'data-primary-destination'));
+        $this->assertSame(1, mb_substr_count($testResponse->getContent() ?? '', 'data-primary-destination'));
         $testResponse->assertDontSeeText(__('app.navigation.signal_room'));
         $testResponse->assertDontSeeText(__('app.navigation.workspace'));
         $testResponse->assertDontSeeHtml('data-workspace-navigation');

--- a/tests/Feature/FormModalCrudFlowTest.php
+++ b/tests/Feature/FormModalCrudFlowTest.php
@@ -90,11 +90,11 @@ class FormModalCrudFlowTest extends TestCase
             'is_public' => true,
         ]);
 
-        $monitoringResponse = $this->actingAs($user)
+        $testResponse = $this->actingAs($user)
             ->from(route('monitorings.index'))
             ->post(route('monitorings.store'), ['modal_form' => 'monitoring-create']);
-        $monitoringResponse->assertRedirect(route('monitorings.index', ['modal' => 'monitoring-create']));
-        $this->get($monitoringResponse->headers->get('Location'))
+        $testResponse->assertRedirect(route('monitorings.index', ['modal' => 'monitoring-create']));
+        $this->get($testResponse->headers->get('Location'))
             ->assertOk()
             ->assertSeeText(__('monitoring.form.sections.basic'));
 

--- a/tests/Feature/FormModalTeamsProfileTest.php
+++ b/tests/Feature/FormModalTeamsProfileTest.php
@@ -45,12 +45,12 @@ class FormModalTeamsProfileTest extends TestCase
         $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
         $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
 
-        $validationResponse = $this->actingAs($admin)->post(route('teams.store'), [
+        $testResponse = $this->actingAs($admin)->post(route('teams.store'), [
             'description' => 'Missing name',
             'modal_form' => 'team-create',
         ]);
 
-        $validationResponse
+        $testResponse
             ->assertRedirect(route('teams.index', ['modal' => 'team-create']))
             ->assertSessionHasErrors('name');
 
@@ -119,14 +119,14 @@ class FormModalTeamsProfileTest extends TestCase
         Package::factory()->create();
         $user = User::factory()->create();
 
-        $validationResponse = $this->actingAs($user)->from(route('profile.edit'))->put(route('password.update'), [
+        $testResponse = $this->actingAs($user)->from(route('profile.edit'))->put(route('password.update'), [
             'current_password' => 'wrong-password',
             'password' => 'new-password',
             'password_confirmation' => 'new-password',
             'modal_form' => 'profile-password',
         ]);
 
-        $validationResponse
+        $testResponse
             ->assertRedirect(route('profile.edit', ['modal' => 'profile-password']))
             ->assertSessionHasErrorsIn('updatePassword', 'current_password');
 

--- a/tests/Feature/MonitoringContextNavigationTest.php
+++ b/tests/Feature/MonitoringContextNavigationTest.php
@@ -10,17 +10,10 @@ use Tests\TestCase;
 
 class MonitoringContextNavigationTest extends TestCase
 {
-    public function test_monitoring_pages_share_the_same_context_navigation_with_one_active_tab(): void
+    public function test_monitoring_pages_share_the_same_context_header_without_redundant_tab_navigation(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);
         $user = User::factory()->create(['package_id' => $package->id]);
-        $tabs = [
-            __('incidents.analytics.overview.tabs.overview'),
-            __('incidents.analytics.overview.tabs.groups'),
-            __('incidents.analytics.overview.tabs.status_pages'),
-            __('incidents.analytics.overview.tabs.analytics'),
-        ];
-
         foreach ([
             'monitorings.index',
             'monitoring-groups.index',
@@ -33,8 +26,7 @@ class MonitoringContextNavigationTest extends TestCase
                 ->assertSeeHtml('data-monitoring-context')
                 ->assertSeeText(__('incidents.analytics.title'))
                 ->assertSeeText(__('incidents.analytics.description'))
-                ->assertSeeTextInOrder($tabs)
-                ->assertSeeHtml('aria-current="page"');
+                ->assertDontSeeHtml('aria-label="' . __('incidents.analytics.title') . '"');
         }
     }
 }

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -47,7 +47,7 @@ class MonitoringFormPresentationTest extends TestCase
         $testResponse->assertSee(__('monitoring.form.advanced_request_settings'));
     }
 
-    public function test_assignment_indicators_and_ownership_actions_only_appear_on_edit_page(): void
+    public function test_detail_context_and_ownership_actions_are_present_on_their_respective_pages(): void
     {
         $user = User::factory()->create([
             'package_id' => Package::factory()->create(['monitoring_limit' => 10])->id,
@@ -67,8 +67,9 @@ class MonitoringFormPresentationTest extends TestCase
         $editResponse = $this->actingAs($user)->get(route('monitorings.edit', $monitoring));
 
         $testResponse->assertOk();
-        $testResponse->assertDontSeeText(__('team.ownership.private'));
-        $testResponse->assertDontSeeText('Production');
+        $testResponse->assertSeeText(__('monitoring.detail.context.ownership'));
+        $testResponse->assertSeeText(__('monitoring.detail.context.private'));
+        $testResponse->assertSeeText('Production');
         $testResponse->assertDontSeeHtml('action="' . route('monitorings.team-ownership.store', $monitoring) . '"');
 
         $editResponse->assertOk();

--- a/tests/Feature/VerifiedEmailRequiredTest.php
+++ b/tests/Feature/VerifiedEmailRequiredTest.php
@@ -78,7 +78,7 @@ class VerifiedEmailRequiredTest extends TestCase
 
         $testResponse = $this->actingAs($user)->get(route('dashboard'));
         $testResponse->assertOk();
-        $testResponse->assertSeeText(__('dashboard.title'));
+        $testResponse->assertSeeText(__('dashboard.greeting', ['name' => $user->name]));
 
         $monitoringsResponse = $this->actingAs($user)->get(route('monitorings.index'));
         $monitoringsResponse->assertOk();


### PR DESCRIPTION
## What changed
- Removed the repeated operations tab navigation from monitoring, monitoring group, status page, and incident analytics pages.
- Reworked the incident analytics filters into a full-width responsive layout with a dedicated affected-service row.
- Updated feature assertions for the current Signal Room dashboard and monitoring detail context.

## Why
The duplicated tab bar competed with the global dashboard navigation, and the incident filter form could clip labels or crowd the action button at narrower desktop widths.

## Validation
- `./vendor/bin/pest` in the Docker PHP container: passed with no failures (647 warnings, 4,140 assertions).
- Targeted `IncidentWorkflowTest` and `MonitoringContextNavigationTest`: passed.
- Laravel Pint: passed.
- `git diff --check`: passed.

No new tests were required beyond updating the affected feature coverage; the existing route and presentation tests now assert the intended UI structure.

Closes #528
Closes #529
Closes #530