### PR TITLE
ci: enable opcache and raise memory/execution-time limits for PHP steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   CI_IMAGE: webguard-ci:${{ github.run_id }}
+  PHP_OPCACHE_ENABLE: "1"
+  PHP_MEMORY_LIMIT: "2048M"
+  PHP_MAX_EXECUTION_TIME: "300"
 
 jobs:
   ci:
@@ -44,6 +47,7 @@ jobs:
       run: |
         docker run --rm --user "$(id -u):$(id -g)" \
           -e COMPOSER_CACHE_DIR=/tmp/composer-cache \
+          -e PHP_OPCACHE_ENABLE -e PHP_MEMORY_LIMIT -e PHP_MAX_EXECUTION_TIME \
           -v "${{ github.workspace }}:/var/www/html" \
           -v "$HOME/.cache/composer/files:/tmp/composer-cache" \
           -w /var/www/html "${{ env.CI_IMAGE }}" \
@@ -52,6 +56,7 @@ jobs:
     - name: Run Rector
       run: |
         docker run --rm --user "$(id -u):$(id -g)" \
+          -e PHP_OPCACHE_ENABLE -e PHP_MEMORY_LIMIT -e PHP_MAX_EXECUTION_TIME \
           -v "${{ github.workspace }}:/var/www/html" \
           -w /var/www/html "${{ env.CI_IMAGE }}" \
           ./vendor/bin/rector process --ansi
@@ -59,6 +64,7 @@ jobs:
     - name: Run Pint
       run: |
         docker run --rm --user "$(id -u):$(id -g)" \
+          -e PHP_OPCACHE_ENABLE -e PHP_MEMORY_LIMIT -e PHP_MAX_EXECUTION_TIME \
           -v "${{ github.workspace }}:/var/www/html" \
           -w /var/www/html "${{ env.CI_IMAGE }}" \
           ./vendor/bin/pint --parallel
@@ -108,6 +114,7 @@ jobs:
     - name: Run PHPStan
       run: |
         docker run --rm --user "$(id -u):$(id -g)" \
+          -e PHP_OPCACHE_ENABLE -e PHP_MEMORY_LIMIT -e PHP_MAX_EXECUTION_TIME \
           -v "${{ github.workspace }}:/var/www/html" \
           -w /var/www/html "${{ env.CI_IMAGE }}" \
           composer analyse
@@ -122,6 +129,7 @@ jobs:
           -e DB_CONNECTION \
           -e DB_DATABASE \
           -e XDEBUG_MODE \
+          -e PHP_OPCACHE_ENABLE -e PHP_MEMORY_LIMIT -e PHP_MAX_EXECUTION_TIME \
           -v "${{ github.workspace }}:/var/www/html" \
           -w /var/www/html "${{ env.CI_IMAGE }}" \
           composer test:coverage -- --parallel
@@ -134,6 +142,7 @@ jobs:
         docker run --rm --user "$(id -u):$(id -g)" \
           -e DB_CONNECTION \
           -e DB_DATABASE \
+          -e PHP_OPCACHE_ENABLE -e PHP_MEMORY_LIMIT -e PHP_MAX_EXECUTION_TIME \
           -v "${{ github.workspace }}:/var/www/html" \
           -w /var/www/html "${{ env.CI_IMAGE }}" \
           php artisan scribe:generate --no-interaction


### PR DESCRIPTION
## Summary
- The `ci` Dockerfile stage already installs the `opcache` PHP extension, but the workflow never enabled it (`PHP_OPCACHE_ENABLE` was unset, so the base image's default \"disabled\" applied), and all containerized PHP steps ran under the base image's default 256M memory limit / 300s-or-lower execution time instead of anything tuned.
- Set `PHP_OPCACHE_ENABLE=1`, `PHP_MEMORY_LIMIT=2048M`, and `PHP_MAX_EXECUTION_TIME=300` (matching the values `docker-compose.yml` already uses for local dev) at the job level and forwarded them via `-e` into every `docker run` invocation (composer install, Rector, Pint, PHPStan, Pest w/ coverage, Scribe generate).

## Test plan
- [x] Validated workflow YAML syntax
- [ ] Confirm CI run duration improves and all steps still pass