### PR TITLE
test(api): enforce contract regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,11 @@ jobs:
         XDEBUG_MODE: coverage
       run: |
         composer test:coverage -- --parallel
+
+    - name: Verify external OpenAPI contract is current
+      env:
+        DB_CONNECTION: sqlite
+        DB_DATABASE: ':memory:'
+      run: |
+        php artisan scribe:generate --no-interaction
+        git diff --exit-code -- storage/app/private/scribe/openapi.yaml

--- a/app/Http/Controllers/Api/Internal/MonitoringListController.php
+++ b/app/Http/Controllers/Api/Internal/MonitoringListController.php
@@ -15,18 +15,19 @@ class MonitoringListController extends Controller
 {
     public function __invoke(Request $request)
     {
+        $authenticatedInstanceCode = (string) $request->attributes->get('authenticated_instance_code');
+        $requestedLocation = (string) $request->query('location', '');
+
+        if ($requestedLocation !== '' && $authenticatedInstanceCode !== '' && $requestedLocation !== $authenticatedInstanceCode) {
+            return response()->json(['message' => 'Unauthorized location'], 403);
+        }
+
         $validated = $request->validate([
             'location' => ['required', 'string', Rule::exists('server_instances', 'code')->where('is_active', true)],
             'type' => ['nullable', 'string', Rule::in(array_column(MonitoringType::cases(), 'value'))],
         ]);
 
-        $authenticatedInstanceCode = (string) $request->attributes->get('authenticated_instance_code');
         $location = $validated['location'];
-
-        if ($authenticatedInstanceCode !== '' && $location !== $authenticatedInstanceCode) {
-            return response()->json(['message' => 'Unauthorized location'], 403);
-        }
-
         $type = $validated['type'] ?? null;
 
         $builder = Monitoring::query()

--- a/app/Http/Controllers/Api/Internal/Ui/MonitoringShowController.php
+++ b/app/Http/Controllers/Api/Internal/Ui/MonitoringShowController.php
@@ -8,16 +8,18 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\InternalUi\MonitoringResource;
 use App\Models\User;
 use App\Queries\MonitoringDetailQuery;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\JsonResource;
 
 class MonitoringShowController extends Controller
 {
-    public function __invoke(Request $request, string $monitoring, MonitoringDetailQuery $monitoringDetailQuery): JsonResource
+    public function __invoke(Request $request, string $monitoring, MonitoringDetailQuery $monitoringDetailQuery): JsonResponse
     {
         /** @var User $user */
         $user = $request->user();
 
-        return MonitoringResource::make($monitoringDetailQuery->findVisible($user, $monitoring));
+        return response()->json([
+            'data' => MonitoringResource::make($monitoringDetailQuery->findVisible($user, $monitoring))->resolve($request),
+        ]);
     }
 }

--- a/docs/test-concept.md
+++ b/docs/test-concept.md
@@ -112,6 +112,9 @@ Every change should include the narrowest useful validation:
   visible text, redirects, validation, and persisted state.
 - API changes: feature tests for authentication, authorization, request validation,
   response schema, pagination, and backward compatibility.
+- External v1 changes: regenerate Scribe and require a clean diff for
+  `storage/app/private/scribe/openapi.yaml`; this makes an undocumented schema
+  drift visible in CI.
 - Jobs and commands: feature tests for scheduling, dispatch behavior, idempotency,
   retries where applicable, and observable side effects.
 - Notifications and mail: feature tests with fakes plus rendering assertions for

--- a/tests/Browser/InternalUiDashboardHydrationTest.php
+++ b/tests/Browser/InternalUiDashboardHydrationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+it('hydrates the dashboard from its JSON projection and exposes a recoverable error state', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $package = Package::factory()->create(['monitoring_limit' => 10]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+    $monitoring = Monitoring::factory()->for($user)->create(['name' => 'JSON hydrated API']);
+
+    $webpage = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]')
+        ->navigate('/dashboard')
+        ->waitForText('JSON hydrated API');
+
+    $webpage->assertScript(<<<'JS'
+function () {
+    const root = document.querySelector('#dashboard-page-content');
+    const loadedProjection = performance.getEntriesByType('resource').some((entry) => entry.name.includes('/api/v1/internal/ui/dashboard'));
+
+    return root !== null
+        && root.querySelector('[data-dashboard-content]') !== null
+        && root.querySelector('[data-dashboard-loading]') === null
+        && loadedProjection
+        && !root.hasAttribute('aria-busy');
+}
+JS, true)
+        ->script(<<<'JS'
+const root = document.querySelector('#dashboard-page-content');
+root.dataset.apiEndpoint = '/api/v1/internal/ui/not-found';
+void window.Alpine.$data(root).load(root);
+JS)
+        ->wait(0.5)
+        ->assertVisible('[data-dashboard-error]')
+        ->assertScript(<<<'JS'
+function () {
+    const root = document.querySelector('#dashboard-page-content');
+    const error = root?.querySelector('[data-dashboard-error]');
+
+    return error !== null
+        && getComputedStyle(error).display !== 'none'
+        && !root.hasAttribute('aria-busy');
+}
+JS, true)
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Concerns/AssertsApiContracts.php
+++ b/tests/Concerns/AssertsApiContracts.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Concerns;
+
+use App\Models\ServerInstance;
+use Illuminate\Testing\TestResponse;
+
+trait AssertsApiContracts
+{
+    /**
+     * @param  list<string>  $paths
+     */
+    protected function assertDataEnvelope(TestResponse $testResponse, array $paths = []): TestResponse
+    {
+        $testResponse->assertOk()->assertJsonStructure(['data']);
+
+        foreach ($paths as $path) {
+            $this->assertNotNull($testResponse->json($path), sprintf('Expected the response to include [%s].', $path));
+        }
+
+        return $testResponse;
+    }
+
+    protected function assertInternalUiTelemetry(TestResponse $testResponse, int $maximumQueries, int $maximumBytes): void
+    {
+        $testResponse
+            ->assertHeader('X-Request-Id')
+            ->assertHeader('X-Query-Count')
+            ->assertHeader('X-Response-Bytes')
+            ->assertHeader('Server-Timing');
+
+        $this->assertLessThanOrEqual($maximumQueries, (int) $testResponse->headers->get('X-Query-Count'));
+        $this->assertLessThanOrEqual($maximumBytes, (int) $testResponse->headers->get('X-Response-Bytes'));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function instanceHeaders(ServerInstance $serverInstance, string $apiKey = 'test-token-1234567890'): array
+    {
+        return [
+            'X-INSTANCE-CODE' => $serverInstance->code,
+            'X-API-KEY' => $apiKey,
+        ];
+    }
+}

--- a/tests/Feature/Api/InternalInstanceRouteCompatibilityTest.php
+++ b/tests/Feature/Api/InternalInstanceRouteCompatibilityTest.php
@@ -9,10 +9,13 @@ use App\Models\Package;
 use App\Models\ServerInstance;
 use App\Models\User;
 use Illuminate\Support\Facades\Route;
+use Tests\Concerns\AssertsApiContracts;
 use Tests\TestCase;
 
 class InternalInstanceRouteCompatibilityTest extends TestCase
 {
+    use AssertsApiContracts;
+
     public function test_legacy_and_target_instance_routes_use_the_same_actions(): void
     {
         foreach ($this->routeNames() as $legacyName => $targetName) {
@@ -53,6 +56,38 @@ class InternalInstanceRouteCompatibilityTest extends TestCase
             ->assertOk()
             ->assertJsonPath('0.id', $assignedMonitoring->id)
             ->assertJsonCount(1);
+    }
+
+    public function test_legacy_and_target_instance_routes_keep_the_same_authentication_and_location_contract(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'contract-instance',
+            'ip_address' => '192.0.2.57',
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+        Monitoring::factory()->for($user)->create([
+            'preferred_location' => $serverInstance->code,
+            'preferred_locations' => [$serverInstance->code],
+        ]);
+
+        foreach ([
+            'v1.internal.monitorings.list',
+            'v1.internal.instances.monitorings.list',
+        ] as $routeName) {
+            $this->flushHeaders();
+
+            $this->getJson(route($routeName, ['location' => $serverInstance->code]))
+                ->assertUnauthorized()
+                ->assertJsonPath('message', 'Unauthorized');
+
+            $this->withHeaders($this->instanceHeaders($serverInstance))
+                ->getJson(route($routeName, ['location' => 'different-instance']))
+                ->assertForbidden()
+                ->assertJsonPath('message', 'Unauthorized location');
+        }
     }
 
     /**

--- a/tests/Feature/Api/InternalUiDashboardApiTest.php
+++ b/tests/Feature/Api/InternalUiDashboardApiTest.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api;
 
+use App\Enums\MonitoringStatus;
 use App\Models\Monitoring;
+use App\Models\MonitoringResponse;
 use App\Models\Package;
 use App\Models\User;
+use Tests\Concerns\AssertsApiContracts;
 use Tests\TestCase;
 
 class InternalUiDashboardApiTest extends TestCase
 {
+    use AssertsApiContracts;
+
     public function test_guest_cannot_read_the_internal_ui_dashboard(): void
     {
         $this->getJson(route('api.v1.internal.ui.dashboard'))
@@ -24,7 +29,9 @@ class InternalUiDashboardApiTest extends TestCase
         $visibleMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Visible API']);
         Monitoring::factory()->create(['name' => 'Hidden API']);
 
-        $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'))
+        $testResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+
+        $testResponse
             ->assertOk()
             ->assertJsonPath('data.summary.total', 1)
             ->assertJsonPath('data.services.0.id', $visibleMonitoring->id)
@@ -37,6 +44,8 @@ class InternalUiDashboardApiTest extends TestCase
             ->assertJsonStructure([
                 'meta' => ['as_of', 'service_pagination'],
             ]);
+
+        $this->assertInternalUiTelemetry($testResponse, 30, 131072);
     }
 
     public function test_dashboard_projection_stays_within_its_response_budget(): void
@@ -48,8 +57,7 @@ class InternalUiDashboardApiTest extends TestCase
         $testResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
 
         $testResponse->assertOk();
-        $this->assertLessThanOrEqual(30, (int) $testResponse->headers->get('X-Query-Count'));
-        $this->assertLessThanOrEqual(131072, (int) $testResponse->headers->get('X-Response-Bytes'));
+        $this->assertInternalUiTelemetry($testResponse, 30, 131072);
     }
 
     public function test_unverified_user_cannot_read_the_internal_ui_dashboard(): void
@@ -80,5 +88,33 @@ class InternalUiDashboardApiTest extends TestCase
             ->getJson(route('api.v1.internal.ui.dashboard'))
             ->assertNotModified()
             ->assertHeader('ETag', $etag);
+    }
+
+    public function test_dashboard_projection_rejects_an_invalid_page_and_changes_its_etag_after_a_monitoring_result(): void
+    {
+        Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Cache contract API']);
+
+        $this->actingAs($user)
+            ->getJson(route('api.v1.internal.ui.dashboard', ['service_page' => 0]))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('service_page');
+
+        $testResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+        $firstEtag = (string) $testResponse->headers->get('ETag');
+
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'response_time' => 120,
+        ]);
+
+        $secondResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.dashboard'));
+
+        $secondResponse
+            ->assertOk()
+            ->assertJsonPath('data.services.0.status', 'up');
+        $this->assertNotSame($firstEtag, (string) $secondResponse->headers->get('ETag'));
     }
 }

--- a/tests/Feature/Api/InternalUiMonitoringApiTest.php
+++ b/tests/Feature/Api/InternalUiMonitoringApiTest.php
@@ -10,10 +10,12 @@ use App\Models\MonitoringResponse;
 use App\Models\Package;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\AssertsApiContracts;
 use Tests\TestCase;
 
 class InternalUiMonitoringApiTest extends TestCase
 {
+    use AssertsApiContracts;
     use RefreshDatabase;
 
     protected function setUp(): void
@@ -61,6 +63,12 @@ class InternalUiMonitoringApiTest extends TestCase
                 'meta' => ['as_of'],
             ])
             ->assertJsonMissing(['name' => 'Hidden API']);
+
+        $this->assertInternalUiTelemetry(
+            $this->actingAs($user)->getJson(route('api.v1.internal.ui.monitorings.index')),
+            10,
+            131072,
+        );
     }
 
     public function test_guest_cannot_read_the_internal_ui_monitoring_projections(): void
@@ -107,5 +115,31 @@ class InternalUiMonitoringApiTest extends TestCase
 
         $this->actingAs($unverifiedUser)->getJson(route('api.v1.internal.ui.monitorings.index'))
             ->assertForbidden();
+    }
+
+    public function test_internal_ui_monitoring_projections_validate_bounded_queries_and_return_a_scoped_detail(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Scoped detail API']);
+
+        $this->actingAs($user)
+            ->getJson(route('api.v1.internal.ui.monitorings.index', ['per_page' => 101]))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('per_page');
+        $this->actingAs($user)
+            ->getJson(route('api.v1.internal.ui.monitorings.cards'))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ids');
+        $this->actingAs($user)
+            ->getJson(route('api.v1.internal.ui.monitorings.cards', ['ids' => array_fill(0, 101, $monitoring->id)]))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('ids');
+
+        $testResponse = $this->actingAs($user)->getJson(route('api.v1.internal.ui.monitorings.show', $monitoring));
+
+        $this->assertDataEnvelope($testResponse, ['data.id', 'data.name']);
+        $testResponse->assertJsonPath('data.id', $monitoring->id)
+            ->assertJsonPath('data.name', 'Scoped detail API');
+        $this->assertInternalUiTelemetry($testResponse, 15, 131072);
     }
 }

--- a/tests/Feature/CiWorkflowRedisExtensionTest.php
+++ b/tests/Feature/CiWorkflowRedisExtensionTest.php
@@ -64,6 +64,22 @@ class CiWorkflowRedisExtensionTest extends TestCase
         $this->assertSame('coverage', $coverageStep['env']['XDEBUG_MODE'] ?? null);
     }
 
+    public function test_ci_verifies_the_generated_external_openapi_contract(): void
+    {
+        $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
+        $testJobSteps = collect($workflowConfig['jobs']['test']['steps'] ?? []);
+        $openApiStep = $testJobSteps->firstWhere('name', 'Verify external OpenAPI contract is current');
+
+        $this->assertIsArray($openApiStep);
+        $this->assertStringContainsString('php artisan scribe:generate --no-interaction', $openApiStep['run'] ?? '');
+        $this->assertStringContainsString(
+            'git diff --exit-code -- storage/app/private/scribe/openapi.yaml',
+            $openApiStep['run'] ?? '',
+        );
+        $this->assertSame('sqlite', $openApiStep['env']['DB_CONNECTION'] ?? null);
+        $this->assertSame(':memory:', $openApiStep['env']['DB_DATABASE'] ?? null);
+    }
+
     public function test_captcha_uses_intervention_image_three_until_package_supports_v4(): void
     {
         $composerConfig = json_decode((string) file_get_contents(base_path('composer.json')), true, 512, JSON_THROW_ON_ERROR);

--- a/tests/Unit/Services/OperationsOverviewCacheTest.php
+++ b/tests/Unit/Services/OperationsOverviewCacheTest.php
@@ -58,6 +58,43 @@ class OperationsOverviewCacheTest extends TestCase
         $this->assertSame(1, $payload['service_pagination']['total']);
     }
 
+    public function test_it_reuses_the_cached_projection_without_rebuilding_it(): void
+    {
+        $user = new User();
+        $user->id = 'user-123';
+        $mock = Mockery::mock(TaggableStore::class);
+        $taggedCache = Mockery::mock();
+        $cachedPayload = null;
+        $buildCount = 0;
+
+        Cache::shouldReceive('getStore')->twice()->andReturn($mock);
+        Cache::shouldReceive('tags')
+            ->twice()
+            ->with(['operations-overview', 'operations-overview:user:user-123'])
+            ->andReturn($taggedCache);
+        $taggedCache->shouldReceive('remember')
+            ->twice()
+            ->with('operations-overview:user:user-123:page:1', 30, Mockery::type('callable'))
+            ->andReturnUsing(function (string $key, int $ttl, callable $callback) use (&$cachedPayload): array {
+                return $cachedPayload ??= $callback();
+            });
+
+        $payloadFactory = function () use (&$buildCount): array {
+            $buildCount++;
+
+            return [
+                'data' => ['summary' => ['total' => 1]],
+                'service_pagination' => ['current_page' => 1, 'last_page' => 1, 'total' => 1, 'from' => 1, 'to' => 1],
+            ];
+        };
+
+        $operationsOverviewCache = resolve(OperationsOverviewCache::class);
+
+        $this->assertSame(1, $operationsOverviewCache->remember($user, 1, $payloadFactory)['data']['summary']['total']);
+        $this->assertSame(1, $operationsOverviewCache->remember($user, 1, $payloadFactory)['data']['summary']['total']);
+        $this->assertSame(1, $buildCount);
+    }
+
     public function test_it_flushes_all_cached_overviews_after_domain_changes(): void
     {
         $mock = Mockery::mock(TaggableStore::class);


### PR DESCRIPTION
## What changed

- Added reusable API contract assertions and browser regression coverage for dashboard JSON hydration, loading/error handling, and the no-JavaScript shell.
- Expanded internal UI validation, isolation, telemetry-budget, conditional-cache, and cache-hit coverage.
- Aligned the internal UI monitoring-detail response with its typed `{ data: ... }` client contract.
- Aligned legacy and target instance-route location authorization with the published scanner contract.
- Added CI enforcement that the generated external OpenAPI specification has no uncommitted drift.

## Why

These checks make the separated external, UI, instance, mobile, and public API boundaries resistant to regressions, while keeping the scanner compatibility contract explicit.

## Testing

- Docker: targeted UI, instance, cache, and CI workflow Pest tests
- Docker: full `composer test`
- Docker: `composer analyse`
- Docker: `./vendor/bin/pint --parallel`
- Docker: `bun run build`
- Docker: `php artisan scribe:generate --no-interaction` plus OpenAPI diff check

## Risks and follow-up

- The added browser test will run in CI. Local visual execution is blocked because the in-app browser cannot resolve the Docker-only `webguard.test` host and the PHP container does not share the Node browser runtime.
- No webguard-instance or webguard-app change is required: the scanner paths and payloads remain compatible.

Closes #598