### PR TITLE
feat(api): expose mobile operations overview

### DIFF
--- a/app/Http/Controllers/Api/MaintenanceDataController.php
+++ b/app/Http/Controllers/Api/MaintenanceDataController.php
@@ -121,14 +121,14 @@ class MaintenanceDataController extends Controller
                     ])
                     ->latest('starts_at')
                     ->get()
-                    ->map(static fn (MaintenanceWindow $window): array => [
-                        'id' => (string) $window->id,
-                        'target' => $window->monitoring?->name ?? $window->monitoringGroup?->name,
-                        'recurrence' => $window->recurrence->value,
-                        'duration_minutes' => $window->duration_minutes,
-                        'timezone' => $window->timezone,
-                        'starts_at' => $window->starts_at->setTimezone($window->timezone)->toDayDateTimeString(),
-                        'can_manage' => $window->isManageableBy($user),
+                    ->map(static fn (MaintenanceWindow $maintenanceWindow): array => [
+                        'id' => (string) $maintenanceWindow->id,
+                        'target' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
+                        'recurrence' => $maintenanceWindow->recurrence->value,
+                        'duration_minutes' => $maintenanceWindow->duration_minutes,
+                        'timezone' => $maintenanceWindow->timezone,
+                        'starts_at' => $maintenanceWindow->starts_at->setTimezone($maintenanceWindow->timezone)->toDayDateTimeString(),
+                        'can_manage' => $maintenanceWindow->isManageableBy($user),
                     ])
                     ->values()
                     ->all(),

--- a/app/Http/Controllers/Api/Mobile/MobileOverviewController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileOverviewController.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\StatusPage;
+use App\Models\User;
+use App\Services\MonitoringOverviewService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MobileOverviewController extends Controller
+{
+    public function __invoke(Request $request, MonitoringOverviewService $monitoringOverviewService): JsonResponse
+    {
+        $validated = $request->validate([
+            'service_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+        $overview = $monitoringOverviewService->overview($user, (int) ($validated['service_page'] ?? 1));
+        $monitorings = $overview['monitorings']->keyBy(fn (Monitoring $monitoring): string => (string) $monitoring->getKey());
+
+        return response()->json([
+            'data' => [
+                'overall_state' => $overview['overallState'],
+                'summary' => $overview['summary'],
+                'services' => $overview['signalRoomServices']->map(
+                    fn (array $service): array => $this->servicePayload($service, $monitorings->get($service['id']))
+                )->values(),
+                'attention' => $overview['attentionItems']->map(
+                    fn (array $item): array => $this->attentionPayload($item)
+                )->values(),
+                'maintenance' => $overview['maintenanceMonitorings']->map(
+                    fn (Monitoring $monitoring): array => $this->maintenancePayload($monitoring)
+                )->values(),
+                'recent_incidents' => $overview['recentIncidents']->map(
+                    fn (Incident $incident): array => $this->incidentPayload($incident)
+                )->values(),
+                'trend' => $overview['trend'],
+                'failed_delivery_count' => $overview['failedDeliveryCount'],
+                'recommended_action' => $overview['recommendedAction'],
+                'capabilities' => [
+                    'can_create_monitoring' => $overview['canCreateMonitoring'],
+                    'can_manage_maintenance' => $overview['canManageMaintenance'],
+                ],
+            ],
+            'meta' => [
+                'generated_at' => now()->toIso8601String(),
+                'service_pagination' => $overview['signalRoomPagination'],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool}  $service
+     * @return array<string, mixed>
+     */
+    private function servicePayload(array $service, ?Monitoring $monitoring): array
+    {
+        $latestResponse = $monitoring?->latestResponseResult;
+
+        return [
+            'id' => $service['id'],
+            'name' => $service['name'],
+            'target' => $service['target'],
+            'type' => $monitoring?->type?->value ?? $monitoring?->type,
+            'group' => $service['group'],
+            'status' => $service['status'],
+            'open_incident' => $service['openIncident'],
+            'last_checked_at' => $latestResponse?->created_at?->toIso8601String(),
+            'response_time_ms' => $latestResponse?->response_time,
+        ];
+    }
+
+    /**
+     * @param  array{type:string,monitoring:Monitoring|null,count:int|null,statusPage:StatusPage|null}  $item
+     * @return array<string, mixed>
+     */
+    private function attentionPayload(array $item): array
+    {
+        $monitoring = $item['monitoring'];
+        $statusPage = $item['statusPage'];
+
+        return [
+            'type' => $item['type'],
+            'count' => $item['count'],
+            'monitoring_id' => $monitoring?->getKey(),
+            'monitoring_name' => $monitoring?->name,
+            'monitoring_target' => $monitoring?->target,
+            'status_page_id' => $statusPage?->getKey(),
+            'status_page_name' => $statusPage?->name,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function maintenancePayload(Monitoring $monitoring): array
+    {
+        return [
+            'monitoring_id' => $monitoring->getKey(),
+            'monitoring_name' => $monitoring->name,
+            'monitoring_target' => $monitoring->target,
+            'status' => $monitoring->isUnderMaintenance() ? 'active' : 'upcoming',
+            'starts_at' => $monitoring->maintenance_from?->toIso8601String(),
+            'ends_at' => $monitoring->maintenance_until?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function incidentPayload(Incident $incident): array
+    {
+        return [
+            'id' => $incident->getKey(),
+            'monitoring_id' => $incident->monitoring?->getKey(),
+            'monitoring_name' => $incident->monitoring?->name,
+            'monitoring_target' => $incident->monitoring?->target,
+            'down_at' => $incident->down_at?->toIso8601String(),
+            'up_at' => $incident->up_at?->toIso8601String(),
+            'resolved' => $incident->up_at !== null,
+        ];
+    }
+}

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\Mobile\MobileOverviewController;
 use App\Http\Controllers\Api\MobilePushDeviceController;
 use App\Http\Controllers\Api\MonitoringManagementController;
 use App\Http\Controllers\Api\TeamController;
@@ -35,6 +36,9 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
     Route::get('/{monitoring}/ssl', [ApiController::class, 'sslStatus']);
     Route::get('/{monitoring}/uptime-calendar', [ApiController::class, 'uptimeCalendar']);
 });
+
+Route::get('/mobile/overview', MobileOverviewController::class)
+    ->name('mobile.overview');
 
 Route::apiResource('mobile-push-devices', MobilePushDeviceController::class)
     ->only(['index', 'store', 'update', 'destroy']);

--- a/tests/Feature/Api/MobileOverviewApiTest.php
+++ b/tests/Feature/Api/MobileOverviewApiTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MobileOverviewApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_read_the_operations_overview(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create();
+        $healthy = Monitoring::factory()->for($user)->create(['name' => 'Healthy API']);
+        $down = Monitoring::factory()->for($user)->create(['name' => 'Down API']);
+        Monitoring::factory()->for($user)->create(['name' => 'Unknown API']);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $healthy->id,
+            'status' => MonitoringStatus::UP,
+            'response_time' => 120,
+        ]);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $down->id,
+            'status' => MonitoringStatus::DOWN,
+            'response_time' => 900,
+        ]);
+        $incident = Incident::query()->create([
+            'monitoring_id' => $down->id,
+            'down_at' => Date::now()->subMinutes(5),
+        ]);
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/v1/mobile/overview');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.overall_state', 'degraded')
+            ->assertJsonPath('data.summary.total', 3)
+            ->assertJsonPath('data.summary.healthy', 1)
+            ->assertJsonPath('data.summary.down', 1)
+            ->assertJsonPath('data.summary.unknown', 1)
+            ->assertJsonPath('data.services.0.name', 'Down API')
+            ->assertJsonPath('data.services.0.open_incident', true)
+            ->assertJsonPath('data.attention.0.type', 'incident')
+            ->assertJsonPath('data.attention.0.monitoring_id', $down->id)
+            ->assertJsonPath('data.recent_incidents.0.id', $incident->id)
+            ->assertJsonPath('meta.service_pagination.total', 3);
+    }
+
+    public function test_overview_only_contains_monitorings_visible_to_the_authenticated_user(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create();
+        Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
+        Monitoring::factory()->create(['name' => 'Hidden API']);
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/v1/mobile/overview');
+
+        $response->assertOk()
+            ->assertJsonPath('data.summary.total', 1)
+            ->assertJsonPath('data.services.0.name', 'Visible API')
+            ->assertJsonMissing(['name' => 'Hidden API']);
+    }
+
+    public function test_overview_supports_bounded_service_pagination(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 20]);
+        $user = User::factory()->create();
+
+        foreach (range(1, 12) as $index) {
+            Monitoring::factory()->for($user)->create(['name' => sprintf('API %02d', $index)]);
+        }
+
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/mobile/overview?service_page=2')
+            ->assertOk()
+            ->assertJsonPath('data.summary.total', 12)
+            ->assertJsonPath('meta.service_pagination.current_page', 2)
+            ->assertJsonPath('meta.service_pagination.last_page', 2)
+            ->assertJsonCount(2, 'data.services');
+    }
+}

--- a/tests/Feature/Api/MobileOverviewApiTest.php
+++ b/tests/Feature/Api/MobileOverviewApiTest.php
@@ -43,9 +43,9 @@ class MobileOverviewApiTest extends TestCase
         ]);
         Sanctum::actingAs($user);
 
