### PR TITLE
fix(ui): standardize dashboard and monitoring tables

### DIFF
--- a/app/Http/Controllers/IncidentAnalyticsController.php
+++ b/app/Http/Controllers/IncidentAnalyticsController.php
@@ -17,6 +17,8 @@ use App\Models\StatusPage;
 use App\Models\StatusPageComponent;
 use App\Services\MonitoringOverviewService;
 use App\Services\MonitoringStatusService;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
@@ -49,6 +51,7 @@ class IncidentAnalyticsController extends Controller
         }
 
         $incidents = $this->incidents($filters, $days);
+        $incidentPaginator = $this->incidentPaginator($filters, $days, $incidentAnalyticsRequest);
         $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
         $durations = $resolvedIncidents->map(
             static fn (Incident $incident): int => (int) $incident->down_at->diffInMinutes($incident->up_at)
@@ -81,6 +84,7 @@ class IncidentAnalyticsController extends Controller
                 'affected_service' => $filters['affected_service'] ?? null,
             ],
             'incidents' => $incidents,
+            'incidentPaginator' => $incidentPaginator,
             'totalCount' => $incidents->count(),
             'resolvedCount' => $resolvedIncidents->count(),
             'openCount' => $incidents->reject(static fn (Incident $incident): bool => $incident->up_at !== null)->count(),
@@ -130,7 +134,7 @@ class IncidentAnalyticsController extends Controller
             'status-pages' => view('incidents.analytics-sections.status-pages', [
                 'statusPages' => $this->statusPages($incidentAnalyticsRequest, $monitoringStatusService),
             ]),
-            'incidents' => view('incidents.analytics-sections.incidents', $this->incidentSectionData($filters, $days)),
+            'incidents' => view('incidents.analytics-sections.incidents', $this->incidentSectionData($filters, $days, $incidentAnalyticsRequest)),
             default => abort(404),
         };
     }
@@ -176,9 +180,9 @@ class IncidentAnalyticsController extends Controller
     }
 
     /**
-     * @return array{filters:array{days:int,incident_type:string|null,severity:string|null,customer_impact:string|null,affected_service:string|null},incidents:EloquentCollection<int, Incident>,totalCount:int,resolvedCount:int,openCount:int,mttrMinutes:int|null,byType:Collection<string,int>,bySeverity:Collection<string,int>,byImpact:Collection<string,int>,byService:Collection<string,int>,repeatServices:Collection<string,int>,incidentTypes:list<IncidentType>,severities:list<IncidentSeverity>,customerImpacts:list<IncidentCustomerImpact>,incidentTrend:array{points:list<array{label:string,count:int,x:float,y:float}>,max:int}}
+     * @return array{filters:array{days:int,incident_type:string|null,severity:string|null,customer_impact:string|null,affected_service:string|null},incidents:EloquentCollection<int, Incident>,incidentPaginator:LengthAwarePaginator,totalCount:int,resolvedCount:int,openCount:int,mttrMinutes:int|null,byType:Collection<string,int>,bySeverity:Collection<string,int>,byImpact:Collection<string,int>,byService:Collection<string,int>,repeatServices:Collection<string,int>,incidentTypes:list<IncidentType>,severities:list<IncidentSeverity>,customerImpacts:list<IncidentCustomerImpact>,incidentTrend:array{points:list<array{label:string,count:int,x:float,y:float}>,max:int}}
      */
-    private function incidentSectionData(array $filters, int $days): array
+    private function incidentSectionData(array $filters, int $days, IncidentAnalyticsRequest $request): array
     {
         $incidents = $this->incidents($filters, $days);
         $resolvedIncidents = $incidents->filter(static fn (Incident $incident): bool => $incident->up_at !== null);
@@ -194,6 +198,7 @@ class IncidentAnalyticsController extends Controller
                 'affected_service' => $filters['affected_service'] ?? null,
             ],
             'incidents' => $incidents,
+            'incidentPaginator' => $this->incidentPaginator($filters, $days, $request),
             'totalCount' => $incidents->count(),
             'resolvedCount' => $resolvedIncidents->count(),
             'openCount' => $incidents->reject(static fn (Incident $incident): bool => $incident->up_at !== null)->count(),
@@ -216,6 +221,18 @@ class IncidentAnalyticsController extends Controller
      */
     private function incidents(array $filters, int $days): EloquentCollection
     {
+        return $this->incidentQuery($filters, $days)->get();
+    }
+
+    private function incidentPaginator(array $filters, int $days, IncidentAnalyticsRequest $request): LengthAwarePaginator
+    {
+        return $this->incidentQuery($filters, $days)
+            ->paginate(10)
+            ->appends($request->except(['async', 'section', 'page']));
+    }
+
+    private function incidentQuery(array $filters, int $days): Builder
+    {
         $builder = Incident::query()
             ->whereHas('monitoring')
             ->with('monitoring')
@@ -232,7 +249,7 @@ class IncidentAnalyticsController extends Controller
             $builder->where('affected_service', 'like', '%' . $filters['affected_service'] . '%');
         }
 
