### PR TITLE
fix: remove duplicate team empty-state action

### DIFF
--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -15,12 +15,6 @@
             <x-container>
             @if ($teams->count() === 0)
                 <x-paragraph>{{ __('team.empty.teams') }}</x-paragraph>
-                @if (!Auth::user()->isDemo())
-                    <x-primary-button :href="route('teams.create')" class="mt-4"
-                        data-form-modal-trigger data-form-modal-name="team-form-modal">
-                        {{ __('team.actions.create') }}
-                    </x-primary-button>
-                @endif
             @else
                 <div class="space-y-3">
                     @foreach ($teams as $team)

--- a/tests/Feature/TeamControllerCoverageTest.php
+++ b/tests/Feature/TeamControllerCoverageTest.php
@@ -24,6 +24,19 @@ class TeamControllerCoverageTest extends TestCase
         Package::factory()->create();
     }
 
+    public function test_empty_team_index_keeps_create_action_only_in_the_header(): void
+    {
+        $admin = User::factory()->create();
+
+        $testResponse = $this->actingAs($admin)->get(route('teams.index'));
+
+        $testResponse->assertOk()
+            ->assertSeeText(__('team.empty.teams'))
+            ->assertSeeHtml('data-form-modal-name="team-form-modal"');
+
+        $this->assertSame(1, mb_substr_count($testResponse->getContent(), 'data-form-modal-name="team-form-modal"'));
+    }
+
     public function test_team_pages_render_index_create_show_and_edit(): void
     {
         $admin = User::factory()->create();


### PR DESCRIPTION
## What changed

- Keep the create-team button in the teams page header.
- Remove the duplicate create-team button from the empty state.
- Add coverage ensuring an empty teams page renders only one create action.

## Testing

- `./vendor/bin/pest tests/Feature/TeamControllerCoverageTest.php` — passed
- `./vendor/bin/pint --test` — passed
- `bun run build` — passed
- `git diff --check` — passed

Closes #550