### PR TITLE
fix: improve monitoring detail responsive breakpoints

### DIFF
--- a/app/Http/Controllers/Api/MaintenanceDataController.php
+++ b/app/Http/Controllers/Api/MaintenanceDataController.php
@@ -121,14 +121,14 @@ class MaintenanceDataController extends Controller
                     ])
                     ->latest('starts_at')
                     ->get()
-                    ->map(static fn (MaintenanceWindow $window): array => [
-                        'id' => (string) $window->id,
-                        'target' => $window->monitoring?->name ?? $window->monitoringGroup?->name,
-                        'recurrence' => $window->recurrence->value,
-                        'duration_minutes' => $window->duration_minutes,
-                        'timezone' => $window->timezone,
-                        'starts_at' => $window->starts_at->setTimezone($window->timezone)->toDayDateTimeString(),
-                        'can_manage' => $window->isManageableBy($user),
+                    ->map(static fn (MaintenanceWindow $maintenanceWindow): array => [
+                        'id' => (string) $maintenanceWindow->id,
+                        'target' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
+                        'recurrence' => $maintenanceWindow->recurrence->value,
+                        'duration_minutes' => $maintenanceWindow->duration_minutes,
+                        'timezone' => $maintenanceWindow->timezone,
+                        'starts_at' => $maintenanceWindow->starts_at->setTimezone($maintenanceWindow->timezone)->toDayDateTimeString(),
+                        'can_manage' => $maintenanceWindow->isManageableBy($user),
                     ])
                     ->values()
                     ->all(),

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -165,9 +165,9 @@
             </x-container>
         </section>
 
-        <div data-monitoring-detail-layout class="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div data-monitoring-detail-layout class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_20rem]">
             <div class="min-w-0 space-y-6">
-        <div class="mb-4 grid grid-cols-1 items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div data-monitoring-primary-cards class="mb-4 grid grid-cols-1 items-stretch gap-4 md:grid-cols-2 2xl:grid-cols-3">
             @if ($regionalConsensus)
                 <x-container>
                     <div class="flex flex-wrap items-center justify-between gap-2">
@@ -360,7 +360,7 @@
             </x-container>
 
             <template x-if="responseStats[responseTimeRange + 'd']">
-                <div class="mb-4 grid grid-cols-1 gap-4 text-center sm:grid-cols-2 xl:grid-cols-3">
+                <div class="mb-4 grid grid-cols-1 gap-4 text-center md:grid-cols-2 2xl:grid-cols-3">
                     <x-container>
                         <x-paragraph
                             class="text-gray-500">{{ __('monitoring.detail.response_time.min') }}</x-paragraph>

--- a/tests/Browser/MonitoringDetailRecentChecksLayoutTest.php
+++ b/tests/Browser/MonitoringDetailRecentChecksLayoutTest.php
@@ -9,7 +9,7 @@ use App\Models\Package;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 
-it('keeps recent check status badges beside their result content at tablet desktop widths', function (): void {
+it('keeps monitoring detail content readable before the desktop side rail breakpoint', function (): void {
     if (! file_exists(public_path('build/manifest.json'))) {
         $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
     }
@@ -36,16 +36,28 @@ it('keeps recent check status badges beside their result content at tablet deskt
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/monitorings/' . $monitoring->id)
-        ->resize(1280, 800)
+        ->resize(1068, 1368)
         ->waitForText(__('monitoring.detail.checks.sources.live'));
 
     $webpage->assertScript(<<<'JS'
 function () {
+    const layout = document.querySelector('[data-monitoring-detail-layout]');
+    const primary = layout?.children[0];
+    const rail = layout?.children[1];
+    const cards = document.querySelector('[data-monitoring-primary-cards]');
     const row = document.querySelector('[data-recent-check-row]');
     const result = row?.querySelector('[data-recent-check-result]');
     const status = row?.querySelector('[data-recent-check-status]');
 
-    if (!row || !result || !status) {
+    if (!layout || !primary || !rail || !cards || !row || !result || !status) {
+        return false;
+    }
+
+    const primaryRect = primary.getBoundingClientRect();
+    const railRect = rail.getBoundingClientRect();
+    const cardRects = [...cards.children].slice(0, 2).map((card) => card.getBoundingClientRect());
+
+    if (railRect.top < primaryRect.bottom - 1 || cardRects.length < 2 || cardRects[0].width < 300) {
         return false;
     }
 

--- a/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
+++ b/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
@@ -59,7 +59,9 @@ class MonitoringDetailRecentChecksSectionTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3');
         $testResponse->assertSeeHtml('grid grid-cols-12 gap-0.5 sm:flex sm:flex-nowrap');
-        $testResponse->assertSeeHtml('grid grid-cols-1 items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-3');
+        $testResponse->assertSeeHtml('grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_20rem]');
+        $testResponse->assertSeeHtml('data-monitoring-primary-cards class="mb-4 grid grid-cols-1 items-stretch gap-4 md:grid-cols-2 2xl:grid-cols-3"');
+        $testResponse->assertSeeHtml('grid grid-cols-1 gap-4 text-center md:grid-cols-2 2xl:grid-cols-3');
         $testResponse->assertSeeHtml('flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between');
         $testResponse->assertSeeHtml('xl:grid-cols-[minmax(13rem,1.25fr)_minmax(0,3fr)_auto] xl:items-center');
     }


### PR DESCRIPTION
## What changed

- Move the monitoring detail side rail to the `xl` breakpoint so tablet-sized layouts keep the main content wide enough.
- Keep the primary monitoring detail cards at two columns until `2xl`.
- Apply the same earlier responsive behavior to response-time summary cards.
- Extend feature and browser layout coverage for the tablet breakpoint.

## Why

At tablet-sized widths, the side rail was rendered beside the main content too early. This reduced the primary column to roughly 389px and caused cramped card wrapping.

## Testing

- Targeted Pest feature test passed: 31 assertions.
- Laravel Pint passed for the changed tests.
- Bun/Vite production build passed.
- In-app browser verification passed at 1068px and 390px with no horizontal overflow.
- The containerized Pest browser test remains unavailable because Playwright is not installed in the PHP test container.

Closes #565