### PR TITLE
fix(profile): use full settings layout by default

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -41,7 +41,7 @@ class ProfileController extends Controller
         $isPasswordForm = $modalForm === 'profile-password';
         $showNotificationChannelsHint = false;
 
-        if (($request->boolean('full') || $isProfileInformationForm) && $user
+        if ((! $request->ajax() || $isProfileInformationForm) && $user
             && ! $user->hasEnabledNotificationChannels() && $user->notification_channels_hint_seen_at === null) {
             $user->forceFill([
                 'notification_channels_hint_seen_at' => now(),
@@ -64,7 +64,6 @@ class ProfileController extends Controller
             'user' => $user,
             'token' => $user?->currentAccessToken(),
             'showNotificationChannelsHint' => $showNotificationChannelsHint,
-            'fullPage' => $request->boolean('full'),
             'modalForm' => $modalForm,
         ]);
     }

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -7,120 +7,54 @@
     </x-slot>
 
     <x-main>
-        <div data-profile-settings class="space-y-6">
-            @if ($fullPage)
-                <div class="grid gap-6 lg:grid-cols-[13rem_minmax(0,1fr)] lg:items-start">
-                    <nav aria-label="{{ __('profile.navigation.heading') }}" class="lg:sticky lg:top-6">
-                        <p class="px-3 text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">{{ __('profile.navigation.heading') }}</p>
-                        <div class="mt-3 space-y-1 text-sm font-semibold">
-                            <a href="#profile-information" class="block rounded-lg px-3 py-2 text-purple-700 hover:bg-purple-50 dark:text-purple-300 dark:hover:bg-purple-950/30">{{ __('profile.navigation.account') }}</a>
-                            <a href="#profile-password" class="block rounded-lg px-3 py-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">{{ __('profile.navigation.security') }}</a>
-                            <a href="#profile-api" class="block rounded-lg px-3 py-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">{{ __('profile.navigation.api') }}</a>
-                            <a href="#profile-delete" class="block rounded-lg px-3 py-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">{{ __('profile.navigation.danger_zone') }}</a>
-                        </div>
+        <div data-profile-settings class="grid gap-6 lg:grid-cols-[15rem_minmax(0,1fr)] lg:items-start">
+            <aside class="lg:sticky lg:top-6">
+                <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                    <p class="px-3 py-2 text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">
+                        {{ __('profile.navigation.heading') }}
+                    </p>
+                    <nav aria-label="{{ __('profile.navigation.heading') }}" class="mt-1 grid gap-1 text-sm font-semibold sm:grid-cols-2 lg:block">
+                        <a href="#profile-information" class="rounded-lg bg-purple-50 px-3 py-2 text-purple-700 transition hover:bg-purple-100 dark:bg-purple-950/30 dark:text-purple-300 dark:hover:bg-purple-950/50">
+                            {{ __('profile.navigation.account') }}
+                        </a>
+                        <a href="#profile-password" class="rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                            {{ __('profile.navigation.security') }}
+                        </a>
+                        <a href="#profile-api" class="rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                            {{ __('profile.navigation.api') }}
+                        </a>
+                        <a href="#profile-delete" class="rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                            {{ __('profile.navigation.danger_zone') }}
+                        </a>
                     </nav>
-
-                    <div class="min-w-0 space-y-6">
-                        <section id="profile-information" class="scroll-mt-6">
-                            <x-container>
-                                @include('profile.partials.update-profile-information-form')
-                            </x-container>
-                        </section>
-                        <section id="profile-password" class="scroll-mt-6">
-                            <x-container>
-                                @include('profile.partials.update-password-form')
-                            </x-container>
-                        </section>
-                        <section id="profile-api" class="scroll-mt-6">
-                            @include('profile.partials.api-configuration')
-                            @include('profile.partials.api-docs')
-                        </section>
-                        <section id="profile-delete" class="scroll-mt-6">
-                            @include('profile.partials.delete-user-form')
-                        </section>
-                    </div>
                 </div>
-            @else
-                <section data-profile-section="account">
-                <x-container>
-                    <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
-                    <x-paragraph>{{ __('profile.information.description') }}</x-paragraph>
+            </aside>
 
-                    <div class="mt-4 flex flex-wrap items-center justify-between gap-4">
-                        <div class="text-sm text-gray-600 dark:text-gray-300">
-                            <p class="font-semibold text-gray-950 dark:text-gray-50">{{ $user->name }}</p>
-                            <p>{{ $user->email }}</p>
-                            <p class="mt-2">{{ __('profile.notification_settings.heading') }}: {{ __('profile.notification_settings.description') }}</p>
-                        </div>
-
-                        <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}"
-                            class="flex flex-wrap gap-2">
-                            <x-primary-button :href="route('profile.edit', ['modal' => 'profile-information'])"
-                                data-form-modal-trigger data-form-modal-name="profile-information-form-modal"
-                                data-form-modal-param="profile-information">
-                                {{ __('profile.actions.update_profile') }}
-                            </x-primary-button>
-
-                            <x-form-modal name="profile-information-form-modal" title="{{ __('profile.information.title') }}"
-                                description="{{ __('profile.notification_settings.description') }}" max-width="6xl"
-                                :show="$modalForm === 'profile-information'">
-                                <div class="p-6" x-ref="content">
-                                    @if ($modalForm === 'profile-information')
-                                        @include('profile.partials.update-profile-information-form', ['modal' => true])
-                                    @else
-                                        <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
-                                        <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
-                                        <div x-html="content"></div>
-                                    @endif
-                                </div>
-                            </x-form-modal>
-                        </div>
-                    </div>
-                </x-container>
+            <div class="min-w-0 space-y-6">
+                <section id="profile-information" data-profile-section="account" class="scroll-mt-6">
+                    <x-container class="space-y-6">
+                        @include('profile.partials.update-profile-information-form', ['modal' => $modalForm === 'profile-information'])
+                    </x-container>
                 </section>
