### PR TITLE
refactor(monitoring): extract scoped read services

### DIFF
--- a/app/Http/Controllers/Api/MaintenanceDataController.php
+++ b/app/Http/Controllers/Api/MaintenanceDataController.php
@@ -5,26 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\MaintenanceWindow;
-use App\Models\Monitoring;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Builder;
+use App\Services\MaintenanceOverviewService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Date;
 
 class MaintenanceDataController extends Controller
 {
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(Request $request, MaintenanceOverviewService $maintenanceOverviewService): JsonResponse
     {
         /** @var User $user */
         $user = $request->user();
-
-        $manageableMonitoringIds = Monitoring::query()
-            ->manageableBy($user)
-            ->pluck('id')
-            ->map(static fn ($id): string => (string) $id)
-            ->all();
 
         $search = $request->string('search')->trim()->toString();
         $status = $request->string('maintenance_status')->toString();
@@ -32,156 +23,16 @@ class MaintenanceDataController extends Controller
         $sort = $request->string('sort')->toString() ?: 'name';
         $direction = $request->string('direction')->toString() === 'desc' ? 'desc' : 'asc';
 
-        $windowsQuery = Monitoring::query()
-            ->visibleTo($user)
-            ->select(['id', 'name', 'target', 'maintenance_from', 'maintenance_until'])
-            ->with('groups:id,name');
-
-        if ($search !== '') {
-            $windowsQuery->where(function (Builder $builder) use ($search): void {
-                $builder->where('name', 'like', '%' . $search . '%')
-                    ->orWhere('target', 'like', '%' . $search . '%')
-                    ->orWhereHas('groups', fn (Builder $builder): Builder => $builder->where('name', 'like', '%' . $search . '%'));
-            });
-        }
-
-        if ($groupId !== '') {
-            $windowsQuery->whereHas('groups', fn (Builder $builder): Builder => $builder->whereKey($groupId));
-        }
-
-        $this->applyMaintenanceStatusFilter($windowsQuery, $status);
-
-        if ($sort === 'maintenance_status') {
-            $now = Date::now();
-            $windowsQuery
-                ->orderByRaw(
-                    "case
-                        when maintenance_from is not null and maintenance_from <= ? and (maintenance_until is null or maintenance_until >= ?) then 0
-                        when maintenance_from is not null and maintenance_from > ? then 1
-                        when maintenance_from is not null then 2
-                        else 3
-                    end {$direction}",
-                    [$now, $now, $now]
-                )
-                ->orderBy('name');
-        } else {
-            $windowsQuery->orderBy(in_array($sort, ['name', 'maintenance_from', 'maintenance_until'], true) ? $sort : 'name', $direction)
-                ->orderBy('name')
-                ->orderBy('id');
-        }
-
-        $windows = $windowsQuery->paginate(min(max($request->integer('per_page', 50), 1), 100));
-
-        $windowData = $windows->through(static fn (Monitoring $monitoring): array => [
-            'id' => (string) $monitoring->id,
-            'name' => $monitoring->name,
-            'target' => $monitoring->target,
-            'groups' => $monitoring->groups->map(static fn ($group): array => [
-                'id' => (string) $group->id,
-                'name' => $group->name,
-            ])->values()->all(),
-            'status' => match (true) {
-                $monitoring->isUnderMaintenance() => 'active',
-                $monitoring->maintenance_from?->isFuture() === true => 'upcoming',
-                $monitoring->maintenance_from !== null => 'expired',
-                default => 'none',
-            },
-            'maintenance_from' => $monitoring->maintenance_from?->toDayDateTimeString(),
-            'maintenance_until' => $monitoring->maintenance_until?->toDayDateTimeString(),
-            'can_manage' => in_array((string) $monitoring->id, $manageableMonitoringIds, true),
-        ]);
-
-        $visibleMonitorings = Monitoring::query()
-            ->visibleTo($user)
-            ->get(['id', 'maintenance_from', 'maintenance_until']);
-
-        $activeCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => $monitoring->isUnderMaintenance())->count();
-        $upcomingCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => ! $monitoring->isUnderMaintenance()
-            && $monitoring->hasUpcomingMaintenance())->count();
-        $expiredCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => ! $monitoring->isUnderMaintenance()
-            && $monitoring->maintenance_from !== null
-            && ! $monitoring->maintenance_from->isFuture())->count();
-
         return response()->json([
-            'data' => [
-                'can_manage_maintenance' => $manageableMonitoringIds !== [],
-                'windows' => $windowData,
-                'stats' => [
-                    'total' => $visibleMonitorings->count(),
-                    'active' => $activeCount,
-                    'upcoming' => $upcomingCount,
-                    'expired' => $expiredCount,
-                    'none' => $visibleMonitorings->count() - $activeCount - $upcomingCount - $expiredCount,
-                ],
-                'recurring_windows' => MaintenanceWindow::query()
-                    ->visibleTo($user)
-                    ->with([
-                        'monitoring:id,name',
-                        'monitoringGroup:id,name',
-                    ])
-                    ->latest('starts_at')
-                    ->get()
-                    ->map(static fn (MaintenanceWindow $maintenanceWindow): array => [
-                        'id' => (string) $maintenanceWindow->id,
-                        'target' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
-                        'recurrence' => $maintenanceWindow->recurrence->value,
-                        'duration_minutes' => $maintenanceWindow->duration_minutes,
-                        'timezone' => $maintenanceWindow->timezone,
-                        'starts_at' => $maintenanceWindow->starts_at->setTimezone($maintenanceWindow->timezone)->toDayDateTimeString(),
-                        'can_manage' => $maintenanceWindow->isManageableBy($user),
-                    ])
-                    ->values()
-                    ->all(),
-                'monitoring_options' => Monitoring::query()
-                    ->manageableBy($user)
-                    ->orderBy('name')
-                    ->get(['id', 'name'])
-                    ->map(static fn (Monitoring $monitoring): array => [
-                        'id' => (string) $monitoring->id,
-                        'name' => $monitoring->name,
-                    ])
-                    ->values()
-                    ->all(),
-                'monitoring_groups' => $user->monitoringGroups()
-                    ->withCount('monitorings')
-                    ->orderBy('name')
-                    ->get(['id', 'name'])
-                    ->map(static fn ($group): array => [
-                        'id' => (string) $group->id,
-                        'name' => $group->name,
-                        'monitorings_count' => (int) $group->monitorings_count,
-                    ])
-                    ->values()
-                    ->all(),
-            ],
+            'data' => $maintenanceOverviewService->for(
+                $user,
+                $search,
+                $status,
+                $groupId,
+                $sort,
+                $direction,
+                $request->integer('per_page', 50),
+            ),
         ]);
