### PR TITLE
perf(api): invalidate overview cache on visibility changes

### DIFF
--- a/app/Observers/OperationsOverviewCacheObserver.php
+++ b/app/Observers/OperationsOverviewCacheObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Services\OperationsOverviewCache;
+use Illuminate\Database\Eloquent\Model;
+
+final class OperationsOverviewCacheObserver
+{
+    public function created(Model $model): void
+    {
+        $this->flush();
+    }
+
+    public function updated(Model $model): void
+    {
+        $this->flush();
+    }
+
+    public function deleted(Model $model): void
+    {
+        $this->flush();
+    }
+
+    public function restored(Model $model): void
+    {
+        $this->flush();
+    }
+
+    private function flush(): void
+    {
+        resolve(OperationsOverviewCache::class)->flush();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,10 +7,13 @@ namespace App\Providers;
 use App\Http\Middleware\RedirectWwwToNonWww;
 use App\Http\View\Composers\NotificationComposer;
 use App\Models\Incident;
+use App\Models\Monitoring;
 use App\Models\MonitoringResponse;
+use App\Models\TeamMembership;
 use App\Models\User;
 use App\Observers\IncidentObserver;
 use App\Observers\MonitoringResponseObserver;
+use App\Observers\OperationsOverviewCacheObserver;
 use App\Observers\UserObserver;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Database\Eloquent\Model;
@@ -58,7 +61,9 @@ class AppServiceProvider extends ServiceProvider
         Model::preventLazyLoading(! app()->isProduction());
 
         Incident::observe(IncidentObserver::class);
+        Monitoring::observe(OperationsOverviewCacheObserver::class);
         MonitoringResponse::observe(MonitoringResponseObserver::class);
+        TeamMembership::observe(OperationsOverviewCacheObserver::class);
         User::observe(UserObserver::class);
         View::composer('layouts.navigation', NotificationComposer::class);
 

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -95,8 +95,9 @@ issue in that repository before Core implementation begins.
   reverse.
 - The operations overview uses a 30-second Redis tagged cache scoped to the
   authenticated user and service page. Monitoring responses and incidents flush
-  the shared overview tag; unsupported or unavailable cache stores serve fresh
-  data instead.
+  the shared overview tag; monitoring and team-membership changes do the same
+  for ownership, maintenance, and role updates. Unsupported or unavailable cache
+  stores serve fresh data instead.
 - Safe read responses may use private cache-control or conditional requests only
   when cache invalidation is defined. Instance write callbacks are not cached.
 - Authenticated external v1 responses include a server-generated `X-Request-Id`,

--- a/tests/Unit/Observers/OperationsOverviewCacheObserverTest.php
+++ b/tests/Unit/Observers/OperationsOverviewCacheObserverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Observers;
+
+use App\Models\Monitoring;
+use App\Models\TeamMembership;
+use App\Observers\OperationsOverviewCacheObserver;
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use Tests\TestCase;
+
+class OperationsOverviewCacheObserverTest extends TestCase
+{
+    public function test_it_flushes_the_operations_overview_after_monitoring_changes(): void
+    {
+        $this->expectOverviewFlush();
+
+        resolve(OperationsOverviewCacheObserver::class)->updated(new Monitoring());
+    }
+
+    public function test_it_flushes_the_operations_overview_after_membership_changes(): void
+    {
+        $this->expectOverviewFlush();
+
+        resolve(OperationsOverviewCacheObserver::class)->deleted(new TeamMembership());
+    }
+
+    private function expectOverviewFlush(): void
+    {
+        $store = Mockery::mock(TaggableStore::class);
+        $taggedCache = Mockery::mock();
+
+        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('tags')->once()->with(['operations-overview'])->andReturn($taggedCache);
+        $taggedCache->shouldReceive('flush')->once();
+    }
+}


### PR DESCRIPTION
## What changed
- invalidate operations-overview projections for monitoring lifecycle changes
- invalidate the same cache when team memberships change
- register a shared observer for those invalidation boundaries and document them

## Why
Cached dashboard and mobile projections must not outlive ownership, maintenance, or role changes that affect a user's visibility.

## Testing
- Docker Pest: `OperationsOverviewCacheObserverTest`, `OperationsOverviewCacheTest`, `InternalUiDashboardApiTest`, and `MobileOverviewApiTest` (10 passed, 47 assertions)
- Docker Laravel Pint on changed PHP files
- Docker PHPStan: `composer analyse`
- `git diff --check`

## Risks and follow-up
This extends the #597 cache slice without changing API payloads or scanner contracts. Additional status-page, notification, conditional-GET, budget, and observability work remains in #597.

Refs #597