### PR TITLE
fix: remove duplicate SSL status card

### DIFF
--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -205,43 +205,6 @@
                 </x-container>
             @endif
 
-            @if ($monitoring->type === MonitoringType::HTTP || $monitoring->type === MonitoringType::KEYWORD)
-                <x-container>
-                    <x-heading type="h2">{{ __('monitoring.detail.ssl.heading') }}</x-heading>
-
-                    <template x-if="sslValid===true">
-                        <div>
-                            <x-paragraph
-                                class="font-bold text-green-600 dark:text-green-600">{{ __('monitoring.detail.ssl.valid') }}</x-paragraph>
-                            <x-paragraph class=""
-                                x-text="'{{ __('monitoring.detail.ssl.expires_in') }}: ' + sslExpiration"></x-paragraph>
-                            <template x-if="sslIssueDate">
-                                <x-paragraph class=""
-                                    x-text="'{{ __('monitoring.detail.ssl.issued_on') }}: ' + sslIssueDate"></x-paragraph>
-                            </template>
-                            <template x-if="sslIssuer">
-                                <x-paragraph class=""
-                                    x-text="'{{ __('monitoring.detail.ssl.issued_from') }}: ' + sslIssuer"></x-paragraph>
-                            </template>
-
-                        </div>
-                    </template>
-
-                    <template x-if="sslValid === false">
-                        <div>
-                            <x-paragraph
-                                class="font-bold text-red-600 dark:text-red-600">{{ __('monitoring.detail.ssl.expired') }}</x-paragraph>
-                        </div>
-                    </template>
-
-                    <template x-if="sslValid === null">
-                        <div x-transition.opacity>
-                            <x-loading-indicator>{{ __('monitoring.detail.no_data') }}</x-loading-indicator>
-                        </div>
-                    </template>
-                </x-container>
-            @endif
-
             @if ($monitoring->isHeartbeat())
                 <x-container>
                     <x-heading type="h2">{{ __('monitoring.detail.heartbeat.heading') }}</x-heading>

--- a/tests/Feature/MonitoringDetailContextLayoutTest.php
+++ b/tests/Feature/MonitoringDetailContextLayoutTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use App\Enums\MonitoringType;
 use App\Models\Monitoring;
+use App\Models\MonitoringSslResult;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -25,6 +26,13 @@ class MonitoringDetailContextLayoutTest extends TestCase
             'target' => 'https://api.example.test/health',
             'notification_channels' => ['discord', 'mobile_push'],
         ]);
+        MonitoringSslResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'issuer' => 'Example CA',
+            'issued_at' => '2026-05-29 00:00:00',
+            'expires_at' => '2026-08-27 00:00:00',
+        ]);
 
         $testResponse = $this->actingAs($user)->get(route('monitorings.show', $monitoring));
 
@@ -39,6 +47,8 @@ class MonitoringDetailContextLayoutTest extends TestCase
         $testResponse->assertSeeText(__('monitoring.detail.context.notifications'));
         $testResponse->assertSeeText(__('notifications.channels.discord'));
         $testResponse->assertSeeText(__('monitoring.detail.context.no_status_pages'));
+        $testResponse->assertSeeText(__('monitoring.detail.context.domain_ssl'));
+        $this->assertSame(1, mb_substr_count($testResponse->getContent(), __('monitoring.detail.ssl.heading')));
         $testResponse->assertSeeText($monitoring->name);
         $testResponse->assertSeeText($monitoring->target);
     }


### PR DESCRIPTION
Closes #554

## What changed
- Removed the duplicate standalone SSL status card from the monitoring detail page.
- Kept the existing SSL status in the Domain and SSL context panel.
- Added regression coverage ensuring the SSL heading is rendered only once on the detail page.

## Why
The detail view already exposes the SSL status in the context rail, so the additional card duplicated the same information.

## Validation
- `./vendor/bin/pest tests/Feature/MonitoringDetailContextLayoutTest.php tests/Feature/MonitoringNotificationSettingsTest.php tests/Feature/PublicLabelPageTest.php`
- `./vendor/bin/pint --test`
- `php artisan view:cache`
- `git diff --check`

No frontend asset changes were needed, so no Vite build was required.