### PR TITLE
feat: add branded WebGuard error pages

### DIFF
--- a/app/Http/Controllers/Api/MaintenanceDataController.php
+++ b/app/Http/Controllers/Api/MaintenanceDataController.php
@@ -121,14 +121,14 @@ class MaintenanceDataController extends Controller
                     ])
                     ->latest('starts_at')
                     ->get()
-                    ->map(static fn (MaintenanceWindow $window): array => [
-                        'id' => (string) $window->id,
-                        'target' => $window->monitoring?->name ?? $window->monitoringGroup?->name,
-                        'recurrence' => $window->recurrence->value,
-                        'duration_minutes' => $window->duration_minutes,
-                        'timezone' => $window->timezone,
-                        'starts_at' => $window->starts_at->setTimezone($window->timezone)->toDayDateTimeString(),
-                        'can_manage' => $window->isManageableBy($user),
+                    ->map(static fn (MaintenanceWindow $maintenanceWindow): array => [
+                        'id' => (string) $maintenanceWindow->id,
+                        'target' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
+                        'recurrence' => $maintenanceWindow->recurrence->value,
+                        'duration_minutes' => $maintenanceWindow->duration_minutes,
+                        'timezone' => $maintenanceWindow->timezone,
+                        'starts_at' => $maintenanceWindow->starts_at->setTimezone($maintenanceWindow->timezone)->toDayDateTimeString(),
+                        'can_manage' => $maintenanceWindow->isManageableBy($user),
                     ])
                     ->values()
                     ->all(),

--- a/resources/lang/de/errors.php
+++ b/resources/lang/de/errors.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'meta_title' => ':status | :app',
+    'eyebrow' => 'WEBGUARD / SYSTEMANTWORT',
+    'status_label' => 'HTTP-Status',
+    'return_hint' => 'Die Monitoring-Oberfläche ist weiterhin erreichbar. Sie können im zentralen Workspace fortfahren.',
+    'actions' => [
+        'dashboard' => 'Dashboard öffnen',
+        'login' => 'Zum Login',
+    ],
+    'status' => [
+        '400' => [
+            'title' => 'Die Anfrage konnte nicht verarbeitet werden.',
+            'message' => 'WebGuard hat eine ungültige Anfrage erhalten. Bitte prüfen Sie die Adresse und versuchen Sie es erneut.',
+        ],
+        '403' => [
+            'title' => 'Dieser Bereich ist geschützt.',
+            'message' => 'Sie haben keine Berechtigung, auf diese WebGuard-Ressource zuzugreifen.',
+        ],
+        '404' => [
+            'title' => 'Dieses Signal wurde nicht gefunden.',
+            'message' => 'Die Seite wurde möglicherweise verschoben, ist abgelaufen oder existiert unter dieser Adresse nicht.',
+        ],
+        '419' => [
+            'title' => 'Ihre Sitzung ist abgelaufen.',
+            'message' => 'Aus Sicherheitsgründen ist diese Anfrage nicht mehr gültig. Bitte starten Sie erneut.',
+        ],
+        '429' => [
+            'title' => 'Zu viele Anfragen.',
+            'message' => 'WebGuard schützt diesen Workspace. Bitte warten Sie einen Moment und versuchen Sie es erneut.',
+        ],
+        '500' => [
+            'title' => 'Auf unserer Seite ist ein Fehler aufgetreten.',
+            'message' => 'WebGuard konnte diese Anfrage nicht abschließen. Bitte versuchen Sie es gleich noch einmal.',
+        ],
+        '503' => [
+            'title' => 'WebGuard ist vorübergehend nicht verfügbar.',
+            'message' => 'Der Dienst wird gerade vorbereitet oder gewartet. Bitte versuchen Sie es in Kürze erneut.',
+        ],
+    ],
+];

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'meta_title' => ':status | :app',
+    'eyebrow' => 'WEBGUARD / SYSTEM RESPONSE',
+    'status_label' => 'HTTP status',
+    'return_hint' => 'The monitoring surface is still here. You can continue from the main workspace.',
+    'actions' => [
+        'dashboard' => 'Open dashboard',
+        'login' => 'Go to login',
+    ],
+    'status' => [
+        '400' => [
+            'title' => 'The request could not be processed.',
+            'message' => 'WebGuard received an invalid request. Please check the address and try again.',
+        ],
+        '403' => [
+            'title' => 'This area is protected.',
+            'message' => 'You do not have permission to access this WebGuard resource.',
+        ],
+        '404' => [
+            'title' => 'This signal was not found.',
+            'message' => 'The page may have moved, expired, or never existed at this address.',
+        ],
+        '419' => [
+            'title' => 'Your session has expired.',
+            'message' => 'For your security, this request is no longer valid. Please start again.',
+        ],
+        '429' => [
+            'title' => 'Too many requests.',
+            'message' => 'WebGuard is protecting this workspace. Please wait a moment and try again.',
+        ],
+        '500' => [
+            'title' => 'Something went wrong on our side.',
+            'message' => 'WebGuard could not complete this request. Please try again in a moment.',
+        ],
+        '503' => [
+            'title' => 'WebGuard is temporarily unavailable.',
+            'message' => 'The service is being prepared or maintained. Please try again shortly.',
+        ],
+    ],
+];

