### PR TITLE
style(ui): use icon-only action buttons

### DIFF
--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -19,14 +19,14 @@ class PasswordController extends Controller
     /**
      * Update the user's password.
      *
-     * @param  Request  $request  The HTTP request instance containing the new password data.
+     * @param  Request  $updatePasswordRequest  The HTTP request instance containing the new password data.
      * @return RedirectResponse A redirect response after updating the password.
      */
-    public function update(UpdatePasswordRequest $request): RedirectResponse
+    public function update(UpdatePasswordRequest $updatePasswordRequest): RedirectResponse
     {
-        $validated = $request->validated();
+        $validated = $updatePasswordRequest->validated();
 
-        $request->user()->update([
+        $updatePasswordRequest->user()->update([
             'password' => Hash::make($validated['password']),
         ]);
 

--- a/app/Http/Requests/UpdatePasswordRequest.php
+++ b/app/Http/Requests/UpdatePasswordRequest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Foundation\Http\Attributes\ErrorBag;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Password;
 
+#[ErrorBag('updatePassword')]
 class UpdatePasswordRequest extends FormRequest
 {
-    protected $errorBag = 'updatePassword';
-
     public function authorize(): bool
     {
         return $this->user() !== null;

--- a/resources/views/admin/packages/partials/rows.blade.php
+++ b/resources/views/admin/packages/partials/rows.blade.php
@@ -10,16 +10,21 @@
             @endif
         </x-table.cell>
         <x-table.cell>
-            <a href="{{ route('admin.packages.edit', $package) }}" class="text-purple-600 hover:underline"
-                data-form-modal-trigger data-form-modal-name="admin-package-form-modal">
-                {{ __('button.edit') }}
-            </a>
-            <form action="{{ route('admin.packages.destroy', $package) }}" method="POST" class="inline"
+            <div class="flex items-center gap-2">
+                <x-secondary-button :href="route('admin.packages.edit', $package)" :icon-only="true"
+                    data-form-modal-trigger data-form-modal-name="admin-package-form-modal"
+                    title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                    <x-icon name="pencil" class="h-4 w-4" />
+                </x-secondary-button>
+                <form action="{{ route('admin.packages.destroy', $package) }}" method="POST" class="inline-flex"
                 data-confirm-message="{{ __('admin.packages.messages.confirm_delete') }}">
                 @csrf
                 @method('DELETE')
-                <button type="submit" class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
-            </form>
+                    <x-danger-button :icon-only="true" title="{{ __('button.delete') }}" aria-label="{{ __('button.delete') }}">
+                        <x-icon name="trash" class="h-4 w-4" />
+                    </x-danger-button>
+                </form>
+            </div>
         </x-table.cell>
     </x-table.row>
 @empty

--- a/resources/views/admin/server-instances/partials/rows.blade.php
+++ b/resources/views/admin/server-instances/partials/rows.blade.php
@@ -61,16 +61,21 @@
         <x-table.cell>{{ $instance->created_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>{{ $instance->updated_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>
-            <a href="{{ route('admin.server-instances.edit', $instance) }}" class="text-purple-600 hover:underline"
-                data-form-modal-trigger data-form-modal-name="admin-server-instance-form-modal">
-                {{ __('button.edit') }}
-            </a>
-            <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST" class="inline"
+            <div class="flex items-center gap-2">
+                <x-secondary-button :href="route('admin.server-instances.edit', $instance)" :icon-only="true"
+                    data-form-modal-trigger data-form-modal-name="admin-server-instance-form-modal"
+                    title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                    <x-icon name="pencil" class="h-4 w-4" />
+                </x-secondary-button>
+                <form action="{{ route('admin.server-instances.destroy', $instance) }}" method="POST" class="inline-flex"
                 data-confirm-message="{{ __('admin.server_instances.messages.confirm_delete') }}">
                 @csrf
                 @method('DELETE')
-                <button type="submit" class="ml-2 text-red-600 hover:underline">{{ __('button.delete') }}</button>
-            </form>
+                    <x-danger-button :icon-only="true" title="{{ __('button.delete') }}" aria-label="{{ __('button.delete') }}">
+                        <x-icon name="trash" class="h-4 w-4" />
+                    </x-danger-button>
+                </form>
+            </div>
         </x-table.cell>
     </x-table.row>
 @empty

--- a/resources/views/admin/users/partials/rows.blade.php
+++ b/resources/views/admin/users/partials/rows.blade.php
@@ -16,20 +16,21 @@
         <x-table.cell>{{ $user->created_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>{{ $user->updated_at->format('d.m.Y') }}</x-table.cell>
         <x-table.cell>
-            <div class="flex items-center gap-3">
-                <a href="{{ route('admin.users.edit', $user) }}"
-                    class="inline-flex min-h-10 items-center text-purple-600 hover:underline"
-                    data-form-modal-trigger data-form-modal-name="admin-user-form-modal">
-                    {{ __('button.edit') }}
-                </a>
+            <div class="flex items-center gap-2">
+                <x-secondary-button :href="route('admin.users.edit', $user)" :icon-only="true"
+                    data-form-modal-trigger data-form-modal-name="admin-user-form-modal"
+                    title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                    <x-icon name="pencil" class="h-4 w-4" />
+                </x-secondary-button>
                 @if ($user->id !== auth()->id())
                     <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline-flex"
                         data-confirm-message="{{ __('user.delete.confirmation_question') }}">
                         @csrf
                         @method('DELETE')
-                        <button type="submit"
-                            class="inline-flex min-h-10 cursor-pointer items-center text-red-600 hover:underline"
-                            data-testid="delete-user-{{ $user->id }}">{{ __('button.delete') }}</button>
+                        <x-danger-button :icon-only="true" title="{{ __('button.delete') }}" aria-label="{{ __('button.delete') }}"
+                            data-testid="delete-user-{{ $user->id }}">
+                            <x-icon name="trash" class="h-4 w-4" />
+                        </x-danger-button>
                     </form>
                 @endif
             </div>

--- a/resources/views/components/api-token-display.blade.php
+++ b/resources/views/components/api-token-display.blade.php
@@ -3,7 +3,7 @@
     <div class="mt-2 flex items-center gap-2">
         <x-text-input type="text" id="api_key_field" class="block w-full" value="{{ $token }}" readonly />
 
-        <x-primary-button
+        <x-primary-button :icon-only="true"
             @click="
             const apiKeyInput = document.getElementById('api_key_field');
             apiKeyInput.select();
@@ -11,8 +11,8 @@
             document.execCommand('copy');
             copied = true;
             setTimeout(() => copied = false, 2000);
-        ">
-            {{ __('api.configuration.actions.copy') }}
+        " title="{{ __('api.configuration.actions.copy') }}" aria-label="{{ __('api.configuration.actions.copy') }}">
+            <x-icon name="copy" class="h-4 w-4" />
         </x-primary-button>
         <span x-show="copied" x-transition.opacity
             class="text-sm text-green-600 dark:text-green-400">{{ __('api.configuration.messages.copied') }}</span>

--- a/resources/views/components/async-table.blade.php
+++ b/resources/views/components/async-table.blade.php
@@ -139,6 +139,8 @@
         <nav class="flex flex-wrap items-center gap-1" aria-label="{{ __('search.table.pagination') }}">
             <button type="button"
                 class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 transition hover:bg-purple-50 hover:text-purple-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                title="{{ __('pagination.previous') }}"
+                aria-label="{{ __('pagination.previous') }}"
                 :disabled="pagination.current_page <= 1 || loading" @click="fetchPage(pagination.current_page - 1)">
                 &laquo;
             </button>
@@ -157,6 +159,8 @@
 
             <button type="button"
                 class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 transition hover:bg-purple-50 hover:text-purple-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                title="{{ __('pagination.next') }}"
+                aria-label="{{ __('pagination.next') }}"
                 :disabled="pagination.current_page >= pagination.last_page || loading"
                 @click="fetchPage(pagination.current_page + 1)">
                 &raquo;

--- a/resources/views/components/danger-button.blade.php
+++ b/resources/views/components/danger-button.blade.php
@@ -1,4 +1,12 @@
+@props(['iconOnly' => false])
+
+@php
+    $class = $iconOnly
+        ? 'inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md border border-transparent bg-red-600 font-semibold text-white transition ease-in-out duration-150 hover:bg-red-500 focus:outline-hidden focus:ring-2 focus:ring-red-500 focus:ring-offset-2 active:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600'
+        : 'inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-red-700 dark:hover:bg-red-600';
+@endphp
+
 <button
-    {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold  text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-red-700 dark:hover:bg-red-600']) }}>
+    {{ $attributes->merge(['type' => 'submit', 'class' => $class]) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/icon.blade.php
+++ b/resources/views/components/icon.blade.php
@@ -1,0 +1,60 @@
+@props(['name'])
+
+<svg {{ $attributes->merge(['class' => 'h-5 w-5']) }} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    @switch($name)
+        @case('eye')
+            <path d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7Z" />
+            <circle cx="12" cy="12" r="3" />
+            @break
+        @case('external-link')
+            <path d="M14 4h6v6" />
+            <path d="m20 4-9 9" />
+            <path d="M18 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4" />
+            @break
+        @case('arrow-left')
+            <path d="m15 18-6-6 6-6" />
+            <path d="M9 12h12" />
+            @break
+        @case('chart')
+            <path d="M4 19V5M4 19h16" />
+            <path d="m7 15 3-4 3 2 5-6" />
+            @break
+        @case('check')
+            <path d="m5 12 4 4L19 6" />
+            @break
+        @case('copy')
+            <rect x="9" y="9" width="11" height="11" rx="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            @break
+        @case('globe')
+            <circle cx="12" cy="12" r="9" />
+            <path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" />
+            @break
+        @case('pencil')
+            <path d="m4 16 8.5-8.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            <path d="m13.5 6.5 4 4" />
+            @break
+        @case('ellipsis')
+            <circle cx="5" cy="12" r="1" />
+            <circle cx="12" cy="12" r="1" />
+            <circle cx="19" cy="12" r="1" />
+            @break
+        @case('refresh')
+            <path d="M20 11a8 8 0 0 0-14.5-4L4 9" />
+            <path d="M4 4v5h5" />
+            <path d="M4 13a8 8 0 0 0 14.5 4L20 15" />
+            <path d="M20 20v-5h-5" />
+            @break
+        @case('send')
+            <path d="m22 2-7 20-4-9-9-4Z" />
+            <path d="M22 2 11 13" />
+            @break
+        @case('trash')
+            <path d="M4 7h16M10 11v6M14 11v6M6 7l1 13h10l1-13M9 7V4h6v3" />
+            @break
+        @case('x')
+            <path d="m6 6 12 12M18 6 6 18" />
+            @break
+    @endswitch
+</svg>

--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,13 +1,19 @@
-@props(['href' => null])
+@props(['href' => null, 'iconOnly' => false])
+
+@php
+    $class = $iconOnly
+        ? 'cursor-pointer inline-flex h-10 w-10 items-center justify-center rounded-md border border-transparent bg-purple-500 font-semibold text-white transition ease-in-out duration-150 hover:bg-purple-600 focus:bg-purple-600 active:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:bg-purple-600 dark:hover:bg-purple-500'
+        : 'cursor-pointer inline-flex w-max items-center px-4 py-2 bg-purple-500 border border-transparent rounded-md font-semibold text-white uppercase tracking-widest hover:bg-purple-600 focus:bg-purple-600 active:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-purple-600 dark:hover:bg-purple-500';
+@endphp
 
 @if ($href)
     <a href="{{ $href }}"
-        {{ $attributes->merge(['class' => 'cursor-pointer inline-flex w-max items-center px-4 py-2 bg-purple-500 border border-transparent rounded-md font-semibold  text-white uppercase tracking-widest hover:bg-purple-600 focus:bg-purple-600 active:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-purple-600 dark:hover:bg-purple-500']) }}>
+        {{ $attributes->merge(['class' => $class]) }}>
         {{ $slot }}
     </a>
 @else
     <button
-        {{ $attributes->merge(['type' => 'submit', 'class' => 'cursor-pointer inline-flex w-max items-center px-4 py-2 bg-purple-500 border border-transparent rounded-md font-semibold  text-white uppercase tracking-widest hover:bg-purple-600 focus:bg-purple-600 active:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-purple-600 dark:hover:bg-purple-500']) }}>
+        {{ $attributes->merge(['type' => 'submit', 'class' => $class]) }}>
         {{ $slot }}
     </button>
 @endif

--- a/resources/views/components/secondary-button.blade.php
+++ b/resources/views/components/secondary-button.blade.php
@@ -1,13 +1,19 @@
-@props(['href' => null])
+@props(['href' => null, 'iconOnly' => false])
+
+@php
+    $class = $iconOnly
+        ? 'cursor-pointer inline-flex h-10 w-10 items-center justify-center rounded-md border border-purple-500 bg-white font-semibold text-purple-600 transition ease-in-out duration-150 hover:bg-purple-50 focus:bg-purple-50 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 active:bg-purple-100 dark:bg-gray-700 dark:text-purple-300'
+        : 'cursor-pointer inline-flex w-max items-center px-4 py-2 bg-white border border-purple-500 rounded-md font-semibold text-purple-600 uppercase tracking-widest hover:bg-purple-50 focus:bg-purple-50 active:bg-purple-100 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-gray-700 dark:text-purple-300';
+@endphp
 
 @if ($href)
     <a href="{{ $href }}"
-        {{ $attributes->merge(['class' => 'cursor-pointer inline-flex w-max items-center px-4 py-2 bg-white border border-purple-500 rounded-md font-semibold  text-purple-600 uppercase tracking-widest hover:bg-purple-50 focus:bg-purple-50 active:bg-purple-100 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-gray-700 dark:text-purple-300']) }}>
+        {{ $attributes->merge(['class' => $class]) }}>
         {{ $slot }}
     </a>
 @else
     <button
-        {{ $attributes->merge(['type' => 'submit', 'class' => 'cursor-pointer inline-flex w-max items-center px-4 py-2 bg-white border border-purple-500 rounded-md font-semibold  text-purple-600 uppercase tracking-widest hover:bg-purple-50 focus:bg-purple-50 active:bg-purple-100 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition ease-in-out duration-150 dark:bg-gray-700 dark:text-purple-300']) }}>
+        {{ $attributes->merge(['type' => 'submit', 'class' => $class]) }}>
         {{ $slot }}
     </button>
 @endif

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -130,12 +130,15 @@
                                     <div class="flex flex-wrap items-center gap-2 sm:justify-end">
                                         @if (!Auth::user()->isDemo())
                                             <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)"
-                                                data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
-                                                {{ __('button.edit') }}
+                                                data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal" :icon-only="true"
+                                                title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                                                <x-icon name="pencil" class="h-4 w-4" />
                                             </x-secondary-button>
                                         @endif
-                                        <a href="{{ route('monitorings.index', ['group_id' => $monitoringGroup->id]) }}" class="text-sm font-semibold text-purple-700 hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-200">
-                                            {{ __('incidents.analytics.overview.view_group') }}
+                                        <a href="{{ route('monitorings.index', ['group_id' => $monitoringGroup->id]) }}"
+                                            class="inline-flex h-10 w-10 items-center justify-center rounded-md text-purple-700 transition hover:bg-purple-50 hover:text-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:bg-purple-950/40 dark:hover:text-purple-200"
+                                            title="{{ __('incidents.analytics.overview.view_group') }}" aria-label="{{ __('incidents.analytics.overview.view_group') }}">
+                                            <x-icon name="eye" class="h-4 w-4" />
                                         </a>
                                     </div>
                                 </div>
@@ -175,9 +178,19 @@
                                 <div class="flex flex-col gap-3 py-4">
                                     <div class="flex items-start justify-between gap-3">
                                         <div class="min-w-0">
-                                            <a href="{{ route('status-pages.show', $statusPage) }}" class="truncate font-semibold text-gray-900 hover:text-purple-700 dark:text-gray-100 dark:hover:text-purple-300">
-                                                {{ $statusPage->name }}
-                                            </a>
+                                            <div class="flex min-w-0 items-center gap-2">
+                                                <a href="{{ route('status-pages.show', $statusPage) }}" class="truncate font-semibold text-gray-900 hover:text-purple-700 dark:text-gray-100 dark:hover:text-purple-300">
+                                                    {{ $statusPage->name }}
+                                                </a>
+                                                @if ($statusPage->is_public)
+                                                    <a href="{{ route('public-status-pages.show', $statusPage) }}" target="_blank" rel="noopener"
+                                                        class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-purple-600 transition hover:bg-purple-100 hover:text-purple-800 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:bg-purple-950/40 dark:hover:text-purple-200"
+                                                        title="{{ __('status_page.detail.open_public_page') }}"
+                                                        aria-label="{{ __('status_page.detail.open_public_page') }}">
+                                                        <x-icon name="external-link" class="h-4 w-4" />
+                                                    </a>
+                                                @endif
+                                            </div>
                                             <div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
                                                 <x-badge :type="$statusPage->is_public ? 'success' : 'warning'">
                                                     {{ $statusPage->is_public ? __('status_page.state.public') : __('status_page.state.private') }}
@@ -196,8 +209,10 @@
                                             <span class="mx-1">·</span>
                                             {{ $statusPageHealth['down'] }} {{ __('dashboard.summary.down') }}
                                         </span>
-                                        <a href="{{ route('status-pages.show', $statusPage) }}" class="font-semibold text-purple-700 hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-200">
-                                            {{ __('incidents.analytics.overview.view_status_page') }}
+                                        <a href="{{ route('status-pages.show', $statusPage) }}"
+                                            class="inline-flex h-10 w-10 items-center justify-center rounded-md text-purple-700 transition hover:bg-purple-50 hover:text-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:bg-purple-950/40 dark:hover:text-purple-200"
+                                            title="{{ __('incidents.analytics.overview.view_status_page') }}" aria-label="{{ __('incidents.analytics.overview.view_status_page') }}">
+                                            <x-icon name="eye" class="h-4 w-4" />
                                         </a>
                                     </div>
                                 </div>

--- a/resources/views/maintenance/partials/rows.blade.php
+++ b/resources/views/maintenance/partials/rows.blade.php
@@ -41,10 +41,12 @@
                         <input type="hidden" name="monitoring_id" value="{{ $monitoring->id }}">
                         <button
                             type="submit"
-                            class="inline-flex min-h-10 cursor-pointer items-center text-sm font-medium text-purple-600 hover:underline dark:text-purple-300"
+                            class="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-purple-600 transition hover:bg-purple-50 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:bg-purple-950/40"
+                            title="{{ __('maintenance.actions.clear') }}"
+                            aria-label="{{ __('maintenance.actions.clear') }}"
                             x-data
                             x-on:click.prevent="if (confirm('{{ __('maintenance.actions.clear_confirmation') }}')) $el.closest('form').submit()">
-                            {{ __('maintenance.actions.clear') }}
+                            <x-icon name="x" class="h-4 w-4" />
                         </button>
                     </form>
                 @else

--- a/resources/views/monitoring-groups/index.blade.php
+++ b/resources/views/monitoring-groups/index.blade.php
@@ -45,19 +45,21 @@
                                 @if (!Auth::user()->isDemo())
                                     <form method="POST" action="{{ route('monitoring-groups.publish-status-page', $monitoringGroup) }}">
                                         @csrf
-                                        <x-secondary-button>
-                                            {{ __('monitoring_group.actions.publish_status_page') }}
+                                        <x-secondary-button :icon-only="true" title="{{ __('monitoring_group.actions.publish_status_page') }}"
+                                            aria-label="{{ __('monitoring_group.actions.publish_status_page') }}">
+                                            <x-icon name="globe" class="h-4 w-4" />
                                         </x-secondary-button>
                                     </form>
-                                    <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)" data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal">
-                                        {{ __('button.edit') }}
+                                    <x-secondary-button :href="route('monitoring-groups.edit', $monitoringGroup)" data-form-modal-trigger data-form-modal-name="monitoring-group-form-modal"
+                                        :icon-only="true" title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                                        <x-icon name="pencil" class="h-4 w-4" />
                                     </x-secondary-button>
                                     <form method="POST" action="{{ route('monitoring-groups.destroy', $monitoringGroup) }}"
                                         data-confirm-message="{{ __('monitoring_group.actions.delete.confirmation') }}">
                                         @csrf
                                         @method('DELETE')
-                                        <x-danger-button>
-                                            {{ __('button.delete') }}
+                                        <x-danger-button :icon-only="true" title="{{ __('button.delete') }}" aria-label="{{ __('button.delete') }}">
+                                            <x-icon name="trash" class="h-4 w-4" />
                                         </x-danger-button>
                                     </form>
                                 @endif

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -429,8 +429,16 @@
                                     </div>
 
                                     <div class="flex items-center gap-2 lg:justify-end">
-                                        <a href="#" x-bind:href="'/monitorings/' + id" class="inline-flex items-center rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition hover:border-purple-300 hover:text-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:text-gray-200 dark:hover:border-purple-500 dark:hover:text-purple-300">{{ __('monitoring.index.workspace.view') }}</a>
-                                        <a href="#" x-bind:href="'/monitorings/' + id + '/edit'" data-form-modal-trigger data-form-modal-name="monitoring-form-modal" class="inline-flex items-center rounded-lg bg-purple-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2">{{ __('button.edit') }}</a>
+                                        <a href="#" x-bind:href="'/monitorings/' + id" title="{{ __('monitoring.index.workspace.view') }}"
+                                            aria-label="{{ __('monitoring.index.workspace.view') }}"
+                                            class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:border-purple-300 hover:text-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:text-gray-200 dark:hover:border-purple-500 dark:hover:text-purple-300">
+                                            <x-icon name="eye" class="h-4 w-4" />
+                                        </a>
+                                        <a href="#" x-bind:href="'/monitorings/' + id + '/edit'" data-form-modal-trigger data-form-modal-name="monitoring-form-modal"
+                                            title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}"
+                                            class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-purple-600 text-white transition hover:bg-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2">
+                                            <x-icon name="pencil" class="h-4 w-4" />
+                                        </a>
                                     </div>
                                 </div>
                             </article>

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -46,9 +46,9 @@
                         <span class="max-w-full break-all">{{ $monitoring->target }}</span>
                         @if ($monitoring->public_label_enabled)
                             <a href="{{ route('public-label', $monitoring) }}" target="_blank" rel="noopener"
-                                class="inline-flex shrink-0 items-center gap-1 font-semibold text-purple-700 hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-200">
-                                {{ __('monitoring.detail.open_public_label') }}
-                                <span aria-hidden="true">↗</span>
+                                class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-purple-700 transition hover:bg-purple-50 hover:text-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:bg-purple-950/40 dark:hover:text-purple-200"
+                                title="{{ __('monitoring.detail.open_public_label') }}" aria-label="{{ __('monitoring.detail.open_public_label') }}">
+                                <x-icon name="external-link" class="h-4 w-4" />
                             </a>
                         @endif
                     </div>
@@ -58,27 +58,30 @@
 
             @if ($canManageMonitoring)
                 <div class="relative" x-data="{ open: false }">
-                    <x-secondary-button @click="open = !open">
-                        {{ __('monitoring.actions.heading') }}
+                    <x-secondary-button @click="open = !open" :icon-only="true"
+                        title="{{ __('monitoring.actions.heading') }}" aria-label="{{ __('monitoring.actions.heading') }}">
+                        <x-icon name="ellipsis" class="h-4 w-4" />
                     </x-secondary-button>
 
                     <div x-show="open" x-transition:enter="transition ease-out duration-100"
                         x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
                         x-transition:leave="transition ease-in duration-75"
                         x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
-                        class="absolute z-10 mt-2 min-w-full rounded-md bg-white shadow-lg" style="display: none">
+                        class="absolute z-10 mt-2 flex gap-1 rounded-md bg-white p-2 shadow-lg dark:bg-gray-800" style="display: none">
                         <a href="{{ route('monitorings.edit', ['monitoring' => $monitoring->id]) }}"
                             data-form-modal-trigger data-form-modal-name="monitoring-form-modal"
-                            class="block px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
-                            {{ __('monitoring.actions.edit') }}
+                            class="inline-flex h-9 w-9 items-center justify-center rounded-md text-gray-700 hover:bg-gray-100 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-gray-200 dark:hover:bg-gray-700"
+                            title="{{ __('monitoring.actions.edit') }}" aria-label="{{ __('monitoring.actions.edit') }}">
+                            <x-icon name="pencil" class="h-4 w-4" />
                         </a>
                         <form method="POST" action="{{ route('monitorings.destroyResults', $monitoring) }}"
                             data-confirm-message="{{ __('monitoring.actions.reset.confirmation') }}">
                             @csrf
                             @method('DELETE')
                             <button type="submit"
-                                class="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
-                                {{ __('monitoring.actions.reset.heading') }}
+                                class="inline-flex h-9 w-9 items-center justify-center rounded-md text-gray-700 hover:bg-gray-100 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-gray-200 dark:hover:bg-gray-700"
+                                title="{{ __('monitoring.actions.reset.heading') }}" aria-label="{{ __('monitoring.actions.reset.heading') }}">
+                                <x-icon name="refresh" class="h-4 w-4" />
                             </button>
                         </form>
                         <form method="POST" action="{{ route('monitorings.destroy', $monitoring) }}"
@@ -86,8 +89,9 @@
                             @csrf
                             @method('DELETE')
                             <button type="submit"
-                                class="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-100 sm:text-right">
-                                {{ __('monitoring.actions.delete.heading') }}
+                                class="inline-flex h-9 w-9 items-center justify-center rounded-md text-red-600 hover:bg-red-50 focus:outline-hidden focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:bg-red-950/30"
+                                title="{{ __('monitoring.actions.delete.heading') }}" aria-label="{{ __('monitoring.actions.delete.heading') }}">
+                                <x-icon name="trash" class="h-4 w-4" />
                             </button>
                         </form>
                     </div>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -80,11 +80,10 @@
 
                     <form method="POST" action="{{ route('notifications.markAllAsRead') }}" class="sm:pb-1">
                         @csrf
-                        <x-secondary-button type="submit" class="!w-full justify-center !border-purple-600 !bg-purple-600 px-3 py-2 text-sm !normal-case !tracking-normal !text-white hover:!border-purple-700 hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!border-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!border-purple-400 dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto">
-                            <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
-                            </svg>
-                            {{ __('notifications.mark_all_as_read') }}
+                        <x-secondary-button type="submit" :icon-only="true"
+                            class="!border-purple-600 !bg-purple-600 !text-white hover:!border-purple-700 hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!border-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!border-purple-400 dark:hover:!bg-purple-400 dark:focus:!ring-purple-400"
+                            title="{{ __('notifications.mark_all_as_read') }}" aria-label="{{ __('notifications.mark_all_as_read') }}">
+                            <x-icon name="check" class="h-4 w-4" />
                         </x-secondary-button>
                     </form>
                 </div>

--- a/resources/views/notifications/partials/notification_list.blade.php
+++ b/resources/views/notifications/partials/notification_list.blade.php
@@ -43,13 +43,11 @@
             </div>
 
             @if (! $isRead)
-                <x-primary-button class="mark-as-read-button shrink-0 !w-full justify-center !bg-purple-600 px-3 py-2 text-sm !normal-case !tracking-normal hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto"
+                <x-primary-button :icon-only="true" class="mark-as-read-button shrink-0 !bg-purple-600 hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400"
+                    title="{{ __('notifications.mark_as_read') }}"
                     aria-label="{{ __('notifications.mark_as_read') }}"
                     @click="markAsRead(event, '{{ $notification->id }}', '{{ route('notifications.markAsRead', $notification) }}', '{{ $type }}')">
-                    <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
-                    </svg>
-                    {{ __('notifications.mark_as_read') }}
+                    <x-icon name="check" class="h-4 w-4" />
                 </x-primary-button>
             @endif
         </div>

--- a/resources/views/notifications/partials/status_board_list.blade.php
+++ b/resources/views/notifications/partials/status_board_list.blade.php
@@ -75,13 +75,11 @@
                     {{ $statusLabel }}
                 </x-badge>
                 @if (! $isRead)
-                    <x-primary-button class="mark-as-read-button !w-full justify-center !bg-purple-600 px-3 py-2 text-xs !normal-case !tracking-normal hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400 sm:!w-auto"
+                    <x-primary-button :icon-only="true" class="mark-as-read-button !bg-purple-600 hover:!bg-purple-700 focus:!bg-purple-700 focus:!ring-purple-500 dark:!bg-purple-500 dark:!text-white dark:hover:!bg-purple-400 dark:focus:!ring-purple-400"
+                        title="{{ __('notifications.mark_as_read') }}"
                         aria-label="{{ __('notifications.mark_as_read') }}"
                         @click="markAsRead(event, '{{ $entry['notification_id'] }}', '{{ route('notifications.markAsRead', $entry['notification_id']) }}', 'status_change')">
-                        <svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="m4 12 5 5L20 6" />
-                        </svg>
-                        {{ __('notifications.mark_as_read') }}
+                        <x-icon name="check" class="h-4 w-4" />
                     </x-primary-button>
                 @endif
             </div>

--- a/resources/views/profile/partials/api-configuration.blade.php
+++ b/resources/views/profile/partials/api-configuration.blade.php
@@ -17,7 +17,10 @@
             data-confirm-message="{{ __('api.configuration.messages.confirm_revoke_token') }}">
             @csrf
             @method('DELETE')
-            <x-danger-button>{{ __('api.configuration.actions.revoke_token') }}</x-danger-button>
+            <x-danger-button :icon-only="true" title="{{ __('api.configuration.actions.revoke_token') }}"
+                aria-label="{{ __('api.configuration.actions.revoke_token') }}">
+                <x-icon name="x" class="h-4 w-4" />
+            </x-danger-button>
         </form>
     </div>
     @if (Auth::user()->tokens->isNotEmpty())

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -4,8 +4,11 @@
         {{ __('profile.delete_account.description') }}
     </x-paragraph>
 
-    <x-danger-button x-data=""
-        x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')">{{ __('button.delete') }}</x-danger-button>
+    <x-danger-button x-data="" :icon-only="true"
+        x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')"
+        title="{{ __('button.delete') }}" aria-label="{{ __('button.delete') }}">
+        <x-icon name="trash" class="h-4 w-4" />
+    </x-danger-button>
 
     <x-modal name="confirm-user-deletion" :show="$errors->userDeletion->isNotEmpty()" focusable>
         <form method="post" action="{{ route('profile.destroy') }}" class="p-6">

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -44,8 +44,10 @@
                             {{ __('profile.information.email_unverified') }}
 
                             <button form="send-verification"
-                                class="focus:outline-hidden rounded-md text-gray-600 underline hover:text-gray-900 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2">
-                                {{ __('profile.information.send_verification_email') }}
+                                class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:outline-hidden focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:text-gray-300 dark:hover:bg-gray-700"
+                                title="{{ __('profile.information.send_verification_email') }}"
+                                aria-label="{{ __('profile.information.send_verification_email') }}">
+                                <x-icon name="send" class="h-4 w-4" />
                             </button>
                         </x-paragraph>
                     </div>
@@ -102,8 +104,9 @@
                         <x-text-checkbox id="notification_channels_slack_enabled" name="notification_channels[slack][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'slack.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
-                        <x-secondary-button form="test-slack-notification-channel" class="text-xs">
-                            {{ __('profile.notification_settings.test.action') }}
+                        <x-secondary-button form="test-slack-notification-channel" :icon-only="true"
+                            title="{{ __('profile.notification_settings.test.action') }}" aria-label="{{ __('profile.notification_settings.test.action') }}">
+                            <x-icon name="send" class="h-4 w-4" />
                         </x-secondary-button>
                     </div>
                     <x-input-error :messages="$errors->get('notification_channels.slack')" />
@@ -124,8 +127,9 @@
                         <x-text-checkbox id="notification_channels_telegram_enabled" name="notification_channels[telegram][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'telegram.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
-                        <x-secondary-button form="test-telegram-notification-channel" class="text-xs">
-                            {{ __('profile.notification_settings.test.action') }}
+                        <x-secondary-button form="test-telegram-notification-channel" :icon-only="true"
+                            title="{{ __('profile.notification_settings.test.action') }}" aria-label="{{ __('profile.notification_settings.test.action') }}">
+                            <x-icon name="send" class="h-4 w-4" />
                         </x-secondary-button>
                     </div>
                     <x-input-error :messages="$errors->get('notification_channels.telegram')" />
@@ -154,8 +158,9 @@
                         <x-text-checkbox id="notification_channels_discord_enabled" name="notification_channels[discord][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'discord.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
-                        <x-secondary-button form="test-discord-notification-channel" class="text-xs">
-                            {{ __('profile.notification_settings.test.action') }}
+                        <x-secondary-button form="test-discord-notification-channel" :icon-only="true"
+                            title="{{ __('profile.notification_settings.test.action') }}" aria-label="{{ __('profile.notification_settings.test.action') }}">
+                            <x-icon name="send" class="h-4 w-4" />
                         </x-secondary-button>
                     </div>
                     <x-input-error :messages="$errors->get('notification_channels.discord')" />
@@ -176,8 +181,9 @@
                         <x-text-checkbox id="notification_channels_teams_enabled" name="notification_channels[teams][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'teams.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
-                        <x-secondary-button form="test-teams-notification-channel" class="text-xs">
-                            {{ __('profile.notification_settings.test.action') }}
+                        <x-secondary-button form="test-teams-notification-channel" :icon-only="true"
+                            title="{{ __('profile.notification_settings.test.action') }}" aria-label="{{ __('profile.notification_settings.test.action') }}">
+                            <x-icon name="send" class="h-4 w-4" />
                         </x-secondary-button>
                     </div>
                     <x-input-error :messages="$errors->get('notification_channels.teams')" />
@@ -198,8 +204,9 @@
                         <x-text-checkbox id="notification_channels_webhook_enabled" name="notification_channels[webhook][enabled]"
                             :checked="(bool) data_get($notificationChannels, 'webhook.enabled', false)"
                             :label="__('profile.notification_settings.enabled')" />
-                        <x-secondary-button form="test-webhook-notification-channel" class="text-xs">
-                            {{ __('profile.notification_settings.test.action') }}
+                        <x-secondary-button form="test-webhook-notification-channel" :icon-only="true"
+                            title="{{ __('profile.notification_settings.test.action') }}" aria-label="{{ __('profile.notification_settings.test.action') }}">
+                            <x-icon name="send" class="h-4 w-4" />
                         </x-secondary-button>
                     </div>
                     <x-input-error :messages="$errors->get('notification_channels.webhook')" />

--- a/resources/views/status-pages/_form.blade.php
+++ b/resources/views/status-pages/_form.blade.php
@@ -120,8 +120,10 @@
                         </div>
 
                         <button type="button" @click="removeComponent(index)"
-                            class="mt-3 text-sm font-medium text-red-600 hover:text-red-700 dark:text-red-400">
-                            {{ __('status_page.form.remove_component') }}
+                            class="mt-3 inline-flex h-10 w-10 items-center justify-center rounded-md text-red-600 transition hover:bg-red-50 focus:outline-hidden focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:bg-red-950/30"
+                            title="{{ __('status_page.form.remove_component') }}"
+                            aria-label="{{ __('status_page.form.remove_component') }}">
+                            <x-icon name="trash" class="h-4 w-4" />
                         </button>
                     </div>
                 </template>

--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -26,7 +26,7 @@
             </x-container>
         @else
             <div data-status-page-overview class="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-                <div class="hidden grid-cols-[minmax(0,1.6fr)_9rem_10rem_12rem] gap-4 border-b border-gray-200 bg-gray-50/80 px-5 py-3 text-xs font-bold uppercase tracking-[0.12em] text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400 md:grid">
+                <div class="hidden grid-cols-[minmax(0,1.6fr)_9rem_10rem_6rem] gap-4 border-b border-gray-200 bg-gray-50/80 px-5 py-3 text-xs font-bold uppercase tracking-[0.12em] text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400 md:grid">
                     <span>{{ __('status_page.table.name') }}</span>
                     <span>{{ __('status_page.table.access') }}</span>
                     <span>{{ __('status_page.table.components') }}</span>
@@ -34,11 +34,21 @@
                 </div>
                 <div class="divide-y divide-gray-200 dark:divide-gray-700">
                     @foreach ($statusPages as $statusPage)
-                        <div data-status-page-row class="grid gap-4 px-5 py-4 transition hover:bg-purple-50/40 dark:hover:bg-purple-950/20 md:grid-cols-[minmax(0,1.6fr)_9rem_10rem_12rem] md:items-center">
+                        <div data-status-page-row class="grid gap-4 px-5 py-4 transition hover:bg-purple-50/40 dark:hover:bg-purple-950/20 md:grid-cols-[minmax(0,1.6fr)_9rem_10rem_6rem] md:items-center">
                             <div class="min-w-0">
-                                <a href="{{ route('status-pages.show', $statusPage) }}" class="truncate text-base font-bold text-gray-900 hover:text-purple-700 dark:text-gray-100 dark:hover:text-purple-300">
-                                    {{ $statusPage->name }}
-                                </a>
+                                <div class="flex min-w-0 items-center gap-2">
+                                    <a href="{{ route('status-pages.show', $statusPage) }}" class="truncate text-base font-bold text-gray-900 hover:text-purple-700 dark:text-gray-100 dark:hover:text-purple-300">
+                                        {{ $statusPage->name }}
+                                    </a>
+                                    @if ($statusPage->is_public)
+                                        <a href="{{ route('public-status-pages.show', $statusPage) }}" target="_blank" rel="noopener"
+                                            class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-purple-600 transition hover:bg-purple-100 hover:text-purple-800 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-purple-300 dark:hover:bg-purple-950/40 dark:hover:text-purple-200"
+                                            title="{{ __('status_page.detail.open_public_page') }}"
+                                            aria-label="{{ __('status_page.detail.open_public_page') }}">
+                                            <x-icon name="external-link" class="h-4 w-4" />
+                                        </a>
+                                    @endif
+                                </div>
                                 @if ($statusPage->description)
                                     <p class="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">{{ $statusPage->description }}</p>
                                 @endif
@@ -58,18 +68,15 @@
                                 {{ trans_choice('status_page.components_count', $statusPage->components_count, ['count' => $statusPage->components_count]) }}
                             </span>
                             <div class="flex flex-wrap justify-start gap-2 md:justify-end">
-                                <x-secondary-button :href="route('status-pages.show', $statusPage)">
-                                    {{ __('button.show') }}
+                                <x-secondary-button :href="route('status-pages.show', $statusPage)" :icon-only="true"
+                                    title="{{ __('button.show') }}" aria-label="{{ __('button.show') }}">
+                                    <x-icon name="eye" class="h-4 w-4" />
                                 </x-secondary-button>
-                                @if ($statusPage->is_public)
-                                    <x-secondary-button :href="route('public-status-pages.show', $statusPage)" target="_blank">
-                                        {{ __('status_page.actions.public_page') }}
-                                    </x-secondary-button>
-                                @endif
                                 @if (!Auth::user()->isDemo())
                                     <x-secondary-button :href="route('status-pages.edit', $statusPage)"
-                                        data-form-modal-trigger data-form-modal-name="status-page-form-modal">
-                                        {{ __('button.edit') }}
+                                        data-form-modal-trigger data-form-modal-name="status-page-form-modal" :icon-only="true"
+                                        title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                                        <x-icon name="pencil" class="h-4 w-4" />
                                     </x-secondary-button>
                                 @endif
                             </div>

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -25,20 +25,22 @@
                 </div>
 
                 <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}" class="flex flex-wrap gap-2">
-                    <x-secondary-button :href="route('incidents.analytics')">
-                        {{ __('incidents.analytics.link') }}
+                    <x-secondary-button :href="route('incidents.analytics')" :icon-only="true"
+                        title="{{ __('incidents.analytics.link') }}" aria-label="{{ __('incidents.analytics.link') }}">
+                        <x-icon name="chart" class="h-4 w-4" />
                     </x-secondary-button>
                     @if (!Auth::user()->isDemo())
                         <x-secondary-button :href="route('status-pages.edit', $statusPage)"
-                            data-form-modal-trigger data-form-modal-name="status-page-form-modal">
-                            {{ __('button.edit') }}
+                            data-form-modal-trigger data-form-modal-name="status-page-form-modal" :icon-only="true"
+                            title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
+                            <x-icon name="pencil" class="h-4 w-4" />
                         </x-secondary-button>
                         <form method="POST" action="{{ route('status-pages.destroy', $statusPage) }}"
                             data-confirm-message="{{ __('status_page.actions.delete_confirmation') }}">
                             @csrf
                             @method('DELETE')
-                            <x-danger-button>
-                                {{ __('button.delete') }}
+                            <x-danger-button :icon-only="true" title="{{ __('button.delete') }}" aria-label="{{ __('button.delete') }}">
+                                <x-icon name="trash" class="h-4 w-4" />
                             </x-danger-button>
                         </form>
                     @endif
@@ -313,9 +315,12 @@
                                                 <x-textarea name="description" rows="2">{{ $followUp->description }}</x-textarea>
                                                 <div class="flex flex-wrap gap-2">
                                                     <x-primary-button>{{ __('status_page.incident_follow_ups.save') }}</x-primary-button>
-                                                    <button type="submit" form="delete-follow-up-{{ $followUp->id }}" class="text-sm text-red-600 hover:underline">
-                                                        {{ __('status_page.incident_follow_ups.delete') }}
-                                                    </button>
+                                                            <button type="submit" form="delete-follow-up-{{ $followUp->id }}"
+                                                                class="inline-flex h-10 w-10 items-center justify-center rounded-md text-red-600 transition hover:bg-red-50 focus:outline-hidden focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:bg-red-950/30"
+                                                                title="{{ __('status_page.incident_follow_ups.delete') }}"
+                                                                aria-label="{{ __('status_page.incident_follow_ups.delete') }}">
+                                                                <x-icon name="trash" class="h-4 w-4" />
+                                                            </button>
                                                 </div>
                                             </form>
                                             <form id="delete-follow-up-{{ $followUp->id }}" method="POST"
@@ -372,8 +377,11 @@
                                                         <x-textarea name="description" rows="2">{{ $timelineEvent['description'] }}</x-textarea>
                                                         <div class="flex flex-wrap gap-2">
                                                             <x-primary-button>{{ __('status_page.incident_timeline.save') }}</x-primary-button>
-                                                            <button type="submit" form="delete-timeline-{{ $timelineEvent['id'] }}" class="text-sm text-red-600 hover:underline">
-                                                                {{ __('status_page.incident_timeline.delete') }}
+                                                            <button type="submit" form="delete-timeline-{{ $timelineEvent['id'] }}"
+                                                                class="inline-flex h-10 w-10 items-center justify-center rounded-md text-red-600 transition hover:bg-red-50 focus:outline-hidden focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:bg-red-950/30"
+                                                                title="{{ __('status_page.incident_timeline.delete') }}"
+                                                                aria-label="{{ __('status_page.incident_timeline.delete') }}">
+                                                                <x-icon name="trash" class="h-4 w-4" />
                                                             </button>
                                                         </div>
                                                     </form>
@@ -490,8 +498,10 @@
                         </div>
                     </dl>
                     @if ($statusPage->is_public)
-                        <a href="{{ route('public-status-pages.show', $statusPage) }}" target="_blank" class="mt-4 inline-flex w-full items-center justify-center rounded-md border border-purple-300 px-3 py-2 text-sm font-semibold text-purple-700 hover:bg-purple-50 dark:border-purple-700 dark:text-purple-300 dark:hover:bg-purple-950/30">
-                            {{ __('status_page.detail.open_public_page') }}
+                        <a href="{{ route('public-status-pages.show', $statusPage) }}" target="_blank" rel="noopener"
+                            class="mt-4 inline-flex h-10 w-10 items-center justify-center rounded-md border border-purple-300 text-purple-700 hover:bg-purple-50 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:border-purple-700 dark:text-purple-300 dark:hover:bg-purple-950/30"
+                            title="{{ __('status_page.detail.open_public_page') }}" aria-label="{{ __('status_page.detail.open_public_page') }}">
+                            <x-icon name="external-link" class="h-4 w-4" />
                         </a>
                     @endif
                 </x-container>

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -36,8 +36,9 @@
                                 </x-paragraph>
                             </div>
 
-                            <x-secondary-button :href="route('teams.show', $team)">
-                                {{ __('button.show') }}
+                            <x-secondary-button :href="route('teams.show', $team)" :icon-only="true"
+                                title="{{ __('button.show') }}" aria-label="{{ __('button.show') }}">
+                                <x-icon name="eye" class="h-4 w-4" />
                             </x-secondary-button>
                         </div>
                     @endforeach

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -15,27 +15,29 @@
             class="ml-auto flex flex-wrap gap-2">
             @if ($isTeamAdmin)
                 <x-secondary-button :href="route('teams.edit', $team)"
-                    data-form-modal-trigger data-form-modal-name="team-form-modal">
-                    {{ __('team.actions.edit') }}
+                    data-form-modal-trigger data-form-modal-name="team-form-modal" :icon-only="true"
+                    title="{{ __('team.actions.edit') }}" aria-label="{{ __('team.actions.edit') }}">
+                    <x-icon name="pencil" class="h-4 w-4" />
                 </x-secondary-button>
                 <form method="POST" action="{{ route('teams.destroy', $team) }}"
                     data-confirm-message="{{ __('team.actions.delete') }}">
                     @csrf
                     @method('DELETE')
-                    <x-danger-button>
-                        {{ __('team.actions.delete') }}
+                    <x-danger-button :icon-only="true" title="{{ __('team.actions.delete') }}" aria-label="{{ __('team.actions.delete') }}">
+                        <x-icon name="trash" class="h-4 w-4" />
                     </x-danger-button>
                 </form>
             @endif
             <form method="POST" action="{{ route('teams.leave', $team) }}">
                 @csrf
                 @method('DELETE')
-                <x-secondary-button>
-                    {{ __('team.actions.leave') }}
+                <x-secondary-button :icon-only="true" title="{{ __('team.actions.leave') }}" aria-label="{{ __('team.actions.leave') }}">
+                    <x-icon name="arrow-left" class="h-4 w-4" />
                 </x-secondary-button>
             </form>
-            <x-secondary-button :href="route('teams.index')">
-                {{ __('button.back') }}
+            <x-secondary-button :href="route('teams.index')" :icon-only="true"
+                title="{{ __('button.back') }}" aria-label="{{ __('button.back') }}">
+                <x-icon name="arrow-left" class="h-4 w-4" />
             </x-secondary-button>
 
             <x-form-modal name="team-form-modal" title="{{ __('team.edit.title', ['team' => $team->name]) }}"
@@ -75,16 +77,16 @@
                                                 </option>
                                             @endforeach
                                         </x-select-input>
-                                        <x-secondary-button>
-                                            {{ __('team.actions.save_role') }}
+                                        <x-secondary-button :icon-only="true" title="{{ __('team.actions.save_role') }}" aria-label="{{ __('team.actions.save_role') }}">
+                                            <x-icon name="check" class="h-4 w-4" />
                                         </x-secondary-button>
                                     </form>
 
                                     <form method="POST" action="{{ route('teams.members.destroy', [$team, $membership]) }}">
                                         @csrf
                                         @method('DELETE')
-                                        <x-danger-button>
-                                            {{ __('team.actions.remove') }}
+                                        <x-danger-button :icon-only="true" title="{{ __('team.actions.remove') }}" aria-label="{{ __('team.actions.remove') }}">
+                                            <x-icon name="trash" class="h-4 w-4" />
                                         </x-danger-button>
                                     </form>
                                 @else
@@ -142,8 +144,8 @@
                                         <form method="POST" action="{{ route('teams.invitations.destroy', [$team, $invitation]) }}">
                                             @csrf
                                             @method('DELETE')
-                                            <x-danger-button>
-                                                {{ __('team.actions.revoke') }}
+                                            <x-danger-button :icon-only="true" title="{{ __('team.actions.revoke') }}" aria-label="{{ __('team.actions.revoke') }}">
+                                                <x-icon name="trash" class="h-4 w-4" />
                                             </x-danger-button>
                                         </form>
                                     @endif

--- a/tests/Browser/DashboardServiceOperationsModalTest.php
+++ b/tests/Browser/DashboardServiceOperationsModalTest.php
@@ -22,19 +22,19 @@ it('opens the dashboard monitoring create actions in a responsive modal', functi
         'password' => Hash::make('password'),
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]');
 
     foreach ([[1280, 800], [390, 640]] as $widthHeight) {
         [$width, $height] = $widthHeight;
-        $page->navigate('/dashboard')->resize($width, $height);
+        $webpage->navigate('/dashboard')->resize($width, $height);
 
         $trigger = 'a[data-form-modal-name="monitoring-form-modal"][href$="/monitorings/create"]';
         $modal = '[data-form-modal="monitoring-form-modal"]';
 
-        $page->assertCount($trigger, 1)
+        $webpage->assertCount($trigger, 1)
             ->click($trigger)
             ->wait(1)
             ->waitForText(__('monitoring.form.sections.basic'))
@@ -52,7 +52,7 @@ JS, true)
             ->assertNoJavaScriptErrors();
 
         if ($width === 390) {
-            $page->assertScript(<<<'JS'
+            $webpage->assertScript(<<<'JS'
 function () {
     const scrollRegion = document.querySelector('[data-form-modal="monitoring-form-modal"] .min-h-0.overflow-y-auto');
 
@@ -62,8 +62,8 @@ function () {
 JS, true);
         }
 
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($modal);
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($modal);
     }
 });
 
@@ -89,21 +89,21 @@ it('opens service operations status page and monitoring group modals responsivel
         'is_public' => true,
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]');
 
     foreach ([[1280, 800], [390, 640]] as $widthHeight) {
         [$width, $height] = $widthHeight;
-        $page->navigate('/incidents/analytics')->resize($width, $height);
+        $webpage->navigate('/incidents/analytics')->resize($width, $height);
 
         $statusTrigger = 'a[data-form-modal-name="status-page-form-modal"][href$="/status-pages/create"]';
         $statusModal = '[data-form-modal="status-page-form-modal"]';
         $groupTrigger = 'a[data-form-modal-name="monitoring-group-form-modal"][href$="/monitoring-groups/' . $group->getRouteKey() . '/edit"]';
         $groupModal = '[data-form-modal="monitoring-group-form-modal"]';
 
-        $page->assertCount($statusTrigger, 1)
+        $webpage->assertCount($statusTrigger, 1)
             ->click($statusTrigger)
             ->wait(1)
             ->waitForText(__('status_page.form.name'))
@@ -117,8 +117,8 @@ function () {
         && document.body.scrollWidth <= document.body.clientWidth;
 }
 JS, true);
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($statusModal)
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($statusModal)
             ->click($groupTrigger)
             ->wait(1)
             ->waitForText(__('monitoring_group.form.name'))
@@ -134,7 +134,7 @@ function () {
 JS, true)
             ->assertNoJavaScriptErrors();
 
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($groupModal);
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($groupModal);
     }
 });

--- a/tests/Browser/FormModalInteractionTest.php
+++ b/tests/Browser/FormModalInteractionTest.php
@@ -33,7 +33,7 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
         'preferred_location' => $instanceCode,
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
@@ -41,10 +41,10 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
 
     foreach ([[1280, 800], [390, 640]] as $iteration => [$width, $height]) {
         if ($iteration > 0) {
-            $page->navigate('/monitorings');
+            $webpage->navigate('/monitorings');
         }
 
-        $page->resize($width, $height);
+        $webpage->resize($width, $height);
 
         $trigger = 'header [data-form-modal-name="monitoring-form-modal"]';
         $modal = '[data-form-modal="monitoring-form-modal"]';
@@ -52,9 +52,9 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
         $nameField = $modal . ' [x-ref="content"] form input[name="name"]';
         $targetField = $modal . ' [x-ref="content"] form input[name="target"]';
 
-        $page->assertCount($trigger, 1)
+        $webpage->assertCount($trigger, 1)
             ->click($trigger);
-        expect($page->script(<<<'JS'
+        expect($webpage->script(<<<'JS'
 async function () {
     const loader = document.querySelector('[x-data="formModalLoader()"]');
     const startedAt = Date.now();
@@ -66,7 +66,7 @@ async function () {
     return loader !== null && window.Alpine.$data(loader)?.loading === false;
 }
 JS))->toBeTrue();
-        $page->waitForText(__('monitoring.form.sections.basic'))
+        $webpage->waitForText(__('monitoring.form.sections.basic'))
             ->assertVisible($modal)
             ->assertScript(<<<'JS'
 function () {
@@ -80,7 +80,7 @@ function () {
 JS, true);
 
         if ($width === 390) {
-            $page->assertScript(<<<'JS'
+            $webpage->assertScript(<<<'JS'
 function () {
     const scrollRegion = document.querySelector('[data-form-modal="monitoring-form-modal"] .min-h-0.overflow-y-auto');
 
@@ -91,23 +91,23 @@ function () {
 JS, true);
         }
 
-        $page->clear($nameField)
+        $webpage->clear($nameField)
             ->press($submit)
             ->assertVisible($modal);
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($modal)
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($modal)
             ->assertScript(<<<'JS'
 function () {
     return document.activeElement === document.querySelector('header [data-form-modal-name="monitoring-form-modal"]');
 }
 JS, true);
-        $page->navigate('/monitorings?modal=monitoring-create')
+        $webpage->navigate('/monitorings?modal=monitoring-create')
             ->waitForText(__('monitoring.form.sections.basic'))
             ->assertVisible($modal)
             ->assertCount($nameField, 1)
             ->fill($nameField, 'Browser modal ' . Str::lower(Str::random(8)))
             ->fill($targetField, 'https://example.com');
-        $page->assertScript(<<<'JS'
+        $webpage->assertScript(<<<'JS'
 function () {
     const modal = document.querySelector('[data-form-modal="monitoring-form-modal"]');
     const form = modal?.querySelector('[x-ref="content"] form');
@@ -117,7 +117,7 @@ function () {
     return Boolean(name && type === 'http' && target === 'https://example.com' && form?.checkValidity());
 }
 JS, true);
-        $page->press($submit)
+        $webpage->press($submit)
             ->waitForText(__('monitoring.messages.created'))
             ->assertNoJavaScriptErrors();
     }
@@ -139,7 +139,7 @@ it('opens the admin package edit form in a focused responsive modal', function (
         'password' => Hash::make('password'),
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $admin->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
@@ -147,15 +147,15 @@ it('opens the admin package edit form in a focused responsive modal', function (
 
     foreach ([[1280, 800], [390, 640]] as $iteration => [$width, $height]) {
         if ($iteration > 0) {
-            $page->navigate('/admin/packages');
+            $webpage->navigate('/admin/packages');
         }
 
-        $page->resize($width, $height);
+        $webpage->resize($width, $height);
 
         $editTrigger = 'a[data-form-modal-name="admin-package-form-modal"][href$="/packages/' . $package->getRouteKey() . '/edit"]';
         $modal = '[data-form-modal="admin-package-form-modal"]';
 
-        $page->assertCount($editTrigger, 1)
+        $webpage->assertCount($editTrigger, 1)
             ->click($editTrigger)
             ->waitForText(__('admin.packages.fields.monitoring_limit'))
             ->assertVisible($modal)
@@ -169,8 +169,8 @@ function () {
         && document.body.scrollWidth <= document.body.clientWidth;
 }
 JS, true);
-        $page->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
-        $page->assertMissing($modal)
+        $webpage->script("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));");
+        $webpage->assertMissing($modal)
             ->assertNoJavaScriptErrors();
     }
 });

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -31,14 +31,14 @@ it('supports desktop service selection and keeps the Signal Room inside the view
         'response_time' => 128,
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
         ->resize(1280, 800);
 
-    $page->assertVisible('[data-signal-room]')
+    $webpage->assertVisible('[data-signal-room]')
         ->assertVisible('[data-signal-service="' . $monitoring->id . '"]')
         ->assertVisible('aside [data-signal-detail]')
         ->assertScript(<<<'JS'
@@ -114,14 +114,14 @@ it('supports mobile filtering, service details and Escape to close the detail sh
     ]);
     $unknown = Monitoring::factory()->for($user)->create(['name' => 'Unknown Search Service']);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
         ->resize(390, 640);
 
-    $page->click('[data-signal-filter="attention"]')
+    $webpage->click('[data-signal-filter="attention"]')
         ->assertScript(<<<JS
 function () {
     const service = document.querySelector('[data-signal-service="{$healthy->id}"]');
@@ -143,10 +143,10 @@ function () {
         && document.body.scrollWidth <= document.body.clientWidth;
 }
 JS, true);
-    $page->keys('input[type="search"]', 'Escape');
-    $page->wait(0.2);
+    $webpage->keys('input[type="search"]', 'Escape');
+    $webpage->wait(0.2);
 
-    $page->assertScript(<<<'JS'
+    $webpage->assertScript(<<<'JS'
 function () {
     const sheet = document.querySelector('[data-signal-mobile-sheet]');
     return sheet !== null && getComputedStyle(sheet).display === 'none';
@@ -179,7 +179,7 @@ it('keeps the desktop language menu within the navigation rail', function (): vo
         'password' => Hash::make('password'),
     ]);
 
-    $page = visit('/login')
+    $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')

--- a/tests/Feature/Admin/AdminFormModalTest.php
+++ b/tests/Feature/Admin/AdminFormModalTest.php
@@ -17,7 +17,7 @@ class AdminFormModalTest extends TestCase
         $admin = $this->adminUser();
         $user = User::factory()->create();
         $package = Package::factory()->create(['is_selectable' => false]);
-        $instance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'modal-instance',
             'ip_address' => '10.0.0.10',
             'api_key_hash' => 'secret',
@@ -40,7 +40,7 @@ class AdminFormModalTest extends TestCase
             ->get(route('admin.server-instances.index'))
             ->assertOk()
             ->assertSeeHtml('data-form-modal-name="admin-server-instance-form-modal"')
-            ->assertSeeHtml('href="' . route('admin.server-instances.edit', $instance) . '"');
+            ->assertSeeHtml('href="' . route('admin.server-instances.edit', $serverInstance) . '"');
     }
 
     public function test_admin_can_load_create_and_edit_forms_as_modal_fragments(): void
@@ -48,7 +48,7 @@ class AdminFormModalTest extends TestCase
         $admin = $this->adminUser();
         $user = User::factory()->unverified()->create();
         $package = Package::factory()->create(['is_selectable' => false]);
-        $instance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'modal-fragment-instance',
             'ip_address' => '10.0.0.11',
             'api_key_hash' => 'secret',
@@ -61,7 +61,7 @@ class AdminFormModalTest extends TestCase
             [route('admin.packages.create', ['modal' => 1]), 'admin-package-create'],
             [route('admin.packages.edit', ['package' => $package, 'modal' => 1]), 'admin-package-edit'],
             [route('admin.server-instances.create', ['modal' => 1]), 'admin-server-instance-create'],
-            [route('admin.server-instances.edit', ['server_instance' => $instance, 'modal' => 1]), 'admin-server-instance-edit'],
+            [route('admin.server-instances.edit', ['server_instance' => $serverInstance, 'modal' => 1]), 'admin-server-instance-edit'],
         ];
 
         foreach ($modalRoutes as [$route, $modalForm]) {
@@ -82,7 +82,7 @@ class AdminFormModalTest extends TestCase
         $admin = $this->adminUser();
         $user = User::factory()->create();
         $package = Package::factory()->create(['is_selectable' => false]);
-        $instance = ServerInstance::query()->create([
+        $serverInstance = ServerInstance::query()->create([
             'code' => 'modal-validation-instance',
             'ip_address' => '10.0.0.12',
             'api_key_hash' => 'secret',
@@ -140,15 +140,15 @@ class AdminFormModalTest extends TestCase
             ->assertSessionHasErrors('ip_address');
 
         $this->actingAs($admin)
-            ->put(route('admin.server-instances.update', $instance), [
-                'code' => $instance->code,
+            ->put(route('admin.server-instances.update', $serverInstance), [
+                'code' => $serverInstance->code,
                 'ip_address' => 'not-an-ip',
                 'api_key' => '',
                 'modal_form' => 'admin-server-instance-edit',
             ])
             ->assertRedirect(route('admin.server-instances.index', [
                 'modal' => 'admin-server-instance-edit',
-                'server_instance' => $instance,
+                'server_instance' => $serverInstance,
             ]));
     }
 

--- a/tests/Feature/AuthenticatedNavigationTest.php
+++ b/tests/Feature/AuthenticatedNavigationTest.php
@@ -29,7 +29,7 @@ class AuthenticatedNavigationTest extends TestCase
         $testResponse->assertSeeHtml('href="' . route('dashboard') . '"');
         $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
         $testResponse->assertSeeHtml('data-secondary-navigation');
-        $this->assertSame(1, substr_count($testResponse->getContent() ?? '', 'data-primary-destination'));
+        $this->assertSame(1, mb_substr_count($testResponse->getContent() ?? '', 'data-primary-destination'));
         $testResponse->assertDontSeeText(__('app.navigation.signal_room'));
         $testResponse->assertDontSeeText(__('app.navigation.workspace'));
         $testResponse->assertDontSeeHtml('data-workspace-navigation');

--- a/tests/Feature/FormModalCrudFlowTest.php
+++ b/tests/Feature/FormModalCrudFlowTest.php
@@ -90,11 +90,11 @@ class FormModalCrudFlowTest extends TestCase
             'is_public' => true,
         ]);
 
-        $monitoringResponse = $this->actingAs($user)
+        $testResponse = $this->actingAs($user)
             ->from(route('monitorings.index'))
             ->post(route('monitorings.store'), ['modal_form' => 'monitoring-create']);
-        $monitoringResponse->assertRedirect(route('monitorings.index', ['modal' => 'monitoring-create']));
-        $this->get($monitoringResponse->headers->get('Location'))
+        $testResponse->assertRedirect(route('monitorings.index', ['modal' => 'monitoring-create']));
+        $this->get($testResponse->headers->get('Location'))
             ->assertOk()
             ->assertSeeText(__('monitoring.form.sections.basic'));
 

--- a/tests/Feature/FormModalTeamsProfileTest.php
+++ b/tests/Feature/FormModalTeamsProfileTest.php
@@ -45,12 +45,12 @@ class FormModalTeamsProfileTest extends TestCase
         $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
         $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::ADMIN]);
 
-        $validationResponse = $this->actingAs($admin)->post(route('teams.store'), [
+        $testResponse = $this->actingAs($admin)->post(route('teams.store'), [
             'description' => 'Missing name',
             'modal_form' => 'team-create',
         ]);
 
-        $validationResponse
+        $testResponse
             ->assertRedirect(route('teams.index', ['modal' => 'team-create']))
             ->assertSessionHasErrors('name');
 
@@ -119,14 +119,14 @@ class FormModalTeamsProfileTest extends TestCase
         Package::factory()->create();
         $user = User::factory()->create();
 
-        $validationResponse = $this->actingAs($user)->from(route('profile.edit'))->put(route('password.update'), [
+        $testResponse = $this->actingAs($user)->from(route('profile.edit'))->put(route('password.update'), [
             'current_password' => 'wrong-password',
             'password' => 'new-password',
             'password_confirmation' => 'new-password',
             'modal_form' => 'profile-password',
         ]);
 
-        $validationResponse
+        $testResponse
             ->assertRedirect(route('profile.edit', ['modal' => 'profile-password']))
             ->assertSessionHasErrorsIn('updatePassword', 'current_password');
 

--- a/tests/Feature/Notifications/NotificationPageDesignTest.php
+++ b/tests/Feature/Notifications/NotificationPageDesignTest.php
@@ -38,7 +38,7 @@ class NotificationPageDesignTest extends TestCase
         $testResponse->assertSeeText(__('notifications.filters.heading'));
         $testResponse->assertSeeText(__('notifications.filters.unread'));
         $testResponse->assertSeeText(__('notifications.filters.all'));
-        $testResponse->assertSeeText(__('notifications.mark_all_as_read'));
+        $testResponse->assertSeeHtml('aria-label="' . __('notifications.mark_all_as_read') . '"');
         $testResponse->assertSeeHtml('bg-purple-600 text-white');
         $testResponse->assertSeeHtml('dark:bg-purple-500 dark:text-white');
         $testResponse->assertSeeHtml('dark:!bg-purple-500 dark:!text-white');

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -410,7 +410,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse = $this->actingAs($user)->get(route('profile.edit', ['modal' => 'profile-information']));
 
         $testResponse->assertOk();
-        $testResponse->assertSeeText(__('profile.notification_settings.test.action'));
+        $testResponse->assertSeeHtml('aria-label="' . __('profile.notification_settings.test.action') . '"');
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'slack']));
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'telegram']));
         $testResponse->assertSeeHtml(route('profile.notification-channels.test', ['channel' => 'discord']));

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -225,14 +225,21 @@ class StatusPageManagementTest extends TestCase
             ->assertOk()
             ->assertSeeText('Old Status')
             ->assertSeeHtml('data-status-page-overview')
-            ->assertSeeHtml('data-status-page-row');
+            ->assertSeeHtml('data-status-page-row')
+            ->assertSeeHtml('aria-label="' . __('button.show') . '"')
+            ->assertSeeHtml('aria-label="' . __('button.edit') . '"')
+            ->assertSeeHtml('title="' . __('status_page.detail.open_public_page') . '"')
+            ->assertSeeHtml('rel="noopener"');
 
         $this->actingAs($user)->get(route('status-pages.show', $statusPage))
             ->assertOk()
             ->assertSeeText('Old Status')
             ->assertSeeHtml('data-status-page-detail-header')
             ->assertSeeHtml('data-status-page-detail-layout')
-            ->assertSeeHtml('data-status-page-context-rail');
+            ->assertSeeHtml('data-status-page-context-rail')
+            ->assertSeeHtml('aria-label="' . __('button.edit') . '"')
+            ->assertSeeHtml('aria-label="' . __('button.delete') . '"')
+            ->assertSeeHtml('aria-label="' . __('status_page.detail.open_public_page') . '"');
 
         $this->actingAs($user)->get(route('status-pages.edit', $statusPage))
             ->assertOk()


### PR DESCRIPTION
## Was geändert wurde

- Utility- und CRUD-Actions auf relevanten Management-Seiten auf Icon-only-Buttons umgestellt.
- Gemeinsame Icon-Komponente und kompakte Button-Varianten ergänzt.
- Öffentliche Statusseiten mit External-Link-Icon neben dem Seitennamen versehen.
- `title`- und `aria-label`-Beschriftungen für symbolische Aktionen ergänzt.
- Pagination-Zurück/Weiter-Buttons im gemeinsamen Async-Table zugänglich beschriftet.
- Primäre Formularaktionen und finale Löschbestätigungen bewusst textbasiert belassen.

## Validierung

- Blade view cache erfolgreich.
- Pest: 99 Tests / 741 Assertions erfolgreich; nach letzter Anpassung zusätzlich 25 Tests / 239 Assertions erfolgreich.
- Bun Frontend-Build erfolgreich.
- `git diff --check` erfolgreich.
- Browser-Smoke-Test bis zum Login erfolgreich; authentifizierte Ansicht war in dieser Umgebung nicht verfügbar.

Closes #534