### PR TITLE
refactor(monitoring): add service read model

### DIFF
--- a/app/Data/MonitoringServiceReadModel.php
+++ b/app/Data/MonitoringServiceReadModel.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use App\Models\Monitoring;
+use JsonSerializable;
+
+final readonly class MonitoringServiceReadModel implements JsonSerializable
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $target,
+        public ?string $type,
+        public ?string $groupName,
+        public string $status,
+        public bool $hasOpenIncident,
+        public ?string $lastCheckedAt,
+        public ?float $responseTimeMs,
+    ) {}
+
+    public static function fromMonitoring(Monitoring $monitoring, string $status): self
+    {
+        $latestResponse = $monitoring->latestResponseResult;
+
+        return new self(
+            id: (string) $monitoring->getKey(),
+            name: (string) $monitoring->name,
+            target: (string) $monitoring->target,
+            type: $monitoring->type?->value,
+            groupName: $monitoring->groups->first()?->name,
+            status: $status,
+            hasOpenIncident: $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null,
+            lastCheckedAt: $latestResponse?->created_at?->toIso8601String(),
+            responseTimeMs: $latestResponse?->response_time,
+        );
+    }
+
+    /**
+     * @return array{id:string,name:string,target:string,type:string|null,group_name:string|null,status:string,open_incident:bool,last_checked_at:string|null,response_time_ms:float|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'target' => $this->target,
+            'type' => $this->type,
+            'group_name' => $this->groupName,
+            'status' => $this->status,
+            'open_incident' => $this->hasOpenIncident,
+            'last_checked_at' => $this->lastCheckedAt,
+            'response_time_ms' => $this->responseTimeMs,
+        ];
+    }
+
+    /**
+     * @return array{id:string,name:string,target:string,type:string|null,group_name:string|null,status:string,open_incident:bool,last_checked_at:string|null,response_time_ms:float|null}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Data\MonitoringServiceReadModel;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringStatus;
 use App\Enums\NotificationDeliveryStatus;
@@ -31,6 +32,7 @@ class MonitoringOverviewService
      * @return array{
      *     monitorings: EloquentCollection<int, Monitoring>,
      *     signalRoomServices: Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>,
+     *     serviceReadModels: Collection<int, MonitoringServiceReadModel>,
      *     signalRoomPagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null},
      *     summary: array{total:int,healthy:int,down:int,unknown:int,paused:int,maintenance:int},
      *     overallState: string,
@@ -81,25 +83,15 @@ class MonitoringOverviewService
             $this->statusPagesByMonitoringId($user)
         );
         $overallState = $this->overallState($summary);
-        $signalRoomServices = $monitorings->map(function (Monitoring $monitoring) use ($statuses): array {
-            $status = (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value);
-            $latestResponse = $monitoring->latestResponseResult;
-
-            return [
-                'id' => (string) $monitoring->getKey(),
-                'name' => (string) $monitoring->name,
-                'target' => (string) $monitoring->target,
-                'status' => $status,
-                'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $status),
-                'group' => (string) ($monitoring->groups->first()?->name ?? __('dashboard.signal_room.ungrouped')),
-                'lastCheck' => $latestResponse?->created_at?->locale(app()->getLocale())->diffForHumans() ?? __('dashboard.signal_room.no_check'),
-                'responseTime' => $latestResponse?->response_time !== null
-                    ? number_format((float) $latestResponse->response_time, 0, ',', '.') . ' ms'
-                    : '—',
-                'openIncident' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null,
-                'href' => route('monitorings.show', $monitoring),
-            ];
-        })->values();
+        $serviceReadModels = $monitorings->map(
+            fn (Monitoring $monitoring): MonitoringServiceReadModel => MonitoringServiceReadModel::fromMonitoring(
+                $monitoring,
+                (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value),
+            )
+        )->values();
+        $signalRoomServices = $serviceReadModels->map(
+            fn (MonitoringServiceReadModel $service): array => $this->servicePresentation($service)
+        );
         $lengthAwarePaginator = new LengthAwarePaginator(
             $signalRoomServices->forPage(max(1, $servicePage), 10)->values(),
             $signalRoomServices->count(),
@@ -111,6 +103,7 @@ class MonitoringOverviewService
         return [
             'monitorings' => $monitorings,
             'signalRoomServices' => $lengthAwarePaginator->getCollection(),
+            'serviceReadModels' => $serviceReadModels->forPage(max(1, $servicePage), 10)->values(),
             'signalRoomPagination' => [
                 'current_page' => $lengthAwarePaginator->currentPage(),
                 'last_page' => $lengthAwarePaginator->lastPage(),
@@ -178,25 +171,37 @@ class MonitoringOverviewService
             fn (Monitoring $monitoring): array => [$monitoring->id => $this->status($monitoring)]
         );
 
-        return $monitorings->map(function (Monitoring $monitoring) use ($statuses): array {
-            $status = (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value);
-            $latestResponse = $monitoring->latestResponseResult;
+        return $monitorings->map(
+            fn (Monitoring $monitoring): array => $this->servicePresentation(
+                MonitoringServiceReadModel::fromMonitoring(
+                    $monitoring,
+                    (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value),
+                )
+            )
+        )->values();
+    }
 
-            return [
-                'id' => (string) $monitoring->getKey(),
-                'name' => (string) $monitoring->name,
-                'target' => (string) $monitoring->target,
-                'status' => $status,
-                'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $status),
-                'group' => (string) ($monitoring->groups->first()?->name ?? __('dashboard.signal_room.ungrouped')),
-                'lastCheck' => $latestResponse?->created_at?->locale(app()->getLocale())->diffForHumans() ?? __('dashboard.signal_room.no_check'),
-                'responseTime' => $latestResponse?->response_time !== null
-                    ? number_format((float) $latestResponse->response_time, 0, ',', '.') . ' ms'
-                    : '—',
-                'openIncident' => $monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null,
-                'href' => route('monitorings.show', $monitoring),
-            ];
-        })->values();
+    /**
+     * @return array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}
+     */
+    private function servicePresentation(MonitoringServiceReadModel $service): array
+    {
+        return [
+            'id' => $service->id,
+            'name' => $service->name,
+            'target' => $service->target,
+            'status' => $service->status,
+            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $service->status),
+            'group' => $service->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
+            'lastCheck' => $service->lastCheckedAt !== null
+                ? Carbon::parse($service->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
+                : (string) __('dashboard.signal_room.no_check'),
+            'responseTime' => $service->responseTimeMs !== null
+                ? number_format($service->responseTimeMs, 0, ',', '.') . ' ms'
+                : '—',
+            'openIncident' => $service->hasOpenIncident,
+            'href' => route('monitorings.show', ['monitoring' => $service->id]),
+        ];
     }
 
     private function status(Monitoring $monitoring): string

