### PR TITLE
feat: add status page delete action to overview

### DIFF
--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -78,6 +78,15 @@
                                         title="{{ __('button.edit') }}" aria-label="{{ __('button.edit') }}">
                                         <x-icon name="pencil" class="h-4 w-4" />
                                     </x-secondary-button>
+                                    <form method="POST" action="{{ route('status-pages.destroy', $statusPage) }}"
+                                        data-confirm-message="{{ __('status_page.actions.delete_confirmation') }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <x-danger-button :icon-only="true" title="{{ __('button.delete') }}"
+                                            aria-label="{{ __('button.delete') }}">
+                                            <x-icon name="trash" class="h-4 w-4" />
+                                        </x-danger-button>
+                                    </form>
                                 @endif
                             </div>
                         </div>

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -228,6 +228,9 @@ class StatusPageManagementTest extends TestCase
             ->assertSeeHtml('data-status-page-row')
             ->assertSeeHtml('aria-label="' . __('button.show') . '"')
             ->assertSeeHtml('aria-label="' . __('button.edit') . '"')
+            ->assertSeeHtml('aria-label="' . __('button.delete') . '"')
+            ->assertSeeHtml('action="' . route('status-pages.destroy', $statusPage) . '"')
+            ->assertSeeHtml('data-confirm-message="' . __('status_page.actions.delete_confirmation') . '"')
             ->assertSeeHtml('title="' . __('status_page.detail.open_public_page') . '"')
             ->assertSeeHtml('rel="noopener"');
 


### PR DESCRIPTION
Closes #556

## What changed
- Added a delete action to every status page row in the overview.
- Reused the existing authorized `status-pages.destroy` route and confirmation dialog.
- Added regression assertions for the delete button, route, and confirmation message.

## Why
Status pages could already be deleted from their detail view, but the overview did not expose the action.

## Validation
- `./vendor/bin/pest tests/Feature/StatusPageManagementTest.php`
- `./vendor/bin/pint --test`
- `php artisan view:cache`
- `git diff --check`

No frontend asset changes were needed, so no Vite build was required.