--- a/resources/views/errors/400.blade.php
+++ b/resources/views/errors/400.blade.php
@@ -1,0 +1,3 @@
+@php($status = 400)
+@php($error = __('errors.status.400'))
+@include('errors.layout')

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,3 @@
+@php($status = 403)
+@php($error = __('errors.status.403'))
+@include('errors.layout')

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,3 @@
+@php($status = 404)
+@php($error = __('errors.status.404'))
+@include('errors.layout')

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,0 +1,3 @@
+@php($status = 419)
+@php($error = __('errors.status.419'))
+@include('errors.layout')

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,0 +1,3 @@
+@php($status = 429)
+@php($error = __('errors.status.429'))
+@include('errors.layout')

--- a/resources/views/errors/4xx.blade.php
+++ b/resources/views/errors/4xx.blade.php
@@ -1,0 +1,7 @@
+@php
+    $status = (int) ($exception?->getStatusCode() ?? 400);
+    $errorKey = in_array($status, [400, 403, 404, 419, 429], true) ? $status : 400;
+    $error = __('errors.status.' . $errorKey);
+@endphp
+
+@include('errors.layout')

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,3 @@
+@php($status = 500)
+@php($error = __('errors.status.500'))
+@include('errors.layout')

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,0 +1,3 @@
+@php($status = 503)
+@php($error = __('errors.status.503'))
+@include('errors.layout')

--- a/resources/views/errors/5xx.blade.php
+++ b/resources/views/errors/5xx.blade.php
@@ -1,0 +1,7 @@
+@php
+    $status = (int) ($exception?->getStatusCode() ?? 500);
+    $errorKey = in_array($status, [500, 503], true) ? $status : 500;
+    $error = __('errors.status.' . $errorKey);
+@endphp
+
+@include('errors.layout')

