### PR TITLE
perf: reduce /monitorings query overhead

### DIFF
--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -86,7 +86,17 @@ class MonitoringController extends Controller
             'maintenance' => ['nullable', 'string', Rule::in(['active'])],
         ]);
 
-        $query = Monitoring::query();
+        $query = Monitoring::query()
+            ->select([
+                'id',
+                'name',
+                'target',
+                'type',
+                'status',
+                'public_label_enabled',
+                'maintenance_from',
+                'maintenance_until',
+            ]);
 
         if ($request->filled('search')) {
             $search = $request->input('search');
@@ -160,8 +170,8 @@ class MonitoringController extends Controller
             default => $query->orderBy('name'),
         };
 
-        $summaryMonitoringIds = (clone $query)->pluck('id')->values();
-        $lengthAwarePaginator = $query->paginate(5);
+        $summaryMonitoringIds = (clone $query)->select('id')->reorder()->pluck('id')->values();
+        $lengthAwarePaginator = $query->withMaintenanceWindowState()->paginate(5);
         $hasActiveFilters = $request->filled('search')
             || $request->filled('types')
             || $request->filled('lifecycle')

--- a/database/migrations/2026_07_26_120000_add_monitoring_index_query_indexes.php
+++ b/database/migrations/2026_07_26_120000_add_monitoring_index_query_indexes.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->index(
+                ['user_id', 'deleted_at', 'status', 'name'],
+                'monitorings_user_status_name_idx'
+            );
+            $table->index(
+                ['team_id', 'deleted_at', 'status', 'name'],
+                'monitorings_team_status_name_idx'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('monitorings', function (Blueprint $table): void {
+            $table->dropIndex('monitorings_user_status_name_idx');
+            $table->dropIndex('monitorings_team_status_name_idx');
+        });
+    }
+};

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -106,6 +106,35 @@ class MonitoringIndexEmptyStateTest extends TestCase
             ->count();
 
         $this->assertLessThanOrEqual(1, $monitoringCountQueries, $queries->implode(PHP_EOL));
+
+        $summaryIdQueries = $queries
+            ->filter(static fn (string $query): bool => preg_match('/select ["`]?id["`]? from ["`]?monitorings["`]?/i', $query) === 1);
+
+        $this->assertNotEmpty($summaryIdQueries, $queries->implode(PHP_EOL));
+        $this->assertTrue(
+            $summaryIdQueries->every(static fn (string $query): bool => ! str_contains(mb_strtolower($query), 'order by')),
+            $summaryIdQueries->implode(PHP_EOL)
+        );
+    }
+
+    public function test_monitoring_index_loads_maintenance_state_without_one_query_per_monitoring(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        Monitoring::factory()->count(6)->for($user)->create();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
+
+        $testResponse->assertOk();
+
+        $maintenanceQueries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(static fn (string $query): bool => str_contains($query, 'maintenance_windows'));
+
+        $this->assertCount(1, $maintenanceQueries, $maintenanceQueries->implode(PHP_EOL));
     }
 
     public function test_demo_user_cannot_access_monitoring_create_route(): void


### PR DESCRIPTION
## What changed

- select only the columns required by the paginated monitoring workspace
- load maintenance-window state once with the page query instead of issuing one lookup per monitoring
- make the cross-page summary ID query select only `id` and skip the full-result sort
- add composite MySQL indexes for private/team monitoring ownership, soft deletes, status, and name ordering
- add query-shape regression coverage

## Why

The `/monitorings` request performed unnecessary work for large monitoring sets: the summary query retained the full monitoring select and sort, while maintenance status could trigger one additional query per rendered row. The new indexes support the authenticated ownership and default ordering predicates.

Closes #585

## Testing

- Docker Pest: `MonitoringIndexEmptyStateTest`, `MonitoringCardDataApiTest`, and `MonitoringGroupTest` — 36 passed, 180 assertions
- Docker PHPStan `composer analyse` — no errors
- Pint and `git diff --check` — passed
- Docker MySQL migration — passed; both new indexes verified with `SHOW INDEX`
- No browser test added because this change is limited to backend query construction and database indexes.