### PR TITLE
fix(ui): replace generic loading states

### DIFF
--- a/resources/views/admin/packages/index.blade.php
+++ b/resources/views/admin/packages/index.blade.php
@@ -44,7 +44,7 @@
                         'modalForm' => 'admin-package-edit',
                     ])
                 @else
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 @endif

--- a/resources/views/admin/server-instances/index.blade.php
+++ b/resources/views/admin/server-instances/index.blade.php
@@ -84,7 +84,7 @@
                         'modalForm' => 'admin-server-instance-edit',
                     ])
                 @else
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 @endif

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -54,7 +54,7 @@
                         'modalForm' => 'admin-user-edit',
                     ])
                 @else
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 @endif

--- a/resources/views/components/loading-indicator.blade.php
+++ b/resources/views/components/loading-indicator.blade.php
@@ -1,8 +1,16 @@
-<div {{ $attributes->merge(['class' => 'flex items-center gap-2  text-gray-500']) }}>
+@props([
+    'showLabel' => true,
+])
+
+<div {{ $attributes->merge(['class' => 'flex items-center gap-2 text-gray-500']) }} role="status" aria-live="polite">
     <svg class="h-5 w-5 animate-spin text-purple-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z">
         </path>
     </svg>
-    <x-span>{{ $slot->isEmpty() ? __('app.messages.loading') : $slot }}</x-span>
+    @if ($showLabel)
+        <x-span>{{ $slot->isEmpty() ? __('app.messages.loading') : $slot }}</x-span>
+    @else
+        <span class="sr-only">{{ $slot->isEmpty() ? __('app.messages.loading') : $slot }}</span>
+    @endif
 </div>

--- a/resources/views/components/loading-skeleton.blade.php
+++ b/resources/views/components/loading-skeleton.blade.php
@@ -1,0 +1,76 @@
+@props([
+    'variant' => 'section',
+])
+
+<div {{ $attributes->merge(['class' => 'animate-pulse']) }}
+    data-loading-skeleton="{{ $variant }}"
+    role="status"
+    aria-live="polite"
+    aria-label="{{ __('app.messages.loading') }}">
+    <span class="sr-only">{{ __('app.messages.loading') }}</span>
+
+    @if ($variant === 'dashboard')
+        <div class="space-y-6">
+            <div class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-7">
+                <div class="h-5 w-32 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                <div class="mt-5 h-9 max-w-md rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+                <div class="mt-3 h-4 max-w-2xl rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                <div class="mt-2 h-4 max-w-xl rounded-full bg-gray-200 dark:bg-gray-700"></div>
+            </div>
+
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div class="h-11 w-full rounded-xl bg-gray-200 dark:bg-gray-700 sm:max-w-md"></div>
+                <div class="flex gap-2">
+                    <div class="h-10 w-20 rounded-xl bg-gray-200 dark:bg-gray-700"></div>
+                    <div class="h-10 w-24 rounded-xl bg-gray-200 dark:bg-gray-700"></div>
+                    <div class="h-10 w-24 rounded-xl bg-gray-200 dark:bg-gray-700"></div>
+                </div>
+            </div>
+
+            <div class="grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]">
+                <div class="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+                    <div class="h-5 w-48 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                    <div class="mt-2 h-3 w-28 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                    <div class="mt-6 space-y-3">
+                        @foreach (range(1, 5) as $row)
+                            <div class="flex items-center gap-3 rounded-2xl border border-gray-100 p-4 dark:border-gray-700">
+                                <div class="h-3 w-3 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                                <div class="min-w-0 flex-1 space-y-2">
+                                    <div class="h-4 w-2/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                                    <div class="h-3 w-3/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                                </div>
+                                <div class="h-4 w-16 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+
+                <div class="hidden rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800 lg:block">
+                    <div class="h-5 w-32 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                    <div class="mt-6 space-y-4">
+                        <div class="h-24 rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+                        <div class="h-4 w-4/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                        <div class="h-4 w-3/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @else
+        <div class="space-y-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+            <div class="h-6 w-2/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+            <div class="h-4 w-3/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+            <div class="space-y-3 pt-2">
+                @foreach (range(1, 4) as $row)
+                    <div class="flex items-center gap-4 rounded-xl border border-gray-100 p-4 dark:border-gray-700">
+                        <div class="h-10 w-10 shrink-0 rounded-xl bg-gray-200 dark:bg-gray-700"></div>
+                        <div class="min-w-0 flex-1 space-y-2">
+                            <div class="h-4 w-2/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                            <div class="h-3 w-3/5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                        </div>
+                        <div class="hidden h-4 w-20 rounded-full bg-gray-200 dark:bg-gray-700 sm:block"></div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/dashboard-shell.blade.php
+++ b/resources/views/dashboard-shell.blade.php
@@ -18,9 +18,8 @@
             aria-live="polite"
         >
             <x-container>
