### PR TITLE
ci: optimize branches before quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [ main ]
+    branches:
+    - '**'
+
+concurrency:
+  group: ci-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 env:
   CI_IMAGE: webguard-ci:${{ github.run_id }}
@@ -69,23 +77,31 @@ jobs:
           -w /var/www/html "${{ env.CI_IMAGE }}" \
           ./vendor/bin/pint --parallel
 
-    - name: Ensure local PR branch exists
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      run: git checkout -B "${{ github.head_ref }}"
+    - name: Ensure writable branch exists
+      if: >
+        github.event_name == 'push' ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      env:
+        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      run: git checkout -B "$BRANCH_NAME"
 
-    - name: Commit auto-fixes (internal pull requests only)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    - name: Commit auto-fixes (internal branches only)
+      if: >
+        (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: 'ci: auto-fixes from pint and rector'
         commit_options: '--no-verify'
-        branch: ${{ github.head_ref }}
+        branch: ${{ github.head_ref || github.ref_name }}
 
     - name: Fail if Rector or Pint would change files
-      if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+      if: >
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
       run: |
         if ! git diff --quiet; then
-          echo "::error::Rector and/or Pint would change tracked files. Run them locally and commit the results."
+          echo "::error::Rector and/or Pint changed tracked files. The branch must be optimized before it can pass CI."
           git diff
           exit 1
         fi


### PR DESCRIPTION
Closes #639

## Summary
- run CI on every branch push as well as pull requests and `main`
- run Rector and Pint before branch quality checks, committing fixes to internal non-`main` branches when needed
- keep fork PRs and the merged `main` revision read-only, failing clearly if formatting changes are required
- cancel superseded runs for the same branch so tests follow the latest auto-fix commit

## Why

A branch should be normalized before its tests run, including branches before a pull request is opened. The push to `main` after a merge now follows the same Rector/Pint-before-tests order while preventing post-merge auto-commits that could interfere with release tagging.

## Testing
- Dockerized `actionlint` validation for `.github/workflows/ci.yml`
- Dockerized Ruby YAML parse
- `git diff --check`
- Docker Compose configuration validation with placeholder local values for required interpolation