### PR TITLE
ci: build CI Docker image once and run rector, pint, and tests sequentially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,77 +6,83 @@ on:
   push:
     branches: [ main ]
 
+env:
+  CI_IMAGE: webguard-ci:${{ github.run_id }}
 
 jobs:
-  auto-fixes:
-    name: "Auto-Fixes (Pint & Rector)"
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+  ci:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build CI image
+      uses: docker/build-push-action@v6
       with:
-        php-version: '8.5'
-        extensions: redis, sockets, zip
-        tools: composer
+        context: .
+        target: ci
+        tags: ${{ env.CI_IMAGE }}
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Cache Composer dependencies
       uses: actions/cache@v5
-      id: composer-cache
       with:
         path: ~/.cache/composer/files
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-composer-
 
-    - name: Install dependencies
-      run: composer install --no-interaction --prefer-dist --optimize-autoloader
+    - name: Install PHP dependencies
+      run: |
+        docker run --rm --user "$(id -u):$(id -g)" \
+          -e COMPOSER_CACHE_DIR=/tmp/composer-cache \
+          -v "${{ github.workspace }}:/var/www/html" \
+          -v "$HOME/.cache/composer/files:/tmp/composer-cache" \
+          -w /var/www/html "${{ env.CI_IMAGE }}" \
+          composer install --no-interaction --prefer-dist --optimize-autoloader
 
     - name: Run Rector
-      run: ./vendor/bin/rector process --ansi --debug
+      run: |
+        docker run --rm --user "$(id -u):$(id -g)" \
+          -v "${{ github.workspace }}:/var/www/html" \
+          -w /var/www/html "${{ env.CI_IMAGE }}" \
+          ./vendor/bin/rector process --ansi --debug
 
     - name: Run Pint
-      run: ./vendor/bin/pint --parallel
+      run: |
+        docker run --rm --user "$(id -u):$(id -g)" \
+          -v "${{ github.workspace }}:/var/www/html" \
+          -w /var/www/html "${{ env.CI_IMAGE }}" \
+          ./vendor/bin/pint --parallel
 
     - name: Ensure local PR branch exists
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       run: git checkout -B "${{ github.head_ref }}"
 
-    - name: Commit changes
+    - name: Commit auto-fixes (internal pull requests only)
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: 'ci: auto-fixes from pint and rector'
         commit_options: '--no-verify'
         branch: ${{ github.head_ref }}
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: redis, mbstring, pdo_mysql, curl, intl, gd, zip, bz2, opcache, xdebug, gmp, ldap, pdo_sqlite, sqlite3, pspell, snmp, tidy
-        coverage: xdebug
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/composer/files
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install Dependencies
-      run: composer install --no-progress --prefer-dist --optimize-autoloader
+    - name: Fail if Rector or Pint would change files
+      if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+      run: |
+        if ! git diff --quiet; then
+          echo "::error::Rector and/or Pint would change tracked files. Run them locally and commit the results."
+          git diff
+          exit 1
+        fi
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
@@ -100,7 +106,11 @@ jobs:
       run: bun run build
 
     - name: Run PHPStan
-      run: composer analyse
+      run: |
+        docker run --rm --user "$(id -u):$(id -g)" \
+          -v "${{ github.workspace }}:/var/www/html" \
+          -w /var/www/html "${{ env.CI_IMAGE }}" \
+          composer analyse
 
     - name: Run tests with coverage
       env:
@@ -108,12 +118,23 @@ jobs:
         DB_DATABASE: ':memory:'
         XDEBUG_MODE: coverage
       run: |
-        composer test:coverage -- --parallel
+        docker run --rm --user "$(id -u):$(id -g)" \
+          -e DB_CONNECTION \
+          -e DB_DATABASE \
+          -e XDEBUG_MODE \
+          -v "${{ github.workspace }}:/var/www/html" \
+          -w /var/www/html "${{ env.CI_IMAGE }}" \
+          composer test:coverage -- --parallel
 
     - name: Verify external OpenAPI contract is current
       env:
         DB_CONNECTION: sqlite
         DB_DATABASE: ':memory:'
       run: |
