### PR TITLE
fix(monitoring): backfill missing response times

### DIFF
--- a/database/migrations/2026_08_02_120000_backfill_missing_monitoring_response_times.php
+++ b/database/migrations/2026_08_02_120000_backfill_missing_monitoring_response_times.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $timestamp = now();
+
+        foreach ($this->datePairs() as [$sourceDate, $targetDate]) {
+            $this->insertMissingDailyResults($sourceDate, $targetDate, $timestamp);
+            $this->backfillResponseTimes($sourceDate, $targetDate, $timestamp);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // This migration corrects historical data and cannot be safely reversed.
+    }
+
+    /**
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function datePairs(): array
+    {
+        return [
+            ['2026-06-18', '2026-06-19'],
+            ['2026-07-09', '2026-07-10'],
+        ];
+    }
+
+    private function backfillResponseTimes(string $sourceDate, string $targetDate, DateTimeInterface $timestamp): void
+    {
+        $sources = DB::table('monitoring_daily_results as source')
+            ->join('monitorings', 'monitorings.id', '=', 'source.monitoring_id')
+            ->whereDate('source.date', $sourceDate)
+            ->where('monitorings.created_at', '<', '2026-06-18')
+            ->where(function ($query): void {
+                $query
+                    ->whereNotNull('source.avg_response_time')
+                    ->orWhereNotNull('source.min_response_time')
+                    ->orWhereNotNull('source.max_response_time');
+            })
+            ->select([
+                'source.monitoring_id',
+                'source.avg_response_time',
+                'source.min_response_time',
+                'source.max_response_time',
+            ])
+            ->get();
+
+        foreach ($sources as $source) {
+            $target = DB::table('monitoring_daily_results')
+                ->where('monitoring_id', $source->monitoring_id)
+                ->whereDate('date', $targetDate)
+                ->first([
+                    'id',
+                    'avg_response_time',
+                    'min_response_time',
+                    'max_response_time',
+                ]);
+
+            if ($target === null) {
+                continue;
+            }
+
+            $values = [];
+
+            foreach (['avg_response_time', 'min_response_time', 'max_response_time'] as $column) {
+                if ($target->{$column} === null && $source->{$column} !== null) {
+                    $values[$column] = $source->{$column};
+                }
+            }
+
+            if ($values === []) {
+                continue;
+            }
+
+            $values['updated_at'] = $timestamp;
+
+            DB::table('monitoring_daily_results')
+                ->where('id', $target->id)
+                ->update($values);
+        }
+    }
+
+    private function insertMissingDailyResults(string $sourceDate, string $targetDate, DateTimeInterface $timestamp): void
+    {
+        DB::table('monitoring_daily_results')->insertUsing(
+            [
+                'monitoring_id',
+                'date',
+                'uptime_total',
+                'downtime_total',
+                'unknown_total',
+                'uptime_percentage',
+                'downtime_percentage',
+                'unknown_percentage',
+                'uptime_minutes',
+                'downtime_minutes',
+                'unknown_minutes',
+                'avg_response_time',
+                'min_response_time',
+                'max_response_time',
+                'incidents_count',
+                'created_at',
+                'updated_at',
+            ],
+            DB::table('monitoring_daily_results as source')
+                ->join('monitorings', 'monitorings.id', '=', 'source.monitoring_id')
+                ->leftJoin('monitoring_daily_results as existing', function (JoinClause $join) use ($targetDate): void {
+                    $join
+                        ->on('existing.monitoring_id', '=', 'source.monitoring_id')
+                        ->whereDate('existing.date', $targetDate);
+                })
+                ->whereDate('source.date', $sourceDate)
+                ->where('monitorings.created_at', '<', '2026-06-18')
+                ->whereNull('existing.id')
+                ->where(function ($query): void {
+                    $query
+                        ->whereNotNull('source.avg_response_time')
+                        ->orWhereNotNull('source.min_response_time')
+                        ->orWhereNotNull('source.max_response_time');
+                })
+                ->select([
+                    'source.monitoring_id',
+                ])
+                ->selectRaw('? as date', [$targetDate])
+                ->addSelect([
+                    'source.uptime_total',
+                    'source.downtime_total',
+                    'source.unknown_total',
+                    'source.uptime_percentage',
+                    'source.downtime_percentage',
+                    'source.unknown_percentage',
+                    'source.uptime_minutes',
+                    'source.downtime_minutes',
+                    'source.unknown_minutes',
+                    'source.avg_response_time',
+                    'source.min_response_time',
+                    'source.max_response_time',
+                    'source.incidents_count',
+                ])
+                ->selectRaw('? as created_at, ? as updated_at', [$timestamp, $timestamp])
+        );
+    }
+};

--- a/tests/Feature/MonitoringResponseTimeBackfillMigrationTest.php
+++ b/tests/Feature/MonitoringResponseTimeBackfillMigrationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Monitoring;
+use App\Models\MonitoringDailyResult;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Tests\TestCase;
+
+class MonitoringResponseTimeBackfillMigrationTest extends TestCase
+{
+    public function test_it_backfills_missing_response_times_for_eligible_monitorings_only(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $eligibleMonitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => '2026-06-17 23:59:59',
+        ]);
+        $ineligibleMonitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => '2026-06-18 00:00:00',
+        ]);
+
+        $this->createDailyResult($eligibleMonitoring, '2026-06-18', 123.4, 100, 150, 10);
+        $this->createDailyResult($eligibleMonitoring, '2026-06-19', null, null, null, 99);
+        $this->createDailyResult($eligibleMonitoring, '2026-07-09', 234.5, 200, 280, 20);
+        $this->createDailyResult($eligibleMonitoring, '2026-07-10', null, null, null, 88);
+
+        $this->createDailyResult($ineligibleMonitoring, '2026-06-18', 321.0, 300, 350, 30);
+        $this->createDailyResult($ineligibleMonitoring, '2026-06-19', null, null, null, 77);
+        $this->createDailyResult($ineligibleMonitoring, '2026-07-09', 432.0, 400, 480, 40);
+        $this->createDailyResult($ineligibleMonitoring, '2026-07-10', null, null, null, 66);
+
+        $this->runMigration();
+
+        $this->assertDailyResult($eligibleMonitoring, '2026-06-19', 123.4, 100, 150, 99);
+        $this->assertDailyResult($eligibleMonitoring, '2026-07-10', 234.5, 200, 280, 88);
+        $this->assertDailyResult($ineligibleMonitoring, '2026-06-19', null, null, null, 77);
+        $this->assertDailyResult($ineligibleMonitoring, '2026-07-10', null, null, null, 66);
+    }
+
+    public function test_it_does_not_overwrite_existing_response_times(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => '2026-06-17 23:59:59',
+        ]);
+
+        $this->createDailyResult($monitoring, '2026-06-18', 123.4, 100, 150, 10);
+        $this->createDailyResult($monitoring, '2026-06-19', 987.6, 900, 999, 99);
+
+        $this->runMigration();
+
+        $this->assertDailyResult($monitoring, '2026-06-19', 987.6, 900, 999, 99);
+    }
+
+    public function test_it_creates_missing_daily_results_for_eligible_monitorings_only(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $eligibleMonitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => '2026-06-17 23:59:59',
+        ]);
+        $ineligibleMonitoring = Monitoring::factory()->for($user)->create([
+            'created_at' => '2026-06-18 00:00:00',
+        ]);
+
+        $this->createDailyResult($eligibleMonitoring, '2026-06-18', 123.4, 100, 150, 10);
+        $this->createDailyResult($eligibleMonitoring, '2026-07-09', 234.5, 200, 280, 20);
+        $this->createDailyResult($ineligibleMonitoring, '2026-06-18', 321.0, 300, 350, 30);
+
+        $this->runMigration();
+
+        $this->assertDailyResult($eligibleMonitoring, '2026-06-19', 123.4, 100, 150, 10);
+        $this->assertDailyResult($eligibleMonitoring, '2026-07-10', 234.5, 200, 280, 20);
+        $this->assertNull(MonitoringDailyResult::query()
+            ->where('monitoring_id', $ineligibleMonitoring->id)
+            ->whereDate('date', '2026-06-19')
+            ->first());
+    }
+
+    private function runMigration(): void
+    {
+        /** @var Migration $migration */
+        $migration = require base_path('database/migrations/2026_08_02_120000_backfill_missing_monitoring_response_times.php');
+
+        $migration->up();
+    }
+
+    private function createDailyResult(
+        Monitoring $monitoring,
+        string $date,
+        ?float $averageResponseTime,
+        ?int $minimumResponseTime,
+        ?int $maximumResponseTime,
+        int $uptimeTotal,
+    ): void {
+        MonitoringDailyResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'date' => $date,
+            'uptime_total' => $uptimeTotal,
+            'downtime_total' => 0,
+            'unknown_total' => 0,
+            'uptime_percentage' => 100.0,
+            'downtime_percentage' => 0.0,
+            'unknown_percentage' => 0.0,
+            'uptime_minutes' => 1_440,
+            'downtime_minutes' => 0,
+            'unknown_minutes' => 0,
+            'avg_response_time' => $averageResponseTime,
+            'min_response_time' => $minimumResponseTime,
+            'max_response_time' => $maximumResponseTime,
+            'incidents_count' => 0,
+        ]);
+    }
+
+    private function assertDailyResult(
+        Monitoring $monitoring,
+        string $date,
+        ?float $averageResponseTime,
+        ?int $minimumResponseTime,
+        ?int $maximumResponseTime,
+        int $uptimeTotal,
+    ): void {
+        $dailyResult = MonitoringDailyResult::query()
+            ->where('monitoring_id', $monitoring->id)
+            ->whereDate('date', $date)
+            ->first();
+
+        $this->assertNotNull($dailyResult);
+        $this->assertSame($averageResponseTime, $dailyResult->avg_response_time);
+        $this->assertSame($minimumResponseTime, $dailyResult->min_response_time);
+        $this->assertSame($maximumResponseTime, $dailyResult->max_response_time);
+        $this->assertSame($uptimeTotal, $dailyResult->uptime_total);
+    }
+}


### PR DESCRIPTION
## What changed

- Adds a data migration for monitoring response-time gaps on 2026-06-19 and 2026-07-10.
- Copies the respective previous day's daily result for monitorings created before 2026-06-18 when the target day is absent.
- Completes only missing response-time fields when a target daily result already exists.

## Why

Daily response-time history is missing for both target dates and needs to remain continuous without overwriting existing values.

## Testing

- Docker: `./vendor/bin/pest tests/Feature/MonitoringResponseTimeBackfillMigrationTest.php` (3 tests, 36 assertions)
- Docker: `./vendor/bin/pint --test` for the changed files
- Docker: `php artisan migrate --pretend --path=database/migrations/2026_08_02_120000_backfill_missing_monitoring_response_times.php`

## Risks and limitations

The migration intentionally copies the source daily aggregate when a target day is absent. It is a one-way historical data correction and cannot be safely reversed.

Closes #644.