### PR TITLE
perf(api): cache operations overview projections

### DIFF
--- a/app/Observers/IncidentObserver.php
+++ b/app/Observers/IncidentObserver.php
@@ -7,6 +7,7 @@ namespace App\Observers;
 use App\Enums\NotificationType;
 use App\Models\Incident;
 use App\Models\MonitoringNotification;
+use App\Services\OperationsOverviewCache;
 
 class IncidentObserver
 {
@@ -15,6 +16,8 @@ class IncidentObserver
      */
     public function created(Incident $incident): void
     {
+        resolve(OperationsOverviewCache::class)->flush();
+
         MonitoringNotification::query()->create([
             'monitoring_id' => $incident->monitoring_id,
             'type' => NotificationType::STATUS_CHANGE,
@@ -29,6 +32,8 @@ class IncidentObserver
      */
     public function updated(Incident $incident): void
     {
+        resolve(OperationsOverviewCache::class)->flush();
+
         if ($incident->wasChanged('up_at') && $incident->up_at !== null) {
             MonitoringNotification::query()->create([
                 'monitoring_id' => $incident->monitoring_id,

--- a/app/Observers/MonitoringResponseObserver.php
+++ b/app/Observers/MonitoringResponseObserver.php
@@ -7,6 +7,7 @@ namespace App\Observers;
 use App\Enums\MonitoringStatus;
 use App\Models\Incident;
 use App\Models\MonitoringResponse;
+use App\Services\OperationsOverviewCache;
 use App\Services\RegionalConsensusService;
 
 class MonitoringResponseObserver
@@ -16,6 +17,8 @@ class MonitoringResponseObserver
      */
     public function created(MonitoringResponse $monitoringResponse): void
     {
+        resolve(OperationsOverviewCache::class)->flush();
+
         $monitoring = $monitoringResponse->monitoring;
 
         if (count($monitoring->preferredLocationCodes()) > 1 && $monitoringResponse->location_code !== null) {

--- a/app/Services/OperationsOverviewCache.php
+++ b/app/Services/OperationsOverviewCache.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+final class OperationsOverviewCache
+{
+    private const TAG = 'operations-overview';
+
+    private const TTL_SECONDS = 30;
+
+    /**
+     * @template T of array{data: array<string, mixed>, service_pagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null}}
+     *
+     * @param  callable(): T  $callback
+     * @return T
+     */
+    public function remember(User $user, int $servicePage, callable $callback): array
+    {
+        if (! $this->supportsTaggedCache()) {
+            return $callback();
+        }
+
+        try {
+            return Cache::tags($this->tags($user))->remember(
+                $this->key($user, $servicePage),
+                self::TTL_SECONDS,
+                $callback,
+            );
+        } catch (Throwable) {
+            return $callback();
+        }
+    }
+
+    public function flush(): void
+    {
+        if (! $this->supportsTaggedCache()) {
+            return;
+        }
+
+        try {
+            Cache::tags([self::TAG])->flush();
+        } catch (Throwable) {
+            // The bounded TTL keeps the projection fresh when the cache is unavailable.
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(User $user): array
+    {
+        return [self::TAG, self::TAG . ':user:' . $user->getKey()];
+    }
+
+    public function key(User $user, int $servicePage): string
+    {
+        return sprintf('%s:user:%s:page:%d', self::TAG, $user->getKey(), max(1, $servicePage));
+    }
+
+    private function supportsTaggedCache(): bool
+    {
+        return Cache::getStore() instanceof TaggableStore;
+    }
+}

--- a/app/Services/OperationsOverviewPayloadService.php
+++ b/app/Services/OperationsOverviewPayloadService.php
@@ -13,13 +13,26 @@ use App\Models\User;
 final class OperationsOverviewPayloadService
 {
     public function __construct(
-        private readonly MonitoringOverviewService $monitoringOverviewService
+        private readonly MonitoringOverviewService $monitoringOverviewService,
+        private readonly OperationsOverviewCache $operationsOverviewCache,
     ) {}
 
     /**
      * @return array{data: array<string, mixed>, service_pagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null}}
      */
     public function for(User $user, int $servicePage = 1): array
+    {
+        return $this->operationsOverviewCache->remember(
+            $user,
+            $servicePage,
+            fn (): array => $this->buildPayload($user, $servicePage),
+        );
+    }
+
+    /**
+     * @return array{data: array<string, mixed>, service_pagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null}}
+     */
+    private function buildPayload(User $user, int $servicePage): array
     {
         $overview = $this->monitoringOverviewService->overview($user, $servicePage);
 

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -93,6 +93,10 @@ issue in that repository before Core implementation begins.
 - Cached data must include the consumer and visibility boundary in its cache key.
   Scanner data must never be returned from a browser-session cache entry, or the
   reverse.
+- The operations overview uses a 30-second Redis tagged cache scoped to the
+  authenticated user and service page. Monitoring responses and incidents flush
+  the shared overview tag; unsupported or unavailable cache stores serve fresh
+  data instead.
 - Safe read responses may use private cache-control or conditional requests only
   when cache invalidation is defined. Instance write callbacks are not cached.
 - Authenticated external v1 responses include a server-generated `X-Request-Id`,

--- a/tests/Unit/Services/OperationsOverviewCacheTest.php
+++ b/tests/Unit/Services/OperationsOverviewCacheTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Models\User;
+use App\Services\OperationsOverviewCache;
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class OperationsOverviewCacheTest extends TestCase
+{
+    public function test_it_scopes_cached_overviews_to_the_user_and_service_page(): void
+    {
+        $user = new User();
+        $user->id = 'user-123';
+        $store = Mockery::mock(TaggableStore::class);
+        $taggedCache = Mockery::mock();
+
+        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('tags')
+            ->once()
+            ->with(['operations-overview', 'operations-overview:user:user-123'])
+            ->andReturn($taggedCache);
+        $taggedCache->shouldReceive('remember')
+            ->once()
+            ->with('operations-overview:user:user-123:page:2', 30, Mockery::type('callable'))
+            ->andReturnUsing(fn (string $key, int $ttl, callable $callback): array => $callback());
+
+        $payload = resolve(OperationsOverviewCache::class)->remember($user, 2, fn (): array => [
+            'data' => ['summary' => ['total' => 1]],
+            'service_pagination' => ['current_page' => 2, 'last_page' => 2, 'total' => 11, 'from' => 11, 'to' => 11],
+        ]);
+
+        $this->assertSame(1, $payload['data']['summary']['total']);
+    }
+
+    public function test_it_serves_fresh_data_when_the_tagged_cache_is_unavailable(): void
+    {
+        $user = new User();
+        $user->id = 'user-123';
+        $store = Mockery::mock(TaggableStore::class);
+        $taggedCache = Mockery::mock();
+
+        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('tags')->once()->andReturn($taggedCache);
+        $taggedCache->shouldReceive('remember')->once()->andThrow(new RuntimeException('Redis unavailable'));
+
+        $payload = resolve(OperationsOverviewCache::class)->remember($user, 1, fn (): array => [
+            'data' => ['summary' => ['total' => 1]],
+            'service_pagination' => ['current_page' => 1, 'last_page' => 1, 'total' => 1, 'from' => 1, 'to' => 1],
+        ]);
+
+        $this->assertSame(1, $payload['service_pagination']['total']);
+    }
+
+    public function test_it_flushes_all_cached_overviews_after_domain_changes(): void
+    {
+        $store = Mockery::mock(TaggableStore::class);
+        $taggedCache = Mockery::mock();
+
+        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('tags')->once()->with(['operations-overview'])->andReturn($taggedCache);
+        $taggedCache->shouldReceive('flush')->once();
+
+        resolve(OperationsOverviewCache::class)->flush();
+    }
+}


### PR DESCRIPTION
## What changed
- add a tagged, per-user and per-service-page cache for operations overview projections
- use a bounded 30-second TTL and serve fresh data when tagged cache access is unavailable
- invalidate the overview tag after monitoring responses and incident changes
- document the cache boundary and add cache ownership tests

## Why
The internal UI and mobile operations overview can reuse a fast projection without sharing data across visibility boundaries or relying on a single web process for freshness.

## Testing
- Docker Pest: `OperationsOverviewCacheTest`, `InternalUiDashboardApiTest`, and `MobileOverviewApiTest` (8 passed, 41 assertions)
- Docker Laravel Pint on changed PHP files
- Docker PHPStan: `composer analyse`
- `git diff --check`

## Risks and follow-up
This is the first #597 cache slice. The cache remains user-scoped and falls back to fresh data if Redis is unavailable. Additional invalidation sources, conditional GET, budgets, and observability remain tracked in #597.

Refs #597