### PR TITLE
fix(docker): preserve mounted node dependencies

### DIFF
--- a/docker/node/entrypoint.sh
+++ b/docker/node/entrypoint.sh
@@ -15,7 +15,7 @@ if [ ! -d node_modules ] || [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
 fi
 
 if ! ls node_modules/@rollup/rollup-linux-* >/dev/null 2>&1; then
-  rm -rf node_modules
+  find node_modules -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
   bun install --frozen-lockfile
 fi
 

--- a/tests/Feature/NodeEntrypointDeploymentConfigTest.php
+++ b/tests/Feature/NodeEntrypointDeploymentConfigTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class NodeEntrypointDeploymentConfigTest extends TestCase
+{
+    public function test_dependency_recovery_preserves_the_mounted_node_modules_directory(): void
+    {
+        $entrypoint = file_get_contents(base_path('docker/node/entrypoint.sh'));
+
+        $this->assertIsString($entrypoint);
+        $this->assertStringContainsString(
+            'find node_modules -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
+            $entrypoint
+        );
+        $this->assertStringNotContainsString('rm -rf node_modules', $entrypoint);
+    }
+}


### PR DESCRIPTION
## What changed
- preserve the mounted `node_modules` volume while clearing incompatible dependency contents
- add a regression test for the Docker node entrypoint

## Why
The local Node service previously attempted to delete its mounted dependency directory when Linux Rollup packages were missing, causing startup to fail.

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.override.yml config -q`
- `./vendor/bin/pest tests/Feature/NodeEntrypointDeploymentConfigTest.php` in the PHP container
- `./vendor/bin/pint --test tests/Feature/NodeEntrypointDeploymentConfigTest.php` in the PHP container
- rebuilt and started the Node service, then ran `bun run build` in that container

## Risks and follow-up
This changes only local Docker dependency recovery; no public or instance API contracts change.

Closes #605