### PR TITLE
refactor(monitoring): complete read model extraction

### DIFF
--- a/app/Data/MonitoringIndexFilters.php
+++ b/app/Data/MonitoringIndexFilters.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use App\Enums\MonitoringLifecycleStatus;
+
+final readonly class MonitoringIndexFilters
+{
+    /**
+     * @param  list<string>  $types
+     * @param  list<string>  $healthStatuses
+     */
+    public function __construct(
+        public ?string $search,
+        public array $types,
+        public array $healthStatuses,
+        public ?MonitoringLifecycleStatus $lifecycleStatus,
+        public ?string $groupId,
+        public ?string $teamId,
+        public ?string $ownership,
+        public bool $onlyActiveMaintenance,
+        public ?string $sort,
+    ) {}
+
+    public function hasActiveFilters(): bool
+    {
+        return $this->search !== null
+            || $this->types !== []
+            || $this->healthStatuses !== []
+            || $this->lifecycleStatus !== null
+            || $this->groupId !== null
+            || $this->teamId !== null
+            || $this->ownership !== null
+            || $this->onlyActiveMaintenance;
+    }
+}

--- a/app/Data/MonitoringIndexReadModel.php
+++ b/app/Data/MonitoringIndexReadModel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use App\Models\Monitoring;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+final readonly class MonitoringIndexReadModel
+{
+    /**
+     * @param  LengthAwarePaginator<int, Monitoring>  $monitorings
+     * @param  Collection<int, string>  $summaryMonitoringIds
+     */
+    public function __construct(
+        public LengthAwarePaginator $monitorings,
+        public Collection $summaryMonitoringIds,
+        public int $total,
+    ) {}
+}

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -12,6 +12,8 @@ use App\Http\Requests\Api\MonitoringDaysRequest;
 use App\Http\Requests\Api\MonitoringUptimeCalendarRequest;
 use App\Http\Requests\Api\MonitoringUptimeSummaryRequest;
 use App\Models\Monitoring;
+use App\Models\User;
+use App\Queries\MonitoringDataQuery;
 use App\Services\MonitoringAvailabilityService;
 use App\Services\MonitoringBadgePayloadService;
 use App\Services\MonitoringCheckHistoryService;
@@ -35,7 +37,8 @@ use Illuminate\Support\Collection;
 class ApiController extends Controller
 {
     public function __construct(
-        private readonly MonitoringStatsCache $monitoringStatsCache
+        private readonly MonitoringStatsCache $monitoringStatsCache,
+        private readonly MonitoringDataQuery $monitoringDataQuery,
     ) {}
 
     /**
@@ -97,7 +100,7 @@ class ApiController extends Controller
         MonitoringDashboardRequest $monitoringDashboardRequest,
         MonitoringDashboardPayloadService $monitoringDashboardPayloadService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $days = $monitoringDashboardRequest->days();
         $calendarStartDate = $monitoringDashboardRequest->calendarStartDate();
@@ -136,7 +139,7 @@ class ApiController extends Controller
         MonitoringDaysRequest $monitoringDaysRequest,
         MonitoringAvailabilityService $monitoringAvailabilityService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $days = $monitoringDaysRequest->days();
         $monitoringDateRange = $monitoringDaysRequest->dateRange();
@@ -177,7 +180,7 @@ class ApiController extends Controller
         MonitoringUptimeSummaryRequest $monitoringUptimeSummaryRequest,
         MonitoringAvailabilityService $monitoringAvailabilityService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $days = $monitoringUptimeSummaryRequest->days();
 
@@ -211,7 +214,7 @@ class ApiController extends Controller
         MonitoringDaysRequest $monitoringDaysRequest,
         MonitoringResponseTimeService $monitoringResponseTimeService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $days = $monitoringDaysRequest->days();
         $monitoringDateRange = $monitoringDaysRequest->dateRange();
@@ -265,7 +268,7 @@ class ApiController extends Controller
         MonitoringChecksRequest $monitoringChecksRequest,
         MonitoringCheckHistoryService $monitoringCheckHistoryService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $days = $monitoringChecksRequest->days();
         $limit = $monitoringChecksRequest->limit();
@@ -306,7 +309,7 @@ class ApiController extends Controller
         Monitoring $monitoring,
         MonitoringHeatmapService $monitoringHeatmapService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $start_date = now()->subHours(23);
         $end_date = now();
@@ -336,7 +339,7 @@ class ApiController extends Controller
         Monitoring $monitoring,
         MonitoringStatusPayloadService $monitoringStatusPayloadService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         return response()->json($monitoringStatusPayloadService->getPayload($monitoring)->toArray());
     }
@@ -414,7 +417,7 @@ class ApiController extends Controller
         MonitoringDaysRequest $monitoringDaysRequest,
         MonitoringIncidentService $monitoringIncidentService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $days = $monitoringDaysRequest->days();
         $monitoringDateRange = $monitoringDaysRequest->dateRange();
@@ -442,7 +445,7 @@ class ApiController extends Controller
         Monitoring $monitoring,
         MonitoringDashboardPayloadService $monitoringDashboardPayloadService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $data = $this->monitoringStatsCache->remember(
             $monitoring,
@@ -473,7 +476,7 @@ class ApiController extends Controller
         MonitoringUptimeCalendarRequest $monitoringUptimeCalendarRequest,
         MonitoringUptimeCalendarService $monitoringUptimeCalendarService
     ): JsonResponse {
-        $this->authorizeMonitoringDataAccess($monitoring);
+        $monitoring = $this->accessibleMonitoring($monitoring);
 
         $startDate = $monitoringUptimeCalendarRequest->startDate();
         $endDate = $monitoringUptimeCalendarRequest->endDate();
@@ -488,14 +491,11 @@ class ApiController extends Controller
         return response()->json($data);
     }
 
-    private function authorizeMonitoringDataAccess(Monitoring $monitoring): void
+    private function accessibleMonitoring(Monitoring $monitoring): Monitoring
     {
+        /** @var User|null $user */
         $user = request()->user();
 
-        if ($user && $monitoring->isVisibleTo($user)) {
-            return;
-        }
-
-        abort_unless($monitoring->public_label_enabled, 404);
+        return $this->monitoringDataQuery->findAccessible($user, (string) $monitoring->getKey());
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Presenters\DashboardServicePresenter;
 use App\Services\MonitoringOverviewService;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class DashboardController extends Controller
 {
-    public function __invoke(Request $request, MonitoringOverviewService $monitoringOverviewService): View
-    {
+    public function __invoke(
+        Request $request,
+        MonitoringOverviewService $monitoringOverviewService,
+        DashboardServicePresenter $dashboardServicePresenter,
+    ): View {
         /** @var User $user */
         $user = $request->user();
 
@@ -20,9 +24,12 @@ class DashboardController extends Controller
             return view('dashboard-shell');
         }
 
-        return view('dashboard', $monitoringOverviewService->overview(
+        $overview = $monitoringOverviewService->overview(
             $user,
             max(1, $request->integer('service_page', 1)),
-        ));
+        );
+        $overview['signalRoomServices'] = $dashboardServicePresenter->present($overview['serviceReadModels']);
+
+        return view('dashboard', $overview);
     }
 }

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Data\MonitoringIndexFilters;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringStatus;
 use App\Enums\MonitoringType;
@@ -15,11 +16,11 @@ use App\Models\ServerInstance;
 use App\Models\Team;
 use App\Models\User;
 use App\Queries\MonitoringDetailQuery;
+use App\Queries\MonitoringIndexQuery;
 use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
 use App\Services\RegionalConsensusService;
 use App\Support\MonitoringPayload;
 use Illuminate\Cache\TaggableStore;
-use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -42,7 +43,8 @@ class MonitoringController extends Controller
      */
     public function index(
         Request $request,
-        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver
+        MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver,
+        MonitoringIndexQuery $monitoringIndexQuery,
     ): View {
         /** @var User $currentUser */
         $currentUser = $request->user()->loadMissing('package');
@@ -87,109 +89,29 @@ class MonitoringController extends Controller
             'maintenance' => ['nullable', 'string', Rule::in(['active'])],
         ]);
 
