### PR TITLE
feat: add collapsible dashboard sidebar

### DIFF
--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -116,31 +116,28 @@ class IncidentAnalyticsController extends Controller
         string $section,
         array $filters,
         int $days,
-        IncidentAnalyticsRequest $request,
+        IncidentAnalyticsRequest $incidentAnalyticsRequest,
         MonitoringOverviewService $monitoringOverviewService,
         MonitoringStatusService $monitoringStatusService,
     ): View {
         return match ($section) {
             'overview' => view('incidents.analytics-sections.overview', [
-                'overview' => $monitoringOverviewService->overview($request->user()),
+                'overview' => $monitoringOverviewService->overview($incidentAnalyticsRequest->user()),
             ]),
             'groups' => view('incidents.analytics-sections.groups', [
-                'groups' => $this->monitoringGroups($request, $monitoringStatusService),
+                'groups' => $this->monitoringGroups($incidentAnalyticsRequest, $monitoringStatusService),
             ]),
             'status-pages' => view('incidents.analytics-sections.status-pages', [
-                'statusPages' => $this->statusPages($request, $monitoringStatusService),
+                'statusPages' => $this->statusPages($incidentAnalyticsRequest, $monitoringStatusService),
             ]),
             'incidents' => view('incidents.analytics-sections.incidents', $this->incidentSectionData($filters, $days)),
             default => abort(404),
         };
     }
 