-                <div data-dashboard-loading class="flex items-center gap-3">
-                    <span class="h-3 w-3 animate-pulse rounded-full bg-purple-600" aria-hidden="true"></span>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                <div data-dashboard-loading>
+                    <x-loading-skeleton variant="dashboard" />
                 </div>
                 <p data-dashboard-error class="text-sm font-semibold text-red-600 dark:text-red-300" hidden>
                     {{ __('search.messages.error') }}
@@ -32,7 +31,7 @@
             <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
                 description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">
                 <div class="p-6" x-ref="content">
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -230,7 +230,7 @@
             <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
                 description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">
                 <div class="p-6" x-ref="content">
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 </div>

--- a/resources/views/incidents/analytics-shell.blade.php
+++ b/resources/views/incidents/analytics-shell.blade.php
@@ -16,9 +16,8 @@
                 @foreach (['overview', 'groups', 'status-pages', 'incidents'] as $section)
                     <section data-analytics-section="{{ $section }}" data-endpoint="{{ route('incidents.analytics', request()->query()) }}" data-error="{{ __('search.messages.error') }}" aria-live="polite">
                         <x-container>
-                            <div class="flex items-center gap-3" data-section-loading>
-                                <span class="h-3 w-3 animate-pulse rounded-full bg-purple-600" aria-hidden="true"></span>
-                                <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                            <div data-section-loading>
+                                <x-loading-skeleton variant="section" />
                             </div>
                             <p data-section-error class="text-sm font-semibold text-red-600 dark:text-red-300" hidden>{{ __('search.messages.error') }}</p>
                         </x-container>

--- a/resources/views/incidents/analytics.blade.php
+++ b/resources/views/incidents/analytics.blade.php
@@ -28,7 +28,7 @@
             <x-form-modal name="status-page-form-modal" title="{{ __('status_page.title') }}"
                 description="{{ __('status_page.form.components') }}" max-width="5xl">
                 <div class="p-6" x-ref="content">
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 </div>
@@ -431,7 +431,7 @@
             <x-form-modal name="monitoring-group-form-modal" title="{{ __('monitoring_group.title') }}"
                 description="{{ __('monitoring_group.form.monitorings') }}" max-width="3xl">
                 <div class="p-6" x-ref="content">
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 </div>

--- a/resources/views/monitoring-groups/index.blade.php
+++ b/resources/views/monitoring-groups/index.blade.php
@@ -92,7 +92,7 @@
                         'modal' => true,
                     ])
                 @else
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 @endif

--- a/resources/views/monitorings/index.blade.php
+++ b/resources/views/monitorings/index.blade.php
@@ -506,7 +506,7 @@
                             'modal' => true,
                         ]))
                     @else
-                        <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                        <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                         <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                         <div x-html="content"></div>
                     @endif

--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -104,7 +104,7 @@
             <x-form-modal name="monitoring-form-modal" title="{{ __('monitoring.title') }}"
                 description="{{ __('monitoring.form.sections.basic') }}" max-width="6xl">
                 <div class="p-6" x-ref="content">
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 </div>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -68,7 +68,7 @@
                                     @if ($modalForm === 'profile-information')
                                         @include('profile.partials.update-profile-information-form', ['modal' => true])
                                     @else
