### PR TITLE
feat(ui-api): add monitoring read projections

### DIFF
--- a/app/Http/Controllers/Api/Internal/Ui/MonitoringCardsController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/MonitoringCardsController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Internal\Ui;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\InternalUi\MonitoringCardsRequest;
+use App\Models\User;
+use App\Services\MonitoringCardDataService;
+use Illuminate\Http\JsonResponse;
+
+class MonitoringCardsController extends Controller
+{
+    public function __invoke(MonitoringCardsRequest $request, MonitoringCardDataService $monitoringCardDataService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $ids = collect($request->monitoringIds());
+
+        return response()->json($monitoringCardDataService->for($user, $ids, $ids, true));
+    }
+}

--- a/app/Http/Controllers/Api/Internal/Ui/MonitoringIndexController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/MonitoringIndexController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Internal\Ui;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\InternalUi\MonitoringIndexRequest;
+use App\Http\Resources\InternalUi\MonitoringResource;
+use App\Models\User;
+use App\Queries\MonitoringOverviewQuery;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class MonitoringIndexController extends Controller
+{
+    public function __invoke(MonitoringIndexRequest $request, MonitoringOverviewQuery $monitoringOverviewQuery): AnonymousResourceCollection
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $monitorings = $monitoringOverviewQuery->paginateFor(
+            $user,
+            $request->page(),
+            $request->perPage(),
+            $request->search(),
+            $request->lifecycleStatus(),
+        );
+
+        return MonitoringResource::collection($monitorings)->additional([
+            'meta' => [
+                'as_of' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Internal/Ui/MonitoringShowController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/MonitoringShowController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Internal\Ui;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\InternalUi\MonitoringResource;
+use App\Models\User;
+use App\Queries\MonitoringDetailQuery;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MonitoringShowController extends Controller
+{
+    public function __invoke(Request $request, string $monitoring, MonitoringDetailQuery $monitoringDetailQuery): JsonResource
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return MonitoringResource::make($monitoringDetailQuery->findVisible($user, $monitoring));
+    }
+}

--- a/app/Http/Requests/InternalUi/MonitoringCardsRequest.php
+++ b/app/Http/Requests/InternalUi/MonitoringCardsRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\InternalUi;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MonitoringCardsRequest extends FormRequest
+{
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'ids' => ['required', 'array', 'min:1', 'max:100'],
+            'ids.*' => ['required', 'string', 'distinct'],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function monitoringIds(): array
+    {
+        /** @var list<string> $ids */
+        $ids = $this->validated('ids');
+
+        return $ids;
+    }
+}

--- a/app/Http/Requests/InternalUi/MonitoringIndexRequest.php
+++ b/app/Http/Requests/InternalUi/MonitoringIndexRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\InternalUi;
+
+use App\Enums\MonitoringLifecycleStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MonitoringIndexRequest extends FormRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'page' => ['nullable', 'integer', 'min:1', 'max:100000'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'search' => ['nullable', 'string', 'max:120'],
+            'lifecycle_status' => ['nullable', 'string', Rule::enum(MonitoringLifecycleStatus::class)],
+        ];
+    }
+
+    public function page(): int
+    {
+        return (int) ($this->validated('page') ?? 1);
+    }
+
+    public function perPage(): int
+    {
+        return (int) ($this->validated('per_page') ?? 20);
+    }
+
+    public function search(): ?string
+    {
+        $search = $this->validated('search');
+
+        return is_string($search) && $search !== '' ? $search : null;
+    }
+
+    public function lifecycleStatus(): ?MonitoringLifecycleStatus
+    {
+        $status = $this->validated('lifecycle_status');
+
+        return is_string($status) ? MonitoringLifecycleStatus::from($status) : null;
+    }
+}

--- a/app/Http/Resources/InternalUi/MonitoringResource.php
+++ b/app/Http/Resources/InternalUi/MonitoringResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\InternalUi;
+
+use App\Models\Monitoring;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Monitoring */
+class MonitoringResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'target' => $this->target,
+            'type' => $this->type?->value ?? $this->type,
+            'lifecycle_status' => $this->status?->value ?? $this->status,
+            'groups' => $this->whenLoaded('groups', fn (): array => $this->groups->map(
+                fn ($group): array => ['id' => $group->id, 'name' => $group->name]
+            )->values()->all()),
+            'latest_check' => $this->whenLoaded('latestResponseResult', fn (): ?array => $this->latestResponseResult ? [
+                'status' => $this->latestResponseResult->status?->value ?? $this->latestResponseResult->status,
+                'checked_at' => $this->latestResponseResult->created_at?->toIso8601String(),
+                'response_time_ms' => $this->latestResponseResult->response_time,
+            ] : null),
+            'open_incident' => $this->whenLoaded('latestIncident', fn (): bool => $this->latestIncident?->up_at === null),
+            'maintenance' => [
+                'starts_at' => $this->maintenance_from?->toIso8601String(),
+                'ends_at' => $this->maintenance_until?->toIso8601String(),
+                'has_recurring_window' => $this->has_enabled_maintenance_windows,
+            ],
+        ];
+    }
+}

