### PR TITLE
fix: clarify monitoring form accordions

### DIFF
--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -55,6 +55,7 @@
         'value' => $serverInstance->code,
         'label' => $serverInstance->code,
     ])->values();
+    $notificationPreferencesFormId = $notificationPreferencesFormId ?? null;
 @endphp
 
 @csrf
@@ -174,8 +175,16 @@
         </section>
 
         <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <summary class="cursor-pointer list-none">
+            <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 [&::-webkit-details-marker]:hidden">
                 <x-heading type="h2">{{ __('monitoring.form.sections.organization') }}</x-heading>
+                <svg class="size-5 shrink-0 text-gray-500 transition-transform group-open:rotate-180 dark:text-gray-400"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+                <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+                <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+                <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+                </svg>
             </summary>
 
             <div>
@@ -376,8 +385,13 @@
 
     <details x-show="type === '{{ MonitoringType::HTTP->value }}' || type === '{{ MonitoringType::KEYWORD->value }}'"
         class="mt-4 rounded-md border border-gray-200 p-4 dark:border-gray-700">
-        <summary class="cursor-pointer font-semibold text-gray-800 dark:text-gray-100">
-            {{ __('monitoring.form.advanced_request_settings') }}
+        <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 font-semibold text-gray-800 [&::-webkit-details-marker]:hidden dark:text-gray-100">
+            <span>{{ __('monitoring.form.advanced_request_settings') }}</span>
+            <svg class="size-5 shrink-0 text-gray-500 transition-transform group-open:rotate-180 dark:text-gray-400"
+                viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25-4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1-1.08 1.06Z" clip-rule="evenodd" />
+            <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+            </svg>
         </summary>
 
     <template x-if="type === '{{ MonitoringType::HTTP->value }}' || type === '{{ MonitoringType::KEYWORD->value }}'">
@@ -415,8 +429,12 @@
         </section>
 
         <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <summary class="cursor-pointer list-none">
+            <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 [&::-webkit-details-marker]:hidden">
                 <x-heading type="h2">{{ __('monitoring.form.sections.sharing') }}</x-heading>
+                <svg class="size-5 shrink-0 text-gray-500 transition-transform group-open:rotate-180 dark:text-gray-400"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                </svg>
             </summary>
 
     <div class="mt-4">
@@ -456,9 +474,21 @@
         </details>
 
         <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <summary class="cursor-pointer list-none">
+            <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 [&::-webkit-details-marker]:hidden">
                 <x-heading type="h2">{{ __('monitoring.form.sections.notifications') }}</x-heading>
+                <svg class="size-5 shrink-0 text-gray-500 transition-transform group-open:rotate-180 dark:text-gray-400"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 1 1-1.08 1.06Z" clip-rule="evenodd" />
+                </svg>
             </summary>
+
+    @if (isset($monitoring) && isset($notificationPreference) && $notificationPreferencesFormId)
+        @include('monitorings._notification_preferences', [
+            'embedded' => true,
+            'formId' => $notificationPreferencesFormId,
+            'fieldIdPrefix' => $fieldIdPrefix ?? 'monitoring_notification_preference',
+        ])
+    @endif
 
     @unless (isset($monitoring))
     <div class="mt-4">
@@ -523,8 +553,12 @@
         </details>
 
         <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <summary class="cursor-pointer list-none">
+            <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 [&::-webkit-details-marker]:hidden">
                 <x-heading type="h2">{{ __('monitoring.form.sections.operations') }}</x-heading>
+                <svg class="size-5 shrink-0 text-gray-500 transition-transform group-open:rotate-180 dark:text-gray-400"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 1 1 .02-1.06Z" clip-rule="evenodd" />
+                </svg>
             </summary>
 
     <div class="mt-4">

--- a/resources/views/monitorings/_modal-form.blade.php
+++ b/resources/views/monitorings/_modal-form.blade.php
@@ -3,14 +3,20 @@
         @include('monitorings._ownership')
     @endif
 
-    <form method="POST" action="{{ $action }}">
+    <form id="monitoring-modal-form" method="POST" action="{{ $action }}">
         <input type="hidden" name="modal_form" value="monitoring-{{ isset($monitoring) ? 'edit' : 'create' }}">
-        @include('monitorings._form', ['modal' => true])
+        @include('monitorings._form', [
+            'modal' => true,
+            'notificationPreferencesFormId' => isset($monitoring) ? 'modal-edit-notification-preferences-form' : null,
+            'fieldIdPrefix' => 'modal_edit_notification_preference',
+        ])
     </form>
 
     @if (isset($monitoring))
