### PR TITLE
fix(ui): remove redundant select arrow icon and fix collapsed sidebar nav layout

### DIFF
--- a/resources/views/components/select-input.blade.php
+++ b/resources/views/components/select-input.blade.php
@@ -3,22 +3,10 @@
 @php
     $selectClasses = $multiple
         ? 'border-gray-300 bg-white focus:border-purple-500 focus:ring-purple-500 rounded-md shadow-xs dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
-        : 'appearance-none border-purple-200 bg-purple-50/40 pr-10 text-gray-900 focus:border-purple-500 focus:ring-purple-500 rounded-md shadow-xs dark:border-purple-800 dark:bg-purple-950/30 dark:text-gray-100';
+        : 'border-purple-200 bg-purple-50/40 text-gray-900 focus:border-purple-500 focus:ring-purple-500 rounded-md shadow-xs dark:border-purple-800 dark:bg-purple-950/30 dark:text-gray-100';
 @endphp
 
-<div class="relative">
-    <select @disabled($disabled) @if ($multiple) multiple @endif data-select-control="native"
-        {{ $attributes->class($selectClasses) }}>
-        {{ $slot }}
-    </select>
-    @unless ($multiple)
-        <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-purple-600 dark:text-purple-300"
-            aria-hidden="true">
-            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd"
-                    d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-.02-1.06z"
-                    clip-rule="evenodd" />
-            </svg>
-        </span>
-    @endunless
-</div>
+<select @disabled($disabled) @if ($multiple) multiple @endif data-select-control="native"
+    {{ $attributes->class($selectClasses) }}>
+    {{ $slot }}
+</select>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -90,7 +90,8 @@
         </div>
 
         <div class="mt-6 hidden space-y-4 lg:block">
-            <div data-notifications-navigation class="flex items-center gap-2">
+            <div data-notifications-navigation class="flex items-center gap-2"
+                :class="{ 'flex-col justify-center': sidebarCollapsed }">
                 <a id="notifications-bell-desktop" href="{{ route('notifications.index') }}"
                     aria-label="{{ __('notifications.title') }}" title="{{ __('notifications.title') }}"
                     @class([
@@ -112,12 +113,13 @@
             <div data-navigation-utilities>
             <x-dropdown align="right" placement="top" width="48" contentClasses="bg-white py-2 dark:bg-slate-900">
                 <x-slot name="trigger">
-                    <button id="profile-menu-desktop" class="flex w-full items-center justify-between gap-3 rounded-xl border border-purple-800 px-3 py-2 text-left text-sm font-medium text-purple-100 transition hover:border-purple-600 hover:bg-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-300">
+                    <button id="profile-menu-desktop" class="flex w-full items-center justify-between gap-3 rounded-xl border border-purple-800 px-3 py-2 text-left text-sm font-medium text-purple-100 transition hover:border-purple-600 hover:bg-purple-900 focus:outline-hidden focus:ring-2 focus:ring-purple-300"
+                        :class="{ 'lg:justify-center lg:px-0': sidebarCollapsed }">
                         <span class="flex min-w-0 items-center gap-2">
                             <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-700 font-bold text-white">{{ mb_strtoupper(mb_substr(Auth::user()->name, 0, 1)) }}</span>
-                            <span class="truncate">{{ Auth::user()->name }}</span>
+                            <span class="truncate" x-show="! sidebarCollapsed" x-cloak>{{ Auth::user()->name }}</span>
                         </span>
-                        <svg class="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clip-rule="evenodd" /></svg>
+                        <svg class="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" x-show="! sidebarCollapsed" x-cloak><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clip-rule="evenodd" /></svg>
                     </button>
                 </x-slot>
                 <x-slot name="content">


### PR DESCRIPTION
Closes #624

## Summary
- Removed the custom SVG chevron overlay from `select-input.blade.php` — native `<select>` already renders its own dropdown indicator, so the overlay was redundant and clashed visually with it. Dropped the now-unneeded `appearance-none`/`pr-10` styling.
- Fixed the collapsed sidebar (`sidebarCollapsed`, `lg:w-20`) layout in `navigation.blade.php`: the notifications bell + language switch row and the profile dropdown trigger now respond to the collapsed state the same way the primary/secondary nav links already do (stack/center, hide labels), instead of overlapping/wrapping.

## Test plan
- [x] `bun run build` passes
- [x] `vendor/bin/pint --test` on changed files passes
- [x] Full Pest suite passes (681 passed, 3 skipped)
- [x] Verified in browser: select dropdowns across monitoring create form show a single native chevron; collapsed sidebar shows bell/flag/avatar cleanly stacked and centered, no overlap