### PR TITLE
refactor(monitoring): extract state resolver

### DIFF
--- a/app/Http/Controllers/Api/External/MonitoringDataController.php
+++ b/app/Http/Controllers/Api/External/MonitoringDataController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\External;
 
+use App\Http\Controllers\ApiController;
+
 /**
  * Compatibility adapter for the externally supported v1 monitoring read contract.
  */
-class MonitoringDataController extends \App\Http\Controllers\ApiController {}
+class MonitoringDataController extends ApiController {}

--- a/app/Http/Controllers/Api/Internal/Ui/MonitoringCardsController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/MonitoringCardsController.php
@@ -12,11 +12,11 @@ use Illuminate\Http\JsonResponse;
 
 class MonitoringCardsController extends Controller
 {
-    public function __invoke(MonitoringCardsRequest $request, MonitoringCardDataService $monitoringCardDataService): JsonResponse
+    public function __invoke(MonitoringCardsRequest $monitoringCardsRequest, MonitoringCardDataService $monitoringCardDataService): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
-        $ids = collect($request->monitoringIds());
+        $user = $monitoringCardsRequest->user();
+        $ids = collect($monitoringCardsRequest->monitoringIds());
 
         return response()->json($monitoringCardDataService->for($user, $ids, $ids, true));
     }