-
-                <section data-profile-section="security">
-                <x-container>
-                    <x-heading type="h2">{{ __('profile.update_password.heading') }}</x-heading>
-                    <x-paragraph>{{ __('profile.update_password.description') }}</x-paragraph>
-
-                    <div x-data="formModalLoader()" data-form-modal-error="{{ __('app.messages.form_modal_load_error') }}"
-                        class="mt-4">
-                        <x-primary-button :href="route('profile.edit', ['modal' => 'profile-password'])"
-                            data-form-modal-trigger data-form-modal-name="profile-password-form-modal"
-                            data-form-modal-param="profile-password">
-                            {{ __('profile.actions.update_password') }}
-                        </x-primary-button>
-
-                        <x-form-modal name="profile-password-form-modal" title="{{ __('profile.update_password.heading') }}"
-                            description="{{ __('profile.update_password.description') }}" max-width="2xl"
-                            :show="$modalForm === 'profile-password'">
-                            <div class="p-6" x-ref="content">
-                                @if ($modalForm === 'profile-password')
-                                    @include('profile.partials.update-password-form', ['modal' => true])
-                                @else
-                                    <x-loading-indicator x-show="loading" x-cloak :show-label="false" class="justify-center" />
-                                    <p x-show="error" x-text="error" class="text-sm text-red-600 dark:text-red-400"></p>
-                                    <div x-html="content"></div>
-                                @endif
-                            </div>
-                        </x-form-modal>
-                    </div>
-                </x-container>
+                <section id="profile-password" data-profile-section="security" class="scroll-mt-6">
+                    <x-container class="space-y-6">
+                        @include('profile.partials.update-password-form', ['modal' => $modalForm === 'profile-password'])
+                    </x-container>
                 </section>