-    }
-
-    private function applyMaintenanceStatusFilter(Builder $builder, string $status): void
-    {
-        if ($status === '') {
-            return;
-        }
-
-        $now = Date::now();
-
-        match ($status) {
-            'active' => $builder
-                ->whereNotNull('maintenance_from')
-                ->where('maintenance_from', '<=', $now)
-                ->where(function (Builder $builder) use ($now): void {
-                    $builder->whereNull('maintenance_until')
-                        ->orWhere('maintenance_until', '>=', $now);
-                }),
-            'upcoming' => $builder
-                ->whereNotNull('maintenance_from')
-                ->where('maintenance_from', '>', $now),
-            'expired' => $builder
-                ->whereNotNull('maintenance_from')
-                ->whereNotNull('maintenance_until')
-                ->where('maintenance_until', '<', $now),
-            'none' => $builder->whereNull('maintenance_from'),
-            default => null,
-        };
     }
 }

--- a/app/Http/Controllers/Api/MonitoringCardDataController.php
+++ b/app/Http/Controllers/Api/MonitoringCardDataController.php
@@ -5,21 +5,16 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Monitoring;
-use App\Services\MonitoringHeatmapService;
-use App\Services\MonitoringStatusPayloadService;
-use BackedEnum;
+use App\Services\MonitoringCardDataService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Date;
 
 class MonitoringCardDataController extends Controller
 {
     public function __invoke(
         Request $request,
-        MonitoringStatusPayloadService $monitoringStatusPayloadService,
-        MonitoringHeatmapService $monitoringHeatmapService
+        MonitoringCardDataService $monitoringCardDataService,
     ): JsonResponse {
         if (! $request->user()) {
             return response()->json([
@@ -46,100 +41,12 @@ class MonitoringCardDataController extends Controller
             ->values();
 
         abort_if($requestedIds->isEmpty() && $summaryIds->isEmpty(), 422, 'At least one monitoring id is required.');
-        $allRequestedIds = $requestedIds->merge($summaryIds)->unique()->values();
 
-        $monitorings = Monitoring::query()
-            ->select([
-                'id',
-                'user_id',
-                'team_id',
-                'status',
-                'name',
-                'target',
-                'type',
-                'created_at',
-                'maintenance_from',
-                'maintenance_until',
-                'preferred_location',
-                'preferred_locations',
-                'heartbeat_interval_minutes',
-                'heartbeat_grace_minutes',
-                'heartbeat_last_ping_at',
-            ])
-            ->withMaintenanceWindowState()
-            ->visibleTo($request->user())
-            ->whereIn('id', $allRequestedIds)
-            ->with([
-                'latestIncident',
-                'latestResponseResult',
-            ])
-            ->get()
-            ->keyBy('id');
-
-        $cardMonitorings = $monitorings->only($requestedIds->all());
-        $heatmaps = $monitoringHeatmapService->getHeatmapsForMonitorings(
-            $cardMonitorings->values(),
-            Date::now()->subHours(23)->startOfHour(),
-            Date::now()->endOfHour()
-        );
-
-        $statusPayloads = $monitorings->mapWithKeys(function (Monitoring $monitoring) use ($monitoringStatusPayloadService): array {
-            return [$monitoring->id => $monitoringStatusPayloadService->getPayload($monitoring, includeMonitoring: false)];
-        });
-
-        $data = $requestedIds->mapWithKeys(function (string $monitoringId) use ($monitorings, $heatmaps, $statusPayloads): array {
-            /** @var Monitoring|null $monitoring */
-            $monitoring = $monitorings->get($monitoringId);
-
-            if (! $monitoring) {
-                return [];
-            }
-
-            return [
-                $monitoringId => array_merge(
-                    $statusPayloads->get($monitoringId)->toArray(),
-                    ['heatmap' => $heatmaps[$monitoringId] ?? []]
-                ),
-            ];
-        });
-
-        $summary = [
-            'attention' => 0,
-            'healthy' => 0,
-            'paused' => 0,
-            'maintenance' => 0,
-        ];
-
-        foreach ($summaryIds as $summaryId) {
-            $monitoring = $monitorings->get($summaryId);
-
-            if (! $monitoring) {
-                continue;
-            }
-
-            $status = $statusPayloads->get($summaryId)->status;
-            $statusValue = $status instanceof BackedEnum ? $status->value : $status;
-
-            if (in_array($statusValue, ['down', 'unknown'], true)) {
-                $summary['attention']++;
-            }
-
-            if ($statusValue === 'up') {
-                $summary['healthy']++;
-            }
-
-            if ($monitoring->isPaused()) {
-                $summary['paused']++;
-            }
-
-            if ($monitoring->isUnderMaintenance()) {
-                $summary['maintenance']++;
-            }
-        }
-
-        return response()->json(array_filter([
-            'data' => $data,
-            'summary' => array_key_exists('summary_ids', $validated) ? $summary : null,
-        ], static fn (mixed $value): bool => $value !== null));
+        return response()->json($monitoringCardDataService->for(
+            $request->user(),
+            $requestedIds,
+            $summaryIds,
+            array_key_exists('summary_ids', $validated),
+        ));
     }
 }

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -14,6 +14,7 @@ use App\Models\Monitoring;
 use App\Models\ServerInstance;
 use App\Models\Team;
 use App\Models\User;
+use App\Queries\MonitoringDetailQuery;
 use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
 use App\Services\RegionalConsensusService;
 use App\Support\MonitoringPayload;
@@ -331,20 +332,14 @@ class MonitoringController extends Controller
      * @param  Monitoring  $monitoring  The monitoring instance to display.
      * @return View The view displaying the monitoring details.
      */
-    public function show(Monitoring $monitoring, RegionalConsensusService $regionalConsensusService): View
-    {
+    public function show(
+        Monitoring $monitoring,
+        MonitoringDetailQuery $monitoringDetailQuery,
+        RegionalConsensusService $regionalConsensusService
+    ): View {
         /** @var User $user */
         $user = Auth::user();
-        $monitoring->loadMissing([
-            'domainResult',
-            'groups',
-            'latestIncident',
-            'latestResponseResult',
-            'sslResult',
-            'statusPageComponents.statusPage',
-            'team.users',
-            'user',
-        ]);
+        $monitoring = $monitoringDetailQuery->findVisible($user, (string) $monitoring->getKey());
 
         $notificationRecipients = $monitoring->team_id !== null
             ? ($monitoring->team?->users ?? collect())

--- a/app/Queries/MonitoringCardQuery.php
+++ b/app/Queries/MonitoringCardQuery.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+
+final class MonitoringCardQuery
+{
+    /**
+     * @param  list<string>  $monitoringIds
+     * @return EloquentCollection<int, Monitoring>
+     */
+    public function for(User $user, array $monitoringIds): EloquentCollection
+    {
+        if ($monitoringIds === []) {
+            return new EloquentCollection();
+        }
+
+        return Monitoring::query()
+            ->select([
+                'id',
+                'user_id',
+                'team_id',
+                'status',
+                'name',
+                'target',
+                'type',
+                'created_at',
+                'maintenance_from',
+                'maintenance_until',
+                'preferred_location',
+                'preferred_locations',
+                'heartbeat_interval_minutes',
+                'heartbeat_grace_minutes',
+                'heartbeat_last_ping_at',
+            ])
+            ->withMaintenanceWindowState()
+            ->visibleTo($user)
+            ->whereIn('id', $monitoringIds)
+            ->with([
+                'latestIncident',
+                'latestResponseResult',
+            ])
+            ->get();
+    }
+}

--- a/app/Queries/MonitoringDetailQuery.php
+++ b/app/Queries/MonitoringDetailQuery.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Monitoring;
+use App\Models\User;
+
+final class MonitoringDetailQuery
+{
+    public function findVisible(User $user, string $monitoringId): Monitoring
+    {
+        return Monitoring::query()
+            ->visibleTo($user)
+            ->withMaintenanceWindowState()
+            ->with([
+                'domainResult',
+                'groups',
+                'latestIncident',
+                'latestResponseResult',
+                'sslResult',
+                'statusPageComponents.statusPage',
+                'team.users',
+                'user',
+            ])
+            ->findOrFail($monitoringId);
+    }
+}

--- a/app/Services/MaintenanceOverviewService.php
+++ b/app/Services/MaintenanceOverviewService.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\MaintenanceWindow;
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Date;
+
+final class MaintenanceOverviewService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function for(
+        User $user,
+        string $search,
+        string $status,
+        string $groupId,
+        string $sort,
+        string $direction,
+        int $perPage,
+    ): array {
+        $manageableMonitoringIds = Monitoring::query()
+            ->manageableBy($user)
+            ->pluck('id')
+            ->map(static fn ($id): string => (string) $id)
+            ->all();
+
+        $windowsQuery = Monitoring::query()
+            ->visibleTo($user)
+            ->select(['id', 'name', 'target', 'maintenance_from', 'maintenance_until'])
+            ->with('groups:id,name');
+
+        if ($search !== '') {
+            $windowsQuery->where(function (Builder $builder) use ($search): void {
+                $builder->where('name', 'like', '%' . $search . '%')
+                    ->orWhere('target', 'like', '%' . $search . '%')
+                    ->orWhereHas('groups', fn (Builder $builder): Builder => $builder->where('name', 'like', '%' . $search . '%'));
+            });
+        }
+
+        if ($groupId !== '') {
+            $windowsQuery->whereHas('groups', fn (Builder $builder): Builder => $builder->whereKey($groupId));
+        }
+
+        $this->applyStatusFilter($windowsQuery, $status);
+
+        if ($sort === 'maintenance_status') {
+            $now = Date::now();
+            $windowsQuery
+                ->orderByRaw(
+                    "case
+                        when maintenance_from is not null and maintenance_from <= ? and (maintenance_until is null or maintenance_until >= ?) then 0
+                        when maintenance_from is not null and maintenance_from > ? then 1
+                        when maintenance_from is not null then 2
+                        else 3
+                    end {$direction}",
+                    [$now, $now, $now]
+                )
+                ->orderBy('name');
+        } else {
+            $windowsQuery->orderBy(in_array($sort, ['name', 'maintenance_from', 'maintenance_until'], true) ? $sort : 'name', $direction)
+                ->orderBy('name')
+                ->orderBy('id');
+        }
+
+        $windows = $windowsQuery->paginate(min(max($perPage, 1), 100));
+        $windowData = $windows->through(static fn (Monitoring $monitoring): array => [
+            'id' => (string) $monitoring->id,
+            'name' => $monitoring->name,
+            'target' => $monitoring->target,
+            'groups' => $monitoring->groups->map(static fn ($group): array => [
+                'id' => (string) $group->id,
+                'name' => $group->name,
+            ])->values()->all(),
+            'status' => match (true) {
+                $monitoring->isUnderMaintenance() => 'active',
+                $monitoring->maintenance_from?->isFuture() === true => 'upcoming',
+                $monitoring->maintenance_from !== null => 'expired',
+                default => 'none',
+            },
+            'maintenance_from' => $monitoring->maintenance_from?->toDayDateTimeString(),
+            'maintenance_until' => $monitoring->maintenance_until?->toDayDateTimeString(),
+            'can_manage' => in_array((string) $monitoring->id, $manageableMonitoringIds, true),
+        ]);
+
+        $visibleMonitorings = Monitoring::query()
+            ->visibleTo($user)
+            ->get(['id', 'maintenance_from', 'maintenance_until']);
+        $activeCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => $monitoring->isUnderMaintenance())->count();
+        $upcomingCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => ! $monitoring->isUnderMaintenance()
+            && $monitoring->hasUpcomingMaintenance())->count();
+        $expiredCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => ! $monitoring->isUnderMaintenance()
+            && $monitoring->maintenance_from !== null
+            && ! $monitoring->maintenance_from->isFuture())->count();
+
+        return [
+            'can_manage_maintenance' => $manageableMonitoringIds !== [],
+            'windows' => $windowData,
+            'stats' => [
+                'total' => $visibleMonitorings->count(),
+                'active' => $activeCount,
+                'upcoming' => $upcomingCount,
+                'expired' => $expiredCount,
+                'none' => $visibleMonitorings->count() - $activeCount - $upcomingCount - $expiredCount,
+            ],
+            'recurring_windows' => MaintenanceWindow::query()
+                ->visibleTo($user)
+                ->with([
+                    'monitoring:id,name',
+                    'monitoringGroup:id,name',
+                ])
+                ->latest('starts_at')
+                ->get()
+                ->map(static fn (MaintenanceWindow $maintenanceWindow): array => [
+                    'id' => (string) $maintenanceWindow->id,
+                    'target' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
+                    'recurrence' => $maintenanceWindow->recurrence->value,
+                    'duration_minutes' => $maintenanceWindow->duration_minutes,
+                    'timezone' => $maintenanceWindow->timezone,
+                    'starts_at' => $maintenanceWindow->starts_at->setTimezone($maintenanceWindow->timezone)->toDayDateTimeString(),
+                    'can_manage' => $maintenanceWindow->isManageableBy($user),
+                ])
+                ->values()
+                ->all(),
+            'monitoring_options' => Monitoring::query()
+                ->manageableBy($user)
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(static fn (Monitoring $monitoring): array => [
+                    'id' => (string) $monitoring->id,
+                    'name' => $monitoring->name,
+                ])
+                ->values()
+                ->all(),
+            'monitoring_groups' => $user->monitoringGroups()
+                ->withCount('monitorings')
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(static fn ($group): array => [
+                    'id' => (string) $group->id,
+                    'name' => $group->name,
+                    'monitorings_count' => (int) $group->monitorings_count,
+                ])
+                ->values()
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  Builder<Monitoring>  $builder
+     */
+    private function applyStatusFilter(Builder $builder, string $status): void
+    {
+        if ($status === '') {
+            return;
+        }
+
+        $now = Date::now();
+
+        match ($status) {
+            'active' => $builder
+                ->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '<=', $now)
+                ->where(function (Builder $builder) use ($now): void {
+                    $builder->whereNull('maintenance_until')
+                        ->orWhere('maintenance_until', '>=', $now);
+                }),
+            'upcoming' => $builder
+                ->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '>', $now),
+            'expired' => $builder
+                ->whereNotNull('maintenance_from')
+                ->whereNotNull('maintenance_until')
+                ->where('maintenance_until', '<', $now),
+            'none' => $builder->whereNull('maintenance_from'),
+            default => null,
+        };
+    }
+}

--- a/app/Services/MonitoringCardDataService.php
+++ b/app/Services/MonitoringCardDataService.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Monitoring;
+use App\Models\User;
+use App\Queries\MonitoringCardQuery;
+use BackedEnum;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+final class MonitoringCardDataService
+{
+    public function __construct(
+        private readonly MonitoringCardQuery $monitoringCardQuery,
+        private readonly MonitoringStatusPayloadService $monitoringStatusPayloadService,
+        private readonly MonitoringHeatmapService $monitoringHeatmapService,
+    ) {}
+
+    /**
+     * @param  Collection<int, string>  $requestedIds
+     * @param  Collection<int, string>  $summaryIds
+     * @return array{data: array<string, array<string, mixed>>, summary?: array{attention:int,healthy:int,paused:int,maintenance:int}}
+     */
+    public function for(User $user, Collection $requestedIds, Collection $summaryIds, bool $includeSummary): array
+    {
+        $monitorings = $this->monitoringCardQuery
+            ->for($user, $requestedIds->merge($summaryIds)->unique()->values()->all())
+            ->keyBy('id');
+
+        $cardMonitorings = $monitorings->only($requestedIds->all());
+        $heatmaps = $this->monitoringHeatmapService->getHeatmapsForMonitorings(
+            $cardMonitorings->values(),
+            Date::now()->subHours(23)->startOfHour(),
+            Date::now()->endOfHour(),
+        );
+
+        $statusPayloads = $monitorings->mapWithKeys(
+            fn (Monitoring $monitoring): array => [
+                $monitoring->id => $this->monitoringStatusPayloadService->getPayload($monitoring, includeMonitoring: false),
+            ]
+        );
+
+        $data = $requestedIds->mapWithKeys(function (string $monitoringId) use ($monitorings, $heatmaps, $statusPayloads): array {
+            /** @var Monitoring|null $monitoring */
+            $monitoring = $monitorings->get($monitoringId);
+
+            if (! $monitoring) {
+                return [];
+            }
+
+            return [
+                $monitoringId => array_merge(
+                    $statusPayloads->get($monitoringId)->toArray(),
+                    ['heatmap' => $heatmaps[$monitoringId] ?? []]
+                ),
+            ];
+        })->all();
+
+        $payload = ['data' => $data];
+
+        if ($includeSummary) {
+            $payload['summary'] = $this->summary($summaryIds, $monitorings, $statusPayloads);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  Collection<int, string>  $summaryIds
+     * @param  Collection<string, Monitoring>  $monitorings
+     * @param  Collection<string, mixed>  $statusPayloads
+     * @return array{attention:int,healthy:int,paused:int,maintenance:int}
+     */
+    private function summary(Collection $summaryIds, Collection $monitorings, Collection $statusPayloads): array
+    {
+        $summary = [
+            'attention' => 0,
+            'healthy' => 0,
+            'paused' => 0,
+            'maintenance' => 0,
+        ];
+
+        foreach ($summaryIds as $summaryId) {
+            /** @var Monitoring|null $monitoring */
+            $monitoring = $monitorings->get($summaryId);
+
+            if (! $monitoring) {
+                continue;
+            }
+
+            $status = $statusPayloads->get($summaryId)->status;
+            $statusValue = $status instanceof BackedEnum ? $status->value : $status;
+
+            if (in_array($statusValue, ['down', 'unknown'], true)) {
+                $summary['attention']++;
+            }
+
+            if ($statusValue === 'up') {
+                $summary['healthy']++;
+            }
+
+            if ($monitoring->isPaused()) {
+                $summary['paused']++;
+            }
+
+            if ($monitoring->isUnderMaintenance()) {
+                $summary['maintenance']++;
+            }
+        }
+
+        return $summary;
+    }
+}

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -123,7 +123,7 @@ class MonitoringOverviewService
             'attentionItems' => $attentionItems,
             'recentIncidents' => Incident::query()
                 ->with('monitoring')
-                ->whereHas('monitoring')
+                ->whereHas('monitoring', fn ($query) => $query->visibleTo($user))
                 ->latest('down_at')
                 ->limit(5)
                 ->get(),

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -39,6 +39,13 @@ objects may be shared; HTTP resources and presentation values may not be shared
 by default. UI resources contain raw locale-neutral values, never rendered HTML,
 translated relative timestamps, or named-route URLs.
 
+Monitoring reads follow the same rule: actor-scoped query classes own overview,
+detail, and batch-card data access. Focused services own health derivation,
+history, incidents, and payload assembly. Browser-specific labels, relative
+timestamps, and route URLs remain in Blade presenters, while external API
+resources keep their existing v1 contract until the external API workstream
+introduces explicit adapters.
+
 The first internal UI projection is `GET /api/v1/internal/ui/dashboard`. It
 returns raw operations data and pagination metadata; the Blade dashboard remains
 the progressive-enhancement shell until the frontend migration is complete.

--- a/tests/Feature/Api/MaintenanceDataApiTest.php
+++ b/tests/Feature/Api/MaintenanceDataApiTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class MaintenanceDataApiTest extends TestCase
+{
+    public function test_maintenance_data_is_scoped_to_the_authenticated_user(): void
+    {
+        Date::setTestNow('2026-07-26 12:00:00');
+
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $visible = Monitoring::factory()->for($user)->create([
+            'name' => 'Visible maintenance',
+            'maintenance_from' => Date::now()->subHour(),
+        ]);
+        Monitoring::factory()->for($otherUser)->create([
+            'name' => 'Hidden maintenance',
+            'maintenance_from' => Date::now()->subHour(),
+        ]);
+
+        $this->actingAs($user)->getJson('/api/maintenance')
+            ->assertOk()
+            ->assertJsonPath('data.stats.total', 1)
+            ->assertJsonPath('data.windows.data.0.id', $visible->id)
+            ->assertJsonPath('data.windows.data.0.status', 'active')
+            ->assertJsonMissing(['name' => 'Hidden maintenance']);
+    }
+}

--- a/tests/Feature/Queries/MonitoringReadQueriesTest.php
+++ b/tests/Feature/Queries/MonitoringReadQueriesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Queries;
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use App\Queries\MonitoringCardQuery;
+use App\Queries\MonitoringDetailQuery;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Tests\TestCase;
+
+class MonitoringReadQueriesTest extends TestCase
+{
+    public function test_detail_query_only_resolves_monitorings_visible_to_the_actor(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $visible = Monitoring::factory()->for($user)->create();
+        $hidden = Monitoring::factory()->for($otherUser)->create();
+
+        $query = app(MonitoringDetailQuery::class);
+
+        $this->assertTrue($query->findVisible($user, $visible->id)->is($visible));
+        $this->expectException(ModelNotFoundException::class);
+
+        $query->findVisible($user, $hidden->id);
+    }
+
+    public function test_card_query_only_returns_requested_monitorings_visible_to_the_actor(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $visible = Monitoring::factory()->for($user)->create();
+        $hidden = Monitoring::factory()->for($otherUser)->create();
+
+        $monitorings = app(MonitoringCardQuery::class)->for($user, [$visible->id, $hidden->id]);
+
+        $this->assertSame([$visible->id], $monitorings->modelKeys());
+        $this->assertTrue($monitorings->first()->relationLoaded('latestIncident'));
+        $this->assertTrue($monitorings->first()->relationLoaded('latestResponseResult'));
+    }
+}


### PR DESCRIPTION
## What changed

- Extracts actor-scoped query classes for monitoring detail and batch-card reads.
- Moves card aggregation and maintenance overview assembly out of API controllers into focused services.
- Makes the dashboard's recent-incident read explicitly enforce the current user's monitoring visibility.
- Keeps existing card and maintenance JSON response shapes intact.
- Documents the monitoring read-layer boundary.

## Why

The same monitoring data serves Blade views, internal UI projections, and external API consumers. Keeping query ownership and visibility checks in the application layer prevents cross-user leakage and allows later HTTP adapters to reuse the reads safely.

## Testing

- Docker Pest: 17 tests, 106 assertions
- Docker PHPStan analysis: clean
- Docker Laravel Pint: clean

## Risks and follow-up

- This is the first implementation slice of #594. The remaining UI presentation split and external API adapters continue in the linked architecture work.

Refs #594