### PR TITLE
perf: split large monitoring views into async sections

### DIFF
--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -45,9 +45,7 @@ class MonitoringCardDataController extends Controller
             ->unique()
             ->values();
 
-        if ($requestedIds->isEmpty() && $summaryIds->isEmpty()) {
-            abort(422, 'At least one monitoring id is required.');
-        }
+        abort_if($requestedIds->isEmpty() && $summaryIds->isEmpty(), 422, 'At least one monitoring id is required.');
         $allRequestedIds = $requestedIds->merge($summaryIds)->unique()->values();
 
         $monitorings = Monitoring::query()

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -16,6 +16,15 @@ class DashboardController extends Controller
         /** @var User $user */
         $user = $request->user();
 
+        if ($request->boolean('service_fragment')) {
+            $serviceMap = $monitoringOverviewService->serviceMap(
+                $user,
+                max(1, $request->integer('service_page', 1)),
+            );
+
+            return view('components.dashboard.service-map-fragment', $serviceMap);
+        }
+
         return view('dashboard', $monitoringOverviewService->overview(
             $user,
             max(1, $request->integer('service_page', 1)),

--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -36,6 +36,18 @@ class IncidentAnalyticsController extends Controller
             return view('incidents.analytics-shell');
         }
 
+        $section = $incidentAnalyticsRequest->string('section')->toString();
+        if ($section !== '') {
+            return $this->section(
+                $section,
+                $filters,
+                $days,
+                $incidentAnalyticsRequest,
+                $monitoringOverviewService,
+                $monitoringStatusService,
+            );
+        }
+
         $incidents = $this->incidents($filters, $days);
         $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
         $durations = $resolvedIncidents->map(
@@ -98,6 +110,107 @@ class IncidentAnalyticsController extends Controller
             'overallState' => $overview['overallState'],
             'incidentTrend' => $this->incidentTrend($incidents, $days),
         ]);
