### PR TITLE
fix: prevent clipped dashboard filter focus

### DIFF
--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -61,7 +61,7 @@
             <input x-model="query" type="search" class="w-full rounded-xl border-gray-200 bg-white py-3 ps-10 pe-4 text-sm shadow-sm placeholder:text-gray-400 focus:border-purple-500 focus:ring-purple-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white" placeholder="{{ __('dashboard.signal_room.search_placeholder') }}">
         </label>
 
-        <div class="flex gap-2 overflow-x-auto pb-1" role="tablist" aria-label="{{ __('dashboard.signal_room.filters.all') }}">
+        <div class="-mx-1 -my-2 flex gap-2 overflow-x-auto px-1 py-2" role="tablist" aria-label="{{ __('dashboard.signal_room.filters.all') }}">
             @foreach (['all', 'attention', 'maintenance', 'paused'] as $filter)
                 <button
                     type="button"
@@ -70,7 +70,7 @@
                     :aria-selected="activeFilter === '{{ $filter }}'"
                     @click="activeFilter = '{{ $filter }}'"
                     :class="activeFilter === '{{ $filter }}' ? 'border-purple-700 bg-purple-700 text-white dark:bg-purple-600' : 'border-gray-200 bg-white text-gray-600 hover:border-purple-200 hover:text-purple-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300'"
-                    class="whitespace-nowrap rounded-xl border px-3.5 py-2.5 text-xs font-bold transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+                    class="whitespace-nowrap rounded-xl border px-3.5 py-2.5 text-xs font-bold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950"
                 >{{ __('dashboard.signal_room.filters.' . $filter) }}</button>
             @endforeach
         </div>

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -110,6 +110,8 @@ class DashboardOverviewTest extends TestCase
             ->assertDontSeeText('Guten Morgen, ' . $user->name)
             ->assertSeeText(__('dashboard.signal_room.heading'))
             ->assertSeeText(__('dashboard.signal_room.service_landscape'))
+            ->assertSeeHtml('overflow-x-auto px-1 py-2')
+            ->assertSeeHtml('focus-visible:ring-2')
             ->assertSeeText(__('dashboard.signal_room.context.heading'))
             ->assertSeeText(__('dashboard.signal_room.context.surfaces_heading'))
             ->assertSeeText(__('dashboard.next_action.heading'))


### PR DESCRIPTION
## What changed

- Add vertical padding to the horizontally scrollable dashboard filter row.
- Use `focus-visible` for filter focus indicators so mouse selection does not leave a clipped ring.
- Add a regression assertion for the focus and overflow classes.

## Why

The filter focus ring was clipped by the scroll container and looked visually cut off in the dashboard.

## Testing

- `./vendor/bin/pest tests/Feature/DashboardOverviewTest.php` — passed
- `./vendor/bin/pint --test` — passed
- `bun run build` — passed
- `git diff --check` — passed

Closes #546