### PR TITLE
feat(legal): link canonical pages to marketing site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://webguard.test
 MARKETING_URL=
+MARKETING_LEGAL_URL=
 SERVICE_URL_PHP=http://webguard.test
 APP_TIMEZONE=Europe/Berlin
 

--- a/app/Support/LegalLinks.php
+++ b/app/Support/LegalLinks.php
@@ -30,7 +30,7 @@ final class LegalLinks
     {
         $baseUrl = config('app.marketing_legal_url');
 
-        if (! filled($baseUrl)) {
+        if (blank($baseUrl)) {
             return $fallback;
         }
 

--- a/app/Support/LegalLinks.php
+++ b/app/Support/LegalLinks.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class LegalLinks
+{
+    public static function imprint(): string
+    {
+        return self::url('imprint', route('imprint'));
+    }
+
+    public static function termsOfUse(): string
+    {
+        return self::url('terms-of-use', route('terms-of-use'));
+    }
+
+    public static function privacyPolicy(): string
+    {
+        return self::url('gdpr', route('gdpr'));
+    }
+
+    public static function isExternal(): bool
+    {
+        return filled(config('app.marketing_legal_url'));
+    }
+
+    private static function url(string $path, string $fallback): string
+    {
+        $baseUrl = config('app.marketing_legal_url');
+
+        if (! filled($baseUrl)) {
+            return $fallback;
+        }
+
+        return mb_rtrim((string) $baseUrl, '/') . '/' . $path;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -58,6 +58,8 @@ return [
 
     'marketing_url' => env('MARKETING_URL'),
 
+    'marketing_legal_url' => env('MARKETING_LEGAL_URL'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,6 +2,7 @@ x-local-app-environment: &local-app-environment
   APP_ENV: "local"
   APP_DEBUG: "true"
   APP_URL: "http://${DOCKER_APP_HOST:-webguard.test}"
+  MARKETING_LEGAL_URL: "${MARKETING_LEGAL_URL:-}"
   DB_CONNECTION: "mysql"
   DB_HOST: "mysql"
   DB_PORT: "3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ x-app-environment: &app-environment
   APP_KEY: "${APP_KEY:?APP_KEY must be set to a persistent Laravel application key}"
   APP_URL: "${SERVICE_URL_PHP:-https://webguard.example.com}"
   MARKETING_URL: "${MARKETING_URL:-}"
+  MARKETING_LEGAL_URL: "${MARKETING_LEGAL_URL:-}"
   APP_TIMEZONE: "Europe/Berlin"
   APP_LOCALE: "en"
   APP_FALLBACK_LOCALE: "en"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -131,6 +131,7 @@ Optional:
 
 - `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_REDIRECT_URI` for GitHub login
 - `MARKETING_URL` for an optional link to a separately deployed marketing website
+- `MARKETING_LEGAL_URL` for optional canonical legal pages on the separately deployed marketing website; the application appends `/imprint`, `/terms-of-use`, and `/gdpr`
 - `IMPRINT_*` fields for legal/imprint content
 
 ### Build and Startup Performance

--- a/resources/views/auth/github-consent.blade.php
+++ b/resources/views/auth/github-consent.blade.php
@@ -16,7 +16,7 @@
                 class="mt-0.5 rounded-sm border-gray-300 text-purple-600 shadow-xs focus:border-purple-300 focus:ring-3 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
                 @checked(old('terms')) required>
             <span class="ms-2 text-sm text-gray-600 dark:text-gray-300">
-                {!! __('auth.register.terms_agreement', ['terms_link' => route('terms-of-use'), 'privacy_link' => route('gdpr')]) !!}
+                {!! __('auth.register.terms_agreement', ['terms_link' => \App\Support\LegalLinks::termsOfUse(), 'privacy_link' => \App\Support\LegalLinks::privacyPolicy()]) !!}
             </span>
         </label>
         <x-input-error :messages="$errors->get('terms')" />
@@ -31,4 +31,3 @@
         </div>
     </form>
 </x-guest-layout>
-

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -159,7 +159,7 @@
                                     class="mt-0.5 rounded-sm border-gray-300 text-purple-600 shadow-xs focus:border-purple-300 focus:ring-3 focus:ring-purple-200 focus:ring-opacity-50 dark:border-gray-600"
                                     @checked(old('terms')) required>
                                 <span class="ms-2 text-sm text-gray-600 dark:text-gray-300">
-                                    {!! __('auth.register.terms_agreement', ['terms_link' => route('terms-of-use'), 'privacy_link' => route('gdpr')]) !!}
+                                    {!! __('auth.register.terms_agreement', ['terms_link' => \App\Support\LegalLinks::termsOfUse(), 'privacy_link' => \App\Support\LegalLinks::privacyPolicy()]) !!}
                                 </span>
                             </label>
                             <x-input-error :messages="$errors->get('terms')" />

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,3 +1,7 @@
+@php
+    $legalLinksExternal = \App\Support\LegalLinks::isExternal();
+@endphp
+
 <footer class="border-t border-slate-200/80 bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/80">
     <x-main class="w-full py-5">
         <div class="flex flex-col gap-3 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
@@ -9,7 +13,7 @@
                 <ul class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-end">
                     @if (config('app.marketing_url'))
                         <li>
-                            <a href="{{ config('app.marketing_url') }}"
+                            <a href="{{ config('app.marketing_url') }}" target="_blank" rel="noopener"
                                 class="text-sm font-medium text-slate-600 transition hover:text-purple-700 dark:text-slate-300 dark:hover:text-purple-300">
                                 {{ __('app.marketing_site') }}
                             </a>
@@ -22,19 +26,22 @@
                         </a>
                     </li>
                     <li>
-                        <a href="{{ route('imprint') }}"
+                        <a href="{{ \App\Support\LegalLinks::imprint() }}"
+                            @if ($legalLinksExternal) target="_blank" rel="noopener" @endif
                             class="text-sm font-medium text-slate-600 transition hover:text-purple-700 dark:text-slate-300 dark:hover:text-purple-300">
                             {{ __('imprint.footer_link') }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ route('terms-of-use') }}"
+                        <a href="{{ \App\Support\LegalLinks::termsOfUse() }}"
+                            @if ($legalLinksExternal) target="_blank" rel="noopener" @endif
                             class="text-sm font-medium text-slate-600 transition hover:text-purple-700 dark:text-slate-300 dark:hover:text-purple-300">
                             {{ __('legal.terms_of_use.footer_link') }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ route('gdpr') }}"
+                        <a href="{{ \App\Support\LegalLinks::privacyPolicy() }}"
+                            @if ($legalLinksExternal) target="_blank" rel="noopener" @endif
                             class="text-sm font-medium text-slate-600 transition hover:text-purple-700 dark:text-slate-300 dark:hover:text-purple-300">
                             {{ __('gdpr.footer_link') }}
                         </a>

--- a/resources/views/components/legal-layout.blade.php
+++ b/resources/views/components/legal-layout.blade.php
@@ -18,6 +18,7 @@
     $seoTwitterImage = isset($twitterImage) ? trim((string) $twitterImage) : $seoOgImage;
     $structuredData = \App\Support\Seo\StructuredData::legalPage($seoTitle, $seoDescription, $seoCanonical, Vite::asset('resources/images/Logo-WebGuard.png'));
     $homeUrl = config('app.marketing_url') ?: route('login');
+    $homeIsExternal = filled(config('app.marketing_url'));
 @endphp
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="{{ $theme === 'dark' ? 'dark' : '' }}" data-theme="{{ $theme }}">
 
@@ -67,7 +68,7 @@
         <header class="relative z-40 border-b border-slate-200/80 bg-white/85 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/80" style="z-index: 40;">
             <nav aria-label="{{ __('app.navigation.home') }}">
                 <x-main class="flex w-full items-center justify-between py-4">
-                    <a href="{{ $homeUrl }}" class="flex items-center gap-3">
+                    <a href="{{ $homeUrl }}" @if ($homeIsExternal) target="_blank" rel="noopener" @endif class="flex items-center gap-3">
                         <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="{{ __('app.logo_alt') }}" class="h-9 w-9">
                         <x-span class="hidden text-lg font-bold tracking-tight text-slate-900 dark:text-white sm:inline">{{ __('app.name') }}</x-span>
                     </a>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -6,6 +6,7 @@
 @php
     $theme = auth()->check() ? auth()->user()->theme : 'system';
     $homeUrl = config('app.marketing_url') ?: route('login');
+    $homeIsExternal = filled(config('app.marketing_url'));
     if (! in_array($theme, ['light', 'dark', 'system'], true)) {
         $theme = 'system';
     }
@@ -42,7 +43,7 @@
         <nav class="border-b border-gray-100 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                 <div class="flex h-16 items-center justify-between">
-                    <a href="{{ $homeUrl }}" class="flex items-center">
+                    <a href="{{ $homeUrl }}" @if ($homeIsExternal) target="_blank" rel="noopener" @endif class="flex items-center">
                         <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="Logo" class="h-8 w-8">
                         <x-span class="ms-2 text-xl font-bold text-gray-800 dark:text-gray-100">
                             {{ __('app.name') }}

--- a/resources/views/layouts/mail.blade.php
+++ b/resources/views/layouts/mail.blade.php
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+@php
+    $legalLinksExternal = \App\Support\LegalLinks::isExternal();
+@endphp
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="UTF-8">
@@ -278,11 +281,11 @@
                 <p>&copy; {{ date('Y') }} {{ __('app.name') }}. {{ __('legal.footer.content') }}</p>
                 <p class="mail-legal-links">
                     @if (config('app.marketing_url'))
-                        <a href="{{ config('app.marketing_url') }}">{{ __('app.marketing_site') }}</a>
+                        <a href="{{ config('app.marketing_url') }}" target="_blank" rel="noopener">{{ __('app.marketing_site') }}</a>
                     @endif
-                    <a href="{{ route('imprint') }}">{{ __('imprint.footer_link') }}</a>
-                    <a href="{{ route('terms-of-use') }}">{{ __('legal.terms_of_use.footer_link') }}</a>
-                    <a href="{{ route('gdpr') }}">{{ __('gdpr.footer_link') }}</a>
+                    <a href="{{ \App\Support\LegalLinks::imprint() }}" @if ($legalLinksExternal) target="_blank" rel="noopener" @endif>{{ __('imprint.footer_link') }}</a>
+                    <a href="{{ \App\Support\LegalLinks::termsOfUse() }}" @if ($legalLinksExternal) target="_blank" rel="noopener" @endif>{{ __('legal.terms_of_use.footer_link') }}</a>
+                    <a href="{{ \App\Support\LegalLinks::privacyPolicy() }}" @if ($legalLinksExternal) target="_blank" rel="noopener" @endif>{{ __('gdpr.footer_link') }}</a>
                 </p>
             </div>
         </div>

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 @php
     $homeUrl = config('app.marketing_url') ?: route('login');
+    $homeIsExternal = filled(config('app.marketing_url'));
 @endphp
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-confirm-title="{{ __('app.confirmation.title') }}"
     data-confirm-confirm="{{ __('app.confirmation.confirm') }}" data-confirm-cancel="{{ __('button.cancel') }}">
@@ -36,7 +37,7 @@
     <nav class="border-b border-gray-100 bg-white dark:border-gray-700 dark:bg-gray-800">
         <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div class="flex h-16 items-center justify-between">
-                <a href="{{ $homeUrl }}" class="flex items-center">
+                <a href="{{ $homeUrl }}" @if ($homeIsExternal) target="_blank" rel="noopener" @endif class="flex items-center">
                     <img src="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" alt="Logo" class="h-8 w-8">
                     <x-span class="ms-2 text-xl font-bold text-gray-800 dark:text-gray-100">
                         {{ __('app.name') }}

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,4 +1,7 @@
 <x-mail::layout>
+@php
+    $legalLinksExternal = \App\Support\LegalLinks::isExternal();
+@endphp
 {{-- Header --}}
 <x-slot:header>
 <x-mail::header :url="config('app.url')" />
@@ -22,11 +25,11 @@
 &copy; {{ date('Y') }} {{ __('app.name') }}. {{ __('legal.footer.content') }}
 
 @if (config('app.marketing_url'))
-<a href="{{ config('app.marketing_url') }}">{{ __('app.marketing_site') }}</a>
+<a href="{{ config('app.marketing_url') }}" target="_blank" rel="noopener">{{ __('app.marketing_site') }}</a>
 @endif
-<a href="{{ route('imprint') }}">{{ __('imprint.footer_link') }}</a>
-<a href="{{ route('terms-of-use') }}">{{ __('legal.terms_of_use.footer_link') }}</a>
-<a href="{{ route('gdpr') }}">{{ __('gdpr.footer_link') }}</a>
+<a href="{{ \App\Support\LegalLinks::imprint() }}" @if ($legalLinksExternal) target="_blank" rel="noopener" @endif>{{ __('imprint.footer_link') }}</a>
+<a href="{{ \App\Support\LegalLinks::termsOfUse() }}" @if ($legalLinksExternal) target="_blank" rel="noopener" @endif>{{ __('legal.terms_of_use.footer_link') }}</a>
+<a href="{{ \App\Support\LegalLinks::privacyPolicy() }}" @if ($legalLinksExternal) target="_blank" rel="noopener" @endif>{{ __('gdpr.footer_link') }}</a>
 </x-mail::footer>
 </x-slot:footer>
 </x-mail::layout>

--- a/tests/Feature/AuthEntryPointsTest.php
+++ b/tests/Feature/AuthEntryPointsTest.php
@@ -83,6 +83,17 @@ class AuthEntryPointsTest extends TestCase
         $testResponse->assertSeeHtml(route('gdpr'));
     }
 
+    public function test_register_mode_uses_configured_external_legal_links(): void
+    {
+        config()->set('app.marketing_legal_url', 'https://marketing.example.test');
+
+        $testResponse = $this->get(route('login', ['mode' => 'register']));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('href="https://marketing.example.test/terms-of-use" target="_blank" rel="noopener"');
+        $testResponse->assertSeeHtml('href="https://marketing.example.test/gdpr" target="_blank" rel="noopener"');
+    }
+
     public function test_register_captcha_image_is_served_locally(): void
     {
         $testResponse = $this->get(url('captcha/register'));

--- a/tests/Feature/FooterMarkupTest.php
+++ b/tests/Feature/FooterMarkupTest.php
@@ -11,6 +11,7 @@ class FooterMarkupTest extends TestCase
     public function test_footer_renders_core_links_and_optional_marketing_link(): void
     {
         config()->set('app.marketing_url', 'https://marketing.example.test');
+        config()->set('app.marketing_legal_url', null);
 
         $this->configureImprint();
 
@@ -20,9 +21,25 @@ class FooterMarkupTest extends TestCase
         $testResponse->assertSeeHtml('class="w-full sm:w-auto"');
         $testResponse->assertSeeHtml('flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-end');
         $testResponse->assertSeeHtml('https://marketing.example.test');
+        $testResponse->assertSeeHtml('target="_blank" rel="noopener"');
         $testResponse->assertSeeHtml(route('imprint'));
         $testResponse->assertSeeHtml(route('terms-of-use'));
         $testResponse->assertSeeHtml(route('gdpr'));
+    }
+
+    public function test_footer_uses_external_marketing_legal_links_when_configured(): void
+    {
+        config()->set('app.marketing_legal_url', 'https://marketing.example.test/legal/');
+
+        $this->configureImprint();
+
+        $testResponse = $this->get(route('imprint'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('href="https://marketing.example.test/legal/imprint"');
+        $testResponse->assertSeeHtml('href="https://marketing.example.test/legal/terms-of-use"');
+        $testResponse->assertSeeHtml('href="https://marketing.example.test/legal/gdpr"');
+        $testResponse->assertSeeHtml('target="_blank" rel="noopener"');
     }
 
     private function configureImprint(): void

--- a/tests/Feature/FooterMarkupTest.php
+++ b/tests/Feature/FooterMarkupTest.php
@@ -11,7 +11,7 @@ class FooterMarkupTest extends TestCase
     public function test_footer_renders_core_links_and_optional_marketing_link(): void
     {
         config()->set('app.marketing_url', 'https://marketing.example.test');
-        config()->set('app.marketing_legal_url', null);
+        config()->set('app.marketing_legal_url');
 
         $this->configureImprint();
 


### PR DESCRIPTION
## What changed

- Add the optional `MARKETING_LEGAL_URL` environment variable and Docker Compose wiring.
- Resolve imprint, terms of use, and privacy policy links to the marketing site's canonical `/imprint`, `/terms-of-use`, and `/gdpr` paths when configured.
- Preserve Core route fallbacks for local and self-hosted deployments.
- Open configured external marketing and legal links in a new tab with `rel="noopener"`.
- Add regression coverage for footer and registration consent links.

## Why

The marketing landing page and its legal content are deployed separately. The application needs configurable canonical links without requiring the marketing deployment for local operation.

## Validation

- Docker Compose configuration check
- 34 focused Pest tests passed
- PHPStan analysis passed
- Laravel Pint passed

Closes #574