### PR TITLE
chore: restore Claude contributor adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Adapter
+
+Follow the canonical repository instructions in `AGENTS.md`.
+
+Before changing files, read the nearest applicable `AGENTS.md` and only the relevant shared skills from `.agent/skills/README.md` and `.agent/skills/`.
+
+Keep changes scoped, preserve user work, prefer Docker-based validation, and keep plans and final output concise.


### PR DESCRIPTION
Closes #642

## Summary
- restore `CLAUDE.md` for contributors using Claude Code
- keep the canonical `AGENTS.md` instructions as the source of truth

## Validation
- `git diff --check`