--- a/resources/views/errors/layout.blade.php
+++ b/resources/views/errors/layout.blade.php
@@ -1,0 +1,89 @@
+@php
+    $theme = auth()->check() ? auth()->user()->theme : 'system';
+    $homeUrl = auth()->check() ? route('dashboard') : route('login');
+    $homeLabel = auth()->check() ? __('errors.actions.dashboard') : __('errors.actions.login');
+
+    if (! in_array($theme, ['light', 'dark', 'system'], true)) {
+        $theme = 'system';
+    }
+@endphp
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="{{ $theme === 'dark' ? 'dark' : '' }}" data-theme="{{ $theme }}">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+
+    <title>{{ __('errors.meta_title', ['status' => $status, 'app' => __('app.name')]) }}</title>
+
+    <link rel="icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
+    <link rel="apple-touch-icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
+
+    @vite(['resources/css/app.css', 'resources/js/app.ts'])
+</head>
+
+<body class="bg-slate-50 font-sans text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
+    <div class="relative flex min-h-screen flex-col overflow-hidden">
+        <div class="pointer-events-none absolute -left-32 -top-32 h-80 w-80 rounded-full bg-purple-200/30 blur-3xl dark:bg-purple-950/30" aria-hidden="true"></div>
+        <div class="pointer-events-none absolute -bottom-40 -right-24 h-96 w-96 rounded-full bg-emerald-100/50 blur-3xl dark:bg-emerald-950/20" aria-hidden="true"></div>
+
+        <header class="relative border-b border-purple-100/80 bg-white/90 dark:border-purple-900/50 dark:bg-slate-900/90">
+            <x-main class="flex h-16 items-center justify-between">
+                <a href="{{ $homeUrl }}" class="flex items-center gap-3" aria-label="{{ __('app.name') }}">
+                    <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="{{ __('app.logo_alt') }}" class="h-9 w-9">
+                    <span class="text-xl font-bold tracking-tight text-slate-900 dark:text-white">{{ __('app.name') }}</span>
+                </a>
+
+                <span class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                    <span class="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.12)]" aria-hidden="true"></span>
+                    {{ __('errors.eyebrow') }}
+                </span>
+            </x-main>
+        </header>
+
+        <main class="relative flex flex-1 items-center px-4 py-12 sm:px-6 lg:px-8">
+            <x-main class="w-full">
+                <section class="mx-auto grid max-w-5xl overflow-hidden rounded-2xl border border-purple-100 bg-white shadow-[0_24px_70px_-35px_rgba(91,33,182,0.45)] dark:border-purple-900/60 dark:bg-slate-900 lg:grid-cols-[0.85fr_1.15fr]">
+                    <div class="relative flex min-h-64 items-center justify-center overflow-hidden border-b border-purple-100 bg-gradient-to-br from-purple-700 via-purple-600 to-indigo-700 p-8 text-white dark:border-purple-900/60 lg:min-h-[28rem] lg:border-b-0 lg:border-e">
+                        <div class="absolute inset-0 opacity-20" aria-hidden="true">
+                            <div class="absolute -left-12 top-8 h-48 w-48 rounded-full border border-white/60"></div>
+                            <div class="absolute -left-20 top-0 h-64 w-64 rounded-full border border-white/40"></div>
+                            <div class="absolute -bottom-20 -right-16 h-64 w-64 rounded-full border border-white/30"></div>
+                            <div class="absolute bottom-8 right-8 h-3 w-3 rounded-full bg-emerald-300"></div>
+                            <div class="absolute right-24 top-16 h-2 w-2 rounded-full bg-white"></div>
+                        </div>
+
+                        <div class="relative text-center">
+                            <span class="text-xs font-bold uppercase tracking-[0.3em] text-purple-200">{{ __('errors.status_label') }}</span>
+                            <p class="mt-2 text-8xl font-extrabold leading-none tracking-[-0.08em] sm:text-9xl">{{ $status }}</p>
+                            <div class="mx-auto mt-6 flex items-center justify-center gap-2 text-sm font-medium text-purple-100">
+                                <span class="h-2 w-2 rounded-full bg-emerald-300"></span>
+                                <span>{{ __('errors.eyebrow') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col justify-center p-8 sm:p-12 lg:p-14">
+                        <p class="text-xs font-bold uppercase tracking-[0.22em] text-purple-600 dark:text-purple-300">{{ __('errors.eyebrow') }}</p>
+                        <h1 class="mt-4 text-3xl font-bold tracking-tight text-slate-950 dark:text-white sm:text-4xl">{{ $error['title'] }}</h1>
+                        <p class="mt-5 max-w-xl text-base leading-7 text-slate-600 dark:text-slate-300">{{ $error['message'] }}</p>
+
+                        <div class="mt-8 flex flex-wrap items-center gap-3">
+                            <x-primary-button :href="$homeUrl" class="gap-2">
+                                <x-icon name="home" class="h-4 w-4" />
+                                {{ $homeLabel }}
+                            </x-primary-button>
+                        </div>
+
+                        <p class="mt-8 border-t border-slate-200 pt-5 text-sm leading-6 text-slate-500 dark:border-slate-700 dark:text-slate-400">{{ __('errors.return_hint') }}</p>
+                    </div>
+                </section>
+            </x-main>
+        </main>
+
+        @include('components.footer')
+    </div>
+</body>
+
+</html>

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+class ErrorPagesTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: int, 2: string}>
+     */
+    public static function brandedErrorViewProvider(): array
+    {
+        return [
+            'forbidden' => ['403', 403, '403'],
+            'session expired' => ['419', 419, '419'],
+            'too many requests' => ['429', 429, '429'],
+            'server error' => ['500', 500, '500'],
+            'unavailable' => ['503', 503, '503'],
+            'unknown client error fallback' => ['4xx', 405, '400'],
+            'unknown server error fallback' => ['5xx', 502, '500'],
+        ];
+    }
+
+    public function test_not_found_page_uses_the_webguard_error_design(): void
+    {
+        $response = $this->get('/webguard-error-page-that-does-not-exist');
+
+        $response->assertNotFound();
+        $response->assertSeeText('404');
+        $response->assertSeeText(__('errors.status.404.title'));
+        $response->assertSeeText(__('errors.eyebrow'));
+        $response->assertSee(__('app.logo_alt'));
+    }
+
+    public function test_error_page_uses_the_active_application_locale(): void
+    {
+        app()->setLocale('de');
+
+        $html = view('errors.404')->render();
+
+        $this->assertStringContainsString('Dieses Signal wurde nicht gefunden.', $html);
+    }
+
+    #[DataProvider('brandedErrorViewProvider')]
+    public function test_common_error_views_render_with_their_status_content(string $view, int $status, string $contentStatus): void
+    {
+        $html = view('errors.' . $view, [
+            'exception' => new HttpException($status),
+        ])->render();
+
+        $this->assertStringContainsString((string) $status, $html);
+        $this->assertStringContainsString((string) __('errors.status.' . $contentStatus . '.title'), $html);
+        $this->assertStringContainsString((string) __('errors.eyebrow'), $html);
+    }
+}

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -28,13 +28,13 @@ class ErrorPagesTest extends TestCase
 
     public function test_not_found_page_uses_the_webguard_error_design(): void
     {
-        $response = $this->get('/webguard-error-page-that-does-not-exist');
+        $testResponse = $this->get('/webguard-error-page-that-does-not-exist');
 
-        $response->assertNotFound();
-        $response->assertSeeText('404');
-        $response->assertSeeText(__('errors.status.404.title'));
-        $response->assertSeeText(__('errors.eyebrow'));
-        $response->assertSee(__('app.logo_alt'));
+        $testResponse->assertNotFound();
+        $testResponse->assertSeeText('404');
+        $testResponse->assertSeeText(__('errors.status.404.title'));
+        $testResponse->assertSeeText(__('errors.eyebrow'));
+        $testResponse->assertSee(__('app.logo_alt'));
     }
 
     public function test_error_page_uses_the_active_application_locale(): void


### PR DESCRIPTION
## What changed
- Added a shared WebGuard-styled error layout with logo, responsive presentation, dark-mode support, and navigation back to the workspace.
- Added localized German and English messages for common 4xx/5xx responses.
- Added specific overrides for 400, 403, 404, 419, 429, 500, and 503 plus 4xx/5xx fallbacks.
- Added rendering coverage for common statuses, fallbacks, branding, and the German locale.

## Why
The Laravel defaults did not match the established WebGuard interface. These pages now provide a consistent and useful recovery path when a request cannot be served.

## Validation
- Docker Pest: 9 tests, 27 assertions passed
- Docker Pint: 3 files passed
- Docker Bun production build passed
- Docker Compose configuration and `git diff --check` passed

Closes #571