### PR TITLE
perf: defer large monitoring views

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -28,14 +28,14 @@ class MonitoringCardDataController extends Controller
         }
 
         $validated = $request->validate([
-            'ids' => ['required', 'array', 'min:1'],
+            'ids' => ['nullable', 'array', 'max:100'],
             'ids.*' => ['required', 'string'],
-            'summary_ids' => ['nullable', 'array', 'min:1'],
+            'summary_ids' => ['nullable', 'array', 'max:100'],
             'summary_ids.*' => ['required', 'string'],
         ]);
 
         /** @var Collection<int, string> $requestedIds */
-        $requestedIds = collect($validated['ids'])
+        $requestedIds = collect($validated['ids'] ?? [])
             ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
             ->unique()
             ->values();
@@ -44,6 +44,10 @@ class MonitoringCardDataController extends Controller
             ->filter(static fn (mixed $id): bool => is_string($id) && $id !== '')
             ->unique()
             ->values();
+
+        if ($requestedIds->isEmpty() && $summaryIds->isEmpty()) {
+            abort(422, 'At least one monitoring id is required.');
+        }
         $allRequestedIds = $requestedIds->merge($summaryIds)->unique()->values();
 
         $monitorings = Monitoring::query()

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -16,6 +16,9 @@ class DashboardController extends Controller
         /** @var User $user */
         $user = $request->user();
 
-        return view('dashboard', $monitoringOverviewService->overview($user));
+        return view('dashboard', $monitoringOverviewService->overview(
+            $user,
+            max(1, $request->integer('service_page', 1)),
+        ));
     }
 }