-        $response = $this->getJson('/api/v1/mobile/overview');
+        $testResponse = $this->getJson('/api/v1/mobile/overview');
 
-        $response
+        $testResponse
             ->assertOk()
             ->assertJsonPath('data.overall_state', 'degraded')
             ->assertJsonPath('data.summary.total', 3)
@@ -68,9 +68,9 @@ class MobileOverviewApiTest extends TestCase
         Monitoring::factory()->create(['name' => 'Hidden API']);
         Sanctum::actingAs($user);
 
-        $response = $this->getJson('/api/v1/mobile/overview');
+        $testResponse = $this->getJson('/api/v1/mobile/overview');
 
-        $response->assertOk()
+        $testResponse->assertOk()
             ->assertJsonPath('data.summary.total', 1)
             ->assertJsonPath('data.services.0.name', 'Visible API')
             ->assertJsonMissing(['name' => 'Hidden API']);


### PR DESCRIPTION
## What changed
- add authenticated `GET /api/v1/mobile/overview`
- expose stable operations-overview fields for mobile clients: summary, services, attention, maintenance, incidents, trend, delivery failures, capabilities, and pagination metadata
- reuse the existing monitoring overview service and visibility rules
- add feature coverage for authenticated access, visibility boundaries, and bounded pagination

## Why
The iOS client needs one stable, permission-aware payload for the new operations-first Signal Room instead of assembling the overview from multiple UI-specific endpoints.

## Validation
- Dockerized targeted Pest: 3 tests, 21 assertions, exit 0
- Dockerized Pint: 569 files passed
- Dockerized PHPStan: no errors

Related: marcel-breuer/webguard-app#20
Closes #567