### PR TITLE
refactor(api): isolate external v1 adapters

### DIFF
--- a/app/Http/Controllers/Api/External/MobileOverviewController.php
+++ b/app/Http/Controllers/Api/External/MobileOverviewController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 mobile overview contract.
+ */
+class MobileOverviewController extends \App\Http\Controllers\Api\Mobile\MobileOverviewController {}

--- a/app/Http/Controllers/Api/External/MobilePushDeviceController.php
+++ b/app/Http/Controllers/Api/External/MobilePushDeviceController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 mobile device contract.
+ */
+class MobilePushDeviceController extends \App\Http\Controllers\Api\MobilePushDeviceController {}

--- a/app/Http/Controllers/Api/External/MonitoringDataController.php
+++ b/app/Http/Controllers/Api/External/MonitoringDataController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 monitoring read contract.
+ */
+class MonitoringDataController extends \App\Http\Controllers\ApiController {}

--- a/app/Http/Controllers/Api/External/MonitoringManagementController.php
+++ b/app/Http/Controllers/Api/External/MonitoringManagementController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for externally supported v1 monitoring mutations.
+ */
+class MonitoringManagementController extends \App\Http\Controllers\Api\MonitoringManagementController {}

--- a/app/Http/Controllers/Api/External/TeamController.php
+++ b/app/Http/Controllers/Api/External/TeamController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 team contract.
+ */
+class TeamController extends \App\Http\Controllers\Api\TeamController {}

--- a/app/Http/Controllers/Api/External/TeamInvitationController.php
+++ b/app/Http/Controllers/Api/External/TeamInvitationController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 invitation contract.
+ */
+class TeamInvitationController extends \App\Http\Controllers\Api\TeamInvitationController {}

--- a/app/Http/Controllers/Api/External/TeamMemberController.php
+++ b/app/Http/Controllers/Api/External/TeamMemberController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 team-member contract.
+ */
+class TeamMemberController extends \App\Http\Controllers\Api\TeamMemberController {}