-    /**
-     * @return array{groups:Collection<int, array{model:MonitoringGroup,summary:array{total:int,healthy:int,down:int,attention:int,state:string}}>,statusPages:Collection<int, array{model:StatusPage,summary:array{total:int,healthy:int,down:int,attention:int,state:string}}>}
-     */
-    private function monitoringGroups(IncidentAnalyticsRequest $request, MonitoringStatusService $monitoringStatusService): Collection
+    private function monitoringGroups(IncidentAnalyticsRequest $incidentAnalyticsRequest, MonitoringStatusService $monitoringStatusService): Collection
     {
-        return $request->user()
+        return $incidentAnalyticsRequest->user()
             ->monitoringGroups()
             ->withCount('monitorings')
             ->with(['monitorings.latestResponseResult', 'monitorings.latestIncident'])
@@ -156,9 +153,9 @@ class IncidentAnalyticsController extends Controller
     /**
      * @return Collection<int, array{model:StatusPage,summary:array{total:int,healthy:int,down:int,attention:int,state:string}}>
      */
-    private function statusPages(IncidentAnalyticsRequest $request, MonitoringStatusService $monitoringStatusService): Collection
+    private function statusPages(IncidentAnalyticsRequest $incidentAnalyticsRequest, MonitoringStatusService $monitoringStatusService): Collection
     {
-        return $request->user()
+        return $incidentAnalyticsRequest->user()
             ->statusPages()
             ->withCount('components')
             ->with([

--- a/resources/lang/de/app.php
+++ b/resources/lang/de/app.php
@@ -31,6 +31,8 @@ return [
     ],
     'navigation' => [
         'home' => 'Hauptnavigation',
+        'collapse_sidebar' => 'Seitenleiste einklappen',
+        'expand_sidebar' => 'Seitenleiste ausklappen',
         'dashboard' => 'Dashboard',
         'signal_room' => 'Signal Room',
         'monitoring' => 'Überwachung',

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -31,6 +31,8 @@ return [
     ],
     'navigation' => [
         'home' => 'Main navigation',
+        'collapse_sidebar' => 'Collapse sidebar',
+        'expand_sidebar' => 'Expand sidebar',
         'dashboard' => 'Dashboard',
         'signal_room' => 'Signal Room',
         'monitoring' => 'Monitoring',

--- a/resources/views/components/icon.blade.php
+++ b/resources/views/components/icon.blade.php
@@ -3,6 +3,36 @@
 <svg {{ $attributes->merge(['class' => 'h-5 w-5']) }} viewBox="0 0 24 24" fill="none" stroke="currentColor"
     stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     @switch($name)
+        @case('home')
+            <path d="m3 10 9-7 9 7" />
+            <path d="M5 9.5V21h14V9.5M9 21v-6h6v6" />
+            @break
+        @case('monitoring')
+            <path d="M4 5h16v12H4z" />
+            <path d="m7 13 3-3 2 2 4-4" />
+            <path d="M8 21h8M12 17v4" />
+            @break
+        @case('groups')
+            <circle cx="9" cy="8" r="3" />
+            <path d="M3 20a6 6 0 0 1 12 0" />
+            <path d="M16 5.5a3 3 0 0 1 0 5.8M17 14a5 5 0 0 1 4 6" />
+            @break
+        @case('status-pages')
+            <path d="M4 5h16v14H4z" />
+            <path d="M8 9h8M8 13h5" />
+            @break
+        @case('incidents')
+            <path d="M12 3 3 20h18L12 3Z" />
+            <path d="M12 9v5M12 17h.01" />
+            @break
+        @case('maintenance')
+            <path d="m14.7 6.3 3-3a4 4 0 0 0-5 5L4 17a2.1 2.1 0 0 0 3 3l8.8-8.7a4 4 0 0 0 5-5l-3 3-3.1-.9-.9-3.1Z" />
+            @break
+        @case('teams')
+            <circle cx="9" cy="8" r="3" />
+            <circle cx="17" cy="9" r="2.25" />
+            <path d="M3 20a6 6 0 0 1 12 0M15 15a5 5 0 0 1 6 5" />
+            @break
         @case('eye')
             <path d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7Z" />
             <circle cx="12" cy="12" r="3" />

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -43,10 +43,12 @@
 </head>
 
 <body
+    x-data="{ mobileOpen: false, sidebarCollapsed: window.localStorage.getItem('webguard.sidebar.collapsed') === 'true' }"
+    x-init="$watch('sidebarCollapsed', value => window.localStorage.setItem('webguard.sidebar.collapsed', value ? 'true' : 'false'))"
     class="flex min-h-screen flex-col justify-start bg-slate-50 font-sans antialiased dark:bg-slate-950 dark:text-gray-100">
     @include('layouts.navigation')
 
-    <div class="min-h-screen lg:ps-64">
+    <div class="min-h-screen" :class="{ 'lg:ps-20': sidebarCollapsed, 'lg:ps-64': ! sidebarCollapsed }">
         @isset($header)
             <header class="border-b border-purple-100/80 bg-white/95 shadow-sm dark:border-purple-900/50 dark:bg-slate-900/95">
                 <x-main>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,43 +1,56 @@
 @php
     $operationsNavigation = [
-        ['label' => __('app.navigation.monitorings'), 'href' => route('monitorings.index'), 'active' => 'monitorings.*'],
-        ['label' => __('app.navigation.monitoring_groups'), 'href' => route('monitoring-groups.index'), 'active' => 'monitoring-groups.*'],
-        ['label' => __('app.navigation.status_pages'), 'href' => route('status-pages.index'), 'active' => 'status-pages.*'],
-        ['label' => __('app.navigation.incidents'), 'href' => route('incidents.analytics'), 'active' => 'incidents.*'],
-        ['label' => __('app.navigation.maintenance'), 'href' => route('maintenance.index'), 'active' => 'maintenance.*'],
+        ['label' => __('app.navigation.monitorings'), 'icon' => 'monitoring', 'href' => route('monitorings.index'), 'active' => 'monitorings.*'],
+        ['label' => __('app.navigation.monitoring_groups'), 'icon' => 'groups', 'href' => route('monitoring-groups.index'), 'active' => 'monitoring-groups.*'],
+        ['label' => __('app.navigation.status_pages'), 'icon' => 'status-pages', 'href' => route('status-pages.index'), 'active' => 'status-pages.*'],
+        ['label' => __('app.navigation.incidents'), 'icon' => 'incidents', 'href' => route('incidents.analytics'), 'active' => 'incidents.*'],
+        ['label' => __('app.navigation.maintenance'), 'icon' => 'maintenance', 'href' => route('maintenance.index'), 'active' => 'maintenance.*'],
     ];
 
     $collaborationNavigation = [
-        ['label' => __('app.navigation.teams'), 'href' => route('teams.index'), 'active' => 'teams.*'],
+        ['label' => __('app.navigation.teams'), 'icon' => 'teams', 'href' => route('teams.index'), 'active' => 'teams.*'],
     ];
 @endphp
 
-<nav x-data="{ open: false }"
-    class="relative z-40 border-b border-purple-900/40 bg-purple-950 text-white lg:fixed lg:inset-y-0 lg:left-0 lg:w-64 lg:overflow-y-auto lg:border-b-0">
+<nav
+    class="relative z-40 border-b border-purple-900/40 bg-purple-950 text-white lg:fixed lg:inset-y-0 lg:left-0 lg:overflow-y-auto lg:border-b-0"
+    :class="{ 'lg:w-20': sidebarCollapsed, 'lg:w-64': ! sidebarCollapsed }">
     <div class="flex min-h-16 items-center justify-between px-4 lg:min-h-screen lg:h-auto lg:flex-col lg:items-stretch lg:px-3 lg:py-5">
-        <a href="{{ route('dashboard') }}" class="flex items-center gap-3 rounded-xl px-2 py-1.5 focus:outline-hidden focus:ring-2 focus:ring-purple-300">
+        <a href="{{ route('dashboard') }}" class="flex items-center gap-3 rounded-xl px-2 py-1.5 focus:outline-hidden focus:ring-2 focus:ring-purple-300" :class="{ 'lg:justify-center': sidebarCollapsed }">
             <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-white p-1.5 shadow-sm">
                 <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="{{ __('app.logo_alt') }}" class="h-full w-full object-contain">
             </span>
-            <span class="text-lg font-bold tracking-tight text-white">{{ __('app.name') }}</span>
+            <span x-show="! sidebarCollapsed" x-cloak class="text-lg font-bold tracking-tight text-white">{{ __('app.name') }}</span>
         </a>
 
-        <div data-primary-navigation class="hidden flex-1 pt-12 lg:block">
+        <div class="mt-3 hidden lg:flex" :class="{ 'justify-center': sidebarCollapsed, 'justify-end': ! sidebarCollapsed }">
+            <button type="button" data-sidebar-toggle @click="sidebarCollapsed = ! sidebarCollapsed"
+                :aria-expanded="(! sidebarCollapsed).toString()"
+                :aria-label="sidebarCollapsed ? '{{ __('app.navigation.expand_sidebar') }}' : '{{ __('app.navigation.collapse_sidebar') }}'"
+                :title="sidebarCollapsed ? '{{ __('app.navigation.expand_sidebar') }}' : '{{ __('app.navigation.collapse_sidebar') }}'"
+                class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-purple-800 text-purple-200 transition hover:border-purple-600 hover:bg-purple-900 hover:text-white focus:outline-hidden focus:ring-2 focus:ring-purple-300">
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                    <path x-show="! sidebarCollapsed" stroke-linecap="round" stroke-linejoin="round" d="m14 6-6 6 6 6m-6-6h12" />
+                    <path x-show="sidebarCollapsed" stroke-linecap="round" stroke-linejoin="round" d="m10 6 6 6-6 6m6-6H4" />
+                </svg>
+            </button>
+        </div>
+
+        <div data-primary-navigation class="hidden flex-1 pt-8 lg:block">
             <a data-primary-destination href="{{ route('dashboard') }}"
                 @class([
                     'flex items-center gap-3 rounded-xl border px-4 py-3 text-sm font-semibold transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
                     'border-purple-400/50 bg-purple-700 text-white shadow-lg shadow-purple-950/20' => request()->routeIs('dashboard'),
                     'border-transparent text-purple-100 hover:border-purple-700 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('dashboard'),
-                ])>
-                <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 13.5 12 5l8 8.5M6.5 11.5v7a1.5 1.5 0 0 0 1.5 1.5h8a1.5 1.5 0 0 0 1.5-1.5v-7" />
-                </svg>
-                <span>{{ __('app.navigation.dashboard') }}</span>
+                ])
+                :class="{ 'lg:justify-center lg:px-0': sidebarCollapsed }">
+                <x-icon name="home" class="h-5 w-5 shrink-0" />
+                <span x-show="! sidebarCollapsed" x-cloak>{{ __('app.navigation.dashboard') }}</span>
             </a>
 
             <div data-secondary-navigation class="mt-8 space-y-6">
                 <div>
-                    <p class="px-3 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.sections.operations') }}</p>
+                    <p x-show="! sidebarCollapsed" x-cloak class="px-3 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.sections.operations') }}</p>
                     <div class="mt-2 space-y-1">
                         @foreach ($operationsNavigation as $item)
                             @php($itemActive = request()->routeIs($item['active']))
@@ -46,16 +59,17 @@
                                     'group flex items-center gap-3 rounded-lg border px-3 py-2.5 text-sm font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
                                     'border-purple-400/30 bg-purple-900/70 text-white' => $itemActive,
                                     'border-transparent text-purple-200 hover:border-purple-800 hover:bg-purple-900/60 hover:text-white' => ! $itemActive,
-                                ])>
-                                <span class="h-1.5 w-1.5 shrink-0 rounded-full {{ $itemActive ? 'bg-purple-200' : 'bg-purple-400/70 group-hover:bg-purple-200' }}"></span>
-                                <span class="truncate">{{ $item['label'] }}</span>
+                                ])
+                                :class="{ 'lg:justify-center lg:px-0': sidebarCollapsed }">
+                                <x-icon name="{{ $item['icon'] }}" class="h-5 w-5 shrink-0" />
+                                <span x-show="! sidebarCollapsed" x-cloak class="truncate">{{ $item['label'] }}</span>
                             </a>
                         @endforeach
                     </div>
                 </div>
 
                 <div>