-
-                <x-secondary-button :href="route('profile.edit', ['full' => 1])">
-                    {{ __('profile.actions.open_full_page') }}
-                </x-secondary-button>
-            @endif
-
-            <section data-profile-section="api">
-                @include('profile.partials.api-configuration')
-                @include('profile.partials.api-docs')
-            </section>
-            <section data-profile-section="danger-zone">
-                @include('profile.partials.delete-user-form')
-            </section>
+                <section id="profile-api" data-profile-section="api" class="scroll-mt-6 space-y-6">
+                    <x-container class="space-y-6">
+                        @include('profile.partials.api-configuration')
+                    </x-container>
+                    <x-container class="space-y-4">
+                        @include('profile.partials.api-docs')
+                    </x-container>
+                </section>
+                <section id="profile-delete" data-profile-section="danger-zone" class="scroll-mt-6">
+                    <x-container class="space-y-4">
+                        @include('profile.partials.delete-user-form')
+                    </x-container>
+                </section>
+            </div>
         </div>
     </x-main>
 </x-app-layout>

--- a/resources/views/profile/partials/api-configuration.blade.php
+++ b/resources/views/profile/partials/api-configuration.blade.php
@@ -1,5 +1,4 @@
-<x-container class="mb-4">
-    <x-heading type="h2">
+<x-heading type="h2">
         {{ __('api.configuration.heading') }}
     </x-heading>
 
@@ -7,13 +6,13 @@
         {{ __('api.configuration.description') }}
     </x-paragraph>
 
-    <div class="mt-2 gap-4 md:flex md:items-center">
+    <div class="flex flex-wrap items-center gap-3">
         <form method="POST" action="{{ route('profile.api-generate-token') }}">
             @csrf
             <x-primary-button>{{ __('api.configuration.actions.generate_token') }}</x-primary-button>
         </form>
 
-        <form method="POST" action="{{ route('profile.api-revoke-token') }}" class="mt-4 md:mt-0"
+        <form method="POST" action="{{ route('profile.api-revoke-token') }}"
             data-confirm-message="{{ __('api.configuration.messages.confirm_revoke_token') }}">
             @csrf
             @method('DELETE')
@@ -26,4 +25,3 @@
     @if (Auth::user()->tokens->isNotEmpty())
         <x-api-token-display :token="Auth::user()->tokens->last()->token" />
     @endif
-</x-container>

--- a/resources/views/profile/partials/api-docs.blade.php
+++ b/resources/views/profile/partials/api-docs.blade.php
@@ -1,5 +1,4 @@
-<x-container class="mb-4">
-    <x-heading type="h2">{{ __('api.docs.heading') }}</x-heading>
+<x-heading type="h2">{{ __('api.docs.heading') }}</x-heading>
     <x-paragraph>
         {{ __('api.docs.description') }}
     </x-paragraph>
@@ -9,4 +8,3 @@
                 class="text-purple-800 underline dark:text-purple-400">{{ __('api.docs.link') }}</a>
         </x-paragraph>
     @endif
-</x-container>

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -1,6 +1,5 @@
-<x-container space="true">
-    <x-heading type="h2">{{ __('profile.delete_account.heading') }}</x-heading>
-    <x-paragraph space="true">
+<x-heading type="h2">{{ __('profile.delete_account.heading') }}</x-heading>
+    <x-paragraph>
         {{ __('profile.delete_account.description') }}
     </x-paragraph>
 
@@ -35,4 +34,3 @@
             </div>
         </form>
     </x-modal>
-</x-container>

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -1,10 +1,9 @@
-<x-container space="true">
-    <x-heading type="h2">{{ __('profile.update_password.heading') }}</x-heading>
+<x-heading type="h2">{{ __('profile.update_password.heading') }}</x-heading>
     <x-paragraph>
         {{ __('profile.update_password.description') }}
     </x-paragraph>
 
-    <form method="post" action="{{ route('password.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('password.update') }}" class="space-y-6">
         @csrf
         @method('put')
         @if (!empty($modal))
