### PR TITLE
fix: remove dashboard all-monitorings link

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -49,9 +49,6 @@
                 <p class="mt-2 max-w-2xl text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.description') }}</p>
             </div>
 
-            <x-dashboard.action-link href="{{ route('monitorings.index') }}" class="shrink-0">
-                {{ __('dashboard.open_monitorings') }}
-            </x-dashboard.action-link>
         </div>
     </x-slot>
 

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -106,6 +106,7 @@ class DashboardOverviewTest extends TestCase
 
         $testResponse->assertOk()
             ->assertSeeText(__('dashboard.greeting', ['name' => $user->name]))
+            ->assertDontSeeText(__('dashboard.open_monitorings'))
             ->assertSeeText('Hi ' . $user->name)
             ->assertDontSeeText('Guten Morgen, ' . $user->name)
             ->assertSeeText(__('dashboard.signal_room.heading'))


### PR DESCRIPTION
## What changed

- Remove the "all monitorings" action link from the dashboard header.
- Keep the greeting, description, and other monitoring navigation unchanged.
- Add a regression assertion that the header link is absent.

## Testing

- `./vendor/bin/pest tests/Feature/DashboardOverviewTest.php` — passed
- `./vendor/bin/pint --test` — passed
- `bun run build` — passed
- `git diff --check` — passed

Closes #548