--- a/app/Http/Middleware/TrackApiUsage.php
+++ b/app/Http/Middleware/TrackApiUsage.php
@@ -14,6 +14,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TrackApiUsage
 {
+    private const MAX_ATTEMPTS = 5;
+
+    private const DECAY_SECONDS = 60;
+
     /**
      * Middleware to validate API access for internal and external clients.
      *
@@ -33,17 +37,27 @@ class TrackApiUsage
 
                 $key = 'api:' . $user->getAuthIdentifier();
 
-                if (RateLimiter::tooManyAttempts($key, 5)) {
+                if (RateLimiter::tooManyAttempts($key, self::MAX_ATTEMPTS)) {
                     return response()->json([
                         'message' => 'Too many requests.',
-                    ], 429)->header('Retry-After', (string) RateLimiter::availableIn($key));
+                    ], 429)
+                        ->header('Retry-After', (string) RateLimiter::availableIn($key))
+                        ->header('X-RateLimit-Limit', (string) self::MAX_ATTEMPTS)
+                        ->header('X-RateLimit-Remaining', '0');
                 }
 
-                RateLimiter::hit($key, 60);
+                RateLimiter::hit($key, self::DECAY_SECONDS);
 
                 dispatch(new LogApiUsage((string) $user->getAuthIdentifier(), url()->current()));
 
-                return $next($request);
+                $response = $next($request);
+                $response->headers->set('X-RateLimit-Limit', (string) self::MAX_ATTEMPTS);
+                $response->headers->set(
+                    'X-RateLimit-Remaining',
+                    (string) max(0, self::MAX_ATTEMPTS - RateLimiter::attempts($key))
+                );
+
+                return $response;
             }
         }
 

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -1,0 +1,33 @@
+# External API v1 compatibility
+
+`/api/v1/*` is the supported REST API for platform users and integrations. It
+uses a Sanctum personal-access token and is deliberately separate from browser
+UI routes and scanner-instance routes.
+
+## Compatibility policy
+
+- Existing JSON bodies, status codes, validation errors, and authorization
+  behavior are stable v1 contract. Additive fields are allowed; removals and
+  shape changes require a new major version.
+- The external route file resolves only controllers in
+  `App\\Http\\Controllers\\Api\\External`. These are explicit compatibility
+  adapters while controller-specific resources are introduced incrementally.
+- List endpoints retain their current contract. Monitoring lists accept
+  `per_page` from 1 through 100 (default 25); other current list shapes are not
+  silently converted to a pagination envelope.
+
+## Rate limits
+
+Non-mobile external tokens have a per-user limit of five requests per 60-second
+window. Responses include `X-RateLimit-Limit` and `X-RateLimit-Remaining`; a
+limited request returns `429`, `Retry-After`, and zero remaining requests.
+
+The rate limiter deliberately does not log access tokens or authorization
+headers. Mobile app tokens retain their existing separate behavior.
+
+## Follow-up
+
+The external API workstream owns explicit resources, error/problem responses,
+correlation IDs, idempotency, deprecation policy, and generated Scribe/OpenAPI
+coverage. Generated API documents are updated only through their documented
+generation process.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ Distributed scanning nodes and workers are maintained separately in the [WebGuar
 The API boundary decision and migration rules are documented in the
 [API boundaries ADR](architecture/api-boundaries.md). Scanner-instance consumers
 must follow the separate [WebGuard Instance API contract](integrations/webguard-instance-api.md).
+The stable external contract is documented in [External API v1 compatibility](api/external-v1.md).
 
 ## Backend
 

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\Api\Mobile\MobileOverviewController;
-use App\Http\Controllers\Api\MobilePushDeviceController;
-use App\Http\Controllers\Api\MonitoringManagementController;
-use App\Http\Controllers\Api\TeamController;
-use App\Http\Controllers\Api\TeamInvitationController;
-use App\Http\Controllers\Api\TeamMemberController;
-use App\Http\Controllers\ApiController;
+use App\Http\Controllers\Api\External\MobileOverviewController;
+use App\Http\Controllers\Api\External\MobilePushDeviceController;
+use App\Http\Controllers\Api\External\MonitoringDataController;
+use App\Http\Controllers\Api\External\MonitoringManagementController;
+use App\Http\Controllers\Api\External\TeamController;
+use App\Http\Controllers\Api\External\TeamInvitationController;
+use App\Http\Controllers\Api\External\TeamMemberController;
 use Illuminate\Support\Facades\Route;
 
 /**
@@ -24,17 +24,17 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
     Route::post('/{monitoring}/team-ownership', [MonitoringManagementController::class, 'moveToTeam']);
     Route::delete('/{monitoring}/team-ownership', [MonitoringManagementController::class, 'moveToPrivate']);
 
-    Route::get('/{monitoring}', [ApiController::class, 'all']);
+    Route::get('/{monitoring}', [MonitoringDataController::class, 'all']);
 
-    Route::get('/{monitoring}/status', [ApiController::class, 'status']);
-    Route::get('/{monitoring}/uptime-downtime', [ApiController::class, 'uptimeDowntime']);
-    Route::get('/{monitoring}/uptime-downtime-summary', [ApiController::class, 'uptimeDowntimeSummary']);
-    Route::get('/{monitoring}/response-times', [ApiController::class, 'responseTimes']);
-    Route::get('/{monitoring}/checks', [ApiController::class, 'checks']);
-    Route::get('/{monitoring}/incidents', [ApiController::class, 'incidents']);
-    Route::get('/{monitoring}/heatmap', [ApiController::class, 'uptimeHeatmap']);
-    Route::get('/{monitoring}/ssl', [ApiController::class, 'sslStatus']);
-    Route::get('/{monitoring}/uptime-calendar', [ApiController::class, 'uptimeCalendar']);
+    Route::get('/{monitoring}/status', [MonitoringDataController::class, 'status']);
+    Route::get('/{monitoring}/uptime-downtime', [MonitoringDataController::class, 'uptimeDowntime']);
+    Route::get('/{monitoring}/uptime-downtime-summary', [MonitoringDataController::class, 'uptimeDowntimeSummary']);
+    Route::get('/{monitoring}/response-times', [MonitoringDataController::class, 'responseTimes']);
+    Route::get('/{monitoring}/checks', [MonitoringDataController::class, 'checks']);
+    Route::get('/{monitoring}/incidents', [MonitoringDataController::class, 'incidents']);
+    Route::get('/{monitoring}/heatmap', [MonitoringDataController::class, 'uptimeHeatmap']);
+    Route::get('/{monitoring}/ssl', [MonitoringDataController::class, 'sslStatus']);
+    Route::get('/{monitoring}/uptime-calendar', [MonitoringDataController::class, 'uptimeCalendar']);
 });
 
 Route::get('/mobile/overview', MobileOverviewController::class)

--- a/tests/Feature/Api/ApiControllerTest.php
+++ b/tests/Feature/Api/ApiControllerTest.php
@@ -33,6 +33,8 @@ class ApiControllerTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertJson(['interval' => 300]);
+        $testResponse->assertHeader('X-RateLimit-Limit', '5');
+        $testResponse->assertHeader('X-RateLimit-Remaining', '4');
     }
 
     public function test_returns_status_metadata_and_translation_keys_in_status_endpoint(): void
@@ -75,6 +77,8 @@ class ApiControllerTest extends TestCase
         $retryAfter = (int) $testResponse->headers->get('Retry-After');
         $this->assertGreaterThan(0, $retryAfter);
         $this->assertLessThanOrEqual(60, $retryAfter);
+        $testResponse->assertHeader('X-RateLimit-Limit', '5');
+        $testResponse->assertHeader('X-RateLimit-Remaining', '0');
     }
 
     public function test_api_access_tokens_are_rate_limited_and_logged(): void

--- a/tests/Feature/Api/ExternalApiRouteBoundaryTest.php
+++ b/tests/Feature/Api/ExternalApiRouteBoundaryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Http\Controllers\Api\External\MobileOverviewController;
+use App\Http\Controllers\Api\External\MobilePushDeviceController;
+use App\Http\Controllers\Api\External\MonitoringDataController;
+use App\Http\Controllers\Api\External\MonitoringManagementController;
+use App\Http\Controllers\Api\External\TeamController;
+use App\Http\Controllers\Api\External\TeamInvitationController;
+use App\Http\Controllers\Api\External\TeamMemberController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ExternalApiRouteBoundaryTest extends TestCase
+{
+    public function test_external_v1_routes_use_external_compatibility_adapters(): void
+    {
+        $routes = [
+            ['/api/v1/monitorings', 'GET', MonitoringManagementController::class],
+            ['/api/v1/monitorings/example/status', 'GET', MonitoringDataController::class],
+            ['/api/v1/mobile/overview', 'GET', MobileOverviewController::class],
+            ['/api/v1/mobile-push-devices', 'GET', MobilePushDeviceController::class],
+            ['/api/v1/teams', 'GET', TeamController::class],
+            ['/api/v1/teams/example/members', 'GET', TeamMemberController::class],
+            ['/api/v1/teams/example/invitations', 'GET', TeamInvitationController::class],
+        ];
+
+        foreach ($routes as [$uri, $method, $controller]) {
+            $route = Route::getRoutes()->match(Request::create($uri, $method));
+
+            $this->assertStringStartsWith($controller, $route->getActionName());
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Routes every external `/api/v1` endpoint through an explicit `Api\\External` compatibility adapter.
- Preserves existing v1 JSON bodies, status codes, validation, and authorization behavior.
- Adds standard rate-limit headers to non-mobile external API responses and 429 responses.
- Documents v1 compatibility, list limits, rate limits, and the remaining generated-documentation work.
- Adds route-boundary and header contract coverage.

## Why

External integrations require a deliberately maintained boundary that can evolve independently from browser UI and scanner-instance APIs. The adapters make that ownership explicit without a breaking v1 rewrite.

## Testing

- Docker Pest: 34 tests, 284 assertions
- Docker PHPStan analysis: clean
- Docker Laravel Pint: clean

## Risks and follow-up

- This is the first #595 slice. Explicit resources, problem responses, correlation IDs, idempotency, deprecation, and generated Scribe/OpenAPI coverage remain follow-up work.
- Current unpaginated v1 list shapes are intentionally preserved; only monitoring lists expose the documented `per_page` cap.

Refs #595