+    }
+
+    private function section(
+        string $section,
+        array $filters,
+        int $days,
+        IncidentAnalyticsRequest $request,
+        MonitoringOverviewService $monitoringOverviewService,
+        MonitoringStatusService $monitoringStatusService,
+    ): View {
+        return match ($section) {
+            'overview' => view('incidents.analytics-sections.overview', [
+                'overview' => $monitoringOverviewService->overview($request->user()),
+            ]),
+            'groups' => view('incidents.analytics-sections.groups', [
+                'groups' => $this->monitoringGroups($request, $monitoringStatusService),
+            ]),
+            'status-pages' => view('incidents.analytics-sections.status-pages', [
+                'statusPages' => $this->statusPages($request, $monitoringStatusService),
+            ]),
+            'incidents' => view('incidents.analytics-sections.incidents', $this->incidentSectionData($filters, $days)),
+            default => abort(404),
+        };
+    }
+
+    /**
+     * @return array{groups:Collection<int, array{model:MonitoringGroup,summary:array{total:int,healthy:int,down:int,attention:int,state:string}}>,statusPages:Collection<int, array{model:StatusPage,summary:array{total:int,healthy:int,down:int,attention:int,state:string}}>}
+     */
+    private function monitoringGroups(IncidentAnalyticsRequest $request, MonitoringStatusService $monitoringStatusService): Collection
+    {
+        return $request->user()
+            ->monitoringGroups()
+            ->withCount('monitorings')
+            ->with(['monitorings.latestResponseResult', 'monitorings.latestIncident'])
+            ->orderBy('name')
+            ->limit(20)
+            ->get()
+            ->map(fn (MonitoringGroup $monitoringGroup): array => [
+                'model' => $monitoringGroup,
+                'summary' => $this->summarizeMonitorings($monitoringGroup->monitorings, $monitoringStatusService),
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array{model:StatusPage,summary:array{total:int,healthy:int,down:int,attention:int,state:string}}>
+     */
+    private function statusPages(IncidentAnalyticsRequest $request, MonitoringStatusService $monitoringStatusService): Collection
+    {
+        return $request->user()
+            ->statusPages()
+            ->withCount('components')
+            ->with([
+                'components.monitorings.latestResponseResult',
+                'components.monitorings.latestIncident',
+                'components.monitoringGroup.monitorings.latestResponseResult',
+                'components.monitoringGroup.monitorings.latestIncident',
+            ])
+            ->latest()
+            ->limit(20)
+            ->get()
+            ->map(function (StatusPage $statusPage) use ($monitoringStatusService): array {
+                return [
+                    'model' => $statusPage,
+                    'summary' => $this->summarizeMonitorings($this->statusPageMonitorings($statusPage), $monitoringStatusService),
+                ];
+            });
+    }
+
+    /**
+     * @return array{filters:array{days:int,incident_type:string|null,severity:string|null,customer_impact:string|null,affected_service:string|null},incidents:EloquentCollection<int, Incident>,totalCount:int,resolvedCount:int,openCount:int,mttrMinutes:int|null,byType:Collection<string,int>,bySeverity:Collection<string,int>,byImpact:Collection<string,int>,byService:Collection<string,int>,repeatServices:Collection<string,int>,incidentTypes:list<IncidentType>,severities:list<IncidentSeverity>,customerImpacts:list<IncidentCustomerImpact>,incidentTrend:array{points:list<array{label:string,count:int,x:float,y:float}>,max:int}}
+     */
+    private function incidentSectionData(array $filters, int $days): array
+    {
+        $incidents = $this->incidents($filters, $days);
+        $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
+        $durations = $resolvedIncidents->map(static fn (Incident $incident): int => (int) $incident->down_at->diffInMinutes($incident->up_at));
+        $byService = $this->groupCounts($incidents, static fn (Incident $incident): string => $incident->affected_service ?: $incident->monitoring->name);
+
+        return [
+            'filters' => [
+                'days' => $days,
+                'incident_type' => $filters['incident_type'] ?? null,
+                'severity' => $filters['severity'] ?? null,
+                'customer_impact' => $filters['customer_impact'] ?? null,
+                'affected_service' => $filters['affected_service'] ?? null,
+            ],
+            'incidents' => $incidents,
+            'totalCount' => $incidents->count(),
+            'resolvedCount' => $resolvedIncidents->count(),
+            'openCount' => $incidents->reject(static fn (Incident $incident): bool => $incident->up_at !== null)->count(),
+            'mttrMinutes' => $durations->isEmpty() ? null : (int) round($durations->avg()),
+            'byType' => $this->groupCounts($incidents, static fn (Incident $incident): string => $incident->incident_type?->value ?? 'unclassified'),
+            'bySeverity' => $this->groupCounts($incidents, static fn (Incident $incident): string => $incident->severity?->value ?? 'unclassified'),
+            'byImpact' => $this->groupCounts($incidents, static fn (Incident $incident): string => $incident->customer_impact?->value ?? 'unclassified'),
+            'byService' => $byService,
+            'repeatServices' => $byService->filter(static fn (int $count): bool => $count > 1),
+            'incidentTypes' => IncidentType::cases(),
+            'severities' => IncidentSeverity::cases(),
+            'customerImpacts' => IncidentCustomerImpact::cases(),
+            'incidentTrend' => $this->incidentTrend($incidents, $days),
+        ];
     }
 
     /**

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -168,6 +168,91 @@ class MonitoringOverviewService
         ];
     }
 
+    /**
+     * Load only the bounded service-map page used by async dashboard navigation.
+     *
+     * @return array{services:Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>,pagination:array{current_page:int,last_page:int,total:int,from:int|null,to:int|null},total:int}
+     */
+    public function serviceMap(User $user, int $servicePage = 1): array
+    {
+        $servicePaginator = Monitoring::query()
+            ->visibleTo($user)
+            ->with([
+                'latestResponseResult' => fn ($query) => $query->select([
+                    'monitoring_response_results.id',
+                    'monitoring_response_results.monitoring_id',
+                    'monitoring_response_results.status',
+                    'monitoring_response_results.response_time',
+                    'monitoring_response_results.created_at',
+                    'monitoring_response_results.updated_at',
+                ]),
+                'latestIncident' => fn ($query) => $query->select([
+                    'incidents.id',
+                    'incidents.monitoring_id',
+                    'incidents.down_at',
+                    'incidents.up_at',
+                ]),
+                'groups:id,name',
+            ])
+            ->orderBy('name')
+            ->paginate(10, [
+                'id',
+                'name',
+                'target',
+                'type',
+                'status',
+                'maintenance_from',
+                'maintenance_until',
+                'heartbeat_interval_minutes',
+                'heartbeat_grace_minutes',
+            ], 'service_page', max(1, $servicePage));
+
+        $services = $this->mapSignalRoomServices($servicePaginator->getCollection());
+
+        return [
+            'services' => $services,
+            'pagination' => [
+                'current_page' => $servicePaginator->currentPage(),
+                'last_page' => $servicePaginator->lastPage(),
+                'total' => $servicePaginator->total(),
+                'from' => $servicePaginator->firstItem(),
+                'to' => $servicePaginator->lastItem(),
+            ],
+            'total' => $servicePaginator->total(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Monitoring>  $monitorings
+     * @return Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>
+     */
+    private function mapSignalRoomServices(Collection $monitorings): Collection
+    {
+        $statuses = $monitorings->mapWithKeys(
+            fn (Monitoring $monitoring): array => [$monitoring->id => $this->status($monitoring)]
+        );
+
+        return $monitorings->map(function (Monitoring $monitoring) use ($statuses): array {
+            $status = (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value);
+            $latestResponse = $monitoring->latestResponseResult;
+
+            return [
+                'id' => (string) $monitoring->getKey(),
+                'name' => (string) $monitoring->name,
+                'target' => (string) $monitoring->target,
+                'status' => $status,
+                'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $status),
+                'group' => (string) ($monitoring->groups->first()?->name ?? __('dashboard.signal_room.ungrouped')),
+                'lastCheck' => $latestResponse?->created_at?->locale(app()->getLocale())->diffForHumans() ?? __('dashboard.signal_room.no_check'),
+                'responseTime' => $latestResponse?->response_time !== null
+                    ? number_format((float) $latestResponse->response_time, 0, ',', '.') . ' ms'
+                    : '—',
+                'openIncident' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null,
+                'href' => route('monitorings.show', $monitoring),
+            ];
+        })->values();
+    }
+
     private function status(Monitoring $monitoring): string
     {
         if ($monitoring->isPaused()) {

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -124,7 +124,7 @@ class MonitoringOverviewService
                 'href' => route('monitorings.show', $monitoring),
             ];
         })->values();
-        $servicePaginator = new LengthAwarePaginator(
+        $lengthAwarePaginator = new LengthAwarePaginator(
             $signalRoomServices->forPage(max(1, $servicePage), 10)->values(),
             $signalRoomServices->count(),
             10,
@@ -134,13 +134,13 @@ class MonitoringOverviewService
 
         return [
             'monitorings' => $monitorings,
-            'signalRoomServices' => $servicePaginator->getCollection(),
+            'signalRoomServices' => $lengthAwarePaginator->getCollection(),
             'signalRoomPagination' => [
-                'current_page' => $servicePaginator->currentPage(),
-                'last_page' => $servicePaginator->lastPage(),
-                'total' => $servicePaginator->total(),
-                'from' => $servicePaginator->firstItem(),
-                'to' => $servicePaginator->lastItem(),
+                'current_page' => $lengthAwarePaginator->currentPage(),
+                'last_page' => $lengthAwarePaginator->lastPage(),
+                'total' => $lengthAwarePaginator->total(),
+                'from' => $lengthAwarePaginator->firstItem(),
+                'to' => $lengthAwarePaginator->lastItem(),
             ],
             'summary' => $summary,
             'overallState' => $overallState,

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -18,6 +18,7 @@ import asyncTable from './components/async-table';
 import confirmDialog, { registerConfirmableForms } from './components/confirm-dialog';
 import formModalLoader from './components/form-modal-loader';
 import signalRoom from './components/signal-room';
+import serviceMapLoader from './components/service-map-loader';
 import incidentAnalyticsLoader from './components/incident-analytics-loader';
 
 const decodeImprintPayload = (payload: string): string => {
@@ -72,6 +73,7 @@ Alpine.data('asyncTable', asyncTable);
 Alpine.data('confirmDialog', confirmDialog);
 Alpine.data('formModalLoader', formModalLoader);
 Alpine.data('signalRoom', signalRoom);
+Alpine.data('serviceMapLoader', serviceMapLoader);
 Alpine.data('incidentAnalyticsLoader', incidentAnalyticsLoader);
 
 window.Alpine = Alpine;

--- a/resources/js/components/incident-analytics-loader.ts
+++ b/resources/js/components/incident-analytics-loader.ts
@@ -1,41 +1,38 @@
 interface IncidentAnalyticsLoaderComponent {
-    endpoint: string;
-    errorMessage: string;
-    loading: boolean;
-    error: string;
     init(this: IncidentAnalyticsLoaderComponent): Promise<void>;
+    showSectionError(this: IncidentAnalyticsLoaderComponent, section: HTMLElement): void;
 }
 
 export default (): IncidentAnalyticsLoaderComponent => ({
-    endpoint: '',
-    errorMessage: '',
-    loading: true,
-    error: '',
-
     async init(this: IncidentAnalyticsLoaderComponent): Promise<void> {
         const root = (this as any).$el as HTMLElement;
-        this.endpoint = root.dataset.endpoint ?? window.location.href;
-        this.errorMessage = root.dataset.error ?? 'Unable to load analytics.';
+        const sections = Array.from(root.querySelectorAll<HTMLElement>('[data-analytics-section]'));
 
-        const endpoint = new URL(this.endpoint, window.location.origin);
-        endpoint.searchParams.set('async', '1');
+        await Promise.all(sections.map(async (section): Promise<void> => {
+            const endpoint = new URL(section.dataset.endpoint ?? window.location.href, window.location.origin);
+            endpoint.searchParams.set('async', '1');
+            endpoint.searchParams.set('section', section.dataset.analyticsSection ?? '');
 
-        const response = await fetch(endpoint.toString()).catch(() => null);
-        if (!response?.ok) {
-            this.loading = false;
-            this.error = this.errorMessage;
-            return;
-        }
+            const response = await fetch(endpoint.toString()).catch(() => null);
+            if (!response?.ok) {
+                this.showSectionError(section);
+                return;
+            }
 
-        const documentText = await response.text();
-        const parsedDocument = new DOMParser().parseFromString(documentText, 'text/html');
-        const content = parsedDocument.querySelector<HTMLElement>('#incident-analytics-page-content');
-        if (!content) {
-            this.loading = false;
-            this.error = this.errorMessage;
-            return;
-        }
+            const documentText = await response.text();
+            const parsedDocument = new DOMParser().parseFromString(documentText, 'text/html');
+            const content = parsedDocument.querySelector<HTMLElement>('[data-analytics-section-content]');
+            if (!content) {
+                this.showSectionError(section);
+                return;
+            }
 
-        root.replaceWith(content);
+            section.replaceChildren(content);
+        }));
+    },
+
+    showSectionError(this: IncidentAnalyticsLoaderComponent, section: HTMLElement): void {
+        section.querySelector<HTMLElement>('[data-section-loading]')?.setAttribute('hidden', 'hidden');
+        section.querySelector<HTMLElement>('[data-section-error]')?.removeAttribute('hidden');
     },
 });

--- a/resources/js/components/monitoring-cards.ts
+++ b/resources/js/components/monitoring-cards.ts
@@ -20,6 +20,7 @@ interface MonitoringCardLoaderComponent {
     attentionCount: number;
     pausedCount: number;
     maintenanceCount: number;
+    summaryError: boolean;
     currentLocale: string;
     updateSummary(this: MonitoringCardLoaderComponent): void;
     updateSince(this: MonitoringCardLoaderComponent): void;
@@ -55,6 +56,7 @@ export default (
     attentionCount: 0,
     pausedCount: 0,
     maintenanceCount: 0,
+    summaryError: false,
 
     currentLocale: getCurrentDayjsLocale(),
 
@@ -83,12 +85,10 @@ export default (
             };
         };
 
-        const [cardPayload, ...summaryPayloads] = await Promise.all([
-            loadBatch(this.monitoringIds),
-            ...summaryBatches.map((batch) => loadBatch([], batch)),
-        ]);
+        const cardPayloadPromise = loadBatch(this.monitoringIds);
+        cardPayloadPromise.then((cardPayload) => {
+            if (!cardPayload) return;
 
-        if (cardPayload) {
             const cardData = cardPayload.data ?? {};
 
             for (const monitoringId of this.monitoringIds) {
@@ -107,18 +107,41 @@ export default (
                     renderHeatmap(heatmapContainer, monitoringCardData.heatmap);
                 }
             }
+        });
+
+        if (summaryBatches.length === 0) {
+            this.updateSummary();
+            await cardPayloadPromise;
+            return;
         }
 
-        const summaries = summaryPayloads.map((payload) => payload?.summary).filter((summary): summary is NonNullable<typeof summary> => summary !== undefined);
-        if (summaryBatches.length > 0 && summaries.length === summaryBatches.length) {
-            this.attentionCount = summaries.reduce((total, summary) => total + summary.attention, 0);
-            this.healthyCount = summaries.reduce((total, summary) => total + summary.healthy, 0);
-            this.pausedCount = summaries.reduce((total, summary) => total + summary.paused, 0);
-            this.maintenanceCount = summaries.reduce((total, summary) => total + summary.maintenance, 0);
-            this.summaryReady = true;
-        } else if (summaryBatches.length === 0) {
-            this.updateSummary();
-        }
+        let nextBatchIndex = 0;
+        let completedBatches = 0;
+        const loadSummaryWorker = async (): Promise<void> => {
+            while (nextBatchIndex < summaryBatches.length) {
+                const batch = summaryBatches[nextBatchIndex++];
+                const payload = await loadBatch([], batch);
+                const summary = payload?.summary;
+
+                if (!summary) {
+                    this.summaryError = true;
+                } else {
+                    this.attentionCount += summary.attention;
+                    this.healthyCount += summary.healthy;
+                    this.pausedCount += summary.paused;
+                    this.maintenanceCount += summary.maintenance;
+                }
+
+                completedBatches++;
+                this.summaryReady = completedBatches === summaryBatches.length;
+            }
+        };
+
+        await Promise.all(Array.from(
+            { length: Math.min(3, summaryBatches.length) },
+            () => loadSummaryWorker(),
+        ));
+        await cardPayloadPromise;
     },
 
     updateSummary(this: MonitoringCardLoaderComponent): void {

--- a/resources/js/components/service-map-loader.ts
+++ b/resources/js/components/service-map-loader.ts
@@ -1,0 +1,68 @@
+interface ServiceMapLoaderComponent {
+    loading: boolean;
+    loadPage(this: ServiceMapLoaderComponent, url: string): Promise<void>;
+    init(this: ServiceMapLoaderComponent): void;
+}
+
+const readServices = (element: HTMLElement): unknown[] => {
+    try {
+        return JSON.parse(element.dataset.services ?? '[]') as unknown[];
+    } catch {
+        return [];
+    }
+};
+
+export default (): ServiceMapLoaderComponent => ({
+    loading: false,
+
+    async loadPage(this: ServiceMapLoaderComponent, url: string): Promise<void> {
+        if (this.loading) return;
+
+        this.loading = true;
+        const root = (this as any).$el as HTMLElement;
+        const endpoint = new URL(url, window.location.origin);
+        endpoint.searchParams.set('service_fragment', '1');
+
+        const response = await fetch(endpoint.toString()).catch(() => null);
+        if (!response?.ok) {
+            this.loading = false;
+            return;
+        }
+
+        const responseText = await response.text();
+        const parsedDocument = new DOMParser().parseFromString(responseText, 'text/html');
+        const nextList = parsedDocument.querySelector<HTMLElement>('#dashboard-service-list');
+        const nextPagination = parsedDocument.querySelector<HTMLElement>('#dashboard-service-pagination');
+        const currentList = root.querySelector<HTMLElement>('#dashboard-service-list');
+        const currentPagination = root.querySelector<HTMLElement>('#dashboard-service-pagination');
+
+        if (!nextList || !currentList) {
+            this.loading = false;
+            return;
+        }
+
+        currentList.replaceWith(nextList);
+        if (currentPagination && nextPagination) {
+            currentPagination.replaceWith(nextPagination);
+        } else if (!currentPagination && nextPagination) {
+            root.append(nextPagination);
+        } else if (currentPagination && !nextPagination) {
+            currentPagination.remove();
+        }
+
+        root.dataset.services = JSON.stringify(readServices(nextList));
+        window.dispatchEvent(new CustomEvent('signal-room:services-updated', {
+            detail: { services: readServices(nextList) },
+        }));
+        window.Alpine?.initTree(nextList);
+        if (nextPagination) window.Alpine?.initTree(nextPagination);
+        this.loading = false;
+    },
+
+    init(this: ServiceMapLoaderComponent): void {
+        const root = (this as any).$el as HTMLElement;
+        window.dispatchEvent(new CustomEvent('signal-room:services-updated', {
+            detail: { services: readServices(root) },
+        }));
+    },
+});

--- a/resources/js/components/signal-room.ts
+++ b/resources/js/components/signal-room.ts
@@ -25,6 +25,7 @@ type SignalRoomComponent = {
     mobileDetailOpen: boolean;
     desktop: boolean;
     resizeHandler: () => void;
+    servicesUpdatedHandler: (event: Event) => void;
     init(): void;
     selectService(serviceId: string): void;
     closeDetail(): void;
@@ -40,6 +41,7 @@ export default (config: SignalRoomConfig): SignalRoomComponent => ({
     mobileDetailOpen: false,
     desktop: false,
     resizeHandler: (): void => undefined,
+    servicesUpdatedHandler: (): void => undefined,
 
     init(): void {
         const mediaQuery = window.matchMedia('(min-width: 1024px)');
@@ -64,10 +66,22 @@ export default (config: SignalRoomConfig): SignalRoomComponent => ({
         window.addEventListener('keydown', keydownHandler);
         document.addEventListener('keydown', keydownHandler);
 
+        this.servicesUpdatedHandler = (event: Event): void => {
+            const services = (event as CustomEvent<{ services?: SignalRoomService[] }>).detail.services;
+            if (!services) return;
+
+            this.services = services;
+            if (!this.services.some((service) => service.id === this.selectedServiceId)) {
+                this.selectedServiceId = this.services[0]?.id ?? null;
+            }
+        };
+        window.addEventListener('signal-room:services-updated', this.servicesUpdatedHandler);
+
         (this as any).$el.addEventListener('alpine:destroy', () => {
             mediaQuery.removeEventListener('change', this.resizeHandler);
             window.removeEventListener('keydown', keydownHandler);
             document.removeEventListener('keydown', keydownHandler);
+            window.removeEventListener('signal-room:services-updated', this.servicesUpdatedHandler);
         });
     },
 

--- a/resources/views/components/dashboard/service-map-fragment.blade.php
+++ b/resources/views/components/dashboard/service-map-fragment.blade.php
@@ -1,0 +1,56 @@
+@props(['services', 'pagination', 'total'])
+
+<section id="dashboard-service-list" data-services='@json($services)' class="min-w-0 rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800" aria-labelledby="signal-room-services-heading">
+    <div class="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-700 sm:px-6">
+        <div>
+            <h3 id="signal-room-services-heading" class="text-base font-extrabold text-gray-950 dark:text-white">{{ __('dashboard.signal_room.service_landscape') }}</h3>
+            <p class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">{{ $total }} {{ __('dashboard.signal_room.active_services') }}</p>
+        </div>
+        <span class="hidden rounded-full bg-gray-100 px-3 py-1.5 text-xs font-bold text-gray-500 dark:bg-gray-700 dark:text-gray-300 sm:inline-flex">{{ __('dashboard.signal_room.target') }}</span>
+    </div>
+
+    <div class="divide-y divide-gray-100 dark:divide-gray-700">
+        @foreach (collect($services)->groupBy('group')->sortKeys() as $groupName => $groupServices)
+            <div class="px-5 py-3 sm:px-6">
+                <p class="mb-2 text-[11px] font-black uppercase tracking-[0.18em] text-gray-400 dark:text-gray-500">{{ $groupName }}</p>
+                <div class="space-y-2">
+                    @foreach ($groupServices as $service)
+                        @php
+                            $serviceTone = match ($service['status']) {
+                                'down' => ['dot' => 'bg-red-500', 'text' => 'text-red-700 dark:text-red-300'],
+                                'unknown' => ['dot' => 'bg-amber-500', 'text' => 'text-amber-700 dark:text-amber-300'],
+                                'maintenance' => ['dot' => 'bg-purple-500', 'text' => 'text-purple-700 dark:text-purple-300'],
+                                'paused' => ['dot' => 'bg-gray-400', 'text' => 'text-gray-600 dark:text-gray-300'],
+                                default => ['dot' => 'bg-emerald-500', 'text' => 'text-emerald-700 dark:text-emerald-300'],
+                            };
+                        @endphp
+                        <button type="button" data-signal-service="{{ $service['id'] }}" @click="selectService(@js($service['id']))" x-show="serviceVisible(@js($service))" :class="selectedServiceId === @js($service['id']) ? 'ring-2 ring-purple-500 ring-offset-1 dark:ring-offset-gray-800' : ''" class="group flex w-full items-center gap-3 rounded-2xl border border-gray-100 bg-gray-50 px-3.5 py-3 text-start transition hover:border-purple-200 hover:bg-purple-50/50 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-700 dark:bg-gray-800/70 dark:hover:border-purple-900 dark:hover:bg-purple-950/20">
+                            <span class="h-2.5 w-2.5 shrink-0 rounded-full {{ $serviceTone['dot'] }}"></span>
+                            <span class="min-w-0 flex-1">
+                                <span class="block truncate text-sm font-extrabold text-gray-900 dark:text-white">{{ $service['name'] }}</span>
+                                <span class="mt-1 block truncate text-xs text-gray-500 dark:text-gray-400">{{ $service['target'] }}</span>
+                            </span>
+                            <span class="hidden shrink-0 text-end sm:block"><span class="block text-xs font-bold {{ $serviceTone['text'] }}">{{ $service['statusLabel'] }}</span><span class="mt-1 block text-[11px] text-gray-400 dark:text-gray-500">{{ $service['lastCheck'] }}</span></span>
+                            <svg class="h-4 w-4 shrink-0 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m9 5 7 7-7 7" /></svg>
+                        </button>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+</section>
+
+@if ($pagination && $pagination['last_page'] > 1)
+    <div id="dashboard-service-pagination" class="mt-5 flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
+        <p>{{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }} {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}</p>
+        <nav class="flex items-center gap-2" aria-label="{{ __('search.table.pagination') }}">
+            @if ($pagination['current_page'] > 1)
+                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">&laquo; {{ __('pagination.previous') }}</a>
+            @endif
+            <span class="rounded-md bg-purple-100 px-3 py-2 font-semibold text-purple-700 dark:bg-purple-900 dark:text-purple-100">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
+            @if ($pagination['current_page'] < $pagination['last_page'])
+                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">{{ __('pagination.next') }} &raquo;</a>
+            @endif
+        </nav>
+    </div>
+@endif

--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -77,7 +77,14 @@
     </div>
 
     <div class="grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]">
-        <section class="min-w-0 rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800" aria-labelledby="signal-room-services-heading">
+        <div
+            x-data="serviceMapLoader()"
+            data-service-map-loader
+            data-services='@json($services)'
+            data-endpoint="{{ route('dashboard') }}"
+            class="min-w-0"
+        >
+        <section id="dashboard-service-list" data-services='@json($services)' class="min-w-0 rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800" aria-labelledby="signal-room-services-heading">
             <div class="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-700 sm:px-6">
                 <div>
                     <h3 id="signal-room-services-heading" class="text-base font-extrabold text-gray-950 dark:text-white">{{ __('dashboard.signal_room.service_landscape') }}</h3>
@@ -133,28 +140,29 @@
             </div>
         </section>
 
+        @if ($pagination && $pagination['last_page'] > 1)
+            <div id="dashboard-service-pagination" class="flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
+                <p>
+                    {{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }}
+                    {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}
+                </p>
+                <nav class="flex items-center gap-2" aria-label="{{ __('search.table.pagination') }}">
+                    @if ($pagination['current_page'] > 1)
+                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">&laquo; {{ __('pagination.previous') }}</a>
+                    @endif
+                    <span class="rounded-md bg-purple-100 px-3 py-2 font-semibold text-purple-700 dark:bg-purple-900 dark:text-purple-100">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
+                    @if ($pagination['current_page'] < $pagination['last_page'])
+                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">{{ __('pagination.next') }} &raquo;</a>
+                    @endif
+                </nav>
+            </div>
+        @endif
+        </div>
+
         <aside class="hidden lg:block">
             <x-dashboard.signal-room-detail />
         </aside>
     </div>
-
-    @if ($pagination && $pagination['last_page'] > 1)
-        <div class="flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
-            <p>
-                {{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }}
-                {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}
-            </p>
-            <nav class="flex items-center gap-2" aria-label="{{ __('search.table.pagination') }}">
-                @if ($pagination['current_page'] > 1)
-                    <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">&laquo; {{ __('pagination.previous') }}</a>
-                @endif
-                <span class="rounded-md bg-purple-100 px-3 py-2 font-semibold text-purple-700 dark:bg-purple-900 dark:text-purple-100">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
-                @if ($pagination['current_page'] < $pagination['last_page'])
-                    <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">{{ __('pagination.next') }} &raquo;</a>
-                @endif
-            </nav>
-        </div>
-    @endif
 
     <div data-signal-mobile-sheet x-show="mobileDetailOpen" x-cloak class="lg:hidden">
         <div class="fixed inset-0 z-40 bg-gray-950/35" aria-hidden="true" @click="closeDetail()"></div>

--- a/resources/views/incidents/analytics-sections/groups.blade.php
+++ b/resources/views/incidents/analytics-sections/groups.blade.php
@@ -1,0 +1,21 @@
+<div data-analytics-section-content>
+    <x-container id="monitoring-groups" class="overflow-hidden">
+        <div class="flex items-start justify-between gap-4 border-b border-gray-200 pb-4 dark:border-gray-700">
+            <x-heading type="h2">{{ __('incidents.analytics.overview.groups') }}</x-heading>
+            <a href="{{ route('monitoring-groups.index') }}" class="text-sm font-semibold text-purple-700 dark:text-purple-300">{{ __('incidents.analytics.overview.view_all_groups') }}</a>
+        </div>
+        @if ($groups->isEmpty())
+            <p class="py-8 text-center text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.overview.empty_groups') }}</p>
+        @else
+            <div class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+                @foreach ($groups as $group)
+                    @php($summary = $group['summary'])
+                    <div class="flex items-center justify-between gap-4 py-4">
+                        <div class="min-w-0"><a href="{{ route('monitorings.index', ['group_id' => $group['model']->id]) }}" class="truncate font-semibold text-gray-900 dark:text-gray-100">{{ $group['model']->name }}</a><p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ trans_choice('monitoring_group.monitorings_count', $summary['total'], ['count' => $summary['total']]) }} · {{ $summary['healthy'] }} {{ __('dashboard.summary.healthy') }}</p></div>
+                        <span class="text-sm font-semibold {{ $summary['down'] > 0 ? 'text-red-600' : 'text-green-600' }}">{{ __('incidents.analytics.overview.status.' . $summary['state']) }}</span>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </x-container>
+</div>

--- a/resources/views/incidents/analytics-sections/incidents.blade.php
+++ b/resources/views/incidents/analytics-sections/incidents.blade.php
@@ -1,0 +1,35 @@
+<div data-analytics-section-content>
+    <section id="incident-analytics" class="space-y-4">
+        <x-container>
+            <x-heading type="h2">{{ __('incidents.analytics.sections.recent') }}</x-heading>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.definitions') }}</p>
+            <form method="GET" action="{{ route('incidents.analytics') }}" class="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+                <x-select-input id="days" name="days"><option value="30" @selected($filters['days'] === 30)>{{ __('incidents.analytics.filters.days_30') }}</option><option value="90" @selected($filters['days'] === 90)>{{ __('incidents.analytics.filters.days_90') }}</option><option value="365" @selected($filters['days'] === 365)>{{ __('incidents.analytics.filters.days_365') }}</option></x-select-input>
+                <x-select-input id="incident_type" name="incident_type"><option value="">{{ __('incidents.analytics.filters.all') }}</option>@foreach ($incidentTypes as $type)<option value="{{ $type->value }}" @selected($filters['incident_type'] === $type->value)>{{ __('incidents.types.' . $type->value) }}</option>@endforeach</x-select-input>
+                <x-select-input id="severity" name="severity"><option value="">{{ __('incidents.analytics.filters.all') }}</option>@foreach ($severities as $severity)<option value="{{ $severity->value }}" @selected($filters['severity'] === $severity->value)>{{ __('incidents.severities.' . $severity->value) }}</option>@endforeach</x-select-input>
+                <x-select-input id="customer_impact" name="customer_impact"><option value="">{{ __('incidents.analytics.filters.all') }}</option>@foreach ($customerImpacts as $impact)<option value="{{ $impact->value }}" @selected($filters['customer_impact'] === $impact->value)>{{ __('incidents.customer_impacts.' . $impact->value) }}</option>@endforeach</x-select-input>
+                <x-primary-button class="justify-center">{{ __('incidents.analytics.filters.apply') }}</x-primary-button>
+                <x-text-input id="affected_service" name="affected_service" :value="$filters['affected_service']" class="sm:col-span-2 lg:col-span-5" placeholder="{{ __('incidents.analytics.filters.affected_service') }}" />
+            </form>
+        </x-container>
+
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            @foreach ([[$totalCount, 'incidents.analytics.metrics.total'], [$resolvedCount, 'incidents.analytics.metrics.resolved'], [$openCount, 'incidents.analytics.metrics.open'], [$mttrMinutes === null ? __('incidents.analytics.metrics.not_available') : __('incidents.analytics.metrics.minutes', ['value' => $mttrMinutes]), 'incidents.analytics.metrics.mttr']] as $metric)
+                <x-container><p class="text-sm text-gray-500 dark:text-gray-400">{{ __($metric[1]) }}</p><p class="mt-2 text-2xl font-semibold">{{ $metric[0] }}</p></x-container>
+            @endforeach
+        </div>
+
+        <x-container>
+            <x-heading type="h2">{{ __('incidents.analytics.sections.recent') }}</x-heading>
+            @if ($incidents->isEmpty())
+                <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.empty') }}</p>
+            @else
+                <div class="mt-4 overflow-x-auto rounded-2xl border border-gray-200 dark:border-gray-700"><table data-incident-overview-table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700"><tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    @foreach ($incidents as $incident)
+                        <tr data-incident-row><td class="px-4 py-3">{{ $incident->up_at ? __('incidents.analytics.table.resolved_state') : __('incidents.analytics.table.open_state') }}</td><td class="px-4 py-3"><a href="{{ route('monitorings.show', $incident->monitoring) }}" class="font-bold text-gray-900 dark:text-gray-100">{{ $incident->monitoring->name }}</a></td><td class="px-4 py-3">{{ $incident->problem_description ?: ($incident->affected_service ?: __('incidents.analytics.unclassified')) }}</td><td class="whitespace-nowrap px-4 py-3">{{ $incident->down_at->toDayDateTimeString() }}</td></tr>
+                    @endforeach
+                </tbody></table></div>
+            @endif
+        </x-container>
+    </section>
+</div>

--- a/resources/views/incidents/analytics-sections/overview.blade.php
+++ b/resources/views/incidents/analytics-sections/overview.blade.php
@@ -1,0 +1,21 @@
+<div data-analytics-section-content>
+    @php
+        $summary = $overview['summary'];
+        $state = $overview['overallState'];
+        $healthTitle = __('incidents.analytics.overview.health.' . $state);
+    @endphp
+    <x-container class="overflow-hidden" id="overview">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+                <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ $healthTitle }}</h2>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.overview.health.updated') }}</p>
+            </div>
+            <div class="grid grid-cols-2 gap-x-8 gap-y-2 text-sm sm:grid-cols-4">
+                <div><p class="text-gray-500 dark:text-gray-400">{{ __('dashboard.summary.total') }}</p><p class="mt-1 text-lg font-semibold">{{ $summary['total'] }}</p></div>
+                <div><p class="text-gray-500 dark:text-gray-400">{{ __('dashboard.summary.healthy') }}</p><p class="mt-1 text-lg font-semibold text-green-600">{{ $summary['healthy'] }}</p></div>
+                <div><p class="text-gray-500 dark:text-gray-400">{{ __('dashboard.summary.down') }}</p><p class="mt-1 text-lg font-semibold text-red-600">{{ $summary['down'] }}</p></div>
+                <div><p class="text-gray-500 dark:text-gray-400">{{ __('dashboard.summary.unknown') }}</p><p class="mt-1 text-lg font-semibold text-yellow-600">{{ $summary['unknown'] }}</p></div>
+            </div>
+        </div>
+    </x-container>
+</div>

--- a/resources/views/incidents/analytics-sections/status-pages.blade.php
+++ b/resources/views/incidents/analytics-sections/status-pages.blade.php
@@ -1,0 +1,18 @@
+<div data-analytics-section-content>
+    <x-container id="status-pages" class="overflow-hidden">
+        <div class="flex items-start justify-between gap-4 border-b border-gray-200 pb-4 dark:border-gray-700">
+            <x-heading type="h2">{{ __('incidents.analytics.overview.status_pages') }}</x-heading>
+            <a href="{{ route('status-pages.index') }}" class="text-sm font-semibold text-purple-700 dark:text-purple-300">{{ __('incidents.analytics.overview.view_all_status_pages') }}</a>
+        </div>
+        @if ($statusPages->isEmpty())
+            <p class="py-8 text-center text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.overview.empty_status_pages') }}</p>
+        @else
+            <div class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+                @foreach ($statusPages as $statusPage)
+                    @php($summary = $statusPage['summary'])
+                    <div class="flex items-center justify-between gap-4 py-4"><div class="min-w-0"><a href="{{ route('status-pages.show', $statusPage['model']) }}" class="truncate font-semibold text-gray-900 dark:text-gray-100">{{ $statusPage['model']->name }}</a><p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $summary['total'] }} {{ __('incidents.analytics.overview.services') }} · {{ $summary['down'] }} {{ __('dashboard.summary.down') }}</p></div><span class="text-sm font-semibold {{ $summary['down'] > 0 ? 'text-red-600' : 'text-green-600' }}">{{ __('incidents.analytics.overview.status.' . $summary['state']) }}</span></div>
+                @endforeach
+            </div>
+        @endif
+    </x-container>
+</div>

--- a/resources/views/incidents/analytics-shell.blade.php
+++ b/resources/views/incidents/analytics-shell.blade.php
@@ -12,13 +12,19 @@
             x-data="incidentAnalyticsLoader()"
             class="space-y-6"
         >
-            <x-container>
-                <div class="flex items-center gap-3" x-show="loading">
-                    <span class="h-3 w-3 animate-pulse rounded-full bg-purple-600" aria-hidden="true"></span>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
-                </div>
-                <p x-show="error" x-text="error" class="text-sm font-semibold text-red-600 dark:text-red-300" x-cloak></p>
-            </x-container>
+            <div class="space-y-6">
+                @foreach (['overview', 'groups', 'status-pages', 'incidents'] as $section)
+                    <section data-analytics-section="{{ $section }}" data-endpoint="{{ route('incidents.analytics', request()->query()) }}" data-error="{{ __('search.messages.error') }}" aria-live="polite">
+                        <x-container>
+                            <div class="flex items-center gap-3" data-section-loading>
+                                <span class="h-3 w-3 animate-pulse rounded-full bg-purple-600" aria-hidden="true"></span>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                            </div>
+                            <p data-section-error class="text-sm font-semibold text-red-600 dark:text-red-300" hidden>{{ __('search.messages.error') }}</p>
+                        </x-container>
+                    </section>
+                @endforeach
+            </div>
         </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -463,6 +463,7 @@
                             <div><p class="text-2xl font-bold text-emerald-600 dark:text-emerald-400" x-text="summaryReady ? healthyCount : '—'"></p><p class="text-xs text-gray-500 dark:text-gray-400">{{ __('monitoring.index.table.healthy') }}</p></div>
                             <div><p class="text-2xl font-bold text-red-600 dark:text-red-400" x-text="summaryReady ? attentionCount : '—'"></p><p class="text-xs text-gray-500 dark:text-gray-400">{{ __('monitoring.index.table.attention') }}</p></div>
                         </div>
+                        <p x-show="summaryError" x-cloak class="mt-3 text-xs text-red-600 dark:text-red-300">{{ __('search.messages.error') }}</p>
                     </section>
 
                     <a href="{{ route('incidents.analytics') }}" class="block rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-purple-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-purple-700">

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -43,6 +43,25 @@ class DashboardOverviewTest extends TestCase
             ->assertSeeHtml('service_page=1');
     }
 
+    public function test_dashboard_service_landscape_page_can_be_loaded_as_a_bounded_fragment(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 20]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->count(11)->for($user)->sequence(
+            fn ($sequence) => ['name' => sprintf('Service %02d', $sequence->index + 1)],
+        )->create();
+
+        $this->actingAs($user)->get(route('dashboard', [
+            'service_fragment' => 1,
+            'service_page' => 2,
+        ]))
+            ->assertOk()
+            ->assertSeeHtml('id="dashboard-service-list"')
+            ->assertSeeText('Service 11')
+            ->assertDontSeeText('Service 01')
+            ->assertDontSeeText(__('dashboard.greeting', ['name' => $user->name]));
+    }
+
     public function test_new_user_sees_a_clear_dashboard_empty_state(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -29,10 +29,10 @@ class DashboardOverviewTest extends TestCase
             fn ($sequence) => ['name' => sprintf('Service %02d', $sequence->index + 1)],
         )->create();
 
-        $firstPage = $this->actingAs($user)->get(route('dashboard'));
+        $testResponse = $this->actingAs($user)->get(route('dashboard'));
         $secondPage = $this->actingAs($user)->get(route('dashboard', ['service_page' => 2]));
 
-        $firstPage->assertOk()
+        $testResponse->assertOk()
             ->assertSeeText('11 ' . __('dashboard.signal_room.active_services'))
             ->assertSeeText('Service 01')
             ->assertDontSeeText('Service 11')

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -32,6 +32,22 @@ class IncidentWorkflowTest extends TestCase
             ->assertDontSeeHtml('data-incident-overview-table');
     }
 
+    public function test_incident_analytics_sections_load_independently(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+
+        foreach (['overview', 'groups', 'status-pages', 'incidents'] as $section) {
+            $this->actingAs($user)->get(route('incidents.analytics', [
+                'async' => 1,
+                'section' => $section,
+            ]))
+                ->assertOk()
+                ->assertSeeHtml('data-analytics-section-content');
+        }
+    }
+
     public function test_owner_can_manage_private_metadata_follow_ups_and_timeline_without_public_disclosure(): void
     {
         Date::setTestNow('2026-07-15 12:00:00');


### PR DESCRIPTION
## What changed

- Load dashboard service-map pagination through a bounded async fragment request.
- Render monitoring card data progressively and limit summary-batch concurrency.
- Split incident analytics into independent overview, groups, status-pages, and incidents requests with loading/error states.
- Add regression coverage for the fragment and section endpoints.

## Why

Large monitoring sets should not block the dashboard or analytics page on one full-page response or an unbounded client request burst.

## Testing

- `./vendor/bin/pest` — passed
- `composer analyse` — passed
- `./vendor/bin/pint --test` — passed
- `bun run build` — passed
- Docker validation was attempted but the local Docker daemon was unavailable; equivalent host checks passed.

Closes #540
Closes #541
Closes #542