### PR TITLE
chore: remove Claude contributor adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-# Claude Code Adapter
-
-Follow the canonical repository instructions in `AGENTS.md`.
-
-Before changing files, read the nearest applicable `AGENTS.md` and only the relevant shared skills from `.agent/skills/README.md` and `.agent/skills/`.
-
-Keep changes scoped, preserve user work, prefer Docker-based validation, and keep plans and final output concise.


### PR DESCRIPTION
Closes #638

## Summary
- remove the repository-level Claude Code adapter
- preserve the canonical AGENTS.md instructions
- verify no Claude or contributor adapter reference remains

## Validation
- `git diff --check`
- repository-wide residual-reference search excluding generated/dependency directories