### PR TITLE
perf(ui): load dashboard components asynchronously

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -25,6 +25,10 @@ class DashboardController extends Controller
             return view('components.dashboard.service-map-fragment', $serviceMap);
         }
 
+        if (! $request->boolean('async')) {
+            return view('dashboard-shell');
+        }
+
         return view('dashboard', $monitoringOverviewService->overview(
             $user,
             max(1, $request->integer('service_page', 1)),

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -20,6 +20,7 @@ import confirmDialog, { registerConfirmableForms } from './components/confirm-di
 import formModalLoader from './components/form-modal-loader';
 import signalRoom from './components/signal-room';
 import serviceMapLoader from './components/service-map-loader';
+import dashboardLoader from './components/dashboard-loader';
 import incidentAnalyticsLoader from './components/incident-analytics-loader';
 
 Alpine.data('monitoringDetail', monitoringDetail);
@@ -32,6 +33,7 @@ Alpine.data('confirmDialog', confirmDialog);
 Alpine.data('formModalLoader', formModalLoader);
 Alpine.data('signalRoom', signalRoom);
 Alpine.data('serviceMapLoader', serviceMapLoader);
+Alpine.data('dashboardLoader', dashboardLoader);
 Alpine.data('incidentAnalyticsLoader', incidentAnalyticsLoader);
 
 window.Alpine = Alpine;

--- a/resources/js/components/dashboard-loader.ts
+++ b/resources/js/components/dashboard-loader.ts
@@ -1,0 +1,35 @@
+interface DashboardLoaderComponent {
+    init(this: DashboardLoaderComponent): Promise<void>;
+    showError(this: DashboardLoaderComponent, root: HTMLElement): void;
+}
+
+export default (): DashboardLoaderComponent => ({
+    async init(this: DashboardLoaderComponent): Promise<void> {
+        const root = (this as any).$el as HTMLElement;
+        const endpoint = new URL(root.dataset.endpoint ?? window.location.href, window.location.origin);
+        endpoint.searchParams.set('async', '1');
+
+        const response = await fetch(endpoint.toString()).catch(() => null);
+        if (!response?.ok) {
+            this.showError(root);
+            return;
+        }
+
+        const documentText = await response.text();
+        const parsedDocument = new DOMParser().parseFromString(documentText, 'text/html');
+        const content = parsedDocument.querySelector<HTMLElement>('[data-dashboard-content]');
+
+        if (!content) {
+            this.showError(root);
+            return;
+        }
+
+        root.replaceWith(content);
+        window.Alpine?.initTree(content);
+    },
+
+    showError(this: DashboardLoaderComponent, root: HTMLElement): void {
+        root.querySelector<HTMLElement>('[data-dashboard-loading]')?.setAttribute('hidden', 'hidden');
+        root.querySelector<HTMLElement>('[data-dashboard-error]')?.removeAttribute('hidden');
+    },
+});

--- a/resources/views/dashboard-shell.blade.php
+++ b/resources/views/dashboard-shell.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <x-heading type="h1">{{ __('dashboard.greeting', ['name' => Auth::user()->name]) }}</x-heading>
+                <p class="mt-2 max-w-2xl text-sm text-gray-500 dark:text-gray-400">{{ __('dashboard.description') }}</p>
+            </div>
+        </div>
+    </x-slot>
+
+    <x-main>
+        <div
+            id="dashboard-page-content"
+            data-dashboard-loader
+            data-endpoint="{{ route('dashboard', request()->query()) }}"
+            x-data="dashboardLoader()"
+            class="space-y-6"
+            aria-live="polite"
+        >
+            <x-container>
+                <div data-dashboard-loading class="flex items-center gap-3">
+                    <span class="h-3 w-3 animate-pulse rounded-full bg-purple-600" aria-hidden="true"></span>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                </div>
+                <p data-dashboard-error class="text-sm font-semibold text-red-600 dark:text-red-300" hidden>
+                    {{ __('search.messages.error') }}
+                </p>
+            </x-container>
+        </div>
+
+        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
+            <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
+                description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">
+                <div class="p-6" x-ref="content">
+                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
+                    <div x-html="content"></div>
+                </div>
+            </x-form-modal>
+        </div>
+    </x-main>
+</x-app-layout>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -53,9 +53,10 @@
     </x-slot>
 
     <x-main>
-        @if ($summary['total'] === 0)
-            <x-dashboard.empty-state :can-create-monitoring="$canCreateMonitoring" modal />
-        @else
+        <div id="dashboard-content" data-dashboard-content>
+            @if ($summary['total'] === 0)
+                <x-dashboard.empty-state :can-create-monitoring="$canCreateMonitoring" modal />
+            @else
             <x-dashboard.signal-room
                 :services="$signalRoomServices"
                 :pagination="$signalRoomPagination"
@@ -223,7 +224,8 @@
                     </x-dashboard.panel>
                 </div>
             </div>
-        @endif
+            @endif
+        </div>
         <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}">
             <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
                 description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">

--- a/tests/Browser/DashboardServiceOperationsModalTest.php
+++ b/tests/Browser/DashboardServiceOperationsModalTest.php
@@ -34,7 +34,8 @@ it('opens the dashboard monitoring create actions in a responsive modal', functi
         $trigger = 'a[data-form-modal-name="monitoring-form-modal"][href$="/monitorings/create"]';
         $modal = '[data-form-modal="monitoring-form-modal"]';
 
-        $webpage->assertCount($trigger, 1)
+        $webpage->waitFor($trigger)
+            ->assertCount($trigger, 1)
             ->click($trigger)
             ->wait(1)
             ->waitForText(__('monitoring.form.sections.basic'))

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -36,6 +36,7 @@ it('supports desktop service selection and keeps the Signal Room inside the view
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
+        ->waitFor('[data-signal-room]')
         ->resize(1280, 800);
 
     $webpage->assertVisible('[data-signal-room]')
@@ -158,6 +159,7 @@ it('supports mobile filtering, service details and Escape to close the detail sh
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
+        ->waitFor('[data-signal-room]')
         ->resize(390, 640);
 
     $webpage->click('[data-signal-filter="attention"]')

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -21,6 +21,20 @@ use Tests\TestCase;
 
 class DashboardOverviewTest extends TestCase
 {
+    public function test_dashboard_renders_a_shell_before_loading_expensive_components(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->for($user)->create();
+
+        $this->actingAs($user)->get(route('dashboard'))
+            ->assertOk()
+            ->assertSeeHtml('data-dashboard-loader')
+            ->assertSeeHtml('x-data="dashboardLoader()"')
+            ->assertSeeText(__('app.loading'))
+            ->assertDontSeeHtml('data-signal-room');
+    }
+
     public function test_dashboard_service_landscape_is_paginated_without_changing_the_global_summary(): void
     {
         $package = Package::factory()->create(['monitoring_limit' => 20]);
@@ -29,8 +43,8 @@ class DashboardOverviewTest extends TestCase
             fn ($sequence) => ['name' => sprintf('Service %02d', $sequence->index + 1)],
         )->create();
 
-        $testResponse = $this->actingAs($user)->get(route('dashboard'));
-        $secondPage = $this->actingAs($user)->get(route('dashboard', ['service_page' => 2]));
+        $testResponse = $this->actingAs($user)->get(route('dashboard', ['async' => 1]));
+        $secondPage = $this->actingAs($user)->get(route('dashboard', ['async' => 1, 'service_page' => 2]));
 
         $testResponse->assertOk()
             ->assertSeeText('11 ' . __('dashboard.signal_room.active_services'))
@@ -53,6 +67,7 @@ class DashboardOverviewTest extends TestCase
         )->create();
 
         $this->actingAs($user)->get(route('dashboard', [
+            'async' => 1,
             'service_fragment' => 1,
             'service_page' => 2,
         ]))
@@ -68,7 +83,7 @@ class DashboardOverviewTest extends TestCase
         $package = Package::factory()->create(['monitoring_limit' => 10]);
         $user = User::factory()->create(['package_id' => $package->id]);
 
-        $this->actingAs($user)->get(route('dashboard'))
+        $this->actingAs($user)->get(route('dashboard', ['async' => 1]))
             ->assertOk()
             ->assertSeeText(__('dashboard.empty.title'))
             ->assertSeeText(__('dashboard.empty.description'))
@@ -103,7 +118,7 @@ class DashboardOverviewTest extends TestCase
         Monitoring::factory()->for($user)->create(['name' => 'Unknown API']);
         Monitoring::factory()->for($otherUser)->create(['name' => 'Private API']);
 
-        $testResponse = $this->actingAs($user)->get(route('dashboard'));
+        $testResponse = $this->actingAs($user)->get(route('dashboard', ['async' => 1]));
 
         $testResponse->assertOk()
             ->assertSeeText(__('dashboard.greeting', ['name' => $user->name]))
@@ -143,7 +158,7 @@ class DashboardOverviewTest extends TestCase
             'status' => MonitoringStatus::UP,
         ]);
 
-        $this->actingAs($user)->get(route('dashboard'))
+        $this->actingAs($user)->get(route('dashboard', ['async' => 1]))
             ->assertOk()
             ->assertSeeText(__('dashboard.state.healthy.title'))
             ->assertSeeText(__('dashboard.attention.empty'))
@@ -176,7 +191,7 @@ class DashboardOverviewTest extends TestCase
             'incident_id' => $incident->id,
         ]) . '#incident-workbench-' . $incident->id;
 