-        $query = Monitoring::query()
-            ->select([
-                'id',
-                'name',
-                'target',
-                'type',
-                'status',
-                'public_label_enabled',
-                'maintenance_from',
-                'maintenance_until',
-            ]);
-
-        if ($request->filled('search')) {
-            $search = $request->input('search');
-            $query->where(function (Builder $builder) use ($search): void {
-                $builder->where('name', 'like', sprintf('%%%s%%', $search))
-                    ->orWhere('target', 'like', sprintf('%%%s%%', $search))
-                    ->orWhere('port', 'like', sprintf('%%%s%%', $search))
-                    ->orWhere('keyword', 'like', sprintf('%%%s%%', $search));
-            });
-        }
-
-        if ($request->filled('types')) {
-            $types = explode(',', (string) $request->input('types'));
-            $query->whereIn('type', $types);
-        }
-
-        if ($request->filled('lifecycle')) {
-            $query->where('status', $request->lifecycle);
-        }
-
-        if ($request->filled('group_id')) {
-            $query->whereHas('groups', function ($builder) use ($request): void {
-                $builder->where('monitoring_groups.id', $request->string('group_id')->toString());
-            });
-        }
-
-        if ($request->filled('team_id')) {
-            $query->where('team_id', $request->string('team_id')->toString());
-        }
-
-        if ($request->input('ownership') === 'private') {
-            $query->whereNull('team_id');
-        } elseif ($request->input('ownership') === 'team') {
-            $query->whereNotNull('team_id');
-        }
-
-        if ($request->filled('health')) {
-            $healthStatuses = explode(',', (string) $request->input('health'));
-
-            $query->where(function (Builder $builder) use ($healthStatuses): void {
-                if (in_array(MonitoringStatus::UP->value, $healthStatuses, true)) {
-                    $builder->orWhereHas('latestResponseResult', fn ($query) => $query->where('status', MonitoringStatus::UP));
-                }
-
-                if (in_array(MonitoringStatus::DOWN->value, $healthStatuses, true)) {
-                    $builder->orWhereHas('latestResponseResult', fn ($query) => $query->where('status', MonitoringStatus::DOWN));
-                }
-
-                if (in_array(MonitoringStatus::UNKNOWN->value, $healthStatuses, true)) {
-                    $builder->orWhereDoesntHave('latestResponseResult')
-                        ->orWhereHas('latestResponseResult', fn ($query) => $query->where('status', MonitoringStatus::UNKNOWN));
-                }
-            });
-        }
-
-        if ($request->input('maintenance') === 'active') {
-            $query->whereNotNull('maintenance_from')
-                ->where('maintenance_from', '<=', now())
-                ->where(function (Builder $builder): void {
-                    $builder->whereNull('maintenance_until')
-                        ->orWhere('maintenance_until', '>=', now());
-                });
-        }
-
-        $query->orderBy('status');
-
-        match ($request->input('sort')) {
-            'name_desc' => $query->orderByDesc('name'),
-            'created_asc' => $query->oldest('monitorings.created_at'),
-            'created_desc' => $query->latest('monitorings.created_at'),
-            default => $query->orderBy('name'),
-        };
-
-        $summaryMonitoringIds = (clone $query)->select('id')->reorder()->pluck('id')->values();
-        $lengthAwarePaginator = $query->withMaintenanceWindowState()->paginate(5);
-        $hasActiveFilters = $request->filled('search')
-            || $request->filled('types')
-            || $request->filled('lifecycle')
-            || $request->filled('group_id')
-            || $request->filled('team_id')
-            || $request->filled('ownership')
-            || $request->filled('health')
-            || $request->filled('maintenance');
+        $filters = new MonitoringIndexFilters(
+            search: $request->filled('search') ? $request->string('search')->toString() : null,
+            types: $request->filled('types') ? explode(',', $request->string('types')->toString()) : [],
+            healthStatuses: $request->filled('health') ? explode(',', $request->string('health')->toString()) : [],
+            lifecycleStatus: $request->filled('lifecycle')
+                ? MonitoringLifecycleStatus::from($request->string('lifecycle')->toString())
+                : null,
+            groupId: $request->filled('group_id') ? $request->string('group_id')->toString() : null,
+            teamId: $request->filled('team_id') ? $request->string('team_id')->toString() : null,
+            ownership: $request->filled('ownership') ? $request->string('ownership')->toString() : null,
+            onlyActiveMaintenance: $request->string('maintenance')->toString() === 'active',
+            sort: $request->filled('sort') ? $request->string('sort')->toString() : null,
+        );
+        $monitoringIndex = $monitoringIndexQuery->for($currentUser, $filters);
+        $lengthAwarePaginator = $monitoringIndex->monitorings;
+        $summaryMonitoringIds = $monitoringIndex->summaryMonitoringIds;
         $privateMonitoringsTotal = $currentUser->monitorings()->whereNull('team_id')->count();
-        $monitoringsTotal = $hasActiveFilters
-            ? Monitoring::query()->count()
-            : $lengthAwarePaginator->total();
+        $monitoringsTotal = $monitoringIndex->total;
         $monitoringLimit = (int) $currentUser->package->monitoring_limit;
         $canCreateMonitoring = ! $currentUser->isDemo()
             && ($privateMonitoringsTotal < $monitoringLimit || $currentUser->administeredTeams()->exists());
 
-        if (! $hasActiveFilters && $monitoringsTotal === 0) {
+        if (! $filters->hasActiveFilters() && $monitoringsTotal === 0) {
             $request->attributes->set('unread_notifications_count', 0);
         }
 
@@ -198,7 +120,7 @@ class MonitoringController extends Controller
         });
         $openIncidentCount = Incident::query()
             ->whereNull('up_at')
-            ->whereHas('monitoring')
+            ->whereHas('monitoring', fn ($query) => $query->visibleTo($currentUser))
             ->count();
         $statusPageCount = $currentUser->statusPages()->count();
         $modalForm = $request->string('modal')->toString();

--- a/app/Http/Controllers/MonitoringController.php
+++ b/app/Http/Controllers/MonitoringController.php
@@ -89,7 +89,7 @@ class MonitoringController extends Controller
             'maintenance' => ['nullable', 'string', Rule::in(['active'])],
         ]);
 