-        php artisan scribe:generate --no-interaction
+        docker run --rm --user "$(id -u):$(id -g)" \
+          -e DB_CONNECTION \
+          -e DB_DATABASE \
+          -v "${{ github.workspace }}:/var/www/html" \
+          -w /var/www/html "${{ env.CI_IMAGE }}" \
+          php artisan scribe:generate --no-interaction
         git diff --exit-code -- storage/app/private/scribe/openapi.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ FROM base AS ci
 
 # Sometimes CI images need to run as root
 USER root
-RUN install-php-extensions sockets
+RUN install-php-extensions bz2 curl gmp intl ldap mbstring opcache pdo_mysql pdo_sqlite pspell redis snmp sockets sqlite3 tidy xdebug zip
 
 ############################################
 # Production Image

--- a/tests/Feature/CiWorkflowRedisExtensionTest.php
+++ b/tests/Feature/CiWorkflowRedisExtensionTest.php
@@ -9,33 +9,29 @@ use Tests\TestCase;
 
 class CiWorkflowRedisExtensionTest extends TestCase
 {
-    public function test_ci_test_job_installs_required_redis_extension(): void
+    public function test_ci_image_installs_required_redis_extension(): void
     {
         $composerConfig = json_decode((string) file_get_contents(base_path('composer.json')), true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertArrayHasKey('ext-redis', $composerConfig['require']);
 
-        $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
-        $testJobSteps = $workflowConfig['jobs']['test']['steps'] ?? [];
-        $setupPhpStep = collect($testJobSteps)->firstWhere('name', 'Setup PHP');
+        $dockerfile = (string) file_get_contents(base_path('Dockerfile'));
+        $ciStage = mb_substr($dockerfile, (int) mb_strpos($dockerfile, 'AS ci'));
+        $installLine = collect(explode("\n", $ciStage))->first(fn (string $line): bool => str_contains($line, 'install-php-extensions'));
 
-        $this->assertIsArray($setupPhpStep);
-        $this->assertIsString($setupPhpStep['with']['extensions'] ?? null);
-        $this->assertStringContainsString('redis', $setupPhpStep['with']['extensions']);
+        $this->assertIsString($installLine);
+        $this->assertStringContainsString('redis', $installLine);
     }
 
-    public function test_ci_jobs_cache_composer_downloads_instead_of_vendor_directory(): void
+    public function test_ci_job_caches_composer_downloads_instead_of_vendor_directory(): void
     {
         $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
+        $cacheStep = collect($workflowConfig['jobs']['ci']['steps'] ?? [])
+            ->firstWhere('name', 'Cache Composer dependencies');
 
-        foreach (['auto-fixes', 'test'] as $jobName) {
-            $cacheStep = collect($workflowConfig['jobs'][$jobName]['steps'] ?? [])
-                ->firstWhere('name', 'Cache Composer dependencies');
-
-            $this->assertIsArray($cacheStep, "Missing Composer cache step for {$jobName}.");
-            $this->assertSame('~/.cache/composer/files', $cacheStep['with']['path'] ?? null);
-            $this->assertNotSame('vendor', $cacheStep['with']['path'] ?? null);
-        }
+        $this->assertIsArray($cacheStep, 'Missing Composer cache step for ci job.');
+        $this->assertSame('~/.cache/composer/files', $cacheStep['with']['path'] ?? null);
+        $this->assertNotSame('vendor', $cacheStep['with']['path'] ?? null);
     }
 
     public function test_ci_runs_phpstan_and_pest_coverage(): void
@@ -49,12 +45,12 @@ class CiWorkflowRedisExtensionTest extends TestCase
         $this->assertFileExists(base_path('phpstan.neon'));
 
         $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
-        $testJobSteps = collect($workflowConfig['jobs']['test']['steps'] ?? []);
-        $phpstanStep = $testJobSteps->firstWhere('name', 'Run PHPStan');
-        $coverageStep = $testJobSteps->firstWhere('name', 'Run tests with coverage');
+        $ciJobSteps = collect($workflowConfig['jobs']['ci']['steps'] ?? []);
+        $phpstanStep = $ciJobSteps->firstWhere('name', 'Run PHPStan');
+        $coverageStep = $ciJobSteps->firstWhere('name', 'Run tests with coverage');
 
         $this->assertIsArray($phpstanStep);
-        $this->assertSame('composer analyse', $phpstanStep['run'] ?? null);
+        $this->assertStringContainsString('composer analyse', $phpstanStep['run'] ?? '');
 
         $this->assertIsArray($coverageStep);
         $this->assertStringContainsString('composer test:coverage', $coverageStep['run'] ?? '');
@@ -67,8 +63,8 @@ class CiWorkflowRedisExtensionTest extends TestCase
     public function test_ci_verifies_the_generated_external_openapi_contract(): void
     {
         $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
-        $testJobSteps = collect($workflowConfig['jobs']['test']['steps'] ?? []);
-        $openApiStep = $testJobSteps->firstWhere('name', 'Verify external OpenAPI contract is current');
+        $ciJobSteps = collect($workflowConfig['jobs']['ci']['steps'] ?? []);
+        $openApiStep = $ciJobSteps->firstWhere('name', 'Verify external OpenAPI contract is current');
 
         $this->assertIsArray($openApiStep);
         $this->assertStringContainsString('php artisan scribe:generate --no-interaction', $openApiStep['run'] ?? '');
@@ -78,6 +74,32 @@ class CiWorkflowRedisExtensionTest extends TestCase
         );
         $this->assertSame('sqlite', $openApiStep['env']['DB_CONNECTION'] ?? null);
         $this->assertSame(':memory:', $openApiStep['env']['DB_DATABASE'] ?? null);
+    }
+
+    public function test_ci_builds_docker_image_before_rector_pint_and_test_steps(): void
+    {
+        $workflowConfig = Yaml::parseFile(base_path('.github/workflows/ci.yml'));
+        $stepNames = collect($workflowConfig['jobs']['ci']['steps'] ?? [])->pluck('name')->filter()->values();
+
+        $buildIndex = $stepNames->search('Build CI image');
+        $rectorIndex = $stepNames->search('Run Rector');
+        $pintIndex = $stepNames->search('Run Pint');
+        $phpstanIndex = $stepNames->search('Run PHPStan');
+        $coverageIndex = $stepNames->search('Run tests with coverage');
+        $openApiIndex = $stepNames->search('Verify external OpenAPI contract is current');
+
+        $this->assertNotFalse($buildIndex);
+        $this->assertNotFalse($rectorIndex);
+        $this->assertNotFalse($pintIndex);
+        $this->assertNotFalse($phpstanIndex);
+        $this->assertNotFalse($coverageIndex);
+        $this->assertNotFalse($openApiIndex);
+
+        $this->assertTrue($buildIndex < $rectorIndex);
+        $this->assertTrue($rectorIndex < $pintIndex);
+        $this->assertTrue($pintIndex < $phpstanIndex);
+        $this->assertTrue($phpstanIndex < $coverageIndex);
+        $this->assertTrue($coverageIndex < $openApiIndex);
     }
 
     public function test_captcha_uses_intervention_image_three_until_package_supports_v4(): void


### PR DESCRIPTION
## Summary
- Build the `ci` target from the existing `Dockerfile` once per workflow run and reuse that image for Rector, Pint, PHPStan, and the coverage test suite.
- Merge the former `auto-fixes` and `test` jobs into a single sequential `ci` job so tests never run in parallel against a pre-fix commit.
- Rector/Pint auto-fix commit-back is preserved for internal pull requests; forked pull requests and pushes to `main` now fail the job if Rector or Pint would change tracked files, instead of silently skipping the check.
- Extend the Dockerfile's `ci` stage with the PHP extensions (xdebug, pdo_sqlite, sqlite3, redis, etc.) the quality/test steps need, since they now run inside that image instead of via `setup-php`.
- Update `tests/Feature/CiWorkflowRedisExtensionTest.php` to assert against the new single-job workflow structure and image-based extension install.

Closes #618

## Test plan
- [x] `docker build --target ci` builds successfully
- [x] Rector, Pint, PHPStan, and `composer test:coverage -- --parallel` all run successfully inside the built `ci` image against this branch
- [x] Updated `tests/Feature/CiWorkflowRedisExtensionTest.php` passes
- [x] Full test suite passes (679 passed, 3 skipped) inside the CI image