-        return $builder->get();
+        return $builder;
     }
 
     /**

--- a/resources/js/components/service-map-loader.ts
+++ b/resources/js/components/service-map-loader.ts
@@ -1,6 +1,7 @@
 interface ServiceMapLoaderComponent {
     loading: boolean;
     loadPage(this: ServiceMapLoaderComponent, url: string): Promise<void>;
+    handlePaginationClick(this: ServiceMapLoaderComponent, event: Event): void;
     init(this: ServiceMapLoaderComponent): void;
 }
 
@@ -49,8 +50,19 @@ export default (): ServiceMapLoaderComponent => ({
         this.loading = false;
     },
 
+    handlePaginationClick(this: ServiceMapLoaderComponent, event: Event): void {
+        const target = event.target as Element | null;
+        const link = target?.closest<HTMLAnchorElement>('[data-pagination-async]');
+
+        if (!link) return;
+
+        event.preventDefault();
+        void this.loadPage(link.href);
+    },
+
     init(this: ServiceMapLoaderComponent): void {
         const root = (this as any).$el as HTMLElement;
+        root.addEventListener('click', (event) => this.handlePaginationClick(event));
         window.dispatchEvent(new CustomEvent('signal-room:services-updated', {
             detail: { services: readServices(root) },
         }));

--- a/resources/views/components/dashboard/service-map-fragment.blade.php
+++ b/resources/views/components/dashboard/service-map-fragment.blade.php
@@ -38,18 +38,7 @@
             </div>
         @endforeach
     </div>
-    @if ($pagination && $pagination['last_page'] > 1)
-        <div id="dashboard-service-pagination" class="flex flex-col gap-3 border-t border-gray-100 px-5 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-            <p>{{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }} {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}</p>
-            <nav class="flex items-center gap-1.5" aria-label="{{ __('search.table.pagination') }}">
-            @if ($pagination['current_page'] > 1)
-                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">&laquo; {{ __('pagination.previous') }}</a>
-            @endif
-            <span class="inline-flex items-center rounded-lg bg-purple-700 px-3 py-2 font-bold text-white dark:bg-purple-600">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
-            @if ($pagination['current_page'] < $pagination['last_page'])
-                <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">{{ __('pagination.next') }} &raquo;</a>
-            @endif
-            </nav>
-        </div>
+    @if ($pagination)
+        <x-pagination id="dashboard-service-pagination" :paginator="$pagination" page-param="service_page" :async="true" class="border-t border-gray-100 px-5 py-4 dark:border-gray-700 sm:px-6" />
     @endif
 </section>

--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -138,22 +138,8 @@
                     </div>
                 @endforeach
             </div>
-        @if ($pagination && $pagination['last_page'] > 1)
-            <div id="dashboard-service-pagination" class="flex flex-col gap-3 border-t border-gray-100 px-5 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-                <p>
-                    {{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }}
-                    {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}
-                </p>
-                <nav class="flex items-center gap-1.5" aria-label="{{ __('search.table.pagination') }}">
-                    @if ($pagination['current_page'] > 1)
-                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] - 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">&laquo; {{ __('pagination.previous') }}</a>
-                    @endif
-                    <span class="inline-flex items-center rounded-lg bg-purple-700 px-3 py-2 font-bold text-white dark:bg-purple-600">{{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}</span>
-                    @if ($pagination['current_page'] < $pagination['last_page'])
-                        <a href="{{ request()->fullUrlWithQuery(['service_page' => $pagination['current_page'] + 1]) }}" @click.prevent="loadPage($el.href)" class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">{{ __('pagination.next') }} &raquo;</a>
-                    @endif
-                </nav>
-            </div>
+        @if ($pagination)
+            <x-pagination id="dashboard-service-pagination" :paginator="$pagination" page-param="service_page" :async="true" class="border-t border-gray-100 px-5 py-4 dark:border-gray-700 sm:px-6" />
         @endif
         </section>
         </div>

--- a/resources/views/components/pagination.blade.php
+++ b/resources/views/components/pagination.blade.php
@@ -1,0 +1,53 @@
+@props([
+    'paginator',
+    'pageParam' => 'page',
+    'async' => false,
+])
+
+@php
+    $pagination = is_array($paginator)
+        ? $paginator
+        : [
+            'current_page' => $paginator->currentPage(),
+            'last_page' => $paginator->lastPage(),
+            'from' => $paginator->firstItem(),
+            'to' => $paginator->lastItem(),
+            'total' => $paginator->total(),
+            'previous_url' => $paginator->previousPageUrl(),
+            'next_url' => $paginator->nextPageUrl(),
+        ];
+
+    $previousUrl = $pagination['previous_url'] ?? request()->fullUrlWithQuery([$pageParam => $pagination['current_page'] - 1]);
+    $nextUrl = $pagination['next_url'] ?? request()->fullUrlWithQuery([$pageParam => $pagination['current_page'] + 1]);
+@endphp
+
+@if ($pagination['last_page'] > 1)
+    <div data-table-pagination {{ $attributes->merge(['class' => 'flex flex-col gap-3 text-sm text-gray-500 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between']) }}>
+        <p>
+            {{ __('search.table.showing') }} {{ $pagination['from'] ?? 0 }} {{ __('search.table.to') }} {{ $pagination['to'] ?? 0 }}
+            {{ __('search.table.of') }} {{ $pagination['total'] }} {{ __('search.table.entries') }}
+        </p>
+
+        <nav class="flex items-center gap-1.5" aria-label="{{ __('search.table.pagination') }}">
+            @if ($pagination['current_page'] > 1)
+                <a href="{{ $previousUrl }}"
+                    @if ($async) data-pagination-async @endif
+                    class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">
+                    {{ __('pagination.previous') }}
+                </a>
+            @endif
+
+            <span class="inline-flex items-center rounded-lg bg-purple-700 px-3 py-2 font-bold text-white dark:bg-purple-600">
+                {{ $pagination['current_page'] }} / {{ $pagination['last_page'] }}
+            </span>
+
+            @if ($pagination['current_page'] < $pagination['last_page'])
+                <a href="{{ $nextUrl }}"
+                    @if ($async) data-pagination-async @endif
+                    class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">
+                    {{ __('pagination.next') }}
+                </a>
+            @endif
+        </nav>
+    </div>
+@endif

--- a/resources/views/incidents/analytics-sections/incidents.blade.php
+++ b/resources/views/incidents/analytics-sections/incidents.blade.php
@@ -21,14 +21,15 @@
 
         <x-container>
             <x-heading type="h2">{{ __('incidents.analytics.sections.recent') }}</x-heading>
-            @if ($incidents->isEmpty())
+            @if ($incidentPaginator->isEmpty())
                 <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.empty') }}</p>
             @else
                 <div class="mt-4 overflow-x-auto rounded-2xl border border-gray-200 dark:border-gray-700"><table data-incident-overview-table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700"><tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                    @foreach ($incidents as $incident)
+                    @foreach ($incidentPaginator as $incident)
                         <tr data-incident-row><td class="px-4 py-3">{{ $incident->up_at ? __('incidents.analytics.table.resolved_state') : __('incidents.analytics.table.open_state') }}</td><td class="px-4 py-3"><a href="{{ route('monitorings.show', $incident->monitoring) }}" class="font-bold text-gray-900 dark:text-gray-100">{{ $incident->monitoring->name }}</a></td><td class="px-4 py-3">{{ $incident->problem_description ?: ($incident->affected_service ?: __('incidents.analytics.unclassified')) }}</td><td class="whitespace-nowrap px-4 py-3">{{ $incident->down_at->toDayDateTimeString() }}</td></tr>
                     @endforeach
                 </tbody></table></div>
+                <x-pagination :paginator="$incidentPaginator" class="mt-4" />
             @endif
         </x-container>
     </section>

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -375,7 +375,7 @@
 
                 <x-container>
                     <x-heading type="h2">{{ __('incidents.analytics.sections.recent') }}</x-heading>
-                    @if ($incidents->isEmpty())
+                    @if ($incidentPaginator->isEmpty())
                         <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{{ __('incidents.analytics.empty') }}</p>
                     @else
                         <div class="mt-4 overflow-x-auto rounded-2xl border border-gray-200 dark:border-gray-700">
@@ -391,7 +391,7 @@
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                                    @foreach ($incidents as $incident)
+                                    @foreach ($incidentPaginator as $incident)
                                         @php($incidentDuration = $incident->up_at ? $incident->down_at->diffForHumans($incident->up_at, true) : __('incidents.analytics.table.ongoing'))
                                         <tr data-incident-row class="group transition hover:bg-purple-50/50 dark:hover:bg-purple-950/20">
                                             <td class="whitespace-nowrap px-4 py-3">
@@ -416,6 +416,7 @@
                                 </tbody>
                             </table>
                         </div>
+                        <x-pagination :paginator="$incidentPaginator" class="mt-4" />
                     @endif
                 </x-container>
 

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -385,10 +385,12 @@
                                 <div class="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_11rem_7rem_auto] lg:items-center">
                                     <div class="min-w-0">
                                         <div class="flex items-center gap-2">
-                                            <span class="h-2.5 w-2.5 shrink-0 rounded-full bg-gray-300" :class="{
+                                            <span class="h-2.5 w-2.5 shrink-0 rounded-full" :class="{
                                                 'bg-emerald-500': statusMap[id] === '{{ MonitoringStatus::UP->value }}',
                                                 'bg-red-500': statusMap[id] === '{{ MonitoringStatus::DOWN->value }}',
-                                                'bg-amber-500': statusMap[id] === '{{ MonitoringStatus::UNKNOWN->value }}' || !statusMap[id]
+                                                'bg-amber-500': statusMap[id] === '{{ MonitoringStatus::UNKNOWN->value }}' || !statusMap[id],
+                                                'bg-purple-500': maintenanceStatusMap[id],
+                                                'bg-gray-400': monitoringStatusMap[id] === 'paused'
                                             }" aria-hidden="true"></span>
                                             <a href="#" x-bind:href="'/monitorings/' + id" class="truncate font-semibold text-gray-900 hover:text-purple-700 focus:outline-hidden focus:ring-2 focus:ring-purple-500 dark:text-gray-100 dark:hover:text-purple-300" x-text="monitoringNames[id] ?? '{{ __('monitoring.general.monitoring_id') }}'.replace(':id', id)"></a>
                                         </div>
@@ -445,9 +447,7 @@
                         </template>
                     </section>
 
-                    <div class="flex justify-center">
-                        {{ $monitorings->withQueryString()->links() }}
-                    </div>
+                    <x-pagination :paginator="$monitorings->withQueryString()" class="mt-1" />
                 </div>
 
                 <aside class="space-y-4 lg:sticky lg:top-6 lg:self-start" aria-label="{{ __('monitoring.index.table.summary') }}">

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -36,7 +36,8 @@ class DashboardOverviewTest extends TestCase
             ->assertSeeText('11 ' . __('dashboard.signal_room.active_services'))
             ->assertSeeText('Service 01')
             ->assertDontSeeText('Service 11')
-            ->assertSeeText('1 / 2');
+            ->assertSeeText('1 / 2')
+            ->assertSeeHtml('data-pagination-async');
         $secondPage->assertOk()
             ->assertSeeText('Service 11')
             ->assertSeeText('2 / 2')

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -278,6 +278,34 @@ class IncidentWorkflowTest extends TestCase
             ->assertDontSeeText('Search API');
     }
 
+    public function test_incident_analytics_paginates_recent_incidents_by_ten(): void
+    {
+        Date::setTestNow('2026-07-15 12:00:00');
+
+        $package = Package::factory()->create(['monitoring_limit' => 20]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create();
+
+        foreach (range(1, 11) as $index) {
+            Incident::query()->create([
+                'monitoring_id' => $monitoring->id,
+                'down_at' => Date::now()->subMinutes($index),
+            ]);
+        }
+
+        $response = $this->actingAs($user)->get(route('incidents.analytics', [
+            'async' => 1,
+            'section' => 'incidents',
+        ]));
+
+        $response->assertOk()
+            ->assertSeeHtml('data-incident-overview-table')
+            ->assertSeeText('1 / 2')
+            ->assertSeeText('11');
+
+        expect(mb_substr_count($response->getContent(), 'data-incident-row'))->toBe(10);
+    }
+
     public function test_incident_analytics_presents_monitoring_groups_and_status_pages_together(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -72,6 +72,20 @@ class MonitoringIndexEmptyStateTest extends TestCase
         $testResponse->assertSeeHtml('href="' . route('status-pages.index') . '"');
     }
 
+    public function test_monitoring_index_uses_the_shared_table_pagination(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->count(6)->for($user)->create();
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
+
+        $testResponse->assertOk()
+            ->assertSeeHtml('data-table-pagination')
+            ->assertSeeText('1 / 2')
+            ->assertSeeText(__('pagination.next'));
+    }
+
     public function test_default_monitoring_index_reuses_paginator_total_without_extra_monitoring_count_query(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 10]);


### PR DESCRIPTION
## What changed

- restore working dashboard service pagination with a shared pagination component and AJAX navigation
- paginate incident analysis at 10 entries per page while preserving aggregate metrics across all matching incidents
- color active monitoring status indicators according to their state
- reuse the shared pagination component for dashboard services, active monitorings, and incident analysis

## Why

Resolves the display and interaction issues reported in #579 and aligns pagination across the affected views.

## Testing

- Full Pest suite: 651 passed, 4,225 assertions
- PHPStan: no errors
- Frontend build: passed
- Browser QA: dashboard pagination navigation, monitoring status colors, incident pagination, and no browser console errors
- Docker validation was attempted but the local Docker daemon was unavailable; host fallback validation was used
- TypeScript no-emit remains blocked by existing TS 6 deprecation diagnostics in the repository tsconfig; the production frontend build passed

Closes #579