### PR TITLE
chore(dev): seed admin, demo, and member users in local environment

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,5 +17,11 @@ class DatabaseSeeder extends Seeder
         $this->call([
             PackageSeeder::class,
         ]);
+
+        if (app()->environment('local')) {
+            $this->call([
+                UserSeeder::class,
+            ]);
+        }
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -36,5 +36,14 @@ class UserSeeder extends Seeder
                 'role' => UserRole::DEMO->value,
             ]
         );
+
+        User::query()->updateOrCreate(
+            ['email' => 'member@example.com'],
+            [
+                'name' => 'Member User',
+                'password' => 'password',
+                'role' => UserRole::REGULAR->value,
+            ]
+        );
     }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -221,8 +221,10 @@ The local override adds everything that should only exist during development:
 
    ```bash
    docker compose -f docker-compose.yml -f docker-compose.override.yml exec php php artisan key:generate
-   docker compose -f docker-compose.yml -f docker-compose.override.yml exec php php artisan migrate
+   docker compose -f docker-compose.yml -f docker-compose.override.yml exec php php artisan migrate --seed
    ```
+
+   Seeding in the `local` environment also creates an admin, a demo, and a regular member account (see `database/seeders/UserSeeder.php`), all with password `password`.
 
 `start-dev.sh` builds the local stack, starts it, and opens a shell inside the `php` container.
 


### PR DESCRIPTION
## Summary
- `UserSeeder` already created an admin (`breuer.marcel@outlook.com`) and demo (`demo@example.com`) account, but was never called from `DatabaseSeeder`, so `php artisan db:seed` did nothing for local dev — no way to log into a fresh docker environment without registering by hand.
- Wired `UserSeeder` into `DatabaseSeeder`, gated to `app()->environment('local')` since it deletes/recreates the admin account by email.
- Added a `member@example.com` (regular role) account so non-admin/non-demo flows can be tested locally too.
- Updated `docs/installation.md` docker setup step to use `migrate --seed` and documented the three accounts (all password `password`).

## Test plan
- [x] `vendor/bin/pint --test` on changed files passes
- [x] Ran `php artisan migrate --seed` against local docker stack, confirmed admin/demo/member accounts created with correct roles
- [x] Logged in as each of the three accounts in the browser