### PR TITLE
fix(ui): render pagination icons

### DIFF
--- a/resources/lang/de/pagination.php
+++ b/resources/lang/de/pagination.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'previous' => '&laquo; Zurück',
-    'next' => 'Weiter &raquo;',
+    'previous' => 'Zurück',
+    'next' => 'Weiter',
 ];

--- a/resources/views/components/async-table.blade.php
+++ b/resources/views/components/async-table.blade.php
@@ -142,7 +142,7 @@
                 title="{{ __('pagination.previous') }}"
                 aria-label="{{ __('pagination.previous') }}"
                 :disabled="pagination.current_page <= 1 || loading" @click="fetchPage(pagination.current_page - 1)">
-                &laquo;
+                <x-icon name="arrow-left" class="h-4 w-4" />
             </button>
 
             <template x-for="page in pages()" :key="`${page}-${pagination.current_page}`">
@@ -163,7 +163,7 @@
                 aria-label="{{ __('pagination.next') }}"
                 :disabled="pagination.current_page >= pagination.last_page || loading"
                 @click="fetchPage(pagination.current_page + 1)">
-                &raquo;
+                <x-icon name="arrow-right" class="h-4 w-4" />
             </button>
         </nav>
     </div>

--- a/resources/views/components/icon.blade.php
+++ b/resources/views/components/icon.blade.php
@@ -46,6 +46,10 @@
             <path d="m15 18-6-6 6-6" />
             <path d="M9 12h12" />
             @break
+        @case('arrow-right')
+            <path d="m9 18 6-6-6-6" />
+            <path d="M3 12h12" />
+            @break
         @case('chart')
             <path d="M4 19V5M4 19h16" />
             <path d="m7 15 3-4 3 2 5-6" />

--- a/resources/views/components/pagination.blade.php
+++ b/resources/views/components/pagination.blade.php
@@ -53,7 +53,8 @@
             @if ($pagination['current_page'] > 1)
                 <a href="{{ $previousUrl }}"
                     @if ($async) data-pagination-async @endif
-                    class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">
+                    class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">
+                    <x-icon name="arrow-left" data-pagination-icon="previous" class="h-4 w-4" />
                     {{ __('pagination.previous') }}
                 </a>
             @endif
@@ -65,8 +66,9 @@
             @if ($pagination['current_page'] < $pagination['last_page'])
                 <a href="{{ $nextUrl }}"
                     @if ($async) data-pagination-async @endif
-                    class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">
+                    class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 font-semibold text-gray-700 transition hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:border-purple-500 dark:hover:bg-purple-950/30 dark:hover:text-purple-200">
                     {{ __('pagination.next') }}
+                    <x-icon name="arrow-right" data-pagination-icon="next" class="h-4 w-4" />
                 </a>
             @endif
         </nav>

--- a/resources/views/maintenance/index.blade.php
+++ b/resources/views/maintenance/index.blade.php
@@ -247,12 +247,14 @@
                     </span>
                     <div class="flex gap-2">
                         <button type="button" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100"
+                            title="{{ __('pagination.previous') }}" aria-label="{{ __('pagination.previous') }}"
                             x-bind:disabled="pagination.current_page <= 1 || loading" @click="load(pagination.current_page - 1)">
-                            &laquo;
+                            <x-icon name="arrow-left" class="h-4 w-4" />
                         </button>
                         <button type="button" class="rounded-md bg-gray-100 px-3 py-2 font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100"
+                            title="{{ __('pagination.next') }}" aria-label="{{ __('pagination.next') }}"
                             x-bind:disabled="pagination.current_page >= pagination.last_page || loading" @click="load(pagination.current_page + 1)">
-                            &raquo;
+                            <x-icon name="arrow-right" class="h-4 w-4" />
                         </button>
                     </div>
                 </div>

--- a/tests/Feature/MonitoringIndexEmptyStateTest.php
+++ b/tests/Feature/MonitoringIndexEmptyStateTest.php
@@ -79,11 +79,19 @@ class MonitoringIndexEmptyStateTest extends TestCase
         Monitoring::factory()->count(6)->for($user)->create();
 
         $testResponse = $this->actingAs($user)->get(route('monitorings.index'));
+        $previousPage = $this->actingAs($user)->get(route('monitorings.index', ['page' => 2]));
 
         $testResponse->assertOk()
             ->assertSeeHtml('data-table-pagination')
             ->assertSeeText('1 / 2')
-            ->assertSeeText(__('pagination.next'));
+            ->assertSeeText(__('pagination.next'))
+            ->assertSeeHtml('data-pagination-icon="next"')
+            ->assertDontSee('&raquo;');
+        $previousPage->assertOk()
+            ->assertSeeText('2 / 2')
+            ->assertSeeText(__('pagination.previous'))
+            ->assertSeeHtml('data-pagination-icon="previous"')
+            ->assertDontSee('&laquo;');
     }
 
     public function test_default_monitoring_index_reuses_paginator_total_without_extra_monitoring_count_query(): void


### PR DESCRIPTION
Closes #591

## What changed
- Replace escaped `&laquo;` and `&raquo;` pagination text with reusable arrow SVG icons.
- Keep visible previous/next labels and accessible titles/ARIA labels.
- Apply the same icon treatment to shared, async-table, and maintenance pagination controls.
- Add regression coverage for both pagination directions.

## Why
The German pagination labels were HTML-escaped and appeared literally as `&laquo;` and `&raquo;` instead of rendering navigation icons.

## Testing
- Monitoring pagination regression: 11 passed (49 assertions)
- Related dashboard and incident tests: 18 passed
- Laravel Pint: passed
- git diff --check: passed

## Risks / limitations
Browser visual QA could not reach the authenticated monitorings page because the local browser session was logged out. Server-rendered regression coverage verifies the generated SVG markup and absence of escaped entity text.