### PR TITLE
fix: keep status page action icons on one row

### DIFF
--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -67,7 +67,7 @@
                             <span class="hidden text-sm text-gray-600 dark:text-gray-300 md:block">
                                 {{ trans_choice('status_page.components_count', $statusPage->components_count, ['count' => $statusPage->components_count]) }}
                             </span>
-                            <div class="flex flex-wrap justify-start gap-2 md:justify-end">
+                            <div class="flex flex-wrap justify-start gap-2 md:flex-nowrap md:justify-end">
                                 <x-secondary-button :href="route('status-pages.show', $statusPage)" :icon-only="true"
                                     title="{{ __('button.show') }}" aria-label="{{ __('button.show') }}">
                                     <x-icon name="eye" class="h-4 w-4" />

--- a/tests/Feature/StatusPageManagementTest.php
+++ b/tests/Feature/StatusPageManagementTest.php
@@ -226,6 +226,7 @@ class StatusPageManagementTest extends TestCase
             ->assertSeeText('Old Status')
             ->assertSeeHtml('data-status-page-overview')
             ->assertSeeHtml('data-status-page-row')
+            ->assertSeeHtml('class="flex flex-wrap justify-start gap-2 md:flex-nowrap md:justify-end"')
             ->assertSeeHtml('aria-label="' . __('button.show') . '"')
             ->assertSeeHtml('aria-label="' . __('button.edit') . '"')
             ->assertSeeHtml('aria-label="' . __('button.delete') . '"')


### PR DESCRIPTION
Closes #558

## What changed
- Keep status page row actions on one line from the medium breakpoint upward.
- Preserve wrapping on mobile widths for responsive layouts.
- Add a regression assertion for the responsive action-group classes.

## Why
The show, edit, and delete icons currently wrap on wider screens, leaving the action column visually inconsistent.

## Validation
- `./vendor/bin/pest tests/Feature/StatusPageManagementTest.php`
- `./vendor/bin/pint --test`
- `php artisan view:cache`
- `git diff --check`

No Vite build was required because no asset files changed.