### PR TITLE
fix: keep dashboard pagination same-origin over HTTPS

### DIFF
--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -129,7 +129,7 @@ class MonitoringOverviewService
             $signalRoomServices->count(),
             10,
             max(1, $servicePage),
-            ['pageName' => 'service_page', 'path' => route('dashboard')],
+            ['pageName' => 'service_page', 'path' => route('dashboard', absolute: false)],
         );
 
         return [

--- a/resources/views/components/dashboard/signal-room.blade.php
+++ b/resources/views/components/dashboard/signal-room.blade.php
@@ -81,7 +81,7 @@
             x-data="serviceMapLoader()"
             data-service-map-loader
             data-services='@json($services)'
-            data-endpoint="{{ route('dashboard') }}"
+            data-endpoint="{{ route('dashboard', absolute: false) }}"
             class="min-w-0"
         >
         <section id="dashboard-service-list" data-services='@json($services)' class="min-w-0 rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800" aria-labelledby="signal-room-services-heading">

--- a/resources/views/components/pagination.blade.php
+++ b/resources/views/components/pagination.blade.php
@@ -19,6 +19,27 @@
 
     $previousUrl = $pagination['previous_url'] ?? request()->fullUrlWithQuery([$pageParam => $pagination['current_page'] - 1]);
     $nextUrl = $pagination['next_url'] ?? request()->fullUrlWithQuery([$pageParam => $pagination['current_page'] + 1]);
+
+    $toRelativeUrl = static function (?string $url): ?string {
+        if ($url === null) {
+            return null;
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false || ! isset($parts['host'])) {
+            return $url;
+        }
+
+        return ($parts['path'] ?? '/')
+            . (isset($parts['query']) ? '?' . $parts['query'] : '')
+            . (isset($parts['fragment']) ? '#' . $parts['fragment'] : '');
+    };
+
+    if ($async) {
+        $previousUrl = $toRelativeUrl($previousUrl);
+        $nextUrl = $toRelativeUrl($nextUrl);
+    }
 @endphp
 
 @if ($pagination['last_page'] > 1)

--- a/resources/views/dashboard-shell.blade.php
+++ b/resources/views/dashboard-shell.blade.php
@@ -12,7 +12,7 @@
         <div
             id="dashboard-page-content"
             data-dashboard-loader
-            data-endpoint="{{ route('dashboard', request()->query()) }}"
+            data-endpoint="{{ route('dashboard', request()->query(), absolute: false) }}"
             x-data="dashboardLoader()"
             class="space-y-6"
             aria-live="polite"

--- a/tests/Browser/DashboardServiceOperationsModalTest.php
+++ b/tests/Browser/DashboardServiceOperationsModalTest.php
@@ -34,7 +34,7 @@ it('opens the dashboard monitoring create actions in a responsive modal', functi
         $trigger = 'a[data-form-modal-name="monitoring-form-modal"][href$="/monitorings/create"]';
         $modal = '[data-form-modal="monitoring-form-modal"]';
 
-        $webpage->waitFor($trigger)
+        $webpage->waitForText(__('dashboard.empty.title'))
             ->assertCount($trigger, 1)
             ->click($trigger)
             ->wait(1)

--- a/tests/Browser/SignalRoomWorkflowTest.php
+++ b/tests/Browser/SignalRoomWorkflowTest.php
@@ -36,7 +36,7 @@ it('supports desktop service selection and keeps the Signal Room inside the view
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
-        ->waitFor('[data-signal-room]')
+        ->waitForText(__('dashboard.signal_room.heading'))
         ->resize(1280, 800);
 
     $webpage->assertVisible('[data-signal-room]')
@@ -135,6 +135,50 @@ JS, true)
         ->assertNoJavaScriptErrors();
 });
 
+it('loads the next dashboard service page when its pagination button is clicked', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create(['monitoring_limit' => 20]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+    Monitoring::factory()->count(11)->for($user)->sequence(
+        fn ($sequence) => ['name' => sprintf('Service %02d', $sequence->index + 1)],
+    )->create();
+
+    $webpage = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/dashboard')
+        ->waitForText(__('dashboard.signal_room.heading'))
+        ->assertScript(<<<'JS'
+function () {
+    const link = document.querySelector('#dashboard-service-pagination a[data-pagination-async]');
+    const href = link?.getAttribute('href') ?? '';
+
+    return href.startsWith('/dashboard?') && !href.startsWith('http://');
+}
+JS, true)
+        ->click('#dashboard-service-pagination a[data-pagination-async]')
+        ->waitForText('Service 11')
+        ->assertScript(<<<'JS'
+function () {
+    const serviceList = document.querySelector('#dashboard-service-list');
+
+    return serviceList !== null
+        && serviceList.textContent.includes('Service 11')
+        && !serviceList.textContent.includes('Service 01');
+}
+JS, true)
+        ->assertNoJavaScriptErrors();
+});
+
 it('supports mobile filtering, service details and Escape to close the detail sheet', function (): void {
     if (! file_exists(public_path('build/manifest.json'))) {
         $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
@@ -159,7 +203,7 @@ it('supports mobile filtering, service details and Escape to close the detail sh
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]')
         ->navigate('/dashboard')
-        ->waitFor('[data-signal-room]')
+        ->waitForText(__('dashboard.signal_room.heading'))
         ->resize(390, 640);
 
     $webpage->click('[data-signal-filter="attention"]')

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -31,6 +31,7 @@ class DashboardOverviewTest extends TestCase
             ->assertOk()
             ->assertSeeHtml('data-dashboard-loader')
             ->assertSeeHtml('x-data="dashboardLoader()"')
+            ->assertSeeHtml('data-endpoint="/dashboard"')
             ->assertSeeText(__('app.loading'))
             ->assertDontSeeHtml('data-signal-room');
     }
@@ -51,7 +52,8 @@ class DashboardOverviewTest extends TestCase
             ->assertSeeText('Service 01')
             ->assertDontSeeText('Service 11')
             ->assertSeeText('1 / 2')
-            ->assertSeeHtml('data-pagination-async');
+            ->assertSeeHtml('data-pagination-async')
+            ->assertSeeHtml('href="/dashboard?');
         $secondPage->assertOk()
             ->assertSeeText('Service 11')
             ->assertSeeText('2 / 2')
@@ -73,6 +75,7 @@ class DashboardOverviewTest extends TestCase
         ]))
             ->assertOk()
             ->assertSeeHtml('id="dashboard-service-list"')
+            ->assertSeeHtml('href="/dashboard?')
             ->assertSeeText('Service 11')
             ->assertDontSeeText('Service 01')
             ->assertDontSeeText(__('dashboard.greeting', ['name' => $user->name]));


### PR DESCRIPTION
## What changed

- emit relative same-origin URLs for dashboard loading and asynchronous pagination
- normalize absolute paginator URLs before rendering async pagination links
- add feature and browser regression coverage for clicking the dashboard service pagination
- replace unsupported browser wait calls with supported text-based waits

## Why

The HTTPS dashboard generated HTTP pagination URLs from `APP_URL`. The browser blocked the asynchronous service fragment as mixed content, so the table pagination button appeared not to work.

Closes #583

## Testing

- Docker Pest `tests/Feature/DashboardOverviewTest.php` — 8 passed, 70 assertions
- Docker PHPStan `composer analyse` — no errors
- Pest Browser `tests/Browser/SignalRoomWorkflowTest.php` — 4 passed, 29 assertions
- focused dashboard modal browser test — 1 passed, 15 assertions
- browser QA — pagination href is relative, the click loads page 2, and no console warnings/errors occur
- `bun run build` — passed