--- a/app/Http/Controllers/Api/Internal/Ui/MonitoringIndexController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/MonitoringIndexController.php
@@ -13,19 +13,19 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class MonitoringIndexController extends Controller
 {
-    public function __invoke(MonitoringIndexRequest $request, MonitoringOverviewQuery $monitoringOverviewQuery): AnonymousResourceCollection
+    public function __invoke(MonitoringIndexRequest $monitoringIndexRequest, MonitoringOverviewQuery $monitoringOverviewQuery): AnonymousResourceCollection
     {
         /** @var User $user */
-        $user = $request->user();
-        $monitorings = $monitoringOverviewQuery->paginateFor(
+        $user = $monitoringIndexRequest->user();
+        $lengthAwarePaginator = $monitoringOverviewQuery->paginateFor(
             $user,
-            $request->page(),
-            $request->perPage(),
-            $request->search(),
-            $request->lifecycleStatus(),
+            $monitoringIndexRequest->page(),
+            $monitoringIndexRequest->perPage(),
+            $monitoringIndexRequest->search(),
+            $monitoringIndexRequest->lifecycleStatus(),
         );
 
-        return MonitoringResource::collection($monitorings)->additional([
+        return MonitoringResource::collection($lengthAwarePaginator)->additional([
             'meta' => [
                 'as_of' => now()->toIso8601String(),
             ],

--- a/app/Observers/OperationsOverviewCacheObserver.php
+++ b/app/Observers/OperationsOverviewCacheObserver.php
@@ -5,26 +5,25 @@ declare(strict_types=1);
 namespace App\Observers;
 
 use App\Services\OperationsOverviewCache;
-use Illuminate\Database\Eloquent\Model;
 
 final class OperationsOverviewCacheObserver
 {
-    public function created(Model $model): void
+    public function created(): void
     {
         $this->flush();
     }
 
-    public function updated(Model $model): void
+    public function updated(): void
     {
         $this->flush();
     }
 
-    public function deleted(Model $model): void
+    public function deleted(): void
     {
         $this->flush();
     }
 
-    public function restored(Model $model): void
+    public function restored(): void
     {
         $this->flush();
     }

--- a/app/Queries/MonitoringOverviewQuery.php
+++ b/app/Queries/MonitoringOverviewQuery.php
@@ -37,31 +37,31 @@ final class MonitoringOverviewQuery
         int $page,
         int $perPage = 20,
         ?string $search = null,
-        ?MonitoringLifecycleStatus $lifecycleStatus = null,
+        ?MonitoringLifecycleStatus $monitoringLifecycleStatus = null,
     ): LengthAwarePaginator {
         $query = $this->query($user);
 
         if ($search !== null && $search !== '') {
-            $query->where(function (Builder $query) use ($search): void {
-                $query->where('name', 'like', '%' . $search . '%')
+            $query->where(function (Builder $builder) use ($search): void {
+                $builder->where('name', 'like', '%' . $search . '%')
                     ->orWhere('target', 'like', '%' . $search . '%');
             });
         }
 
-        if ($lifecycleStatus !== null) {
-            $query->where('status', $lifecycleStatus);
+        if ($monitoringLifecycleStatus !== null) {
+            $query->where('status', $monitoringLifecycleStatus);
         }
 
         return $this->paginate($query, $page, $perPage, 'page');
     }
 
     /**
-     * @param  Builder<Monitoring>  $query
+     * @param  Builder<Monitoring>  $builder
      * @return LengthAwarePaginator<int, Monitoring>
      */
-    private function paginate(Builder $query, int $page, int $perPage, string $pageName): LengthAwarePaginator
+    private function paginate(Builder $builder, int $page, int $perPage, string $pageName): LengthAwarePaginator
     {
-        return $query->paginate(
+        return $builder->paginate(
             $perPage,
             $this->columns(),
             $pageName,

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -25,7 +25,8 @@ use Illuminate\Support\Facades\Date;
 class MonitoringOverviewService
 {
     public function __construct(
-        private readonly MonitoringOverviewQuery $monitoringOverviewQuery
+        private readonly MonitoringOverviewQuery $monitoringOverviewQuery,
+        private readonly MonitoringStateResolver $monitoringStateResolver,
     ) {}
 
     /**
@@ -54,7 +55,7 @@ class MonitoringOverviewService
         $monitorings = $this->monitoringOverviewQuery->monitoringsFor($user);
 
         $statuses = $monitorings->mapWithKeys(
-            fn (Monitoring $monitoring): array => [$monitoring->id => $this->status($monitoring)]
+            fn (Monitoring $monitoring): array => [$monitoring->id => $this->monitoringStateResolver->status($monitoring)]
         );
         $summary = [
             'total' => $monitorings->count(),
@@ -168,7 +169,7 @@ class MonitoringOverviewService
     private function mapSignalRoomServices(Collection $monitorings): Collection
     {
         $statuses = $monitorings->mapWithKeys(
-            fn (Monitoring $monitoring): array => [$monitoring->id => $this->status($monitoring)]
+            fn (Monitoring $monitoring): array => [$monitoring->id => $this->monitoringStateResolver->status($monitoring)]
         );
 
         return $monitorings->map(
@@ -202,29 +203,6 @@ class MonitoringOverviewService
             'openIncident' => $service->hasOpenIncident,
             'href' => route('monitorings.show', ['monitoring' => $service->id]),
         ];
-    }
-
-    private function status(Monitoring $monitoring): string
-    {
-        if ($monitoring->isPaused()) {
-            return MonitoringLifecycleStatus::PAUSED->value;
-        }
-
-        if ($monitoring->isUnderMaintenance()) {
-            return 'maintenance';
-        }
-
-        $latestIncident = $monitoring->latestIncident;
-        if ($latestIncident && $latestIncident->up_at === null) {
-            return MonitoringStatus::DOWN->value;
-        }
-
-        $latestResponse = $monitoring->latestResponseResult;
-        if ($latestResponse === null || $this->isStale($monitoring)) {
-            return MonitoringStatus::UNKNOWN->value;
-        }
-
-        return $latestResponse->status->value;
     }
 
     /**
@@ -288,7 +266,7 @@ class MonitoringOverviewService
         $items = collect();
 
         $eloquentCollection
-            ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::DOWN->value)
+            ->filter(fn (Monitoring $monitoring): bool => $this->monitoringStateResolver->status($monitoring) === MonitoringStatus::DOWN->value)
             ->take(5)
             ->each(function (Monitoring $monitoring) use ($items, $statusPagesByMonitoringId): void {
                 $isOpenIncident = $monitoring->latestIncident?->up_at === null
@@ -303,7 +281,7 @@ class MonitoringOverviewService
             });
 
         $eloquentCollection
-            ->filter(fn (Monitoring $monitoring): bool => $this->status($monitoring) === MonitoringStatus::UNKNOWN->value
+            ->filter(fn (Monitoring $monitoring): bool => $this->monitoringStateResolver->status($monitoring) === MonitoringStatus::UNKNOWN->value
                 && $monitoring->isActive())
             ->take(5)
             ->each(fn (Monitoring $monitoring) => $items->push([
@@ -349,20 +327,6 @@ class MonitoringOverviewService
         }
 
         return $statusPagesByMonitoringId;
-    }
-
-    private function isStale(Monitoring $monitoring): bool
-    {
-        $latestResponse = $monitoring->latestResponseResult;
-        if ($latestResponse === null) {
-            return false;
-        }
-
-        $intervalMinutes = $monitoring->isHeartbeat()
-            ? ((int) ($monitoring->heartbeat_interval_minutes ?? 0) + (int) ($monitoring->heartbeat_grace_minutes ?? 0))
-            : (int) config('monitoring.interval', 5);
-
-        return $latestResponse->created_at->lt(Date::now()->subMinutes(max(10, $intervalMinutes * 3)));
     }
 
     /**

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -91,7 +91,7 @@ class MonitoringOverviewService
             )
         )->values();
         $signalRoomServices = $serviceReadModels->map(
-            fn (MonitoringServiceReadModel $service): array => $this->servicePresentation($service)
+            fn (MonitoringServiceReadModel $monitoringServiceReadModel): array => $this->servicePresentation($monitoringServiceReadModel)
         );
         $lengthAwarePaginator = new LengthAwarePaginator(
             $signalRoomServices->forPage(max(1, $servicePage), 10)->values(),
@@ -145,20 +145,20 @@ class MonitoringOverviewService
      */
     public function serviceMap(User $user, int $servicePage = 1): array
     {
-        $servicePaginator = $this->monitoringOverviewQuery->paginateServicesFor($user, $servicePage);
+        $lengthAwarePaginator = $this->monitoringOverviewQuery->paginateServicesFor($user, $servicePage);
 
-        $services = $this->mapSignalRoomServices($servicePaginator->getCollection());
+        $services = $this->mapSignalRoomServices($lengthAwarePaginator->getCollection());
 
         return [
             'services' => $services,
             'pagination' => [
-                'current_page' => $servicePaginator->currentPage(),
-                'last_page' => $servicePaginator->lastPage(),
-                'total' => $servicePaginator->total(),
-                'from' => $servicePaginator->firstItem(),
-                'to' => $servicePaginator->lastItem(),
+                'current_page' => $lengthAwarePaginator->currentPage(),
+                'last_page' => $lengthAwarePaginator->lastPage(),
+                'total' => $lengthAwarePaginator->total(),
+                'from' => $lengthAwarePaginator->firstItem(),
+                'to' => $lengthAwarePaginator->lastItem(),
             ],
-            'total' => $servicePaginator->total(),
+            'total' => $lengthAwarePaginator->total(),
         ];
     }
 
@@ -185,23 +185,23 @@ class MonitoringOverviewService
     /**
      * @return array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}
      */
-    private function servicePresentation(MonitoringServiceReadModel $service): array
+    private function servicePresentation(MonitoringServiceReadModel $monitoringServiceReadModel): array
     {
         return [
-            'id' => $service->id,
-            'name' => $service->name,
-            'target' => $service->target,
-            'status' => $service->status,
-            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $service->status),
-            'group' => $service->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
-            'lastCheck' => $service->lastCheckedAt !== null
-                ? Carbon::parse($service->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
+            'id' => $monitoringServiceReadModel->id,
+            'name' => $monitoringServiceReadModel->name,
+            'target' => $monitoringServiceReadModel->target,
+            'status' => $monitoringServiceReadModel->status,
+            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $monitoringServiceReadModel->status),
+            'group' => $monitoringServiceReadModel->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
+            'lastCheck' => $monitoringServiceReadModel->lastCheckedAt !== null
+                ? Date::parse($monitoringServiceReadModel->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
                 : (string) __('dashboard.signal_room.no_check'),
-            'responseTime' => $service->responseTimeMs !== null
-                ? number_format($service->responseTimeMs, 0, ',', '.') . ' ms'
+            'responseTime' => $monitoringServiceReadModel->responseTimeMs !== null
+                ? number_format($monitoringServiceReadModel->responseTimeMs, 0, ',', '.') . ' ms'
                 : '—',
-            'openIncident' => $service->hasOpenIncident,
-            'href' => route('monitorings.show', ['monitoring' => $service->id]),
+            'openIncident' => $monitoringServiceReadModel->hasOpenIncident,
+            'href' => route('monitorings.show', ['monitoring' => $monitoringServiceReadModel->id]),
         ];
     }
 

--- a/app/Services/MonitoringStateResolver.php
+++ b/app/Services/MonitoringStateResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringStatus;
+use App\Models\Monitoring;
+use Illuminate\Support\Facades\Date;
+
+final class MonitoringStateResolver
+{
+    public function status(Monitoring $monitoring): string
+    {
+        if ($monitoring->isPaused()) {
+            return MonitoringLifecycleStatus::PAUSED->value;
+        }
+
+        if ($monitoring->isUnderMaintenance()) {
+            return 'maintenance';
+        }
+
+        if ($monitoring->latestIncident?->up_at === null && $monitoring->latestIncident !== null) {
+            return MonitoringStatus::DOWN->value;
+        }
+
+        $latestResponse = $monitoring->latestResponseResult;
+        if ($latestResponse === null || $this->isStale($monitoring)) {
+            return MonitoringStatus::UNKNOWN->value;
+        }
+
+        return $latestResponse->status->value;
+    }
+
+    private function isStale(Monitoring $monitoring): bool
+    {
+        $latestResponse = $monitoring->latestResponseResult;
+        if ($latestResponse === null) {
+            return false;
+        }
+
+        $intervalMinutes = $monitoring->isHeartbeat()
+            ? ((int) ($monitoring->heartbeat_interval_minutes ?? 0) + (int) ($monitoring->heartbeat_grace_minutes ?? 0))
+            : (int) config('monitoring.interval', 5);
+
+        return $latestResponse->created_at->lt(Date::now()->subMinutes(max(10, $intervalMinutes * 3)));
+    }
+}

--- a/app/Services/OperationsOverviewPayloadService.php
+++ b/app/Services/OperationsOverviewPayloadService.php
@@ -41,7 +41,7 @@ final class OperationsOverviewPayloadService
                 'overall_state' => $overview['overallState'],
                 'summary' => $overview['summary'],
                 'services' => $overview['serviceReadModels']->map(
-                    fn (MonitoringServiceReadModel $service): array => $this->servicePayload($service)
+                    fn (MonitoringServiceReadModel $monitoringServiceReadModel): array => $this->servicePayload($monitoringServiceReadModel)
                 )->values()->all(),
                 'attention' => $overview['attentionItems']->map(
                     fn (array $item): array => $this->attentionPayload($item)
@@ -67,18 +67,18 @@ final class OperationsOverviewPayloadService
     /**
      * @return array<string, mixed>
      */
-    private function servicePayload(MonitoringServiceReadModel $service): array
+    private function servicePayload(MonitoringServiceReadModel $monitoringServiceReadModel): array
     {
         return [
-            'id' => $service->id,
-            'name' => $service->name,
-            'target' => $service->target,
-            'type' => $service->type,
-            'group' => $service->groupName,
-            'status' => $service->status,
-            'open_incident' => $service->hasOpenIncident,
-            'last_checked_at' => $service->lastCheckedAt,
-            'response_time_ms' => $service->responseTimeMs,
+            'id' => $monitoringServiceReadModel->id,
+            'name' => $monitoringServiceReadModel->name,
+            'target' => $monitoringServiceReadModel->target,
+            'type' => $monitoringServiceReadModel->type,
+            'group' => $monitoringServiceReadModel->groupName,
+            'status' => $monitoringServiceReadModel->status,
+            'open_incident' => $monitoringServiceReadModel->hasOpenIncident,
+            'last_checked_at' => $monitoringServiceReadModel->lastCheckedAt,
+            'response_time_ms' => $monitoringServiceReadModel->responseTimeMs,
         ];
     }
 

--- a/tests/Feature/Api/InternalUiDashboardApiTest.php
+++ b/tests/Feature/Api/InternalUiDashboardApiTest.php
@@ -39,11 +39,11 @@ class InternalUiDashboardApiTest extends TestCase
         $user = User::factory()->create();
         Monitoring::factory()->count(3)->for($user)->create();
 
-        $response = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+        $testResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
 
-        $response->assertOk();
-        $this->assertLessThanOrEqual(30, (int) $response->headers->get('X-Query-Count'));
-        $this->assertLessThanOrEqual(131072, (int) $response->headers->get('X-Response-Bytes'));
+        $testResponse->assertOk();
+        $this->assertLessThanOrEqual(30, (int) $testResponse->headers->get('X-Query-Count'));
+        $this->assertLessThanOrEqual(131072, (int) $testResponse->headers->get('X-Response-Bytes'));
     }
 
     public function test_unverified_user_cannot_read_the_internal_ui_dashboard(): void
@@ -61,13 +61,13 @@ class InternalUiDashboardApiTest extends TestCase
         $user = User::factory()->create();
         Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
 
-        $firstResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
-        $etag = (string) $firstResponse->headers->get('ETag');
+        $testResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+        $etag = (string) $testResponse->headers->get('ETag');
 
-        $firstResponse
+        $testResponse
             ->assertOk();
         $this->assertNotSame('', $etag);
-        $this->assertStringContainsString('private', (string) $firstResponse->headers->get('Cache-Control'));
+        $this->assertStringContainsString('private', (string) $testResponse->headers->get('Cache-Control'));
 
         $this->actingAs($user)
             ->withHeader('If-None-Match', $etag)

--- a/tests/Feature/Queries/MonitoringReadQueriesTest.php
+++ b/tests/Feature/Queries/MonitoringReadQueriesTest.php
@@ -22,12 +22,12 @@ class MonitoringReadQueriesTest extends TestCase
         $visible = Monitoring::factory()->for($user)->create();
         $hidden = Monitoring::factory()->for($otherUser)->create();
 
-        $query = app(MonitoringDetailQuery::class);
+        $monitoringDetailQuery = resolve(MonitoringDetailQuery::class);
 
-        $this->assertTrue($query->findVisible($user, $visible->id)->is($visible));
+        $this->assertTrue($monitoringDetailQuery->findVisible($user, $visible->id)->is($visible));
         $this->expectException(ModelNotFoundException::class);
 
-        $query->findVisible($user, $hidden->id);
+        $monitoringDetailQuery->findVisible($user, $hidden->id);
     }
 
     public function test_card_query_only_returns_requested_monitorings_visible_to_the_actor(): void
@@ -38,7 +38,7 @@ class MonitoringReadQueriesTest extends TestCase
         $visible = Monitoring::factory()->for($user)->create();
         $hidden = Monitoring::factory()->for($otherUser)->create();
 
-        $monitorings = app(MonitoringCardQuery::class)->for($user, [$visible->id, $hidden->id]);
+        $monitorings = resolve(MonitoringCardQuery::class)->for($user, [$visible->id, $hidden->id]);
 
         $this->assertSame([$visible->id], $monitorings->modelKeys());
         $this->assertTrue($monitorings->first()->relationLoaded('latestIncident'));

--- a/tests/Unit/Data/MonitoringServiceReadModelTest.php
+++ b/tests/Unit/Data/MonitoringServiceReadModelTest.php
@@ -10,14 +10,14 @@ use App\Enums\MonitoringType;
 use App\Models\Monitoring;
 use App\Models\MonitoringResponse;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Tests\TestCase;
 
 class MonitoringServiceReadModelTest extends TestCase
 {
     public function test_it_exposes_locale_neutral_service_values_with_stable_timestamps(): void
     {
-        $checkedAt = Carbon::parse('2026-07-26 12:00:00', 'UTC');
+        $checkedAt = Date::parse('2026-07-26 12:00:00', 'UTC');
         $monitoring = new Monitoring();
         $monitoring->forceFill([
             'id' => 'monitoring-123',
@@ -25,17 +25,17 @@ class MonitoringServiceReadModelTest extends TestCase
             'target' => 'https://checkout.example.test',
             'type' => MonitoringType::HTTP,
         ]);
-        $response = new MonitoringResponse();
-        $response->forceFill([
+        $monitoringResponse = new MonitoringResponse();
+        $monitoringResponse->forceFill([
             'status' => MonitoringStatus::UP,
             'response_time' => 123.4,
             'created_at' => $checkedAt,
         ]);
-        $monitoring->setRelation('latestResponseResult', $response);
+        $monitoring->setRelation('latestResponseResult', $monitoringResponse);
         $monitoring->setRelation('latestIncident', null);
         $monitoring->setRelation('groups', new EloquentCollection());
 
-        $service = MonitoringServiceReadModel::fromMonitoring($monitoring, MonitoringStatus::UP->value);
+        $monitoringServiceReadModel = MonitoringServiceReadModel::fromMonitoring($monitoring, MonitoringStatus::UP->value);
 
         $this->assertSame([
             'id' => 'monitoring-123',
@@ -45,8 +45,8 @@ class MonitoringServiceReadModelTest extends TestCase
             'group_name' => null,
             'status' => 'up',
             'open_incident' => false,
-            'last_checked_at' => $response->created_at->toIso8601String(),
+            'last_checked_at' => $monitoringResponse->created_at->toIso8601String(),
             'response_time_ms' => 123.4,
-        ], $service->toArray());
+        ], $monitoringServiceReadModel->toArray());
     }
 }

--- a/tests/Unit/Observers/OperationsOverviewCacheObserverTest.php
+++ b/tests/Unit/Observers/OperationsOverviewCacheObserverTest.php
@@ -30,10 +30,10 @@ class OperationsOverviewCacheObserverTest extends TestCase
 
     private function expectOverviewFlush(): void
     {
-        $store = Mockery::mock(TaggableStore::class);
+        $mock = Mockery::mock(TaggableStore::class);
         $taggedCache = Mockery::mock();
 
-        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('getStore')->once()->andReturn($mock);
         Cache::shouldReceive('tags')->once()->with(['operations-overview'])->andReturn($taggedCache);
         $taggedCache->shouldReceive('flush')->once();
     }

--- a/tests/Unit/Services/OperationsOverviewCacheTest.php
+++ b/tests/Unit/Services/OperationsOverviewCacheTest.php
@@ -18,10 +18,10 @@ class OperationsOverviewCacheTest extends TestCase
     {
         $user = new User();
         $user->id = 'user-123';
-        $store = Mockery::mock(TaggableStore::class);
+        $mock = Mockery::mock(TaggableStore::class);
         $taggedCache = Mockery::mock();
 
-        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('getStore')->once()->andReturn($mock);
         Cache::shouldReceive('tags')
             ->once()
             ->with(['operations-overview', 'operations-overview:user:user-123'])
@@ -43,10 +43,10 @@ class OperationsOverviewCacheTest extends TestCase
     {
         $user = new User();
         $user->id = 'user-123';
-        $store = Mockery::mock(TaggableStore::class);
+        $mock = Mockery::mock(TaggableStore::class);
         $taggedCache = Mockery::mock();
 
-        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('getStore')->once()->andReturn($mock);
         Cache::shouldReceive('tags')->once()->andReturn($taggedCache);
         $taggedCache->shouldReceive('remember')->once()->andThrow(new RuntimeException('Redis unavailable'));
 
@@ -60,10 +60,10 @@ class OperationsOverviewCacheTest extends TestCase
 
     public function test_it_flushes_all_cached_overviews_after_domain_changes(): void
     {
-        $store = Mockery::mock(TaggableStore::class);
+        $mock = Mockery::mock(TaggableStore::class);
         $taggedCache = Mockery::mock();
 
-        Cache::shouldReceive('getStore')->once()->andReturn($store);
+        Cache::shouldReceive('getStore')->once()->andReturn($mock);
         Cache::shouldReceive('tags')->once()->with(['operations-overview'])->andReturn($taggedCache);
         $taggedCache->shouldReceive('flush')->once();
 


### PR DESCRIPTION
## What changed
- extract monitoring status and stale-response derivation from the overview presenter into a reusable application service
- preserve UI-specific labels, relative timestamps, and URLs in the presenter
- keep dashboard, internal UI, and mobile projections on the same actor-scoped read path

## Why
Monitoring state derivation is client-neutral domain logic and should not be coupled to Blade or HTTP presentation.

## Testing
- Docker Pest: dashboard, internal UI dashboard, and mobile overview coverage (14 passed, 110 assertions)
- Docker Laravel Pint
- Docker PHPStan

## Risks and follow-up
This is a behavior-preserving #594 slice. Further overview/read-model extraction remains tracked in #594.

Refs #594