--- a/app/Services/OperationsOverviewPayloadService.php
+++ b/app/Services/OperationsOverviewPayloadService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Data\MonitoringServiceReadModel;
 use App\Models\Incident;
 use App\Models\Monitoring;
 use App\Models\StatusPage;
@@ -21,16 +22,13 @@ final class OperationsOverviewPayloadService
     public function for(User $user, int $servicePage = 1): array
     {
         $overview = $this->monitoringOverviewService->overview($user, $servicePage);
-        $monitorings = $overview['monitorings']->keyBy(
-            fn (Monitoring $monitoring): string => (string) $monitoring->getKey()
-        );
 
         return [
             'data' => [
                 'overall_state' => $overview['overallState'],
                 'summary' => $overview['summary'],
-                'services' => $overview['signalRoomServices']->map(
-                    fn (array $service): array => $this->servicePayload($service, $monitorings->get($service['id']))
+                'services' => $overview['serviceReadModels']->map(
+                    fn (MonitoringServiceReadModel $service): array => $this->servicePayload($service)
                 )->values()->all(),
                 'attention' => $overview['attentionItems']->map(
                     fn (array $item): array => $this->attentionPayload($item)
@@ -54,23 +52,20 @@ final class OperationsOverviewPayloadService
     }
 
     /**
-     * @param  array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}  $service
      * @return array<string, mixed>
      */
-    private function servicePayload(array $service, ?Monitoring $monitoring): array
+    private function servicePayload(MonitoringServiceReadModel $service): array
     {
-        $latestResponse = $monitoring?->latestResponseResult;
-
         return [
-            'id' => $service['id'],
-            'name' => $service['name'],
-            'target' => $service['target'],
-            'type' => $monitoring?->type?->value ?? $monitoring?->type,
-            'group' => $service['group'],
-            'status' => $service['status'],
-            'open_incident' => $service['openIncident'],
-            'last_checked_at' => $latestResponse?->created_at?->toIso8601String(),
-            'response_time_ms' => $latestResponse?->response_time,
+            'id' => $service->id,
+            'name' => $service->name,
+            'target' => $service->target,
+            'type' => $service->type,
+            'group' => $service->groupName,
+            'status' => $service->status,
+            'open_incident' => $service->hasOpenIncident,
+            'last_checked_at' => $service->lastCheckedAt,
+            'response_time_ms' => $service->responseTimeMs,
         ];
     }
 

--- a/tests/Unit/Data/MonitoringServiceReadModelTest.php
+++ b/tests/Unit/Data/MonitoringServiceReadModelTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Data;
+
+use App\Data\MonitoringServiceReadModel;
+use App\Enums\MonitoringStatus;
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class MonitoringServiceReadModelTest extends TestCase
+{
+    public function test_it_exposes_locale_neutral_service_values_with_stable_timestamps(): void
+    {
+        $checkedAt = Carbon::parse('2026-07-26 12:00:00', 'UTC');
+        $monitoring = new Monitoring();
+        $monitoring->forceFill([
+            'id' => 'monitoring-123',
+            'name' => 'Checkout API',
+            'target' => 'https://checkout.example.test',
+            'type' => MonitoringType::HTTP,
+        ]);
+        $response = new MonitoringResponse();
+        $response->forceFill([
+            'status' => MonitoringStatus::UP,
+            'response_time' => 123.4,
+            'created_at' => $checkedAt,
+        ]);
+        $monitoring->setRelation('latestResponseResult', $response);
+        $monitoring->setRelation('latestIncident', null);
+        $monitoring->setRelation('groups', new EloquentCollection());
+
+        $service = MonitoringServiceReadModel::fromMonitoring($monitoring, MonitoringStatus::UP->value);
+
+        $this->assertSame([
+            'id' => 'monitoring-123',
+            'name' => 'Checkout API',
+            'target' => 'https://checkout.example.test',
+            'type' => 'http',
+            'group_name' => null,
+            'status' => 'up',
+            'open_incident' => false,
+            'last_checked_at' => $response->created_at->toIso8601String(),
+            'response_time_ms' => 123.4,
+        ], $service->toArray());
+    }
+}


### PR DESCRIPTION
## What changed
- introduced a locale-neutral monitoring service read model with stable identifiers and timestamps
- moved dashboard-only labels, relative times, and URLs into the presentation adapter
- updated the internal UI and mobile overview projections to consume the shared read model

## Why
The same monitoring service data is now reusable across clients without coupling API payloads to Blade-specific formatting.

## Testing
- Docker Pest: `MonitoringServiceReadModelTest`, `InternalUiDashboardApiTest`, `MobileOverviewApiTest`, and `DashboardOverviewTest` (14 passed, 104 assertions)
- Docker Laravel Pint on changed files
- Docker PHPStan: `composer analyse`
- `git diff --check`

## Risks and follow-up
This is a behavior-preserving #594 slice. It does not change external API responses or scanner-instance contracts; further read-model extractions remain tracked in #594.

Refs #594