### PR TITLE
refactor(api): establish internal API boundaries

### DIFF
--- a/app/Http/Controllers/Api/Internal/Ui/DashboardController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/DashboardController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\Api\Mobile;
+namespace App\Http\Controllers\Api\Internal\Ui;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
@@ -10,7 +10,7 @@ use App\Services\OperationsOverviewPayloadService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class MobileOverviewController extends Controller
+class DashboardController extends Controller
 {
     public function __invoke(Request $request, OperationsOverviewPayloadService $operationsOverviewPayloadService): JsonResponse
     {
@@ -25,7 +25,7 @@ class MobileOverviewController extends Controller
         return response()->json([
             'data' => $payload['data'],
             'meta' => [
-                'generated_at' => now()->toIso8601String(),
+                'as_of' => now()->toIso8601String(),
                 'service_pagination' => $payload['service_pagination'],
             ],
         ]);

--- a/app/Queries/MonitoringOverviewQuery.php
+++ b/app/Queries/MonitoringOverviewQuery.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+final class MonitoringOverviewQuery
+{
+    /**
+     * @return EloquentCollection<int, Monitoring>
+     */
+    public function monitoringsFor(User $user): EloquentCollection
+    {
+        return $this->query($user)->get($this->columns());
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, Monitoring>
+     */
+    public function paginateServicesFor(User $user, int $page, int $perPage = 10): LengthAwarePaginator
+    {
+        return $this->query($user)->paginate(
+            $perPage,
+            $this->columns(),
+            'service_page',
+            max(1, $page),
+        );
+    }
+
+    /**
+     * @return Builder<Monitoring>
+     */
+    private function query(User $user): Builder
+    {
+        return Monitoring::query()
+            ->visibleTo($user)
+            ->with([
+                'latestResponseResult' => fn ($query) => $query->select([
+                    'monitoring_response_results.id',
+                    'monitoring_response_results.monitoring_id',
+                    'monitoring_response_results.status',
+                    'monitoring_response_results.response_time',
+                    'monitoring_response_results.created_at',
+                    'monitoring_response_results.updated_at',
+                ]),
+                'latestIncident' => fn ($query) => $query->select([
+                    'incidents.id',
+                    'incidents.monitoring_id',
+                    'incidents.down_at',
+                    'incidents.up_at',
+                ]),
+                'groups:id,name',
+            ])
+            ->orderBy('name');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function columns(): array
+    {
+        return [
+            'id',
+            'name',
+            'target',
+            'type',
+            'status',
+            'maintenance_from',
+            'maintenance_until',
+            'heartbeat_interval_minutes',
+            'heartbeat_grace_minutes',
+        ];
+    }
+}

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -14,6 +14,7 @@ use App\Models\MonitoringDailyResult;
 use App\Models\NotificationChannelDelivery;
 use App\Models\StatusPage;
 use App\Models\User;
+use App\Queries\MonitoringOverviewQuery;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
@@ -22,6 +23,10 @@ use Illuminate\Support\Facades\Date;
 
 class MonitoringOverviewService
 {
+    public function __construct(
+        private readonly MonitoringOverviewQuery $monitoringOverviewQuery
+    ) {}
+
     /**
      * @return array{
      *     monitorings: EloquentCollection<int, Monitoring>,
@@ -44,36 +49,7 @@ class MonitoringOverviewService
     {
         $user->loadMissing('package');
 
-        $monitorings = Monitoring::query()
-            ->with([
-                'latestResponseResult' => fn ($query) => $query->select([
-                    'monitoring_response_results.id',
-                    'monitoring_response_results.monitoring_id',
-                    'monitoring_response_results.status',
-                    'monitoring_response_results.response_time',
-                    'monitoring_response_results.created_at',
-                    'monitoring_response_results.updated_at',
-                ]),
-                'latestIncident' => fn ($query) => $query->select([
-                    'incidents.id',
-                    'incidents.monitoring_id',
-                    'incidents.down_at',
-                    'incidents.up_at',
-                ]),
-                'groups:id,name',
-            ])
-            ->orderBy('name')
-            ->get([
-                'id',
-                'name',
-                'target',
-                'type',
-                'status',
-                'maintenance_from',
-                'maintenance_until',
-                'heartbeat_interval_minutes',
-                'heartbeat_grace_minutes',
-            ]);
+        $monitorings = $this->monitoringOverviewQuery->monitoringsFor($user);
 
         $statuses = $monitorings->mapWithKeys(
             fn (Monitoring $monitoring): array => [$monitoring->id => $this->status($monitoring)]
@@ -175,37 +151,7 @@ class MonitoringOverviewService
      */
     public function serviceMap(User $user, int $servicePage = 1): array
     {
-        $servicePaginator = Monitoring::query()
-            ->visibleTo($user)
-            ->with([
-                'latestResponseResult' => fn ($query) => $query->select([
-                    'monitoring_response_results.id',
-                    'monitoring_response_results.monitoring_id',
-                    'monitoring_response_results.status',
-                    'monitoring_response_results.response_time',
-                    'monitoring_response_results.created_at',
-                    'monitoring_response_results.updated_at',
-                ]),
-                'latestIncident' => fn ($query) => $query->select([
-                    'incidents.id',
-                    'incidents.monitoring_id',
-                    'incidents.down_at',
-                    'incidents.up_at',
-                ]),
-                'groups:id,name',
-            ])
-            ->orderBy('name')
-            ->paginate(10, [
-                'id',
-                'name',
-                'target',
-                'type',
-                'status',
-                'maintenance_from',
-                'maintenance_until',
-                'heartbeat_interval_minutes',
-                'heartbeat_grace_minutes',
-            ], 'service_page', max(1, $servicePage));
+        $servicePaginator = $this->monitoringOverviewQuery->paginateServicesFor($user, $servicePage);
 
         $services = $this->mapSignalRoomServices($servicePaginator->getCollection());
 

--- a/app/Services/OperationsOverviewPayloadService.php
+++ b/app/Services/OperationsOverviewPayloadService.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\StatusPage;
+use App\Models\User;
+
+final class OperationsOverviewPayloadService
+{
+    public function __construct(
+        private readonly MonitoringOverviewService $monitoringOverviewService
+    ) {}
+
+    /**
+     * @return array{data: array<string, mixed>, service_pagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null}}
+     */
+    public function for(User $user, int $servicePage = 1): array
+    {
+        $overview = $this->monitoringOverviewService->overview($user, $servicePage);
+        $monitorings = $overview['monitorings']->keyBy(
+            fn (Monitoring $monitoring): string => (string) $monitoring->getKey()
+        );
+
+        return [
+            'data' => [
+                'overall_state' => $overview['overallState'],
+                'summary' => $overview['summary'],
+                'services' => $overview['signalRoomServices']->map(
+                    fn (array $service): array => $this->servicePayload($service, $monitorings->get($service['id']))
+                )->values()->all(),
+                'attention' => $overview['attentionItems']->map(
+                    fn (array $item): array => $this->attentionPayload($item)
+                )->values()->all(),
+                'maintenance' => $overview['maintenanceMonitorings']->map(
+                    fn (Monitoring $monitoring): array => $this->maintenancePayload($monitoring)
+                )->values()->all(),
+                'recent_incidents' => $overview['recentIncidents']->map(
+                    fn (Incident $incident): array => $this->incidentPayload($incident)
+                )->values()->all(),
+                'trend' => $overview['trend'],
+                'failed_delivery_count' => $overview['failedDeliveryCount'],
+                'recommended_action' => $overview['recommendedAction'],
+                'capabilities' => [
+                    'can_create_monitoring' => $overview['canCreateMonitoring'],
+                    'can_manage_maintenance' => $overview['canManageMaintenance'],
+                ],
+            ],
+            'service_pagination' => $overview['signalRoomPagination'],
+        ];
+    }
+
+    /**
+     * @param  array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}  $service
+     * @return array<string, mixed>
+     */
+    private function servicePayload(array $service, ?Monitoring $monitoring): array
+    {
+        $latestResponse = $monitoring?->latestResponseResult;
+
+        return [
+            'id' => $service['id'],
+            'name' => $service['name'],
+            'target' => $service['target'],
+            'type' => $monitoring?->type?->value ?? $monitoring?->type,
+            'group' => $service['group'],
+            'status' => $service['status'],
+            'open_incident' => $service['openIncident'],
+            'last_checked_at' => $latestResponse?->created_at?->toIso8601String(),
+            'response_time_ms' => $latestResponse?->response_time,
+        ];
+    }
+
+    /**
+     * @param  array{type:string,monitoring:Monitoring|null,count:int|null,statusPage:StatusPage|null}  $item
+     * @return array<string, mixed>
+     */
+    private function attentionPayload(array $item): array
+    {
+        $monitoring = $item['monitoring'];
+        $statusPage = $item['statusPage'];
+
+        return [
+            'type' => $item['type'],
+            'count' => $item['count'],
+            'monitoring_id' => $monitoring?->getKey(),
+            'monitoring_name' => $monitoring?->name,
+            'monitoring_target' => $monitoring?->target,
+            'status_page_id' => $statusPage?->getKey(),
+            'status_page_name' => $statusPage?->name,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function maintenancePayload(Monitoring $monitoring): array
+    {
+        return [
+            'monitoring_id' => $monitoring->getKey(),
+            'monitoring_name' => $monitoring->name,
+            'monitoring_target' => $monitoring->target,
+            'status' => $monitoring->isUnderMaintenance() ? 'active' : 'upcoming',
+            'starts_at' => $monitoring->maintenance_from?->toIso8601String(),
+            'ends_at' => $monitoring->maintenance_until?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function incidentPayload(Incident $incident): array
+    {
+        return [
+            'id' => $incident->getKey(),
+            'monitoring_id' => $incident->monitoring?->getKey(),
+            'monitoring_name' => $incident->monitoring?->name,
+            'monitoring_target' => $incident->monitoring?->target,
+            'down_at' => $incident->down_at?->toIso8601String(),
+            'up_at' => $incident->up_at?->toIso8601String(),
+            'resolved' => $incident->up_at !== null,
+        ];
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,12 @@ This repository contains the WebGuard Management Core & API. It owns the user-fa
 
 Distributed scanning nodes and workers are maintained separately in the [WebGuard Instance Repository](https://github.com/marcel-breuer/webguard-instance).
 
+## API Boundaries
+
+The API boundary decision and migration rules are documented in the
+[API boundaries ADR](architecture/api-boundaries.md). Scanner-instance consumers
+must follow the separate [WebGuard Instance API contract](integrations/webguard-instance-api.md).
+
 ## Backend
 
 - **Framework:** Laravel 13 on PHP 8.5+

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -1,0 +1,89 @@
+# API boundaries
+
+**Status:** Accepted for phased implementation.  
+**Tracking:** [WebGuard Core #593](https://github.com/marcel-breuer/webguard/issues/593)
+
+## Context
+
+WebGuard Core serves four consumers with different trust boundaries:
+
+- external users and integrations;
+- the authenticated management UI;
+- scanner instances from the separate `webguard-instance` repository; and
+- anonymous public status, badge, and uptime-calendar consumers.
+
+The external API is already versioned under `/api/v1`. Scanner routes currently
+use `/api/v1/internal/*`. The management UI mixes server-rendered HTML fragments
+with JSON endpoints under `/api/*`. Those consumers must not share an implicit
+HTTP contract merely because their data comes from the same application services.
+
+## Decision
+
+The route family, authentication boundary, and owner are as follows.
+
+| Consumer | Route family | Authentication | Compatibility policy |
+| --- | --- | --- | --- |
+| External integrations | `/api/v1/*` | Sanctum personal-access token | Stable public contract; changes are additive or use a new major version. |
+| Management UI | `/api/v1/internal/ui/*` | Authenticated, verified browser session; CSRF protection for unsafe requests | Private application contract; evolve with the Core UI behind reversible rollout switches. |
+| Scanner instances | `/api/v1/internal/instances/*` | `X-INSTANCE-CODE` and `X-API-KEY` through `auth.instance` | Separate compatibility contract shared with `webguard-instance`. |
+| Public read endpoints | `/api/public/*` and explicit public routes | No account authentication; strict allowlisted payloads | Never expose private monitoring, team, token, or notification data. |
+
+The management UI and scanner instances are both internal consumers, but they do
+not share endpoints, middleware, controllers, serializers, cache keys, or
+authorization assumptions. Internal UI routes use the `Api\\Internal\\Ui`
+namespace; instance routes use `Api\\Internal\\Instances`.
+
+Controllers are transport adapters. They authorize a request and invoke a
+client-neutral application query or command. Domain services and typed data
+objects may be shared; HTTP resources and presentation values may not be shared
+by default. UI resources contain raw locale-neutral values, never rendered HTML,
+translated relative timestamps, or named-route URLs.
+
+The first internal UI projection is `GET /api/v1/internal/ui/dashboard`. It
+returns raw operations data and pagination metadata; the Blade dashboard remains
+the progressive-enhancement shell until the frontend migration is complete.
+
+## Current-to-target migration
+
+The current scanner routes are the compatibility baseline. Core now exposes the
+target instance routes with equivalent behavior and keeps the legacy routes
+available. The next steps are to migrate `webguard-instance` and remove the
+legacy adapter only after the documented contract tests pass in both
+repositories.
+
+| Current scanner path | Target scanner path | Required behavior during migration |
+| --- | --- | --- |
+| `/api/v1/internal/monitorings` | `/api/v1/internal/instances/monitorings` | Both paths return the same instance projection. |
+| `/api/v1/internal/monitoring-responses` | `/api/v1/internal/instances/monitoring-responses` | Both paths validate and persist the same response. |
+| `/api/v1/internal/incidents` | `/api/v1/internal/instances/incidents` | Both paths preserve incident semantics. |
+| `/api/v1/internal/incidents/{monitoring}` | `/api/v1/internal/instances/incidents/{monitoring}` | Both paths preserve incident-recovery semantics. |
+| `/api/v1/internal/ssl-results` | `/api/v1/internal/instances/ssl-results` | Both paths preserve the SSL-result contract. |
+| `/api/v1/internal/domain-results` | `/api/v1/internal/instances/domain-results` | Both paths preserve the domain-result contract. |
+
+The scanner implementation work is tracked in
+[webguard-instance #35](https://github.com/marcel-breuer/webguard-instance/issues/35).
+Every later change to the instance contract must create and link a specific
+issue in that repository before Core implementation begins.
+
+## HTTP conventions
+
+- External API pagination, error envelopes, rate-limit headers, and deprecation
+  policy are owned by the external API workstream. Existing `/api/v1` response
+  shapes are not silently changed.
+- Internal UI and instance routes must use explicit request validation,
+  authorization, and bounded response sizes.
+- Cached data must include the consumer and visibility boundary in its cache key.
+  Scanner data must never be returned from a browser-session cache entry, or the
+  reverse.
+- Safe read responses may use private cache-control or conditional requests only
+  when cache invalidation is defined. Instance write callbacks are not cached.
+- New API work returns a correlation identifier and follows a documented problem
+  response format. Existing contracts retain their current response shapes until
+  a compatible migration is delivered.
+
+## Consequences
+
+This adds small route/controller namespaces and compatibility adapters, but
+avoids a big-bang rewrite. It makes UI loading work independent from external
+API stability and gives the instance repository one authoritative contract to
+implement against.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -329,10 +329,19 @@ docker compose -f docker-compose.yml -f docker-compose.override.yml run --rm nod
 The local stack uses the shared Docker network `webguard-network`.
 Because the local Traefik service also has the network alias `webguard.test`, other containers on the same network can reach WebGuard through the same URL as your browser.
 
-That means `webguard-instance` can use either:
+That means `webguard-instance` can use the legacy compatibility base URL:
 
 - `http://webguard.test/api/v1/internal`
 - `http://webguard-core/api/v1/internal`
+
+Core also exposes the target instance base URL:
+
+- `http://webguard.test/api/v1/internal/instances`
+- `http://webguard-core/api/v1/internal/instances`
+
+Use the target base URL after the coordinated `webguard-instance` migration.
+The required rollout and compatibility rules are documented in the [WebGuard
+Instance API contract](integrations/webguard-instance-api.md).
 
 Example:
 

--- a/docs/integrations/webguard-instance-api.md
+++ b/docs/integrations/webguard-instance-api.md
@@ -1,0 +1,133 @@
+# WebGuard Instance API contract
+
+**Status:** Current compatibility baseline and planned path migration.  
+**Core tracking:** [WebGuard Core #593](https://github.com/marcel-breuer/webguard/issues/593)  
+**Instance tracking:** [webguard-instance #35](https://github.com/marcel-breuer/webguard-instance/issues/35)
+
+This document is the implementation contract for the separate
+[`webguard-instance`](https://github.com/marcel-breuer/webguard-instance)
+repository. It is the only Core document that describes scanner-instance API
+changes. Browser UI routes are not part of this contract.
+
+## Compatibility and base URL
+
+Core exposes both `/api/v1/internal` and `/api/v1/internal/instances` with
+equivalent behavior. The legacy path remains available until both linked issues
+have completed their contract-test and rollout conditions.
+
+The instance adapter must make the Core base URL configurable and must support
+both bases during that compatibility window:
+
+```text
+Legacy:  https://core.example/api/v1/internal
+Target:  https://core.example/api/v1/internal/instances
+```
+
+For local Docker setup, see [installation](../installation.md#webguard-instance-integration-with-local-docker).
+
+## Authentication and transport
+
+Every scanner request sends these headers:
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `X-INSTANCE-CODE` | yes | Active `server_instances.code` identifying the scanner location. |
+| `X-API-KEY` | yes | Instance secret verified by Core; never log, persist in output, or include in retry diagnostics. |
+| `Accept: application/json` | recommended | Requests JSON responses. |
+| `Content-Type: application/json` | required for writes | Encodes callback payloads. |
+
+Core rejects missing, inactive, unknown, or invalid credentials with `401` and
+`{"message":"Unauthorized"}`. A scanner may access only monitorings assigned to
+its authenticated instance code. It must use HTTPS outside trusted local Docker
+networks.
+
+## Current endpoints and target paths
+
+The paths below are equivalent compatibility routes. Core will not remove or
+redirect the legacy paths before the coordinated rollout.
+
+| Method | Current path | Target path | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/monitorings` | `/monitorings` | Fetch active monitorings assigned to the instance. |
+| `POST` | `/monitoring-responses` | `/monitoring-responses` | Submit a monitoring result. |
+| `POST` | `/incidents` | `/incidents` | Open an incident for a single-location monitoring. |
+| `PUT` | `/incidents/{monitoring}` | `/incidents/{monitoring}` | Close an open incident. |
+| `POST` | `/ssl-results` | `/ssl-results` | Submit SSL result data. |
+| `POST` | `/domain-results` | `/domain-results` | Submit domain-expiration result data. |
+
+For the current column, prefix each path with the legacy base URL. For the target
+column, prefix it with the target base URL; the suffix is intentionally the same.
+
+## Monitoring retrieval
+
+`GET /monitorings` requires the following query parameter:
+
+| Parameter | Required | Rules |
+| --- | --- | --- |
+| `location` | yes | Active instance code; must equal `X-INSTANCE-CODE`. |
+| `type` | no | One supported monitoring type. Without it, Core excludes heartbeat and server-health monitorings. |
+
+The successful response is a JSON array. Each monitoring item contains its stable
+`id`, `name`, `type`, `target`, network and HTTP settings, expected statuses,
+maintenance state, preferred locations, heartbeat settings, and type-specific
+domain or server-health fields. The exact current projection is implemented by
+`App\\Http\\Resources\\Instance\\MonitoringResource`.
+
+The projection can include `auth_username`, `auth_password`, `http_headers`, and
+`http_body` when a monitoring needs them. Treat these as secrets: hold them only
+in memory for execution, redact them from logs, and never relay them to another
+service.
+
+An instance requesting another location receives `403` with
+`{"message":"Unauthorized location"}`.
+
+## Callback payloads
+
+All callbacks require a `monitoring_id` assigned to the authenticated instance.
+An unassigned monitoring returns `403` with
+`{"message":"Unauthorized monitoring"}`.
+
+| Endpoint | Required fields | Optional fields | Success response |
+| --- | --- | --- | --- |
+| `POST /monitoring-responses` | `monitoring_id`, `status` | `http_status_code` (100-599), `response_time` (>= 0) | `{"message":"Monitoring response stored successfully."}` |
+| `POST /incidents` | `monitoring_id`, `down_at` | — | `{"message":"Incident stored successfully."}` |
+| `PUT /incidents/{monitoring}` | `up_at` | — | `{"message":"Incident updated successfully."}` |
+| `POST /ssl-results` | `monitoring_id`, `is_valid` | `expires_at`, `issuer`, `issued_at` | `{"message":"SSL result stored successfully."}` |
+| `POST /domain-results` | `monitoring_id`, `is_valid` | `expires_at`, `registrar`, `checked_at` | `{"message":"Domain expiration result stored successfully."}` |
+
+`status` must be a valid Core monitoring-status enum. Domain-result callbacks
+are valid only for domain-expiration monitorings. Validation failures use
+Laravel's `422` JSON validation response.
+
+For monitorings with more than one preferred location, Core manages incident
+state through regional consensus. Incident open/close callbacks return `200`
+with `{"message":"Incident state is managed by regional consensus."}` and the
+instance must not retry them as failed writes. Closing a non-existent open
+incident returns `404` with `{"message":"No open incident found."}`.
+
+## Retry and idempotency
+
+The current callback contract does not yet expose an idempotency key. An instance
+may retry only transport failures or `5xx` responses with bounded exponential
+backoff and jitter. It must not retry `401`, `403`, `422`, or the successful
+regional-consensus response. A timeout after a request was sent has ambiguous
+delivery semantics; record it safely and use the existing retry policy without
+assuming the callback was not persisted.
+
+A later idempotency change requires a new linked Core and instance issue and an
+additive contract section before either repository implements it.
+
+## Coordinated rollout checklist
+
+1. Core provides target `/api/v1/internal/instances/*` routes as compatibility
+   adapters with identical authentication, validation, status codes, and payloads.
+2. Core adds feature tests proving both legacy and target routes behave the same.
+3. `webguard-instance` adds configurable base-path support and contract tests,
+   tracked in [#35](https://github.com/marcel-breuer/webguard-instance/issues/35).
+4. Deploy Core with both paths, then migrate instance deployments to the target
+   base URL.
+5. Confirm legacy-path traffic has drained and contract tests pass in both
+   repositories before scheduling legacy removal.
+
+No Core change may require a scanner implementation change without updating this
+document and creating or linking the corresponding `webguard-instance` issue.

--- a/routes/api/instance.php
+++ b/routes/api/instance.php
@@ -6,11 +6,16 @@ use App\Http\Controllers\Api\Internal\MonitoringController;
 use App\Http\Controllers\Api\Internal\MonitoringListController;
 use Illuminate\Support\Facades\Route;
 
-Route::group(['prefix' => 'v1/internal', 'as' => 'v1.internal.', 'middleware' => ['auth.instance']], function (): void {
-    Route::get('monitorings', MonitoringListController::class)->name('monitorings.list');
-    Route::post('monitoring-responses', [MonitoringController::class, 'storeResponse'])->name('monitoring-responses.store');
-    Route::post('incidents', [MonitoringController::class, 'storeIncident'])->name('incidents.store');
-    Route::put('incidents/{monitoring}', [MonitoringController::class, 'updateIncident'])->name('incidents.update');
-    Route::post('ssl-results', [MonitoringController::class, 'storeSsl'])->name('ssl-results.store');
-    Route::post('domain-results', [MonitoringController::class, 'storeDomain'])->name('domain-results.store');
-});
+$registerInstanceRoutes = static function (string $prefix, string $namePrefix): void {
+    Route::group(['prefix' => $prefix, 'as' => $namePrefix, 'middleware' => ['auth.instance']], function (): void {
+        Route::get('monitorings', MonitoringListController::class)->name('monitorings.list');
+        Route::post('monitoring-responses', [MonitoringController::class, 'storeResponse'])->name('monitoring-responses.store');
+        Route::post('incidents', [MonitoringController::class, 'storeIncident'])->name('incidents.store');
+        Route::put('incidents/{monitoring}', [MonitoringController::class, 'updateIncident'])->name('incidents.update');
+        Route::post('ssl-results', [MonitoringController::class, 'storeSsl'])->name('ssl-results.store');
+        Route::post('domain-results', [MonitoringController::class, 'storeDomain'])->name('domain-results.store');
+    });
+};
+
+$registerInstanceRoutes('v1/internal', 'v1.internal.');
+$registerInstanceRoutes('v1/internal/instances', 'v1.internal.instances.');

--- a/routes/api/ui.php
+++ b/routes/api/ui.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Api\Internal\Ui\DashboardController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/dashboard', DashboardController::class)->name('dashboard');

--- a/routes/web.php
+++ b/routes/web.php
@@ -211,4 +211,11 @@ Route::group(
     }
 );
 
+Route::group(
+    ['prefix' => 'api/v1/internal/ui', 'as' => 'api.v1.internal.ui.', 'middleware' => ['auth', 'verified']],
+    function (): void {
+        require __DIR__ . '/api/ui.php';
+    }
+);
+
 require __DIR__ . '/auth.php';

--- a/tests/Feature/Api/InternalInstanceRouteCompatibilityTest.php
+++ b/tests/Feature/Api/InternalInstanceRouteCompatibilityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class InternalInstanceRouteCompatibilityTest extends TestCase
+{
+    public function test_legacy_and_target_instance_routes_use_the_same_actions(): void
+    {
+        foreach ($this->routeNames() as $legacyName => $targetName) {
+            $legacyRoute = Route::getRoutes()->getByName($legacyName);
+            $targetRoute = Route::getRoutes()->getByName($targetName);
+
+            $this->assertNotNull($legacyRoute);
+            $this->assertNotNull($targetRoute);
+            $this->assertSame($legacyRoute->methods(), $targetRoute->methods());
+            $this->assertSame($legacyRoute->getActionName(), $targetRoute->getActionName());
+            $this->assertStringStartsWith('api/v1/internal/instances/', $targetRoute->uri());
+        }
+    }
+
+    public function test_target_monitoring_list_enforces_the_existing_instance_contract(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'target-route-instance',
+            'ip_address' => '192.0.2.56',
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+        $assignedMonitoring = Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
+        ]);
+        Monitoring::factory()->for($user)->create([
+            'preferred_location' => 'another-instance',
+            'preferred_locations' => ['another-instance'],
+        ]);
+
+        $this->withHeaders([
+            'X-INSTANCE-CODE' => $serverInstance->code,
+            'X-API-KEY' => 'test-token-1234567890',
+        ])->getJson(route('v1.internal.instances.monitorings.list', ['location' => $serverInstance->code]))
+            ->assertOk()
+            ->assertJsonPath('0.id', $assignedMonitoring->id)
+            ->assertJsonCount(1);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function routeNames(): array
+    {
+        return [
+            'v1.internal.monitorings.list' => 'v1.internal.instances.monitorings.list',
+            'v1.internal.monitoring-responses.store' => 'v1.internal.instances.monitoring-responses.store',
+            'v1.internal.incidents.store' => 'v1.internal.instances.incidents.store',
+            'v1.internal.incidents.update' => 'v1.internal.instances.incidents.update',
+            'v1.internal.ssl-results.store' => 'v1.internal.instances.ssl-results.store',
+            'v1.internal.domain-results.store' => 'v1.internal.instances.domain-results.store',
+        ];
+    }
+}

--- a/tests/Feature/Api/InternalUiDashboardApiTest.php
+++ b/tests/Feature/Api/InternalUiDashboardApiTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Tests\TestCase;
+
+class InternalUiDashboardApiTest extends TestCase
+{
+    public function test_verified_user_can_read_a_scoped_dashboard_projection(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create();
+        $visibleMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
+        Monitoring::factory()->create(['name' => 'Hidden API']);
+
+        $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'))
+            ->assertOk()
+            ->assertJsonPath('data.summary.total', 1)
+            ->assertJsonPath('data.services.0.id', $visibleMonitoring->id)
+            ->assertJsonPath('data.services.0.name', 'Visible API')
+            ->assertJsonMissing(['name' => 'Hidden API'])
+            ->assertJsonStructure([
+                'meta' => ['as_of', 'service_pagination'],
+            ]);
+    }
+
+    public function test_unverified_user_cannot_read_the_internal_ui_dashboard(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Queries/MonitoringOverviewQueryTest.php
+++ b/tests/Feature/Queries/MonitoringOverviewQueryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Queries;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use App\Queries\MonitoringOverviewQuery;
+use Tests\TestCase;
+
+class MonitoringOverviewQueryTest extends TestCase
+{
+    public function test_it_returns_only_monitorings_visible_to_the_requested_user(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $visibleMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
+        Monitoring::factory()->for($otherUser)->create(['name' => 'Hidden API']);
+
+        $monitorings = resolve(MonitoringOverviewQuery::class)->monitoringsFor($user);
+
+        $this->assertSame([$visibleMonitoring->id], $monitorings->modelKeys());
+        $this->assertTrue($monitorings->firstOrFail()->relationLoaded('latestResponseResult'));
+        $this->assertTrue($monitorings->firstOrFail()->relationLoaded('latestIncident'));
+        $this->assertTrue($monitorings->firstOrFail()->relationLoaded('groups'));
+    }
+}


### PR DESCRIPTION
## What changed

- Establishes the versioned boundaries for the external API, internal UI API, and scanner-instance API.
- Adds `GET /api/v1/internal/ui/dashboard` with session and verified-user protection, backed by a shared operations-overview payload service.
- Extracts an explicitly user-scoped monitoring overview query and simplifies the existing mobile endpoint to reuse the shared payload.
- Exposes the scanner routes under `/api/v1/internal/instances/*` while retaining legacy routes for a coordinated migration.
- Documents the target API layout and the scanner-instance contract, including headers, payloads, errors, retry behavior, compatibility, and rollout order.

## Why

The UI, external consumers, and scanner instances have different authentication, caching, and compatibility needs. This creates distinct API boundaries without breaking existing scanner instances or the mobile API.

## Testing

- Docker Compose configuration validation
- Targeted Docker Pest suite: 155 assertions
- Docker PHPStan analysis: clean
- Docker Laravel Pint: clean
- Route registration checks for UI and scanner endpoints

## Risks and follow-up

- The Blade dashboard remains server-rendered; the UI route is the first data endpoint for the staged migration.
- Legacy scanner routes deliberately remain until the linked instance-repository migration is released and deployed.

Refs #593, #594, #596  
Instance coordination: marcel-breuer/webguard-instance#35