--- a/app/Queries/MonitoringOverviewQuery.php
+++ b/app/Queries/MonitoringOverviewQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Queries;
 
+use App\Enums\MonitoringLifecycleStatus;
 use App\Models\Monitoring;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -25,10 +26,45 @@ final class MonitoringOverviewQuery
      */
     public function paginateServicesFor(User $user, int $page, int $perPage = 10): LengthAwarePaginator
     {
-        return $this->query($user)->paginate(
+        return $this->paginate($this->query($user), $page, $perPage, 'service_page');
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, Monitoring>
+     */
+    public function paginateFor(
+        User $user,
+        int $page,
+        int $perPage = 20,
+        ?string $search = null,
+        ?MonitoringLifecycleStatus $lifecycleStatus = null,
+    ): LengthAwarePaginator {
+        $query = $this->query($user);
+
+        if ($search !== null && $search !== '') {
+            $query->where(function (Builder $query) use ($search): void {
+                $query->where('name', 'like', '%' . $search . '%')
+                    ->orWhere('target', 'like', '%' . $search . '%');
+            });
+        }
+
+        if ($lifecycleStatus !== null) {
+            $query->where('status', $lifecycleStatus);
+        }
+
+        return $this->paginate($query, $page, $perPage, 'page');
+    }
+
+    /**
+     * @param  Builder<Monitoring>  $query
+     * @return LengthAwarePaginator<int, Monitoring>
+     */
+    private function paginate(Builder $query, int $page, int $perPage, string $pageName): LengthAwarePaginator
+    {
+        return $query->paginate(
             $perPage,
             $this->columns(),
-            'service_page',
+            $pageName,
             max(1, $page),
         );
     }
@@ -39,6 +75,7 @@ final class MonitoringOverviewQuery
     private function query(User $user): Builder
     {
         return Monitoring::query()
+            ->withMaintenanceWindowState()
             ->visibleTo($user)
             ->with([
                 'latestResponseResult' => fn ($query) => $query->select([

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -55,6 +55,12 @@ does not parse server-rendered dashboard fragments, keeping the internal API
 contract independent from Blade markup. The former asynchronous HTML endpoint
 remains temporarily as a reversible compatibility fallback.
 
+The current UI read contract also exposes `GET /api/v1/internal/ui/monitorings`,
+`GET /api/v1/internal/ui/monitorings/{monitoring}`, and the bounded
+`GET /api/v1/internal/ui/monitorings/cards?ids[]=` projection. These routes use
+the session-and-verification boundary, return raw locale-neutral values, and
+scope every result to the authenticated user.
+
 ## Current-to-target migration
 
 The current scanner routes are the compatibility baseline. Core now exposes the

--- a/routes/api/ui.php
+++ b/routes/api/ui.php
@@ -3,6 +3,12 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Api\Internal\Ui\DashboardController;
+use App\Http\Controllers\Api\Internal\Ui\MonitoringCardsController;
+use App\Http\Controllers\Api\Internal\Ui\MonitoringIndexController;
+use App\Http\Controllers\Api\Internal\Ui\MonitoringShowController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/dashboard', DashboardController::class)->name('dashboard');
+Route::get('/monitorings', MonitoringIndexController::class)->name('monitorings.index');
+Route::get('/monitorings/cards', MonitoringCardsController::class)->name('monitorings.cards');
+Route::get('/monitorings/{monitoring}', MonitoringShowController::class)->name('monitorings.show');

--- a/tests/Feature/Api/InternalUiMonitoringApiTest.php
+++ b/tests/Feature/Api/InternalUiMonitoringApiTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InternalUiMonitoringApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_verified_user_can_list_only_visible_monitorings_with_a_bounded_page(): void
+    {
+        $user = User::factory()->create();
+        $visibleMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
+        Monitoring::factory()->for($user)->create(['name' => 'Another API']);
+        Monitoring::factory()->create(['name' => 'Hidden API']);
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $visibleMonitoring->id,
+            'status' => MonitoringStatus::UP,
+            'response_time' => 128.4,
+        ]);
+
+        $this->actingAs($user)->getJson(route('api.v1.internal.ui.monitorings.index', [
+            'per_page' => 1,
+            'search' => 'Visible',
+        ]))
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $visibleMonitoring->id)
+            ->assertJsonPath('data.0.latest_check.status', MonitoringStatus::UP->value)
+            ->assertJsonPath('data.0.latest_check.response_time_ms', 128.4)
+            ->assertJsonPath('meta.per_page', 1)
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonStructure([
+                'data' => [[
+                    'id',
+                    'name',
+                    'target',
+                    'type',
+                    'lifecycle_status',
+                    'groups',
+                    'latest_check',
+                    'open_incident',
+                    'maintenance',
+                ]],
+                'meta' => ['as_of'],
+            ])
+            ->assertJsonMissing(['name' => 'Hidden API']);
+    }
+
+    public function test_internal_ui_monitoring_detail_returns_not_found_for_another_users_monitoring(): void
+    {
+        $user = User::factory()->create();
+        $foreignMonitoring = Monitoring::factory()->create();
+
+        $this->actingAs($user)->getJson(route('api.v1.internal.ui.monitorings.show', $foreignMonitoring))
+            ->assertNotFound();
+    }
+
+    public function test_internal_ui_monitoring_cards_are_scoped_and_require_a_verified_session(): void
+    {
+        $user = User::factory()->create();
+        $visibleMonitoring = Monitoring::factory()->for($user)->create();
+        $foreignMonitoring = Monitoring::factory()->create();
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $visibleMonitoring->id,
+            'status' => MonitoringStatus::UP,
+            'response_time' => 128.4,
+        ]);
+
+        $this->actingAs($user)->getJson(route('api.v1.internal.ui.monitorings.cards', [
+            'ids' => [$visibleMonitoring->id, $foreignMonitoring->id],
+        ]))
+            ->assertOk()
+            ->assertJsonPath('data.' . $visibleMonitoring->id . '.status', MonitoringStatus::UP->value)
+            ->assertJsonMissingPath('data.' . $foreignMonitoring->id);
+
+        $unverifiedUser = User::factory()->unverified()->create();
+
+        $this->actingAs($unverifiedUser)->getJson(route('api.v1.internal.ui.monitorings.index'))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## What changed
- Added verified-session internal UI routes for paginated monitoring lists, scoped monitoring detail, and bounded card batches.
- Added typed request validation and locale-neutral monitoring resources.
- Extended the actor-scoped monitoring overview query with search, lifecycle filtering, UI pagination, and maintenance-window presence without per-row maintenance lookups.
- Documented the monitoring UI read contract.

## Why
The management UI now has dedicated monitoring read projections under `/api/v1/internal/ui`, without sharing scanner endpoints or external API response shapes.

## Testing
- `docker compose -p webguard-core-0530 -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps php ./vendor/bin/pest tests/Feature/Api/InternalUiMonitoringApiTest.php tests/Feature/Api/InternalUiDashboardApiTest.php tests/Feature/DashboardOverviewTest.php tests/Feature/Api/MonitoringCardDataApiTest.php` (19 passed, 131 assertions)
- `docker compose -p webguard-core-0530 -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps php ./vendor/bin/pint --test app/Queries/MonitoringOverviewQuery.php app/Http/Controllers/Api/Internal/Ui app/Http/Requests/InternalUi app/Http/Resources/InternalUi tests/Feature/Api/InternalUiMonitoringApiTest.php`
- `docker compose -p webguard-core-0530 -f docker-compose.yml -f docker-compose.override.yml run --rm --no-deps php composer analyse`

## Risks and follow-up
These are read-only projections; no existing UI consumer is switched in this change. Maintenance values intentionally remain raw and include recurring-window presence so the endpoint avoids per-row maintenance queries. Additional UI projections remain tracked in #596.

Refs #596