-                    <p class="px-3 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.sections.collaboration') }}</p>
+                    <p x-show="! sidebarCollapsed" x-cloak class="px-3 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.sections.collaboration') }}</p>
                     <div class="mt-2 space-y-1">
                         @foreach ($collaborationNavigation as $item)
                             @php($itemActive = request()->routeIs($item['active']))
@@ -64,9 +78,10 @@
                                     'group flex items-center gap-3 rounded-lg border px-3 py-2.5 text-sm font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300',
                                     'border-purple-400/30 bg-purple-900/70 text-white' => $itemActive,
                                     'border-transparent text-purple-200 hover:border-purple-800 hover:bg-purple-900/60 hover:text-white' => ! $itemActive,
-                                ])>
-                                <span class="h-1.5 w-1.5 shrink-0 rounded-full {{ $itemActive ? 'bg-purple-200' : 'bg-purple-400/70 group-hover:bg-purple-200' }}"></span>
-                                <span class="truncate">{{ $item['label'] }}</span>
+                                ])
+                                :class="{ 'lg:justify-center lg:px-0': sidebarCollapsed }">
+                                <x-icon name="{{ $item['icon'] }}" class="h-5 w-5 shrink-0" />
+                                <span x-show="! sidebarCollapsed" x-cloak class="truncate">{{ $item['label'] }}</span>
                             </a>
                         @endforeach
                     </div>
