### PR TITLE
fix(audit): stabilize old attribute logs

### DIFF
--- a/app/Models/Monitoring.php
+++ b/app/Models/Monitoring.php
@@ -86,6 +86,11 @@ class Monitoring extends Model
     use SoftDeletes;
 
     /**
+     * @var array<string, mixed>
+     */
+    private array $activityLogOriginalAttributes = [];
+
+    /**
      * Get the user that owns the monitoring.
      *
      * @return BelongsTo<User, $this>
@@ -426,12 +431,29 @@ class Monitoring extends Model
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    public function activityLogOriginalAttributes(): array
+    {
+        return $this->activityLogOriginalAttributes;
+    }
+
+    public function forgetActivityLogOriginalAttributes(): void
+    {
+        $this->activityLogOriginalAttributes = [];
+    }
+
+    /**
      * Apply the global scope to ensure all queries are restricted to the authenticated user.
      */
     #[Override]
     protected static function booted(): void
     {
         parent::boot();
+
+        static::updating(function (self $monitoring): void {
+            $monitoring->activityLogOriginalAttributes = $monitoring->getRawOriginal();
+        });
 
         static::addGlobalScope('user', function (Builder $builder): void {
             if (Auth::check()) {

--- a/app/Support/ActivityLog/RedactActivityLogChanges.php
+++ b/app/Support/ActivityLog/RedactActivityLogChanges.php
@@ -42,11 +42,18 @@ class RedactActivityLogChanges extends LogActivityAction
 
     protected function transformChanges(Model $activity): void
     {
-        $activity->attribute_changes = $this->redactCollection(
-            $this->withMissingOldAttributes($activity->attribute_changes ?? collect(), $activity),
-            $activity
-        );
-        $activity->properties = $this->redactCollection($activity->properties ?? collect(), $activity);
+        try {
+            $activity->attribute_changes = $this->redactCollection(
+                $this->withMissingOldAttributes($activity->attribute_changes ?? collect(), $activity),
+                $activity
+            );
+            $activity->properties = $this->redactCollection($activity->properties ?? collect(), $activity);
+        } finally {
+            if ($activity->subject instanceof Model
+                && method_exists($activity->subject, 'forgetActivityLogOriginalAttributes')) {
+                $activity->subject->forgetActivityLogOriginalAttributes();
+            }
+        }
     }
 
     /**
@@ -70,11 +77,15 @@ class RedactActivityLogChanges extends LogActivityAction
             ? $model->subject->getPrevious()
             : [];
 
+        if (method_exists($model->subject, 'activityLogOriginalAttributes')) {
+            $previous = array_replace($previous, $model->subject->activityLogOriginalAttributes());
+        }
+
         foreach (array_keys($changes['attributes']) as $attribute) {
             if (! is_string($attribute)) {
                 continue;
             }
-            if (array_key_exists($attribute, $old)) {
+            if (array_key_exists($attribute, $old) && $old[$attribute] !== null) {
                 continue;
             }
             if (! array_key_exists($attribute, $previous)) {

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -10,7 +10,10 @@ use App\Models\Monitoring;
 use App\Models\Package;
 use App\Models\ServerInstance;
 use App\Models\User;
+use App\Support\ActivityLog\RedactActivityLogChanges;
 use App\Support\HttpStatusCodeRanges;
+use Closure;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
 use Tests\TestCase;
 
@@ -173,6 +176,44 @@ class AuditLogTest extends TestCase
         $this->assertStringNotContainsString('fresh-header-token', $encodedChanges);
         $this->assertStringNotContainsString('fresh-body-secret', $encodedChanges);
         $this->assertStringNotContainsString('fresh-basic-password', $encodedChanges);
+    }
+
+    public function test_monitoring_audit_log_uses_captured_originals_when_eloquent_previous_values_are_empty(): void
+    {
+        Package::factory()->create();
+
+        $monitoring = Monitoring::factory()->for(User::factory())->create([
+            'name' => 'Sensitive HTTP Monitor',
+        ]);
+        $monitoring->disableLogging()->update([
+            'name' => 'Renamed Sensitive HTTP Monitor',
+        ]);
+
+        $this->assertSame('Sensitive HTTP Monitor', data_get($monitoring->activityLogOriginalAttributes(), 'name'));
+
+        Closure::bind(function (): void {
+            $this->previous = [];
+        }, $monitoring, Model::class)();
+
+        $activity = new Activity();
+        $activity->event = 'updated';
+        $activity->setRelation('subject', $monitoring);
+        $activity->attribute_changes = collect([
+            'attributes' => ['name' => 'Renamed Sensitive HTTP Monitor'],
+            'old' => ['name' => null],
+        ]);
+
+        $action = new class extends RedactActivityLogChanges
+        {
+            public function transform(Activity $activity): void
+            {
+                $this->transformChanges($activity);
+            }
+        };
+        $action->transform($activity);
+
+        $this->assertSame('Sensitive HTTP Monitor', data_get($activity->attribute_changes, 'old.name'));
+        $this->assertSame([], $monitoring->activityLogOriginalAttributes());
     }
 
     public function test_heartbeat_monitoring_audit_log_redacts_ping_url_and_token(): void


### PR DESCRIPTION
## What changed
- Capture monitoring raw originals before updates.
- Use captured originals when the activity log supplies a null old-value placeholder.
- Clear the temporary snapshot after the audit entry is transformed.

## Why
The parallel CI run intermittently lost `old.name` in monitoring audit entries because the Eloquent previous-value state was unavailable.

## Validation
- Docker: `tests/Feature/AuditLogTest.php --parallel --processes=4`
- Docker: full Pest suite with four parallel processes
- Docker: focused PHPStan analysis
- Docker: Pint and `git diff --check`

Closes #650