-        $filters = new MonitoringIndexFilters(
+        $monitoringIndexFilters = new MonitoringIndexFilters(
             search: $request->filled('search') ? $request->string('search')->toString() : null,
             types: $request->filled('types') ? explode(',', $request->string('types')->toString()) : [],
             healthStatuses: $request->filled('health') ? explode(',', $request->string('health')->toString()) : [],
@@ -102,16 +102,16 @@ class MonitoringController extends Controller
             onlyActiveMaintenance: $request->string('maintenance')->toString() === 'active',
             sort: $request->filled('sort') ? $request->string('sort')->toString() : null,
         );
-        $monitoringIndex = $monitoringIndexQuery->for($currentUser, $filters);
-        $lengthAwarePaginator = $monitoringIndex->monitorings;
-        $summaryMonitoringIds = $monitoringIndex->summaryMonitoringIds;
+        $monitoringIndexReadModel = $monitoringIndexQuery->for($currentUser, $monitoringIndexFilters);
+        $lengthAwarePaginator = $monitoringIndexReadModel->monitorings;
+        $summaryMonitoringIds = $monitoringIndexReadModel->summaryMonitoringIds;
         $privateMonitoringsTotal = $currentUser->monitorings()->whereNull('team_id')->count();
-        $monitoringsTotal = $monitoringIndex->total;
+        $monitoringsTotal = $monitoringIndexReadModel->total;
         $monitoringLimit = (int) $currentUser->package->monitoring_limit;
         $canCreateMonitoring = ! $currentUser->isDemo()
             && ($privateMonitoringsTotal < $monitoringLimit || $currentUser->administeredTeams()->exists());
 
-        if (! $filters->hasActiveFilters() && $monitoringsTotal === 0) {
+        if (! $monitoringIndexFilters->hasActiveFilters() && $monitoringsTotal === 0) {
             $request->attributes->set('unread_notifications_count', 0);
         }
 

--- a/app/Presenters/DashboardServicePresenter.php
+++ b/app/Presenters/DashboardServicePresenter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presenters;
+
+use App\Data\MonitoringServiceReadModel;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+final class DashboardServicePresenter
+{
+    /**
+     * @param  Collection<int, MonitoringServiceReadModel>  $services
+     * @return Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>
+     */
+    public function present(Collection $services): Collection
+    {
+        return $services->map(fn (MonitoringServiceReadModel $service): array => [
+            'id' => $service->id,
+            'name' => $service->name,
+            'target' => $service->target,
+            'status' => $service->status,
+            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $service->status),
+            'group' => $service->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
+            'lastCheck' => $service->lastCheckedAt !== null
+                ? Date::parse($service->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
+                : (string) __('dashboard.signal_room.no_check'),
+            'responseTime' => $service->responseTimeMs !== null
+                ? number_format($service->responseTimeMs, 0, ',', '.') . ' ms'
+                : '—',
+            'openIncident' => $service->hasOpenIncident,
+            'href' => route('monitorings.show', ['monitoring' => $service->id]),
+        ])->values();
+    }
+}

--- a/app/Presenters/DashboardServicePresenter.php
+++ b/app/Presenters/DashboardServicePresenter.php
@@ -16,21 +16,21 @@ final class DashboardServicePresenter
      */
     public function present(Collection $services): Collection
     {
-        return $services->map(fn (MonitoringServiceReadModel $service): array => [
-            'id' => $service->id,
-            'name' => $service->name,
-            'target' => $service->target,
-            'status' => $service->status,
-            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $service->status),
-            'group' => $service->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
-            'lastCheck' => $service->lastCheckedAt !== null
-                ? Date::parse($service->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
+        return $services->map(fn (MonitoringServiceReadModel $monitoringServiceReadModel): array => [
+            'id' => $monitoringServiceReadModel->id,
+            'name' => $monitoringServiceReadModel->name,
+            'target' => $monitoringServiceReadModel->target,
+            'status' => $monitoringServiceReadModel->status,
+            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $monitoringServiceReadModel->status),
+            'group' => $monitoringServiceReadModel->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
+            'lastCheck' => $monitoringServiceReadModel->lastCheckedAt !== null
+                ? Date::parse($monitoringServiceReadModel->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
                 : (string) __('dashboard.signal_room.no_check'),
-            'responseTime' => $service->responseTimeMs !== null
-                ? number_format($service->responseTimeMs, 0, ',', '.') . ' ms'
+            'responseTime' => $monitoringServiceReadModel->responseTimeMs !== null
+                ? number_format($monitoringServiceReadModel->responseTimeMs, 0, ',', '.') . ' ms'
                 : '—',
-            'openIncident' => $service->hasOpenIncident,
-            'href' => route('monitorings.show', ['monitoring' => $service->id]),
+            'openIncident' => $monitoringServiceReadModel->hasOpenIncident,
+            'href' => route('monitorings.show', ['monitoring' => $monitoringServiceReadModel->id]),
         ])->values();
     }
 }

--- a/app/Queries/MaintenanceOverviewQuery.php
+++ b/app/Queries/MaintenanceOverviewQuery.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\MaintenanceWindow;
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+
+final class MaintenanceOverviewQuery
+{
+    /**
+     * @return list<string>
+     */
+    public function manageableMonitoringIdsFor(User $user): array
+    {
+        return Monitoring::query()
+            ->manageableBy($user)
+            ->pluck('id')
+            ->map(static fn ($id): string => (string) $id)
+            ->all();
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, Monitoring>
+     */
+    public function paginateWindowsFor(
+        User $user,
+        string $search,
+        string $status,
+        string $groupId,
+        string $sort,
+        string $direction,
+        int $perPage,
+    ): LengthAwarePaginator {
+        $windows = Monitoring::query()
+            ->visibleTo($user)
+            ->select(['id', 'name', 'target', 'maintenance_from', 'maintenance_until'])
+            ->with('groups:id,name');
+
+        if ($search !== '') {
+            $windows->where(function (Builder $builder) use ($search): void {
+                $builder->where('name', 'like', '%' . $search . '%')
+                    ->orWhere('target', 'like', '%' . $search . '%')
+                    ->orWhereHas('groups', fn (Builder $builder): Builder => $builder->where('name', 'like', '%' . $search . '%'));
+            });
+        }
+
+        if ($groupId !== '') {
+            $windows->whereHas('groups', fn (Builder $builder): Builder => $builder->whereKey($groupId));
+        }
+
+        $this->applyStatusFilter($windows, $status);
+        $this->applySort($windows, $sort, $direction);
+
+        return $windows->paginate(min(max($perPage, 1), 100));
+    }
+
+    /**
+     * @return Collection<int, Monitoring>
+     */
+    public function visibleMaintenanceStatesFor(User $user): Collection
+    {
+        return Monitoring::query()
+            ->visibleTo($user)
+            ->get(['id', 'maintenance_from', 'maintenance_until']);
+    }
+
+    /**
+     * @return Collection<int, MaintenanceWindow>
+     */
+    public function recurringWindowsFor(User $user): Collection
+    {
+        return MaintenanceWindow::query()
+            ->visibleTo($user)
+            ->with([
+                'monitoring:id,name',
+                'monitoringGroup:id,name',
+            ])
+            ->latest('starts_at')
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, Monitoring>
+     */
+    public function manageableMonitoringOptionsFor(User $user): Collection
+    {
+        return Monitoring::query()
+            ->manageableBy($user)
+            ->orderBy('name')
+            ->get(['id', 'name']);
+    }
+
+    private function applyStatusFilter(Builder $builder, string $status): void
+    {
+        if ($status === '') {
+            return;
+        }
+
+        $now = Date::now();
+
+        match ($status) {
+            'active' => $builder
+                ->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '<=', $now)
+                ->where(function (Builder $builder) use ($now): void {
+                    $builder->whereNull('maintenance_until')
+                        ->orWhere('maintenance_until', '>=', $now);
+                }),
+            'upcoming' => $builder
+                ->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '>', $now),
+            'expired' => $builder
+                ->whereNotNull('maintenance_from')
+                ->whereNotNull('maintenance_until')
+                ->where('maintenance_until', '<', $now),
+            'none' => $builder->whereNull('maintenance_from'),
+            default => null,
+        };
+    }
+
+    private function applySort(Builder $builder, string $sort, string $direction): void
+    {
+        if ($sort === 'maintenance_status') {
+            $now = Date::now();
+            $builder
+                ->orderByRaw(
+                    "case
+                        when maintenance_from is not null and maintenance_from <= ? and (maintenance_until is null or maintenance_until >= ?) then 0
+                        when maintenance_from is not null and maintenance_from > ? then 1
+                        when maintenance_from is not null then 2
+                        else 3
+                    end {$direction}",
+                    [$now, $now, $now]
+                )
+                ->orderBy('name');
+
+            return;
+        }
+
+        $builder->orderBy(in_array($sort, ['name', 'maintenance_from', 'maintenance_until'], true) ? $sort : 'name', $direction)
+            ->orderBy('name')
+            ->orderBy('id');
+    }
+}

--- a/app/Queries/MonitoringCheckHistoryQuery.php
+++ b/app/Queries/MonitoringCheckHistoryQuery.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use Carbon\Carbon;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+final class MonitoringCheckHistoryQuery
+{
+    private const LIVE_TABLE = 'monitoring_response_results';
+
+    private const ARCHIVED_TABLE = 'monitoring_response_archived';
+
+    /**
+     * @return Collection<int, object>
+     */
+    public function for(string $monitoringId, ?Carbon $startDate, Carbon $endDate, int $offset, int $limit): Collection
+    {
+        $archiveCutoffDate = Date::now()->subWeek()->startOfDay();
+
+        if ($startDate !== null && $startDate->gte($archiveCutoffDate)) {
+            return $this->sourceQuery(self::LIVE_TABLE, 'live', $monitoringId, $startDate, $endDate)
+                ->latest()
+                ->orderByDesc('id')
+                ->offset($offset)
+                ->limit($limit)
+                ->get();
+        }
+
+        if ($startDate === null) {
+            $liveRows = $this->sourceQuery(self::LIVE_TABLE, 'live', $monitoringId, null, null)
+                ->latest()
+                ->orderByDesc('id')
+                ->offset($offset)
+                ->limit($limit)
+                ->get();
+            $oldestLiveCheckedAt = $liveRows->last()?->created_at;
+
+            if ($liveRows->count() === $limit && $oldestLiveCheckedAt !== null && Date::parse((string) $oldestLiveCheckedAt)->gte($archiveCutoffDate)) {
+                return $liveRows;
+            }
+        }
+
+        $live = $this->sourceQuery(self::LIVE_TABLE, 'live', $monitoringId, $startDate, $startDate !== null ? $endDate : null);
+        $archived = $this->sourceQuery(self::ARCHIVED_TABLE, 'archived', $monitoringId, $startDate, $startDate !== null ? $endDate : null);
+
+        return DB::query()
+            ->fromSub($live->unionAll($archived), 'monitoring_results')
+            ->latest()
+            ->orderByDesc('id')
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
+    }
+
+    private function sourceQuery(
+        string $table,
+        string $source,
+        string $monitoringId,
+        ?Carbon $startDate,
+        ?Carbon $endDate,
+    ): Builder {
+        $builder = DB::table($table)
+            ->selectRaw("'{$source}' as source, id, status, http_status_code, response_time, server_health_metrics, created_at")
+            ->where('monitoring_id', $monitoringId);
+
+        if ($startDate !== null && $endDate !== null) {
+            $builder->whereBetween('created_at', [$startDate, $endDate]);
+        }
+
+        return $builder;
+    }
+}

--- a/app/Queries/MonitoringCheckHistoryQuery.php
+++ b/app/Queries/MonitoringCheckHistoryQuery.php
@@ -46,11 +46,11 @@ final class MonitoringCheckHistoryQuery
             }
         }
 
-        $live = $this->sourceQuery(self::LIVE_TABLE, 'live', $monitoringId, $startDate, $startDate !== null ? $endDate : null);
+        $builder = $this->sourceQuery(self::LIVE_TABLE, 'live', $monitoringId, $startDate, $startDate !== null ? $endDate : null);
         $archived = $this->sourceQuery(self::ARCHIVED_TABLE, 'archived', $monitoringId, $startDate, $startDate !== null ? $endDate : null);
 
         return DB::query()
-            ->fromSub($live->unionAll($archived), 'monitoring_results')
+            ->fromSub($builder->unionAll($archived), 'monitoring_results')
             ->latest()
             ->orderByDesc('id')
             ->offset($offset)

--- a/app/Queries/MonitoringDataQuery.php
+++ b/app/Queries/MonitoringDataQuery.php
@@ -10,12 +10,12 @@ use Illuminate\Database\Eloquent\Builder;
 
 final class MonitoringDataQuery
 {
-    public function findAccessible(?User $actor, string $monitoringId): Monitoring
+    public function findAccessible(?User $user, string $monitoringId): Monitoring
     {
         return Monitoring::query()
-            ->where(function (Builder $builder) use ($actor): void {
-                if ($actor !== null) {
-                    $builder->visibleTo($actor);
+            ->where(function (Builder $builder) use ($user): void {
+                if ($user !== null) {
+                    $builder->visibleTo($user);
                 }
 
                 $builder->orWhere('public_label_enabled', true);

--- a/app/Queries/MonitoringDataQuery.php
+++ b/app/Queries/MonitoringDataQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+
+final class MonitoringDataQuery
+{
+    public function findAccessible(?User $actor, string $monitoringId): Monitoring
+    {
+        return Monitoring::query()
+            ->where(function (Builder $builder) use ($actor): void {
+                if ($actor !== null) {
+                    $builder->visibleTo($actor);
+                }
+
+                $builder->orWhere('public_label_enabled', true);
+            })
+            ->findOrFail($monitoringId);
+    }
+}

--- a/app/Queries/MonitoringIncidentQuery.php
+++ b/app/Queries/MonitoringIncidentQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Queries;
 
+use App\Models\Incident;
 use App\Models\Monitoring;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 final class MonitoringIncidentQuery
 {
     /**
-     * @return Collection<int, \App\Models\Incident>
+     * @return Collection<int, Incident>
      */
     public function for(Monitoring $monitoring, Carbon $startDate, Carbon $endDate): Collection
     {

--- a/app/Queries/MonitoringIncidentQuery.php
+++ b/app/Queries/MonitoringIncidentQuery.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Monitoring;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+
+final class MonitoringIncidentQuery
+{
+    /**
+     * @return Collection<int, \App\Models\Incident>
+     */
+    public function for(Monitoring $monitoring, Carbon $startDate, Carbon $endDate): Collection
+    {
+        return $monitoring->incidents()
+            ->whereBetween('down_at', [$startDate->startOfDay(), $endDate->endOfDay()])
+            ->select('down_at', 'up_at')
+            ->latest('down_at')
+            ->get();
+    }
+}

--- a/app/Queries/MonitoringIndexQuery.php
+++ b/app/Queries/MonitoringIndexQuery.php
@@ -14,9 +14,9 @@ use Illuminate\Support\Facades\Date;
 
 final class MonitoringIndexQuery
 {
-    public function for(User $user, MonitoringIndexFilters $filters, int $perPage = 5): MonitoringIndexReadModel
+    public function for(User $user, MonitoringIndexFilters $monitoringIndexFilters, int $perPage = 5): MonitoringIndexReadModel
     {
-        $query = $this->query($user, $filters);
+        $query = $this->query($user, $monitoringIndexFilters);
         $summaryMonitoringIds = (clone $query)->select('id')->reorder()->pluck('id')->values();
         $monitorings = $query->withMaintenanceWindowState()->paginate($perPage);
 
@@ -30,7 +30,7 @@ final class MonitoringIndexQuery
     /**
      * @return Builder<Monitoring>
      */
-    private function query(User $user, MonitoringIndexFilters $filters): Builder
+    private function query(User $user, MonitoringIndexFilters $monitoringIndexFilters): Builder
     {
         $query = Monitoring::query()
             ->visibleTo($user)
@@ -45,57 +45,57 @@ final class MonitoringIndexQuery
                 'maintenance_until',
             ]);
 
-        if ($filters->search !== null) {
-            $query->where(function (Builder $builder) use ($filters): void {
-                $builder->where('name', 'like', '%' . $filters->search . '%')
-                    ->orWhere('target', 'like', '%' . $filters->search . '%')
-                    ->orWhere('port', 'like', '%' . $filters->search . '%')
-                    ->orWhere('keyword', 'like', '%' . $filters->search . '%');
+        if ($monitoringIndexFilters->search !== null) {
+            $query->where(function (Builder $builder) use ($monitoringIndexFilters): void {
+                $builder->where('name', 'like', '%' . $monitoringIndexFilters->search . '%')
+                    ->orWhere('target', 'like', '%' . $monitoringIndexFilters->search . '%')
+                    ->orWhere('port', 'like', '%' . $monitoringIndexFilters->search . '%')
+                    ->orWhere('keyword', 'like', '%' . $monitoringIndexFilters->search . '%');
             });
         }
 
-        if ($filters->types !== []) {
-            $query->whereIn('type', $filters->types);
+        if ($monitoringIndexFilters->types !== []) {
+            $query->whereIn('type', $monitoringIndexFilters->types);
         }
 
-        if ($filters->lifecycleStatus !== null) {
-            $query->where('status', $filters->lifecycleStatus);
+        if ($monitoringIndexFilters->lifecycleStatus !== null) {
+            $query->where('status', $monitoringIndexFilters->lifecycleStatus);
         }
 
-        if ($filters->groupId !== null) {
-            $query->whereHas('groups', function (Builder $builder) use ($filters): void {
-                $builder->where('monitoring_groups.id', $filters->groupId);
+        if ($monitoringIndexFilters->groupId !== null) {
+            $query->whereHas('groups', function (Builder $builder) use ($monitoringIndexFilters): void {
+                $builder->where('monitoring_groups.id', $monitoringIndexFilters->groupId);
             });
         }
 
-        if ($filters->teamId !== null) {
-            $query->where('team_id', $filters->teamId);
+        if ($monitoringIndexFilters->teamId !== null) {
+            $query->where('team_id', $monitoringIndexFilters->teamId);
         }
 
-        if ($filters->ownership === 'private') {
+        if ($monitoringIndexFilters->ownership === 'private') {
             $query->whereNull('team_id');
-        } elseif ($filters->ownership === 'team') {
+        } elseif ($monitoringIndexFilters->ownership === 'team') {
             $query->whereNotNull('team_id');
         }
 
-        if ($filters->healthStatuses !== []) {
-            $query->where(function (Builder $builder) use ($filters): void {
-                if (in_array(MonitoringStatus::UP->value, $filters->healthStatuses, true)) {
-                    $builder->orWhereHas('latestResponseResult', fn (Builder $query) => $query->where('status', MonitoringStatus::UP));
+        if ($monitoringIndexFilters->healthStatuses !== []) {
+            $query->where(function (Builder $builder) use ($monitoringIndexFilters): void {
+                if (in_array(MonitoringStatus::UP->value, $monitoringIndexFilters->healthStatuses, true)) {
+                    $builder->orWhereHas('latestResponseResult', fn (Builder $builder) => $builder->where('status', MonitoringStatus::UP));
                 }
 
-                if (in_array(MonitoringStatus::DOWN->value, $filters->healthStatuses, true)) {
-                    $builder->orWhereHas('latestResponseResult', fn (Builder $query) => $query->where('status', MonitoringStatus::DOWN));
+                if (in_array(MonitoringStatus::DOWN->value, $monitoringIndexFilters->healthStatuses, true)) {
+                    $builder->orWhereHas('latestResponseResult', fn (Builder $builder) => $builder->where('status', MonitoringStatus::DOWN));
                 }
 
-                if (in_array(MonitoringStatus::UNKNOWN->value, $filters->healthStatuses, true)) {
+                if (in_array(MonitoringStatus::UNKNOWN->value, $monitoringIndexFilters->healthStatuses, true)) {
                     $builder->orWhereDoesntHave('latestResponseResult')
-                        ->orWhereHas('latestResponseResult', fn (Builder $query) => $query->where('status', MonitoringStatus::UNKNOWN));
+                        ->orWhereHas('latestResponseResult', fn (Builder $builder) => $builder->where('status', MonitoringStatus::UNKNOWN));
                 }
             });
         }
 
-        if ($filters->onlyActiveMaintenance) {
+        if ($monitoringIndexFilters->onlyActiveMaintenance) {
             $now = Date::now();
             $query->whereNotNull('maintenance_from')
                 ->where('maintenance_from', '<=', $now)
@@ -107,7 +107,7 @@ final class MonitoringIndexQuery
 
         $query->orderBy('status');
 
-        match ($filters->sort) {
+        match ($monitoringIndexFilters->sort) {
             'name_desc' => $query->orderByDesc('name'),
             'created_asc' => $query->oldest('monitorings.created_at'),
             'created_desc' => $query->latest('monitorings.created_at'),

--- a/app/Queries/MonitoringIndexQuery.php
+++ b/app/Queries/MonitoringIndexQuery.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Data\MonitoringIndexFilters;
+use App\Data\MonitoringIndexReadModel;
+use App\Enums\MonitoringStatus;
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Date;
+
+final class MonitoringIndexQuery
+{
+    public function for(User $user, MonitoringIndexFilters $filters, int $perPage = 5): MonitoringIndexReadModel
+    {
+        $query = $this->query($user, $filters);
+        $summaryMonitoringIds = (clone $query)->select('id')->reorder()->pluck('id')->values();
+        $monitorings = $query->withMaintenanceWindowState()->paginate($perPage);
+
+        return new MonitoringIndexReadModel(
+            monitorings: $monitorings,
+            summaryMonitoringIds: $summaryMonitoringIds,
+            total: $monitorings->total(),
+        );
+    }
+
+    /**
+     * @return Builder<Monitoring>
+     */
+    private function query(User $user, MonitoringIndexFilters $filters): Builder
+    {
+        $query = Monitoring::query()
+            ->visibleTo($user)
+            ->select([
+                'id',
+                'name',
+                'target',
+                'type',
+                'status',
+                'public_label_enabled',
+                'maintenance_from',
+                'maintenance_until',
+            ]);
+
+        if ($filters->search !== null) {
+            $query->where(function (Builder $builder) use ($filters): void {
+                $builder->where('name', 'like', '%' . $filters->search . '%')
+                    ->orWhere('target', 'like', '%' . $filters->search . '%')
+                    ->orWhere('port', 'like', '%' . $filters->search . '%')
+                    ->orWhere('keyword', 'like', '%' . $filters->search . '%');
+            });
+        }
+
+        if ($filters->types !== []) {
+            $query->whereIn('type', $filters->types);
+        }
+
+        if ($filters->lifecycleStatus !== null) {
+            $query->where('status', $filters->lifecycleStatus);
+        }
+
+        if ($filters->groupId !== null) {
+            $query->whereHas('groups', function (Builder $builder) use ($filters): void {
+                $builder->where('monitoring_groups.id', $filters->groupId);
+            });
+        }
+
+        if ($filters->teamId !== null) {
+            $query->where('team_id', $filters->teamId);
+        }
+
+        if ($filters->ownership === 'private') {
+            $query->whereNull('team_id');
+        } elseif ($filters->ownership === 'team') {
+            $query->whereNotNull('team_id');
+        }
+
+        if ($filters->healthStatuses !== []) {
+            $query->where(function (Builder $builder) use ($filters): void {
+                if (in_array(MonitoringStatus::UP->value, $filters->healthStatuses, true)) {
+                    $builder->orWhereHas('latestResponseResult', fn (Builder $query) => $query->where('status', MonitoringStatus::UP));
+                }
+
+                if (in_array(MonitoringStatus::DOWN->value, $filters->healthStatuses, true)) {
+                    $builder->orWhereHas('latestResponseResult', fn (Builder $query) => $query->where('status', MonitoringStatus::DOWN));
+                }
+
+                if (in_array(MonitoringStatus::UNKNOWN->value, $filters->healthStatuses, true)) {
+                    $builder->orWhereDoesntHave('latestResponseResult')
+                        ->orWhereHas('latestResponseResult', fn (Builder $query) => $query->where('status', MonitoringStatus::UNKNOWN));
+                }
+            });
+        }
+
+        if ($filters->onlyActiveMaintenance) {
+            $now = Date::now();
+            $query->whereNotNull('maintenance_from')
+                ->where('maintenance_from', '<=', $now)
+                ->where(function (Builder $builder) use ($now): void {
+                    $builder->whereNull('maintenance_until')
+                        ->orWhere('maintenance_until', '>=', $now);
+                });
+        }
+
+        $query->orderBy('status');
+
+        match ($filters->sort) {
+            'name_desc' => $query->orderByDesc('name'),
+            'created_asc' => $query->oldest('monitorings.created_at'),
+            'created_desc' => $query->latest('monitorings.created_at'),
+            default => $query->orderBy('name'),
+        };
+
+        return $query;
+    }
+}

--- a/app/Services/MaintenanceOverviewService.php
+++ b/app/Services/MaintenanceOverviewService.php
@@ -26,7 +26,7 @@ final class MaintenanceOverviewService
         int $perPage,
     ): array {
         $manageableMonitoringIds = $this->maintenanceOverviewQuery->manageableMonitoringIdsFor($user);
-        $windows = $this->maintenanceOverviewQuery->paginateWindowsFor(
+        $lengthAwarePaginator = $this->maintenanceOverviewQuery->paginateWindowsFor(
             $user,
             $search,
             $status,
@@ -35,7 +35,7 @@ final class MaintenanceOverviewService
             $direction,
             $perPage,
         );
-        $windowData = $windows->through(static fn (Monitoring $monitoring): array => [
+        $windowData = $lengthAwarePaginator->through(static fn (Monitoring $monitoring): array => [
             'id' => (string) $monitoring->id,
             'name' => $monitoring->name,
             'target' => $monitoring->target,

--- a/app/Services/MaintenanceOverviewService.php
+++ b/app/Services/MaintenanceOverviewService.php
@@ -7,11 +7,12 @@ namespace App\Services;
 use App\Models\MaintenanceWindow;
 use App\Models\Monitoring;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Date;
+use App\Queries\MaintenanceOverviewQuery;
 
 final class MaintenanceOverviewService
 {
+    public function __construct(private readonly MaintenanceOverviewQuery $maintenanceOverviewQuery) {}
+
     /**
      * @return array<string, mixed>
      */
@@ -24,51 +25,16 @@ final class MaintenanceOverviewService
         string $direction,
         int $perPage,
     ): array {
-        $manageableMonitoringIds = Monitoring::query()
-            ->manageableBy($user)
-            ->pluck('id')
-            ->map(static fn ($id): string => (string) $id)
-            ->all();
-
-        $windowsQuery = Monitoring::query()
-            ->visibleTo($user)
-            ->select(['id', 'name', 'target', 'maintenance_from', 'maintenance_until'])
-            ->with('groups:id,name');
-
-        if ($search !== '') {
-            $windowsQuery->where(function (Builder $builder) use ($search): void {
-                $builder->where('name', 'like', '%' . $search . '%')
-                    ->orWhere('target', 'like', '%' . $search . '%')
-                    ->orWhereHas('groups', fn (Builder $builder): Builder => $builder->where('name', 'like', '%' . $search . '%'));
-            });
-        }
-
-        if ($groupId !== '') {
-            $windowsQuery->whereHas('groups', fn (Builder $builder): Builder => $builder->whereKey($groupId));
-        }
-
-        $this->applyStatusFilter($windowsQuery, $status);
-
-        if ($sort === 'maintenance_status') {
-            $now = Date::now();
-            $windowsQuery
-                ->orderByRaw(
-                    "case
-                        when maintenance_from is not null and maintenance_from <= ? and (maintenance_until is null or maintenance_until >= ?) then 0
-                        when maintenance_from is not null and maintenance_from > ? then 1
-                        when maintenance_from is not null then 2
-                        else 3
-                    end {$direction}",
-                    [$now, $now, $now]
-                )
-                ->orderBy('name');
-        } else {
-            $windowsQuery->orderBy(in_array($sort, ['name', 'maintenance_from', 'maintenance_until'], true) ? $sort : 'name', $direction)
-                ->orderBy('name')
-                ->orderBy('id');
-        }
-
-        $windows = $windowsQuery->paginate(min(max($perPage, 1), 100));
+        $manageableMonitoringIds = $this->maintenanceOverviewQuery->manageableMonitoringIdsFor($user);
+        $windows = $this->maintenanceOverviewQuery->paginateWindowsFor(
+            $user,
+            $search,
+            $status,
+            $groupId,
+            $sort,
+            $direction,
+            $perPage,
+        );
         $windowData = $windows->through(static fn (Monitoring $monitoring): array => [
             'id' => (string) $monitoring->id,
             'name' => $monitoring->name,
@@ -88,9 +54,7 @@ final class MaintenanceOverviewService
             'can_manage' => in_array((string) $monitoring->id, $manageableMonitoringIds, true),
         ]);
 
-        $visibleMonitorings = Monitoring::query()
-            ->visibleTo($user)
-            ->get(['id', 'maintenance_from', 'maintenance_until']);
+        $visibleMonitorings = $this->maintenanceOverviewQuery->visibleMaintenanceStatesFor($user);
         $activeCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => $monitoring->isUnderMaintenance())->count();
         $upcomingCount = $visibleMonitorings->filter(static fn (Monitoring $monitoring): bool => ! $monitoring->isUnderMaintenance()
             && $monitoring->hasUpcomingMaintenance())->count();
@@ -108,14 +72,7 @@ final class MaintenanceOverviewService
                 'expired' => $expiredCount,
                 'none' => $visibleMonitorings->count() - $activeCount - $upcomingCount - $expiredCount,
             ],
-            'recurring_windows' => MaintenanceWindow::query()
-                ->visibleTo($user)
-                ->with([
-                    'monitoring:id,name',
-                    'monitoringGroup:id,name',
-                ])
-                ->latest('starts_at')
-                ->get()
+            'recurring_windows' => $this->maintenanceOverviewQuery->recurringWindowsFor($user)
                 ->map(static fn (MaintenanceWindow $maintenanceWindow): array => [
                     'id' => (string) $maintenanceWindow->id,
                     'target' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
@@ -127,10 +84,7 @@ final class MaintenanceOverviewService
                 ])
                 ->values()
                 ->all(),
-            'monitoring_options' => Monitoring::query()
-                ->manageableBy($user)
-                ->orderBy('name')
-                ->get(['id', 'name'])
+            'monitoring_options' => $this->maintenanceOverviewQuery->manageableMonitoringOptionsFor($user)
                 ->map(static fn (Monitoring $monitoring): array => [
                     'id' => (string) $monitoring->id,
                     'name' => $monitoring->name,
@@ -149,36 +103,5 @@ final class MaintenanceOverviewService
                 ->values()
                 ->all(),
         ];
-    }
-
-    /**
-     * @param  Builder<Monitoring>  $builder
-     */
-    private function applyStatusFilter(Builder $builder, string $status): void
-    {
-        if ($status === '') {
-            return;
-        }
-
-        $now = Date::now();
-
-        match ($status) {
-            'active' => $builder
-                ->whereNotNull('maintenance_from')
-                ->where('maintenance_from', '<=', $now)
-                ->where(function (Builder $builder) use ($now): void {
-                    $builder->whereNull('maintenance_until')
-                        ->orWhere('maintenance_until', '>=', $now);
-                }),
-            'upcoming' => $builder
-                ->whereNotNull('maintenance_from')
-                ->where('maintenance_from', '>', $now),
-            'expired' => $builder
-                ->whereNotNull('maintenance_from')
-                ->whereNotNull('maintenance_until')
-                ->where('maintenance_until', '<', $now),
-            'none' => $builder->whereNull('maintenance_from'),
-            default => null,
-        };
     }
 }

--- a/app/Services/MonitoringCheckHistoryService.php
+++ b/app/Services/MonitoringCheckHistoryService.php
@@ -5,18 +5,15 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Monitoring;
+use App\Queries\MonitoringCheckHistoryQuery;
 use App\Support\MonitoringStatusMeta;
 use Carbon\Carbon;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Facades\DB;
 
 class MonitoringCheckHistoryService
 {
-    private const LIVE_TABLE = 'monitoring_response_results';
-
-    private const ARCHIVED_TABLE = 'monitoring_response_archived';
+    public function __construct(private readonly MonitoringCheckHistoryQuery $monitoringCheckHistoryQuery) {}
 
     /**
      * @return array{data: array<int, array{id: string, checked_at: string, status: string, http_status_code: int|null, response_time: float|null, server_health_metrics: array<string, mixed>|null, status_identifier: string, status_key: string, source: string}>, has_more: bool, next_offset: int|null}
@@ -29,109 +26,15 @@ class MonitoringCheckHistoryService
         int $offset
     ): array {
         $pageSize = $limit + 1;
-        $archiveCutoffDate = Date::now()->subWeek()->startOfDay();
-
-        if ($startDate !== null && $startDate->gte($archiveCutoffDate)) {
-            $rows = $this->buildSourceQuery(
-                self::LIVE_TABLE,
-                'live',
-                $monitoring->id,
-                $startDate,
-                $endDate,
-                $offset,
-                $pageSize
-            )->get();
-
-            return $this->paginateRows($rows, $limit, $offset);
-        }
-
-        if ($startDate === null) {
-            $liveRows = $this->buildSourceQuery(
-                self::LIVE_TABLE,
-                'live',
-                $monitoring->id,
-                null,
-                null,
-                $offset,
-                $pageSize
-            )->get();
-
-            $oldestLiveCheckedAt = $liveRows->last()?->created_at;
-
-            if (
-                $liveRows->count() === $pageSize
-                && $oldestLiveCheckedAt !== null
-                && Date::parse((string) $oldestLiveCheckedAt)->gte($archiveCutoffDate)
-            ) {
-                return $this->paginateRows($liveRows, $limit, $offset);
-            }
-        }
-
-        $rows = $this->buildUnionQuery(
-            $monitoring->id,
+        $rows = $this->monitoringCheckHistoryQuery->for(
+            (string) $monitoring->getKey(),
             $startDate,
-            $startDate !== null ? $endDate : null
-        )
-            ->offset($offset)
-            ->limit($pageSize)
-            ->get();
+            $endDate,
+            $offset,
+            $pageSize,
+        );
 
         return $this->paginateRows($rows, $limit, $offset);
-    }
-
-    private function buildSourceQuery(
-        string $table,
-        string $source,
-        string $monitoringId,
-        ?Carbon $startDate,
-        ?Carbon $endDate,
-        int $offset,
-        int $limit
-    ): QueryBuilder {
-        return $this->buildSourceSubquery($table, $source, $monitoringId, $startDate, $endDate)->latest()
-            ->orderByDesc('id')
-            ->offset($offset)
-            ->limit($limit);
-    }
-
-    private function buildUnionQuery(string $monitoringId, ?Carbon $startDate, ?Carbon $endDate): QueryBuilder
-    {
-        $builder = $this->buildSourceSubquery(
-            self::LIVE_TABLE,
-            'live',
-            $monitoringId,
-            $startDate,
-            $endDate
-        );
-        $archivedQuery = $this->buildSourceSubquery(
-            self::ARCHIVED_TABLE,
-            'archived',
-            $monitoringId,
-            $startDate,
-            $endDate
-        );
-
-        return DB::query()
-            ->fromSub($builder->unionAll($archivedQuery), 'monitoring_results')->latest()
-            ->orderByDesc('id');
-    }
-
-    private function buildSourceSubquery(
-        string $table,
-        string $source,
-        string $monitoringId,
-        ?Carbon $startDate,
-        ?Carbon $endDate
-    ): QueryBuilder {
-        $builder = DB::table($table)
-            ->selectRaw("'{$source}' as source, id, status, http_status_code, response_time, server_health_metrics, created_at")
-            ->where('monitoring_id', $monitoringId);
-
-        if ($startDate !== null && $endDate !== null) {
-            $builder->whereBetween('created_at', [$startDate, $endDate]);
-        }
-
-        return $builder;
     }
 
     /**

--- a/app/Services/MonitoringIncidentService.php
+++ b/app/Services/MonitoringIncidentService.php
@@ -6,25 +6,22 @@ namespace App\Services;
 
 use App\Data\MonitoringIncidentPayload;
 use App\Models\Monitoring;
+use App\Queries\MonitoringIncidentQuery;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 
 class MonitoringIncidentService
 {
+    public function __construct(private readonly MonitoringIncidentQuery $monitoringIncidentQuery) {}
+
     /**
      * @return Collection<int, MonitoringIncidentPayload>
      */
     public function getIncidents(Monitoring $monitoring, Carbon $startDate, Carbon $endDate): Collection
     {
-        $startDate = $startDate->startOfDay();
-        $endDate = $endDate->endOfDay();
-
-        return $monitoring->incidents()
-            ->whereBetween('down_at', [$startDate, $endDate])
-            ->select('down_at', 'up_at')
-            ->latest('down_at')
-            ->get()
+        return $this->monitoringIncidentQuery
+            ->for($monitoring, $startDate, $endDate)
             ->map(function ($incident): MonitoringIncidentPayload {
                 $downAt = Date::parse($incident->down_at);
                 $upAt = $incident->up_at ? Date::parse($incident->up_at) : null;

--- a/app/Services/MonitoringOverviewService.php
+++ b/app/Services/MonitoringOverviewService.php
@@ -17,7 +17,6 @@ use App\Models\StatusPage;
 use App\Models\User;
 use App\Queries\MonitoringOverviewQuery;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
@@ -32,7 +31,6 @@ class MonitoringOverviewService
     /**
      * @return array{
      *     monitorings: EloquentCollection<int, Monitoring>,
-     *     signalRoomServices: Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>,
      *     serviceReadModels: Collection<int, MonitoringServiceReadModel>,
      *     signalRoomPagination: array{current_page:int,last_page:int,total:int,from:int|null,to:int|null},
      *     summary: array{total:int,healthy:int,down:int,unknown:int,paused:int,maintenance:int},
@@ -90,27 +88,21 @@ class MonitoringOverviewService
                 (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value),
             )
         )->values();
-        $signalRoomServices = $serviceReadModels->map(
-            fn (MonitoringServiceReadModel $monitoringServiceReadModel): array => $this->servicePresentation($monitoringServiceReadModel)
-        );
-        $lengthAwarePaginator = new LengthAwarePaginator(
-            $signalRoomServices->forPage(max(1, $servicePage), 10)->values(),
-            $signalRoomServices->count(),
-            10,
-            max(1, $servicePage),
-            ['pageName' => 'service_page', 'path' => route('dashboard', absolute: false)],
-        );
+        $pagedServiceReadModels = $serviceReadModels->forPage(max(1, $servicePage), 10)->values();
+        $serviceCount = $serviceReadModels->count();
+        $lastPage = max(1, (int) ceil($serviceCount / 10));
+        $firstItem = $pagedServiceReadModels->isEmpty() ? null : (($servicePage - 1) * 10) + 1;
+        $lastItem = $pagedServiceReadModels->isEmpty() ? null : min($servicePage * 10, $serviceCount);
 
         return [
             'monitorings' => $monitorings,
-            'signalRoomServices' => $lengthAwarePaginator->getCollection(),
-            'serviceReadModels' => $serviceReadModels->forPage(max(1, $servicePage), 10)->values(),
+            'serviceReadModels' => $pagedServiceReadModels,
             'signalRoomPagination' => [
-                'current_page' => $lengthAwarePaginator->currentPage(),
-                'last_page' => $lengthAwarePaginator->lastPage(),
-                'total' => $lengthAwarePaginator->total(),
-                'from' => $lengthAwarePaginator->firstItem(),
-                'to' => $lengthAwarePaginator->lastItem(),
+                'current_page' => max(1, $servicePage),
+                'last_page' => $lastPage,
+                'total' => $serviceCount,
+                'from' => $firstItem,
+                'to' => $lastItem,
             ],
             'summary' => $summary,
             'overallState' => $overallState,
@@ -141,13 +133,13 @@ class MonitoringOverviewService
     /**
      * Load only the bounded service-map page used by async dashboard navigation.
      *
-     * @return array{services:Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>,pagination:array{current_page:int,last_page:int,total:int,from:int|null,to:int|null},total:int}
+     * @return array{services:Collection<int, MonitoringServiceReadModel>,pagination:array{current_page:int,last_page:int,total:int,from:int|null,to:int|null},total:int}
      */
     public function serviceMap(User $user, int $servicePage = 1): array
     {
         $lengthAwarePaginator = $this->monitoringOverviewQuery->paginateServicesFor($user, $servicePage);
 
-        $services = $this->mapSignalRoomServices($lengthAwarePaginator->getCollection());
+        $services = $this->serviceReadModels($lengthAwarePaginator->getCollection());
 
         return [
             'services' => $services,
@@ -164,45 +156,20 @@ class MonitoringOverviewService
 
     /**
      * @param  Collection<int, Monitoring>  $monitorings
-     * @return Collection<int, array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}>
+     * @return Collection<int, MonitoringServiceReadModel>
      */
-    private function mapSignalRoomServices(Collection $monitorings): Collection
+    private function serviceReadModels(Collection $monitorings): Collection
     {
         $statuses = $monitorings->mapWithKeys(
             fn (Monitoring $monitoring): array => [$monitoring->id => $this->monitoringStateResolver->status($monitoring)]
         );
 
         return $monitorings->map(
-            fn (Monitoring $monitoring): array => $this->servicePresentation(
-                MonitoringServiceReadModel::fromMonitoring(
-                    $monitoring,
-                    (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value),
-                )
+            fn (Monitoring $monitoring): MonitoringServiceReadModel => MonitoringServiceReadModel::fromMonitoring(
+                $monitoring,
+                (string) $statuses->get($monitoring->getKey(), MonitoringStatus::UNKNOWN->value),
             )
         )->values();
-    }
-
-    /**
-     * @return array{id:string,name:string,target:string,status:string,statusLabel:string,group:string,lastCheck:string,responseTime:string,openIncident:bool,href:string}
-     */
-    private function servicePresentation(MonitoringServiceReadModel $monitoringServiceReadModel): array
-    {
-        return [
-            'id' => $monitoringServiceReadModel->id,
-            'name' => $monitoringServiceReadModel->name,
-            'target' => $monitoringServiceReadModel->target,
-            'status' => $monitoringServiceReadModel->status,
-            'statusLabel' => (string) __('dashboard.signal_room.statuses.' . $monitoringServiceReadModel->status),
-            'group' => $monitoringServiceReadModel->groupName ?? (string) __('dashboard.signal_room.ungrouped'),
-            'lastCheck' => $monitoringServiceReadModel->lastCheckedAt !== null
-                ? Date::parse($monitoringServiceReadModel->lastCheckedAt)->locale(app()->getLocale())->diffForHumans()
-                : (string) __('dashboard.signal_room.no_check'),
-            'responseTime' => $monitoringServiceReadModel->responseTimeMs !== null
-                ? number_format($monitoringServiceReadModel->responseTimeMs, 0, ',', '.') . ' ms'
-                : '—',
-            'openIncident' => $monitoringServiceReadModel->hasOpenIncident,
-            'href' => route('monitorings.show', ['monitoring' => $monitoringServiceReadModel->id]),
-        ];
     }
 
     /**

--- a/tests/Feature/Queries/MonitoringIndexQueryTest.php
+++ b/tests/Feature/Queries/MonitoringIndexQueryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Queries;
+
+use App\Data\MonitoringIndexFilters;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use App\Queries\MonitoringIndexQuery;
+use Tests\TestCase;
+
+class MonitoringIndexQueryTest extends TestCase
+{
+    public function test_it_paginates_only_monitorings_visible_to_the_actor(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $visibleMonitorings = Monitoring::factory()->count(3)->for($user)->create();
+        Monitoring::factory()->for($otherUser)->create(['name' => 'Hidden monitoring']);
+
+        $readModel = resolve(MonitoringIndexQuery::class)->for($user, $this->filters(), 2);
+
+        $this->assertSame(3, $readModel->total);
+        $this->assertCount(2, $readModel->monitorings);
+        $this->assertEqualsCanonicalizing($visibleMonitorings->modelKeys(), $readModel->summaryMonitoringIds->all());
+        $this->assertNotContains('Hidden monitoring', $readModel->monitorings->pluck('name')->all());
+    }
+
+    private function filters(): MonitoringIndexFilters
+    {
+        return new MonitoringIndexFilters(
+            search: null,
+            types: [],
+            healthStatuses: [],
+            lifecycleStatus: null,
+            groupId: null,
+            teamId: null,
+            ownership: null,
+            onlyActiveMaintenance: false,
+            sort: null,
+        );
+    }
+}

--- a/tests/Feature/Queries/MonitoringIndexQueryTest.php
+++ b/tests/Feature/Queries/MonitoringIndexQueryTest.php
@@ -21,12 +21,12 @@ class MonitoringIndexQueryTest extends TestCase
         $visibleMonitorings = Monitoring::factory()->count(3)->for($user)->create();
         Monitoring::factory()->for($otherUser)->create(['name' => 'Hidden monitoring']);
 
-        $readModel = resolve(MonitoringIndexQuery::class)->for($user, $this->filters(), 2);
+        $monitoringIndexReadModel = resolve(MonitoringIndexQuery::class)->for($user, $this->filters(), 2);
 
-        $this->assertSame(3, $readModel->total);
-        $this->assertCount(2, $readModel->monitorings);
-        $this->assertEqualsCanonicalizing($visibleMonitorings->modelKeys(), $readModel->summaryMonitoringIds->all());
-        $this->assertNotContains('Hidden monitoring', $readModel->monitorings->pluck('name')->all());
+        $this->assertSame(3, $monitoringIndexReadModel->total);
+        $this->assertCount(2, $monitoringIndexReadModel->monitorings);
+        $this->assertEqualsCanonicalizing($visibleMonitorings->modelKeys(), $monitoringIndexReadModel->summaryMonitoringIds->all());
+        $this->assertNotContains('Hidden monitoring', $monitoringIndexReadModel->monitorings->pluck('name')->all());
     }
 
     private function filters(): MonitoringIndexFilters

--- a/tests/Feature/Queries/MonitoringReadQueriesTest.php
+++ b/tests/Feature/Queries/MonitoringReadQueriesTest.php
@@ -8,6 +8,7 @@ use App\Models\Monitoring;
 use App\Models\Package;
 use App\Models\User;
 use App\Queries\MonitoringCardQuery;
+use App\Queries\MonitoringDataQuery;
 use App\Queries\MonitoringDetailQuery;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Tests\TestCase;
@@ -43,5 +44,23 @@ class MonitoringReadQueriesTest extends TestCase
         $this->assertSame([$visible->id], $monitorings->modelKeys());
         $this->assertTrue($monitorings->first()->relationLoaded('latestIncident'));
         $this->assertTrue($monitorings->first()->relationLoaded('latestResponseResult'));
+    }
+
+    public function test_data_query_allows_actor_visible_and_public_monitorings_without_leaking_private_ones(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $visible = Monitoring::factory()->for($user)->create();
+        $public = Monitoring::factory()->for($otherUser)->create(['public_label_enabled' => true]);
+        $private = Monitoring::factory()->for($otherUser)->create(['public_label_enabled' => false]);
+
+        $monitoringDataQuery = resolve(MonitoringDataQuery::class);
+
+        $this->assertTrue($monitoringDataQuery->findAccessible($user, $visible->id)->is($visible));
+        $this->assertTrue($monitoringDataQuery->findAccessible($user, $public->id)->is($public));
+        $this->expectException(ModelNotFoundException::class);
+
+        $monitoringDataQuery->findAccessible($user, $private->id);
     }
 }


### PR DESCRIPTION
## What changed

- Extracted actor-scoped monitoring index, data-access, history, incident, and maintenance queries.
- Added read-model inputs for the monitoring index and moved dashboard-specific labels, relative timestamps, formatting, and route URLs into a UI presenter.
- Kept external v1 response shapes intact while routing each data endpoint through the shared access query.

## Why

Completes the monitoring read-model boundary so Blade, internal UI, mobile, and external adapters reuse scoped application reads without sharing presentation concerns.

## Testing

- Docker: targeted monitoring UI, API, query, history, incident, maintenance, mobile, and team Pest tests.
- Docker: complete Pest suite (no test failures; local .env-dependent assertions reported as warnings after the local config-cache reset).
- Docker: PHPStan/Larastan.
- Laravel Pint.

## Risks and follow-up

No route or external v1 JSON contract changes. Scanner-instance contracts were not changed.

Closes #594