### PR TITLE
perf(api): complete internal ui observability

### DIFF
--- a/app/Http/Middleware/MeasureInternalUiRequest.php
+++ b/app/Http/Middleware/MeasureInternalUiRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MeasureInternalUiRequest
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = Str::uuid()->toString();
+        $startedAt = hrtime(true);
+        $connection = DB::connection();
+        $connection->flushQueryLog();
+        $connection->enableQueryLog();
+
+        try {
+            $response = $next($request);
+            $durationMs = (hrtime(true) - $startedAt) / 1_000_000;
+            $queryCount = count($connection->getQueryLog());
+
+            $response->headers->set('X-Request-Id', $requestId);
+            $response->headers->set('X-Query-Count', (string) $queryCount);
+            $response->headers->set('X-Response-Bytes', (string) mb_strlen((string) $response->getContent()));
+            $response->headers->set('Server-Timing', sprintf('app;dur=%.1f', $durationMs));
+
+            return $response;
+        } finally {
+            $connection->disableQueryLog();
+            $connection->flushQueryLog();
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,8 +7,13 @@ namespace App\Providers;
 use App\Http\Middleware\RedirectWwwToNonWww;
 use App\Http\View\Composers\NotificationComposer;
 use App\Models\Incident;
+use App\Models\MaintenanceWindow;
 use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
 use App\Models\MonitoringResponse;
+use App\Models\NotificationChannelDelivery;
+use App\Models\StatusPage;
+use App\Models\StatusPageComponent;
 use App\Models\TeamMembership;
 use App\Models\User;
 use App\Observers\IncidentObserver;
@@ -64,6 +69,11 @@ class AppServiceProvider extends ServiceProvider
         Monitoring::observe(OperationsOverviewCacheObserver::class);
         MonitoringResponse::observe(MonitoringResponseObserver::class);
         TeamMembership::observe(OperationsOverviewCacheObserver::class);
+        MaintenanceWindow::observe(OperationsOverviewCacheObserver::class);
+        MonitoringNotification::observe(OperationsOverviewCacheObserver::class);
+        NotificationChannelDelivery::observe(OperationsOverviewCacheObserver::class);
+        StatusPage::observe(OperationsOverviewCacheObserver::class);
+        StatusPageComponent::observe(OperationsOverviewCacheObserver::class);
         User::observe(UserObserver::class);
         View::composer('layouts.navigation', NotificationComposer::class);
 

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -102,6 +102,10 @@ issue in that repository before Core implementation begins.
   when cache invalidation is defined. Instance write callbacks are not cached.
 - `GET /api/v1/internal/ui/dashboard` uses a private ETag derived from the
   user-scoped projection and returns `304 Not Modified` when it is unchanged.
+- Internal UI responses expose server-generated request IDs, query counts,
+  response bytes, and application timing without query bindings or request data.
+  Dashboard budgets are 30 queries and 128 KiB per uncached response; cached
+  responses target zero database queries.
 - Authenticated external v1 responses include a server-generated `X-Request-Id`,
   including rate-limit responses, without changing their JSON bodies. New API
   work follows the documented problem-response format; existing contracts retain

--- a/routes/api/ui.php
+++ b/routes/api/ui.php
@@ -6,9 +6,12 @@ use App\Http\Controllers\Api\Internal\Ui\DashboardController;
 use App\Http\Controllers\Api\Internal\Ui\MonitoringCardsController;
 use App\Http\Controllers\Api\Internal\Ui\MonitoringIndexController;
 use App\Http\Controllers\Api\Internal\Ui\MonitoringShowController;
+use App\Http\Middleware\MeasureInternalUiRequest;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/dashboard', DashboardController::class)->name('dashboard');
-Route::get('/monitorings', MonitoringIndexController::class)->name('monitorings.index');
-Route::get('/monitorings/cards', MonitoringCardsController::class)->name('monitorings.cards');
-Route::get('/monitorings/{monitoring}', MonitoringShowController::class)->name('monitorings.show');
+Route::middleware(MeasureInternalUiRequest::class)->group(function (): void {
+    Route::get('/dashboard', DashboardController::class)->name('dashboard');
+    Route::get('/monitorings', MonitoringIndexController::class)->name('monitorings.index');
+    Route::get('/monitorings/cards', MonitoringCardsController::class)->name('monitorings.cards');
+    Route::get('/monitorings/{monitoring}', MonitoringShowController::class)->name('monitorings.show');
+});

--- a/tests/Feature/Api/InternalUiDashboardApiTest.php
+++ b/tests/Feature/Api/InternalUiDashboardApiTest.php
@@ -24,9 +24,26 @@ class InternalUiDashboardApiTest extends TestCase
             ->assertJsonPath('data.services.0.id', $visibleMonitoring->id)
             ->assertJsonPath('data.services.0.name', 'Visible API')
             ->assertJsonMissing(['name' => 'Hidden API'])
+            ->assertHeader('X-Request-Id')
+            ->assertHeader('X-Query-Count')
+            ->assertHeader('X-Response-Bytes')
+            ->assertHeader('Server-Timing')
             ->assertJsonStructure([
                 'meta' => ['as_of', 'service_pagination'],
             ]);
+    }
+
+    public function test_dashboard_projection_stays_within_its_response_budget(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create();
+        Monitoring::factory()->count(3)->for($user)->create();
+
+        $response = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+
+        $response->assertOk();
+        $this->assertLessThanOrEqual(30, (int) $response->headers->get('X-Query-Count'));
+        $this->assertLessThanOrEqual(131072, (int) $response->headers->get('X-Response-Bytes'));
     }
 
     public function test_unverified_user_cannot_read_the_internal_ui_dashboard(): void


### PR DESCRIPTION
## What changed
- invalidate dashboard caches for maintenance, notification, and status-page changes
- add request IDs, query-count, response-byte, and timing headers to internal UI projections
- document and test the dashboard query and payload budgets

## Why
The internal UI projection now has explicit freshness boundaries and measurable request budgets without logging query bindings, targets, or bodies.

## Testing
- Docker Pest: internal dashboard API and cache observer coverage
- Docker Pint and PHPStan

Closes #597