-        <div class="mt-6">
-            @include('monitorings._notification_preferences', ['fieldIdPrefix' => 'modal_edit_notification_preference'])
-        </div>
+        <form id="modal-edit-notification-preferences-form" method="POST"
+            action="{{ route('monitorings.notification-preferences.update', $monitoring) }}" class="hidden">
+            @csrf
+            @method('PATCH')
+        </form>
     @endif
 </div>

--- a/resources/views/monitorings/_notification_preferences.blade.php
+++ b/resources/views/monitorings/_notification_preferences.blade.php
@@ -3,19 +3,36 @@
     $selectedNotificationChannels = is_array($selectedNotificationChannels) ? $selectedNotificationChannels : [];
     $enabledNotificationChannels = $enabledNotificationChannels ?? Auth::user()->enabledNotificationChannelKeys();
     $fieldIdPrefix = $fieldIdPrefix ?? 'monitoring_notification_preference';
+    $embedded = $embedded ?? false;
+    $formId = $formId ?? null;
 @endphp
 
 <section class="rounded-lg border border-gray-200 bg-gray-50/70 p-4 shadow-none dark:border-gray-700 dark:bg-gray-900/30 sm:p-5"
     data-monitoring-notification-preferences>
     <x-heading type="h3">{{ __('team.sections.notification_preferences') }}</x-heading>
-    <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
-        class="mt-4 space-y-4">
-        @csrf
-        @method('PATCH')
+    @unless ($embedded)
+        <form method="POST" action="{{ route('monitorings.notification-preferences.update', $monitoring) }}"
+            class="mt-4 space-y-4">
+            @csrf
+            @method('PATCH')
+    @endunless
 
-        <x-text-checkbox id="{{ $fieldIdPrefix }}_notification_on_failure" name="notification_on_failure" value="1"
-            :checked="$notificationPreference->notification_on_failure"
-            label="{{ __('monitoring.form.notification_on_failure_enabled') }}" />
+    <div @class(['mt-4 space-y-4' => $embedded, 'space-y-4' => ! $embedded])>
+        @if ($embedded)
+            <label for="{{ $fieldIdPrefix }}_notification_on_failure" class="inline-flex items-center">
+                <input id="{{ $fieldIdPrefix }}_notification_on_failure" name="notification_on_failure" type="checkbox"
+                    value="1" form="{{ $formId }}"
+                    class="shadow-xs focus:ring-3 rounded-sm border-gray-300 text-purple-600 focus:border-purple-300 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
+                    @checked($notificationPreference->notification_on_failure)>
+                <x-span class="ms-2 text-gray-600 dark:text-gray-300">
+                    {{ __('monitoring.form.notification_on_failure_enabled') }}
+                </x-span>
+            </label>
+        @else
+            <x-text-checkbox id="{{ $fieldIdPrefix }}_notification_on_failure" name="notification_on_failure" value="1"
+                :checked="$notificationPreference->notification_on_failure"
+                label="{{ __('monitoring.form.notification_on_failure_enabled') }}" />
+        @endif
 
         <div>
             <x-input-label for="{{ $fieldIdPrefix }}_notification_channels" :value="__('monitoring.form.notification_channels')" />
@@ -28,6 +45,7 @@
                     @foreach ($enabledNotificationChannels as $channel)
                         <label class="flex items-center gap-2 rounded-md border border-gray-200 p-3 text-sm dark:border-gray-700">
                             <input type="checkbox" name="notification_channels[]" value="{{ $channel }}"
+                                @if ($embedded) form="{{ $formId }}" @endif
                                 class="rounded-sm border-gray-300 text-purple-600 shadow-xs focus:border-purple-300 focus:ring-3 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
                                 @checked(in_array($channel, $selectedNotificationChannels, true))>
                             <span>{{ __('profile.notification_settings.channels.' . $channel . '.title') }}</span>
@@ -41,13 +59,25 @@
 
         <div>
             <x-input-label for="{{ $fieldIdPrefix }}_ssl_expiry_warning_days" :value="__('monitoring.form.ssl_expiry_warning_days')" />