@@ -135,16 +150,16 @@
                 @endif
             </a>
             <x-language-switch id="language-switch-mobile" placement="bottom" />
-            <button type="button" @click="open = ! open" class="inline-flex items-center justify-center rounded-xl border border-purple-800 p-2 text-purple-100 transition hover:bg-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-300" aria-label="{{ __('app.navigation.home') }}">
+            <button type="button" @click="mobileOpen = ! mobileOpen" class="inline-flex items-center justify-center rounded-xl border border-purple-800 p-2 text-purple-100 transition hover:bg-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-300" aria-label="{{ __('app.navigation.home') }}">
                 <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                    <path :class="{ 'hidden': open, 'inline-flex': !open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    <path :class="{ 'hidden': !open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    <path :class="{ 'hidden': mobileOpen, 'inline-flex': !mobileOpen }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    <path :class="{ 'hidden': !mobileOpen, 'inline-flex': mobileOpen }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
             </button>
         </div>
     </div>
 
-    <div data-mobile-navigation x-cloak x-show="open" x-transition class="border-t border-purple-900/60 px-4 pb-4 pt-3 lg:hidden">
+    <div data-mobile-navigation x-cloak x-show="mobileOpen" x-transition class="border-t border-purple-900/60 px-4 pb-4 pt-3 lg:hidden">
         <p class="px-3 pb-2 text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">{{ __('app.navigation.dashboard') }}</p>
         <a href="{{ route('dashboard') }}" @class(['block w-full rounded-xl px-4 py-2.5 text-start text-base font-medium transition focus:outline-hidden focus:ring-2 focus:ring-purple-300', 'bg-purple-700 text-white' => request()->routeIs('dashboard'), 'text-purple-100 hover:bg-purple-900/70 hover:text-white' => ! request()->routeIs('dashboard')])>{{ __('app.navigation.dashboard') }}</a>
 

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -50,7 +50,46 @@ function () {
 
     return primaryNavigation.querySelectorAll('[data-primary-destination]').length === 1
         && primaryNavigation.querySelector('[data-secondary-navigation]') !== null
-        && primaryNavigation.querySelector('[data-notifications-navigation]') !== null;
+        && document.querySelector('[data-notifications-navigation]') !== null;
+}
+JS, true)
+        ->click('[data-sidebar-toggle]')
+        ->assertScript(<<<'JS'
+function () {
+    const rail = document.querySelector('nav');
+    const content = document.querySelector('body > div.min-h-screen');
+    const toggle = document.querySelector('[data-sidebar-toggle]');
+    const destinations = document.querySelectorAll('[data-secondary-destination]');
+
+    return rail !== null
+        && content !== null
+        && toggle?.getAttribute('aria-expanded') === 'false'
+        && rail.getBoundingClientRect().width < 100
+        && content.getBoundingClientRect().left < 100
+        && destinations.length === 6
+        && [...destinations].every((destination) => destination.querySelector('svg') !== null);
+}
+JS, true)
+        ->navigate('/dashboard')
+        ->assertScript(<<<'JS'
+function () {
+    const rail = document.querySelector('nav');
+    const toggle = document.querySelector('[data-sidebar-toggle]');
+
+    return rail !== null
+        && toggle?.getAttribute('aria-expanded') === 'false'
+        && rail.getBoundingClientRect().width < 100;
+}
+JS, true)
+        ->click('[data-sidebar-toggle]')
+        ->assertScript(<<<'JS'
+function () {
+    const rail = document.querySelector('nav');
+    const toggle = document.querySelector('[data-sidebar-toggle]');
+
+    return rail !== null
+        && toggle?.getAttribute('aria-expanded') === 'true'
+        && rail.getBoundingClientRect().width >= 240;
 }
 JS, true)
         ->assertScript(<<<'JS'

--- a/tests/Feature/AuthenticatedNavigationTest.php
+++ b/tests/Feature/AuthenticatedNavigationTest.php
@@ -29,6 +29,8 @@ class AuthenticatedNavigationTest extends TestCase
         $testResponse->assertSeeHtml('href="' . route('dashboard') . '"');
         $testResponse->assertSeeHtml('href="' . route('monitorings.index') . '"');
         $testResponse->assertSeeHtml('data-secondary-navigation');
+        $testResponse->assertSeeHtml('data-sidebar-toggle');
+        $testResponse->assertSeeHtml(__('app.navigation.collapse_sidebar'));
         $this->assertSame(1, mb_substr_count($testResponse->getContent() ?? '', 'data-primary-destination'));
         $testResponse->assertDontSeeText(__('app.navigation.signal_room'));
         $testResponse->assertDontSeeText(__('app.navigation.workspace'));


### PR DESCRIPTION
## What changed
- add an accessible collapse/expand control to the authenticated dashboard sidebar
- switch the compact rail to icon-only navigation while preserving every destination
- move the main content padding with the rail and persist the preference in local storage
- add English and German labels plus focused feature and browser coverage

## Why
On iPad-sized screens, the fixed sidebar consumes valuable horizontal space. The compact mode keeps all navigation actions available while giving the dashboard more room.

## Validation
- Docker Vite production build
- Docker PHPStan/Larastan: 275 files, no errors
- Docker Pest suite: 656 passed, 4,227 assertions, 3 existing environment skips
- Pint passed for changed PHP/Blade/test files
- Browser workflow: 3 passed, 22 assertions, including persistence after navigation

Closes #560