### PR TITLE
feat(api): add external request identifiers

### DIFF
--- a/app/Http/Middleware/TrackApiUsage.php
+++ b/app/Http/Middleware/TrackApiUsage.php
@@ -27,23 +27,26 @@ class TrackApiUsage
      */
     public function handle(Request $request, Closure $next): Response
     {
+        $requestId = Str::uuid()->toString();
+        $request->attributes->set('request_id', $requestId);
+
         if (auth('sanctum')->check()) {
             $user = auth('sanctum')->user();
 
             if ($user) {
                 if ($this->isMobileAppToken($user->currentAccessToken())) {
-                    return $next($request);
+                    return $this->withRequestId($next($request), $requestId);
                 }
 
                 $key = 'api:' . $user->getAuthIdentifier();
 
                 if (RateLimiter::tooManyAttempts($key, self::MAX_ATTEMPTS)) {
-                    return response()->json([
+                    return $this->withRequestId(response()->json([
                         'message' => 'Too many requests.',
                     ], 429)
                         ->header('Retry-After', (string) RateLimiter::availableIn($key))
                         ->header('X-RateLimit-Limit', (string) self::MAX_ATTEMPTS)
-                        ->header('X-RateLimit-Remaining', '0');
+                        ->header('X-RateLimit-Remaining', '0'), $requestId);
                 }
 
                 RateLimiter::hit($key, self::DECAY_SECONDS);
@@ -57,11 +60,18 @@ class TrackApiUsage
                     (string) max(0, self::MAX_ATTEMPTS - RateLimiter::attempts($key))
                 );
 
-                return $response;
+                return $this->withRequestId($response, $requestId);
             }
         }
 
         abort(403);
+    }
+
+    private function withRequestId(Response $response, string $requestId): Response
+    {
+        $response->headers->set('X-Request-Id', $requestId);
+
+        return $response;
     }
 
     private function isMobileAppToken(mixed $accessToken): bool

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -95,9 +95,10 @@ issue in that repository before Core implementation begins.
   reverse.
 - Safe read responses may use private cache-control or conditional requests only
   when cache invalidation is defined. Instance write callbacks are not cached.
-- New API work returns a correlation identifier and follows a documented problem
-  response format. Existing contracts retain their current response shapes until
-  a compatible migration is delivered.
+- Authenticated external v1 responses include a server-generated `X-Request-Id`,
+  including rate-limit responses, without changing their JSON bodies. New API
+  work follows the documented problem-response format; existing contracts retain
+  their current response shapes until a compatible migration is delivered.
 
 ## Consequences
 

--- a/tests/Feature/Api/ApiControllerTest.php
+++ b/tests/Feature/Api/ApiControllerTest.php
@@ -35,6 +35,10 @@ class ApiControllerTest extends TestCase
         $testResponse->assertJson(['interval' => 300]);
         $testResponse->assertHeader('X-RateLimit-Limit', '5');
         $testResponse->assertHeader('X-RateLimit-Remaining', '4');
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            (string) $testResponse->headers->get('X-Request-Id')
+        );
     }
 
     public function test_returns_status_metadata_and_translation_keys_in_status_endpoint(): void
@@ -79,6 +83,10 @@ class ApiControllerTest extends TestCase
         $this->assertLessThanOrEqual(60, $retryAfter);
         $testResponse->assertHeader('X-RateLimit-Limit', '5');
         $testResponse->assertHeader('X-RateLimit-Remaining', '0');
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            (string) $testResponse->headers->get('X-Request-Id')
+        );
     }
 
     public function test_api_access_tokens_are_rate_limited_and_logged(): void


### PR DESCRIPTION
## What changed
- add a server-generated `X-Request-Id` to authenticated external v1 responses
- include the header on rate-limited responses and retain existing rate-limit headers
- document the external v1 correlation-header convention

## Why
External consumers can correlate a response with operational support without exposing tokens, targets, request bodies, or changing established JSON payloads.

## Testing
- Docker Pest: `tests/Feature/Api/ApiControllerTest.php` (17 passed, 180 assertions)
- Docker Laravel Pint on changed PHP files
- Docker PHPStan: `composer analyse`
- `git diff --check`

## Risks and follow-up
The additive header is backwards compatible. Error-envelope standardization, idempotency, and generated OpenAPI coverage remain tracked in #595.

Refs #595