### PR TITLE
fix: style dashboard service-map pagination

### DIFF
--- a/resources/js/components/service-map-loader.ts
+++ b/resources/js/components/service-map-loader.ts
@@ -32,9 +32,7 @@ export default (): ServiceMapLoaderComponent => ({
         const responseText = await response.text();
         const parsedDocument = new DOMParser().parseFromString(responseText, 'text/html');
         const nextList = parsedDocument.querySelector<HTMLElement>('#dashboard-service-list');
-        const nextPagination = parsedDocument.querySelector<HTMLElement>('#dashboard-service-pagination');
         const currentList = root.querySelector<HTMLElement>('#dashboard-service-list');
-        const currentPagination = root.querySelector<HTMLElement>('#dashboard-service-pagination');
 
         if (!nextList || !currentList) {
             this.loading = false;
@@ -42,20 +40,12 @@ export default (): ServiceMapLoaderComponent => ({
         }
 
         currentList.replaceWith(nextList);
-        if (currentPagination && nextPagination) {
-            currentPagination.replaceWith(nextPagination);
-        } else if (!currentPagination && nextPagination) {
-            root.append(nextPagination);
-        } else if (currentPagination && !nextPagination) {
-            currentPagination.remove();
-        }
 
         root.dataset.services = JSON.stringify(readServices(nextList));
         window.dispatchEvent(new CustomEvent('signal-room:services-updated', {
             detail: { services: readServices(nextList) },
         }));
         window.Alpine?.initTree(nextList);
-        if (nextPagination) window.Alpine?.initTree(nextPagination);
         this.loading = false;
     },
 

--- a/resources/views/components/dashboard/service-map-fragment.blade.php
+++ b/resources/views/components/dashboard/service-map-fragment.blade.php
@@ -38,19 +38,18 @@
             </div>
         @endforeach
     </div>
-</section>
-
-@if ($pagination && $pagination['last_page'] > 1)
-    <div id="dashboard-service-pagination" class="mt-5 flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
-        <p>{{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }} {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}</p>
-        <nav class="flex items-center gap-2" aria-label="{{ __('search.table.pagination') }}">
+    @if ($pagination && $pagination['last_page'] > 1)
+        <div id="dashboard-service-pagination" class="flex flex-col gap-3 border-t border-gray-100 px-5 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+            <p>{{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }} {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}</p>
+            <nav class="flex items-center gap-1.5" aria-label="{{ __('search.table.pagination') }}">
             @if ($pagination['current_page'] > 1)
-                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">&laquo; {{ __('pagination.previous') }}</a>
+                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">&laquo; {{ __('pagination.previous') }}</a>
             @endif
-            <span class="rounded-md bg-purple-100 px-3 py-2 font-semibold text-purple-700 dark:bg-purple-900 dark:text-purple-100">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
+            <span class="inline-flex items-center rounded-lg bg-purple-700 px-3 py-2 font-bold text-white dark:bg-purple-600">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
             @if ($pagination['current_page'] < $pagination['last_page'])
-                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">{{ __('pagination.next') }} &raquo;</a>
+                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">{{ __('pagination.next') }} &raquo;</a>
             @endif
-        </nav>
-    </div>
-@endif
+            </nav>
+        </div>
+    @endif
+</section>

--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -138,25 +138,24 @@
                     </div>
                 @endforeach
             </div>
-        </section>
-
         @if ($pagination && $pagination['last_page'] > 1)
-            <div id="dashboard-service-pagination" class="flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
+            <div id="dashboard-service-pagination" class="flex flex-col gap-3 border-t border-gray-100 px-5 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between sm:px-6">
                 <p>
                     {{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }}
                     {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}
                 </p>
-                <nav class="flex items-center gap-2" aria-label="{{ __('search.table.pagination') }}">
+                <nav class="flex items-center gap-1.5" aria-label="{{ __('search.table.pagination') }}">
                     @if ($pagination['current_page'] > 1)
-                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">&laquo; {{ __('pagination.previous') }}</a>
+                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">&laquo; {{ __('pagination.previous') }}</a>
                     @endif
-                    <span class="rounded-md bg-purple-100 px-3 py-2 font-semibold text-purple-700 dark:bg-purple-900 dark:text-purple-100">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
+                    <span class="inline-flex items-center rounded-lg bg-purple-700 px-3 py-2 font-bold text-white dark:bg-purple-600">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
                     @if ($pagination['current_page'] < $pagination['last_page'])
-                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">{{ __('pagination.next') }} &raquo;</a>
+                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">{{ __('pagination.next') }} &raquo;</a>
                     @endif
                 </nav>
             </div>
         @endif
+        </section>
         </div>
 
         <aside class="hidden lg:block">


### PR DESCRIPTION
## What changed

- Move dashboard service-map pagination into the service card as a bordered footer.
- Align previous, current-page, and next controls with the existing light/dark card styles.
- Replace the full service-map card during async navigation so the footer stays synchronized.

## Why

The pagination appeared detached below the card and did not match the dashboard's visual hierarchy.

## Testing

- `./vendor/bin/pest tests/Feature/DashboardOverviewTest.php` — passed
- `./vendor/bin/pint --test` — passed
- `bun run build` — passed
- `git diff --check` — passed

Closes #544