-            <x-text-input id="{{ $fieldIdPrefix }}_ssl_expiry_warning_days" type="number" min="1" max="365"
-                name="ssl_expiry_warning_days" :value="old('ssl_expiry_warning_days', $notificationPreference->ssl_expiry_warning_days)" required />
+            <input id="{{ $fieldIdPrefix }}_ssl_expiry_warning_days" type="number" min="1" max="365"
+                name="ssl_expiry_warning_days" value="{{ old('ssl_expiry_warning_days', $notificationPreference->ssl_expiry_warning_days) }}"
+                @if ($embedded) form="{{ $formId }}" @endif
+                class="mt-1 w-full rounded-md border-gray-300 shadow-xs focus:border-purple-500 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                required>
             <x-input-error :messages="$errors->get('ssl_expiry_warning_days')" />
         </div>
 
-        <x-secondary-button>
-            {{ __('button.save') }}
-        </x-secondary-button>
-    </form>
+        @if ($embedded)
+            <x-secondary-button form="{{ $formId }}">
+                {{ __('button.save') }}
+            </x-secondary-button>
+        @else
+            <x-secondary-button>
+                {{ __('button.save') }}
+            </x-secondary-button>
+        @endif
+    </div>
+    @unless ($embedded)
+        </form>
+    @endunless
 </section>

--- a/resources/views/monitorings/edit.blade.php
+++ b/resources/views/monitorings/edit.blade.php
@@ -24,12 +24,19 @@
         @include('monitorings._ownership')
 
         <x-container>
-            <form method="POST" action="{{ route('monitorings.update', $monitoring) }}">
-                @include('monitorings._form')
+            <form id="monitoring-edit-form" method="POST" action="{{ route('monitorings.update', $monitoring) }}">
+                @include('monitorings._form', [
+                    'notificationPreferencesFormId' => 'edit-notification-preferences-form',
+                    'fieldIdPrefix' => 'edit_notification_preference',
+                ])
             </form>
         </x-container>
 
-        @include('monitorings._notification_preferences', ['fieldIdPrefix' => 'edit_notification_preference'])
+        <form id="edit-notification-preferences-form" method="POST"
+            action="{{ route('monitorings.notification-preferences.update', $monitoring) }}" class="hidden">
+            @csrf
+            @method('PATCH')
+        </form>
     </x-main>
 </x-app-layout>
 @endif

--- a/tests/Feature/MonitoringFormPresentationTest.php
+++ b/tests/Feature/MonitoringFormPresentationTest.php
@@ -44,6 +44,7 @@ class MonitoringFormPresentationTest extends TestCase
         $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
         $editResponse->assertSeeHtml('href="' . route('monitorings.show', $monitoring) . '"');
         $testResponse->assertSeeHtml('<details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">');
+        $testResponse->assertSeeHtml('group-open:rotate-180');
         $testResponse->assertSee(__('monitoring.form.advanced_request_settings'));
     }
 
@@ -79,6 +80,13 @@ class MonitoringFormPresentationTest extends TestCase
         $editResponse->assertSeeHtml('data-monitoring-ownership-badge');
         $editResponse->assertSeeHtml('data-monitoring-form-actions');
         $editResponse->assertSeeHtml('data-monitoring-notification-preferences');
+        $editResponse->assertSeeHtml('id="edit-notification-preferences-form"');
+        $editResponse->assertSeeHtml('form="edit-notification-preferences-form"');
+        $editResponse->assertSeeInOrder([
+            __('monitoring.form.sections.notifications'),
+            __('team.sections.notification_preferences'),
+            'data-monitoring-form-actions',
+        ]);
         $editResponse->assertSeeHtml('data-select-control="native"');
         $editResponse->assertSeeHtml('data-select-control="multi"');
     }


### PR DESCRIPTION
Closes #552

## What changed
- Added visible chevron indicators with open-state rotation to all monitoring form accordions, including advanced request settings.
- Moved per-monitoring notification preferences into the Notifications accordion while keeping the dedicated PATCH endpoint and avoiding nested forms.
- Applied the same structure to the full-page and modal edit flows.
- Added regression assertions for accordion indicators, notification form placement, and form association.

## Why
Collapsed sections previously looked like plain headings, and notification settings appeared below the primary form actions, disconnected from the Notifications section.

## Validation
- `./vendor/bin/pest tests/Feature/MonitoringNotificationPreferenceControllerTest.php tests/Feature/MonitoringFormPresentationTest.php tests/Feature/MonitoringNotificationSettingsTest.php`
- `./vendor/bin/pint --test`
- `php artisan view:cache`
- `bun run build`
- `git diff --check`

The local browser smoke check could not reach an authenticated monitoring form because the standalone environment has no configured local SQLite/session database; application feature tests and the production asset build passed.