--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -31,6 +31,11 @@ class IncidentAnalyticsController extends Controller
     ): View {
         $filters = $incidentAnalyticsRequest->validated();
         $days = (int) ($filters['days'] ?? 90);
+
+        if (! $incidentAnalyticsRequest->boolean('async')) {
+            return view('incidents.analytics-shell');
+        }
+
         $incidents = $this->incidents($filters, $days);
         $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
         $durations = $resolvedIncidents->map(

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -15,6 +15,7 @@ use App\Models\NotificationChannelDelivery;
 use App\Models\StatusPage;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
@@ -25,6 +26,7 @@ class MonitoringOverviewService
      * @return array{
      *     monitorings: EloquentCollection<int, Monitoring>,
      *     signalRoomServices: Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>,
+     *     signalRoomPagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null},
      *     summary: array{total:int,healthy:int,down:int,unknown:int,paused:int,maintenance:int},
      *     overallState: string,
      *     attentionItems: Collection<int, array{type:string,monitoring:Monitoring|null,count:int|null}>,
@@ -38,7 +40,7 @@ class MonitoringOverviewService
      *     canManageMaintenance: bool
      * }
      */
-    public function overview(User $user): array
+    public function overview(User $user, int $servicePage = 1): array
     {
         $user->loadMissing('package');
 
@@ -103,28 +105,43 @@ class MonitoringOverviewService
             $this->statusPagesByMonitoringId($user)
         );
         $overallState = $this->overallState($summary);
+        $signalRoomServices = $monitorings->map(function (Monitoring $monitoring) use ($statuses): array {
+            $status = (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value);
+            $latestResponse = $monitoring->latestResponseResult;
+
+            return [
+                'id' => (string) $monitoring->getKey(),
+                'name' => (string) $monitoring->name,
+                'target' => (string) $monitoring->target,
+                'status' => $status,
+                'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $status),
+                'group' => (string) ($monitoring->groups->first()?->name ?? __('dashboard.signal_room.ungrouped')),
+                'lastCheck' => $latestResponse?->created_at?->locale(app()->getLocale())->diffForHumans() ?? __('dashboard.signal_room.no_check'),
+                'responseTime' => $latestResponse?->response_time !== null
+                    ? number_format((float) $latestResponse->response_time, 0, ',', '.') . ' ms'
+                    : '—',
+                'openIncident' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null,
+                'href' => route('monitorings.show', $monitoring),
+            ];
+        })->values();
+        $servicePaginator = new LengthAwarePaginator(
+            $signalRoomServices->forPage(max(1, $servicePage), 10)->values(),
+            $signalRoomServices->count(),
+            10,
+            max(1, $servicePage),
+            ['pageName' => 'service_page', 'path' => route('dashboard')],
+        );
 
         return [
             'monitorings' => $monitorings,
-            'signalRoomServices' => $monitorings->map(function (Monitoring $monitoring) use ($statuses): array {
-                $status = (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value);
-                $latestResponse = $monitoring->latestResponseResult;
-
-                return [
-                    'id' => (string) $monitoring->getKey(),
-                    'name' => (string) $monitoring->name,
-                    'target' => (string) $monitoring->target,
-                    'status' => $status,
-                    'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $status),
-                    'group' => (string) ($monitoring->groups->first()?->name ?? __('dashboard.signal_room.ungrouped')),
-                    'lastCheck' => $latestResponse?->created_at?->locale(app()->getLocale())->diffForHumans() ?? __('dashboard.signal_room.no_check'),
-                    'responseTime' => $latestResponse?->response_time !== null
-                        ? number_format((float) $latestResponse->response_time, 0, ',', '.') . ' ms'
-                        : '—',
-                    'openIncident' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null,
-                    'href' => route('monitorings.show', $monitoring),
-                ];
-            })->values(),
+            'signalRoomServices' => $servicePaginator->getCollection(),
+            'signalRoomPagination' => [
+                'current_page' => $servicePaginator->currentPage(),
+                'last_page' => $servicePaginator->lastPage(),
+                'total' => $servicePaginator->total(),
+                'from' => $servicePaginator->firstItem(),
+                'to' => $servicePaginator->lastItem(),
+            ],
             'summary' => $summary,
             'overallState' => $overallState,
             'attentionItems' => $attentionItems,

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -18,6 +18,7 @@ import asyncTable from './components/async-table';
 import confirmDialog, { registerConfirmableForms } from './components/confirm-dialog';
 import formModalLoader from './components/form-modal-loader';
 import signalRoom from './components/signal-room';
+import incidentAnalyticsLoader from './components/incident-analytics-loader';
 
 const decodeImprintPayload = (payload: string): string => {
     try {
@@ -71,6 +72,7 @@ Alpine.data('asyncTable', asyncTable);
 Alpine.data('confirmDialog', confirmDialog);
 Alpine.data('formModalLoader', formModalLoader);
 Alpine.data('signalRoom', signalRoom);
+Alpine.data('incidentAnalyticsLoader', incidentAnalyticsLoader);
 
 window.Alpine = Alpine;
 window.Chart = Chart;

--- a/resources/js/components/incident-analytics-loader.ts
+++ b/resources/js/components/incident-analytics-loader.ts
@@ -1,0 +1,41 @@
+interface IncidentAnalyticsLoaderComponent {
+    endpoint: string;
+    errorMessage: string;
+    loading: boolean;
+    error: string;
+    init(this: IncidentAnalyticsLoaderComponent): Promise<void>;
+}
+
+export default (): IncidentAnalyticsLoaderComponent => ({
+    endpoint: '',
+    errorMessage: '',
+    loading: true,
+    error: '',
+
+    async init(this: IncidentAnalyticsLoaderComponent): Promise<void> {
+        const root = (this as any).$el as HTMLElement;
+        this.endpoint = root.dataset.endpoint ?? window.location.href;
+        this.errorMessage = root.dataset.error ?? 'Unable to load analytics.';
+
+        const endpoint = new URL(this.endpoint, window.location.origin);
+        endpoint.searchParams.set('async', '1');
+
+        const response = await fetch(endpoint.toString()).catch(() => null);
+        if (!response?.ok) {
+            this.loading = false;
+            this.error = this.errorMessage;
+            return;
+        }
+
+        const documentText = await response.text();
+        const parsedDocument = new DOMParser().parseFromString(documentText, 'text/html');
+        const content = parsedDocument.querySelector<HTMLElement>('#incident-analytics-page-content');
+        if (!content) {
+            this.loading = false;
+            this.error = this.errorMessage;
+            return;
+        }
+
+        root.replaceWith(content);
+    },
+});

--- a/resources/js/components/monitoring-cards.ts
+++ b/resources/js/components/monitoring-cards.ts
@@ -62,53 +62,61 @@ export default (
         this.hasMonitorings = this.monitoringIds.length > 0;
         if (!this.hasMonitorings) return;
 
-        const query = new URLSearchParams();
+        const summaryBatches = Array.from({ length: Math.ceil(this.summaryMonitoringIds.length / 50) }, (_, index) =>
+            this.summaryMonitoringIds.slice(index * 50, (index + 1) * 50)
+        );
 
-        this.monitoringIds.forEach((id: string) => query.append('ids[]', id));
-        this.summaryMonitoringIds.forEach((id: string) => query.append('summary_ids[]', id));
-
-        const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
-        if (!response?.ok) {
-            return;
-        }
-
-        const payload = await response.json() as {
+        const loadBatch = async (ids: string[], summaryIds: string[] = []): Promise<{
             data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }>;
-            summary?: {
-                attention: number;
-                healthy: number;
-                paused: number;
-                maintenance: number;
+            summary?: { attention: number; healthy: number; paused: number; maintenance: number };
+        } | null> => {
+            const query = new URLSearchParams();
+            ids.forEach((id: string) => query.append('ids[]', id));
+            summaryIds.forEach((id: string) => query.append('summary_ids[]', id));
+
+            const response = await fetch(`/api/monitorings/card-data?${query.toString()}`).catch(() => null);
+            if (!response?.ok) return null;
+
+            return await response.json() as {
+                data?: Record<string, { status?: string; since?: string | null; heatmap?: unknown[] }>;
+                summary?: { attention: number; healthy: number; paused: number; maintenance: number };
             };
         };
-        const cardData = payload.data ?? {};
 
-        for (const monitoringId of this.monitoringIds) {
-            const monitoringCardData = cardData[monitoringId];
-            if (!monitoringCardData) {
-                continue;
-            }
+        const [cardPayload, ...summaryPayloads] = await Promise.all([
+            loadBatch(this.monitoringIds),
+            ...summaryBatches.map((batch) => loadBatch([], batch)),
+        ]);
 
-            this.statusMap = { ...this.statusMap, [monitoringId]: monitoringCardData.status ?? '' };
-            this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: monitoringCardData.since ?? null };
-            this.sinceMap = {
-                ...this.sinceMap,
-                [monitoringId]: monitoringCardData.since ? humanizeDistance(monitoringCardData.since, { withoutSuffix: true }) : '',
-            };
+        if (cardPayload) {
+            const cardData = cardPayload.data ?? {};
 
-            const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
-            if (heatmapContainer && monitoringCardData.heatmap) {
-                renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
+            for (const monitoringId of this.monitoringIds) {
+                const monitoringCardData = cardData[monitoringId];
+                if (!monitoringCardData) continue;
+
+                this.statusMap = { ...this.statusMap, [monitoringId]: monitoringCardData.status ?? '' };
+                this.sinceDateMap = { ...this.sinceDateMap, [monitoringId]: monitoringCardData.since ?? null };
+                this.sinceMap = {
+                    ...this.sinceMap,
+                    [monitoringId]: monitoringCardData.since ? humanizeDistance(monitoringCardData.since, { withoutSuffix: true }) : '',
+                };
+
+                const heatmapContainer = document.getElementById(`monitoring-heatmap-${monitoringId}`);
+                if (heatmapContainer && monitoringCardData.heatmap) {
+                    renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
+                }
             }
         }
 
-        if (payload.summary) {
-            this.attentionCount = payload.summary.attention;
-            this.healthyCount = payload.summary.healthy;
-            this.pausedCount = payload.summary.paused;
-            this.maintenanceCount = payload.summary.maintenance;
+        const summaries = summaryPayloads.map((payload) => payload?.summary).filter((summary): summary is NonNullable<typeof summary> => summary !== undefined);
+        if (summaryBatches.length > 0 && summaries.length === summaryBatches.length) {
+            this.attentionCount = summaries.reduce((total, summary) => total + summary.attention, 0);
+            this.healthyCount = summaries.reduce((total, summary) => total + summary.healthy, 0);
+            this.pausedCount = summaries.reduce((total, summary) => total + summary.paused, 0);
+            this.maintenanceCount = summaries.reduce((total, summary) => total + summary.maintenance, 0);
             this.summaryReady = true;
-        } else {
+        } else if (summaryBatches.length === 0) {
             this.updateSummary();
         }
     },

--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -1,5 +1,6 @@
 @props([
     'services',
+    'pagination' => null,
     'summary',
     'overallState',
     'canCreateMonitoring' => false,
@@ -136,6 +137,24 @@
             <x-dashboard.signal-room-detail />
         </aside>
     </div>
+
+    @if ($pagination && $pagination['last_page'] > 1)
+        <div class="flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
+            <p>
+                {{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }}
+                {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}
+            </p>
+            <nav class="flex items-center gap-2" aria-label="{{ __('search.table.pagination') }}">
+                @if ($pagination['current_page'] > 1)
+                    <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">&laquo; {{ __('pagination.previous') }}</a>
+                @endif
+                <span class="rounded-md bg-purple-100 px-3 py-2 font-semibold text-purple-700 dark:bg-purple-900 dark:text-purple-100">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
+                @if ($pagination['current_page'] < $pagination['last_page'])
+                    <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">{{ __('pagination.next') }} &raquo;</a>
+                @endif
+            </nav>
+        </div>
+    @endif
 
     <div data-signal-mobile-sheet x-show="mobileDetailOpen" x-cloak class="lg:hidden">
         <div class="fixed inset-0 z-40 bg-gray-950/35" aria-hidden="true" @click="closeDetail()"></div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -61,6 +61,7 @@
         @else
             <x-dashboard.signal-room
                 :services="$signalRoomServices"
+                :pagination="$signalRoomPagination"
                 :summary="$summary"
                 :overall-state="$overallState"
                 :can-create-monitoring="$canCreateMonitoring"

--- a/resources/views/incidents/analytics-shell.blade.php
+++ b/resources/views/incidents/analytics-shell.blade.php
@@ -1,0 +1,24 @@
+<x-app-layout>
+    <x-slot name="header">
+        <x-monitoring-operations-header />
+    </x-slot>
+
+    <x-main>
+        <div
+            id="incident-analytics-page-content"
+            data-incident-analytics-loader
+            data-endpoint="{{ route('incidents.analytics', request()->query()) }}"
+            data-error="{{ __('search.messages.error') }}"
+            x-data="incidentAnalyticsLoader()"
+            class="space-y-6"
+        >
+            <x-container>
+                <div class="flex items-center gap-3" x-show="loading">
+                    <span class="h-3 w-3 animate-pulse rounded-full bg-purple-600" aria-hidden="true"></span>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                </div>
+                <p x-show="error" x-text="error" class="text-sm font-semibold text-red-600 dark:text-red-300" x-cloak></p>
+            </x-container>
+        </div>
+    </x-main>
+</x-app-layout>

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -23,6 +23,7 @@
     </x-slot>
 
     <x-main>
+        <div id="incident-analytics-page-content">
         <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
             <x-form-modal name="status-page-form-modal" title="{{ __('status_page.title') }}"
                 description="{{ __('status_page.form.components') }}" max-width="5xl">
@@ -434,6 +435,7 @@
                     <div x-html="content"></div>
                 </div>
             </x-form-modal>
+        </div>
         </div>
     </x-main>
 </x-app-layout>

--- a/tests/Feature/Api/MonitoringCardDataApiTest.php
+++ b/tests/Feature/Api/MonitoringCardDataApiTest.php
@@ -157,6 +157,39 @@ class MonitoringCardDataApiTest extends TestCase
         $testResponse->assertJsonPath('data.' . $monitorings->first()->id . '.heatmap.0.uptime', 0);
     }
 
+    public function test_card_data_endpoint_can_load_summary_batches_without_card_payloads(): void
+    {
+        Date::setTestNow('2026-04-12 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 2]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitorings = Monitoring::factory()->count(2)->for($user)->create();
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitorings->first()->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 120,
+            'created_at' => Date::now()->subMinutes(5),
+            'updated_at' => Date::now()->subMinutes(5),
+        ]);
+
+        $testResponse = $this->actingAs($user)->getJson('/api/monitorings/card-data?' . http_build_query([
+            'summary_ids' => $monitorings->pluck('id')->all(),
+        ]));
+
+        $testResponse->assertOk()
+            ->assertExactJson([
+                'data' => [],
+                'summary' => [
+                    'attention' => 1,
+                    'healthy' => 1,
+                    'paused' => 0,
+                    'maintenance' => 0,
+                ],
+            ]);
+    }
+
     public function test_card_data_endpoint_requires_authentication(): void
     {
         Date::setTestNow('2026-04-12 12:00:00');

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -21,6 +21,28 @@ use Tests\TestCase;
 
 class DashboardOverviewTest extends TestCase
 {
+    public function test_dashboard_service_landscape_is_paginated_without_changing_the_global_summary(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 20]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->count(11)->for($user)->sequence(
+            fn ($sequence) => ['name' => sprintf('Service %02d', $sequence->index + 1)],
+        )->create();
+
+        $firstPage = $this->actingAs($user)->get(route('dashboard'));
+        $secondPage = $this->actingAs($user)->get(route('dashboard', ['service_page' => 2]));
+
+        $firstPage->assertOk()
+            ->assertSeeText('11 ' . __('dashboard.signal_room.active_services'))
+            ->assertSeeText('Service 01')
+            ->assertDontSeeText('Service 11')
+            ->assertSeeText('1 / 2');
+        $secondPage->assertOk()
+            ->assertSeeText('Service 11')
+            ->assertSeeText('2 / 2')
+            ->assertSeeHtml('service_page=1');
+    }
+
     public function test_new_user_sees_a_clear_dashboard_empty_state(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -19,6 +19,19 @@ use Tests\TestCase;
 
 class IncidentWorkflowTest extends TestCase
 {
+    public function test_incident_analytics_initial_request_returns_a_fast_loading_shell(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->count(20)->for($user)->create();
+
+        $this->actingAs($user)->get(route('incidents.analytics'))
+            ->assertOk()
+            ->assertSeeHtml('data-incident-analytics-loader')
+            ->assertSeeText(__('app.loading'))
+            ->assertDontSeeHtml('data-incident-overview-table');
+    }
+
     public function test_owner_can_manage_private_metadata_follow_ups_and_timeline_without_public_disclosure(): void
     {
         Date::setTestNow('2026-07-15 12:00:00');
@@ -238,6 +251,7 @@ class IncidentWorkflowTest extends TestCase
         $this->actingAs($user)->get(route('incidents.analytics', [
             'days' => 90,
             'severity' => IncidentSeverity::HIGH->value,
+            'async' => 1,
         ]))
             ->assertOk()
             ->assertSeeText('Average MTTR')
@@ -269,7 +283,7 @@ class IncidentWorkflowTest extends TestCase
             'source_type' => StatusPageComponentSource::MONITORING_GROUP,
         ]);
 
-        $this->actingAs($user)->get(route('incidents.analytics'))
+        $this->actingAs($user)->get(route('incidents.analytics', ['async' => 1]))
             ->assertOk()
             ->assertSeeText(__('incidents.analytics.overview.groups'))
             ->assertSeeText(__('incidents.analytics.overview.status_pages'))
@@ -303,7 +317,7 @@ class IncidentWorkflowTest extends TestCase
             'down_at' => Date::now()->subMinutes(30),
         ]);
 
-        $this->actingAs($user)->get(route('incidents.analytics'))
+        $this->actingAs($user)->get(route('incidents.analytics', ['async' => 1]))
             ->assertOk()
             ->assertSeeText('Checkout API')
             ->assertDontSeeText('Other API');
@@ -331,7 +345,7 @@ class IncidentWorkflowTest extends TestCase
                 'up_at' => Date::now()->subMinutes(30),
             ]);
 
-            $this->actingAs($user)->get(route('incidents.analytics'))
+            $this->actingAs($user)->get(route('incidents.analytics', ['async' => 1]))
                 ->assertOk()
                 ->assertSeeText($localizedExpectation['label'])
                 ->assertDontSeeText('incidents.types.unclassified')


### PR DESCRIPTION
## What changed

- Paginate the dashboard service landscape with a dedicated `service_page` parameter.
- Split monitoring card and summary requests into bounded batches so large monitoring sets do not create oversized URLs.
- Return a lightweight `/incidents/analytics` shell and load the full analytics workspace asynchronously with loading and error states.
- Add regression coverage for dashboard pagination, summary-only card-data batches, and the analytics loading shell.

## Why

Users with hundreds or thousands of monitorings were receiving oversized card-data URLs and expensive initial analytics/dashboard responses. The new bounded and deferred loading paths keep the initial pages responsive while preserving the existing data scope and filters.

## Issues

Closes #536
Closes #537
Closes #538

## Validation

- Targeted Pest: 20 passed, 155 assertions.
- Full Pest suite: 651 passed, 4,254 assertions.
- PHPStan: passed.
- Pint: passed.
- Vite build: passed.
- Docker validation was attempted but the local Docker daemon was unavailable in this environment.