### PR TITLE
perf(api): add dashboard conditional requests

### DIFF
--- a/app/Http/Controllers/Api/Internal/Ui/DashboardController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/DashboardController.php
@@ -7,12 +7,12 @@ namespace App\Http\Controllers\Api\Internal\Ui;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Services\OperationsOverviewPayloadService;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class DashboardController extends Controller
 {
-    public function __invoke(Request $request, OperationsOverviewPayloadService $operationsOverviewPayloadService): JsonResponse
+    public function __invoke(Request $request, OperationsOverviewPayloadService $operationsOverviewPayloadService): Response
     {
         $validated = $request->validate([
             'service_page' => ['nullable', 'integer', 'min:1', 'max:100'],
@@ -21,6 +21,13 @@ class DashboardController extends Controller
         /** @var User $user */
         $user = $request->user();
         $payload = $operationsOverviewPayloadService->for($user, (int) ($validated['service_page'] ?? 1));
+        $etag = '"' . hash('sha256', json_encode($payload, JSON_THROW_ON_ERROR)) . '"';
+
+        if (in_array($etag, $request->getETags(), true)) {
+            return response('', Response::HTTP_NOT_MODIFIED)
+                ->header('ETag', $etag)
+                ->header('Cache-Control', 'private, max-age=0, must-revalidate');
+        }
 
         return response()->json([
             'data' => $payload['data'],
@@ -28,6 +35,8 @@ class DashboardController extends Controller
                 'as_of' => now()->toIso8601String(),
                 'service_pagination' => $payload['service_pagination'],
             ],
-        ]);
+        ])
+            ->header('ETag', $etag)
+            ->header('Cache-Control', 'private, max-age=0, must-revalidate');
     }
 }

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -100,6 +100,8 @@ issue in that repository before Core implementation begins.
   stores serve fresh data instead.
 - Safe read responses may use private cache-control or conditional requests only
   when cache invalidation is defined. Instance write callbacks are not cached.
+- `GET /api/v1/internal/ui/dashboard` uses a private ETag derived from the
+  user-scoped projection and returns `304 Not Modified` when it is unchanged.
 - Authenticated external v1 responses include a server-generated `X-Request-Id`,
   including rate-limit responses, without changing their JSON bodies. New API
   work follows the documented problem-response format; existing contracts retain

--- a/tests/Feature/Api/InternalUiDashboardApiTest.php
+++ b/tests/Feature/Api/InternalUiDashboardApiTest.php
@@ -37,4 +37,25 @@ class InternalUiDashboardApiTest extends TestCase
         $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'))
             ->assertForbidden();
     }
+
+    public function test_dashboard_projection_supports_private_conditional_get_requests(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create();
+        Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
+
+        $firstResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+        $etag = (string) $firstResponse->headers->get('ETag');
+
+        $firstResponse
+            ->assertOk();
+        $this->assertNotSame('', $etag);
+        $this->assertStringContainsString('private', (string) $firstResponse->headers->get('Cache-Control'));
+
+        $this->actingAs($user)
+            ->withHeader('If-None-Match', $etag)
+            ->getJson(route('api.v1.internal.ui.dashboard'))
+            ->assertNotModified()
+            ->assertHeader('ETag', $etag);
+    }
 }


### PR DESCRIPTION
## What changed
- add a private ETag to the authenticated internal dashboard projection
- return `304 Not Modified` for matching `If-None-Match` values
- document the private conditional-GET behavior and add API coverage

## Why
Unchanged dashboard projections avoid transferring the JSON payload while retaining strict user-scoped authorization and cache boundaries.

## Testing
- Docker Pest: `InternalUiDashboardApiTest` (3 passed, 15 assertions)
- Docker Laravel Pint on changed PHP files
- Docker PHPStan: `composer analyse`
- `git diff --check`

## Risks and follow-up
This affects only the private internal UI route. ETags are derived from the user-scoped payload and no external or scanner contract changes.

Refs #597