@@ -41,4 +40,3 @@
             @endif
         </div>
     </form>
-</x-container>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,8 +1,7 @@
-<x-container space="true">
-    @php
-        $notificationChannels = old('notification_channels', $user->notification_channels ?? []);
-        $notificationChannelKeys = ['slack', 'telegram', 'discord', 'teams', 'webhook'];
-    @endphp
+@php
+    $notificationChannels = old('notification_channels', $user->notification_channels ?? []);
+    $notificationChannelKeys = ['slack', 'telegram', 'discord', 'teams', 'webhook'];
+@endphp
 
     <x-heading type="h2">{{ __('profile.information.heading') }}</x-heading>
     <x-paragraph>
@@ -13,7 +12,7 @@
         @csrf
     </form>
 
-    <form method="post" action="{{ route('profile.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('profile.update') }}" class="space-y-6">
         @csrf
         @method('patch')
         @if (!empty($modal))
@@ -288,4 +287,3 @@
             @csrf
         </form>
     @endforeach
-</x-container>

--- a/tests/Feature/FormModalTeamsProfileTest.php
+++ b/tests/Feature/FormModalTeamsProfileTest.php
@@ -81,9 +81,12 @@ class FormModalTeamsProfileTest extends TestCase
         $this->actingAs($user)
             ->get(route('profile.edit'))
             ->assertOk()
-            ->assertSeeHtml('data-form-modal-name="profile-information-form-modal"')
-            ->assertSeeHtml('data-form-modal-name="profile-password-form-modal"')
-            ->assertSeeText(__('profile.actions.open_full_page'));
+            ->assertSeeHtml('id="profile-information"')
+            ->assertSeeHtml('id="profile-password"')
+            ->assertSeeHtml('id="profile-api"')
+            ->assertSeeHtml('id="profile-delete"')
+            ->assertDontSeeHtml('data-form-modal-name="profile-information-form-modal"')
+            ->assertDontSeeHtml('data-form-modal-name="profile-password-form-modal"');
 
         $this->actingAs($user)
             ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -101,7 +101,7 @@ class ProfileNotificationSettingsTest extends TestCase
             'notification_channels_hint_seen_at' => null,
         ]);
 
-        $testResponse = $this->actingAs($user)->get(route('profile.edit', ['full' => 1]));
+        $testResponse = $this->actingAs($user)->get(route('profile.edit'));
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('data-profile-settings')
             ->assertSeeHtml('id="profile-information"')
@@ -118,7 +118,7 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse->assertSeeText(__('profile.notification_settings.hint_banner'));
         $testResponse->assertSeeHtml('data-confirm-message="' . __('api.configuration.messages.confirm_revoke_token') . '"');
 
-        $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit', ['full' => 1]));
+        $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit'));
         $secondResponse->assertOk();
         $secondResponse->assertDontSeeText(__('profile.notification_settings.hint_banner'));
     }


### PR DESCRIPTION
Closes #634

## What changed

- Use the existing full profile settings layout for the default profile route; `full=1` is no longer required.
- Remove the compact modal presentation from the normal profile page while preserving AJAX form fragments.
- Consolidate the profile sections into one aligned two-column layout with responsive navigation and consistent card spacing.
- Remove duplicate API and account deletion rendering.
- Keep notification-channel hint behavior consistent on the default page.

## Validation

- Docker Pest: `FormModalTeamsProfileTest.php`, `ProfileNotificationSettingsTest.php`, `LocalePreferenceTest.php` passed (29 tests, 201 assertions in the full focused run; the final changed-scope run passed 19 tests and 166 assertions).
- Docker Pint passed for changed PHP files.
- Docker Vite production build passed.
- Targeted PHPStan passed for changed PHP files.
- Full PHPStan was attempted but the container killed a worker with exit 137 at completion due to memory pressure; no PHPStan diagnostics were reported.