-        $this->actingAs($user)->get(route('dashboard'))
+        $this->actingAs($user)->get(route('dashboard', ['async' => 1]))
             ->assertOk()
             ->assertSeeHtml('href="' . $incidentWorkspaceUrl . '"')
             ->assertSeeText(__('dashboard.attention.open_incident'))
@@ -216,7 +231,7 @@ class DashboardOverviewTest extends TestCase
             'error_message' => 'Webhook unavailable',
         ]);
 
-        $this->actingAs($user)->get(route('dashboard'))
+        $this->actingAs($user)->get(route('dashboard', ['async' => 1]))
             ->assertOk()
             ->assertSeeText(__('dashboard.maintenance.heading'))
             ->assertSeeText(__('dashboard.maintenance.upcoming'))


### PR DESCRIPTION
## What changed

- render a lightweight dashboard shell immediately
- load the full dashboard content asynchronously with loading and error states
- preserve dashboard query parameters and initialize interactive Alpine components after the fragment replacement
- update feature and browser coverage for deferred dashboard rendering

## Why

The initial `/dashboard` request previously executed the complete monitoring overview before returning. Deferring that work lets the dashboard shell render immediately while retaining the existing dashboard content and pagination behavior.

Closes #581

## Testing

- Docker Pest: `tests/Feature/DashboardOverviewTest.php` — 8 passed, 67 assertions
- Docker PHPStan: `composer analyse` — no errors
- `bun run build` — passed using the host fallback because the Docker Node entrypoint could not remove the bind-mounted `node_modules`
- Browser QA: dashboard content replaced the async loader, Signal Room rendered, service pagination remained functional, and no console warnings/errors were reported

No new dependencies were added.