### PR TITLE
fix(profile): stack settings navigation links

### DIFF
--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -13,17 +13,17 @@
                     <p class="px-3 py-2 text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">
                         {{ __('profile.navigation.heading') }}
                     </p>
-                    <nav aria-label="{{ __('profile.navigation.heading') }}" class="mt-1 grid gap-1 text-sm font-semibold sm:grid-cols-2 lg:block">
-                        <a href="#profile-information" class="rounded-lg bg-purple-50 px-3 py-2 text-purple-700 transition hover:bg-purple-100 dark:bg-purple-950/30 dark:text-purple-300 dark:hover:bg-purple-950/50">
+                    <nav aria-label="{{ __('profile.navigation.heading') }}" class="mt-1 space-y-1 text-sm font-semibold">
+                        <a href="#profile-information" class="block w-full rounded-lg bg-purple-50 px-3 py-2 text-purple-700 transition hover:bg-purple-100 dark:bg-purple-950/30 dark:text-purple-300 dark:hover:bg-purple-950/50">
                             {{ __('profile.navigation.account') }}
                         </a>
-                        <a href="#profile-password" class="rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                        <a href="#profile-password" class="block w-full rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
                             {{ __('profile.navigation.security') }}
                         </a>
-                        <a href="#profile-api" class="rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                        <a href="#profile-api" class="block w-full rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
                             {{ __('profile.navigation.api') }}
                         </a>
-                        <a href="#profile-delete" class="rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+                        <a href="#profile-delete" class="block w-full rounded-lg px-3 py-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
                             {{ __('profile.navigation.danger_zone') }}
                         </a>
                     </nav>

--- a/tests/Feature/FormModalTeamsProfileTest.php
+++ b/tests/Feature/FormModalTeamsProfileTest.php
@@ -85,6 +85,7 @@ class FormModalTeamsProfileTest extends TestCase
             ->assertSeeHtml('id="profile-password"')
             ->assertSeeHtml('id="profile-api"')
             ->assertSeeHtml('id="profile-delete"')
+            ->assertDontSeeHtml('sm:grid-cols-2')
             ->assertDontSeeHtml('data-form-modal-name="profile-information-form-modal"')
             ->assertDontSeeHtml('data-form-modal-name="profile-password-form-modal"');
 


### PR DESCRIPTION
Closes #636

## What changed

- Keep the profile account settings navigation in one vertical list at every viewport.
- Make each navigation link block-level and full width so labels do not get squeezed into narrow columns.
- Add a regression assertion that prevents the previous two-column class from returning.

## Validation

- Docker Pest: `FormModalTeamsProfileTest.php` and `ProfileNotificationSettingsTest.php` passed (19 tests, 167 assertions).
- Docker Vite production build passed.
- Rendered Playwright QA passed at 390x844 and 1440x1000: all four links were block-level, 332px wide at mobile, with no overlap or clipping.
- In-app Browser could not reach the local host; Playwright was used as the documented fallback after that environment limitation.