-                                        <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                                        <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                                         <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                                         <div x-html="content"></div>
                                     @endif
@@ -99,7 +99,7 @@
                                 @if ($modalForm === 'profile-password')
                                     @include('profile.partials.update-password-form', ['modal' => true])
                                 @else
-                                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                                     <div x-html="content"></div>
                                 @endif

--- a/resources/views/status-pages/index.blade.php
+++ b/resources/views/status-pages/index.blade.php
@@ -122,7 +122,7 @@
                         'modal' => true,
                     ])
                 @else
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 @endif

--- a/resources/views/status-pages/show.blade.php
+++ b/resources/views/status-pages/show.blade.php
@@ -47,7 +47,7 @@
                     <x-form-modal name="status-page-form-modal" title="{{ __('status_page.title') }}"
                         description="{{ __('status_page.form.components') }}" max-width="5xl">
                         <div class="p-6" x-ref="content">
-                            <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                            <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                             <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                             <div x-html="content"></div>
                         </div>

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -58,7 +58,7 @@
                             'modalForm' => 'team-edit',
                         ])
                     @else
-                        <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                        <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                         <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                         <div x-html="content"></div>
                     @endif

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -43,7 +43,7 @@
             <x-form-modal name="team-form-modal" title="{{ __('team.edit.title', ['team' => $team->name]) }}"
                 description="{{ __('team.title') }}" max-width="3xl">
                 <div class="p-6" x-ref="content">
-                    <p x-show="loading" class="text-sm text-gray-500 dark:text-gray-400">{{ __('app.loading') }}</p>
+                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
                     <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
                     <div x-html="content"></div>
                 </div>

--- a/tests/Feature/DashboardOverviewTest.php
+++ b/tests/Feature/DashboardOverviewTest.php
@@ -32,7 +32,9 @@ class DashboardOverviewTest extends TestCase
             ->assertSeeHtml('data-dashboard-loader')
             ->assertSeeHtml('x-data="dashboardLoader()"')
             ->assertSeeHtml('data-endpoint="/dashboard"')
-            ->assertSeeText(__('app.loading'))
+            ->assertSeeHtml('data-loading-skeleton="dashboard"')
+            ->assertSeeHtml('class="h-5 w-5 animate-spin text-purple-500"')
+            ->assertDontSeeText(__('app.loading'))
             ->assertDontSeeHtml('data-signal-room');
     }
 

--- a/tests/Feature/IncidentWorkflowTest.php
+++ b/tests/Feature/IncidentWorkflowTest.php
@@ -28,7 +28,8 @@ class IncidentWorkflowTest extends TestCase
         $this->actingAs($user)->get(route('incidents.analytics'))
             ->assertOk()
             ->assertSeeHtml('data-incident-analytics-loader')
-            ->assertSeeText(__('app.loading'))
+            ->assertSeeHtml('data-loading-skeleton="section"')
+            ->assertDontSeeText(__('app.loading'))
             ->assertDontSeeHtml('data-incident-overview-table');
     }
 


### PR DESCRIPTION
Closes #589

## What changed
- Replace generic app.loading text on asynchronous dashboard and incident analytics shells with reusable content-aware skeletons.
- Use spinner-only indicators for compact form-modal loading states, with screen-reader text retained.
- Update shell regression assertions.

## Why
The old generic loading text did not communicate what content was about to appear and was visually inconsistent across async surfaces.

## Testing
- Added/updated feature coverage for dashboard and incident loading shells.
- Focused: 21 passed (184 assertions)
- composer test: 652 passed, 3 skipped (4157 assertions; Docker)
- composer analyse: passed
- Laravel Pint: passed
- Bun/Vite production build: passed

## Risks / limitations
Browser visual QA could not reach the authenticated dashboard because the local browser session had no signed-in account. Server-rendered assertions cover the loading markup; manual visual verification should be repeated in an authenticated session.