### PR TITLE
feat(api-keys): manage scoped API keys

### DIFF
--- a/app/Enums/ApiKeyAbility.php
+++ b/app/Enums/ApiKeyAbility.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ApiKeyAbility: string
+{
+    case SERVER_HEALTH_WRITE = 'server-health:write';
+    case ANALYTICS_READ = 'analytics:read';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/Api/ApiKeyController.php
+++ b/app/Http/Controllers/Api/ApiKeyController.php
@@ -24,30 +24,30 @@ class ApiKeyController extends Controller
         $state = $request->string('state')->toString();
         abort_unless(in_array($state, ['', 'active', 'revoked'], true), 422);
 
-        $keys = $this->apiKeyService->paginate($user, min(max($request->integer('per_page', 25), 1), 100), $state ?: null);
+        $lengthAwarePaginator = $this->apiKeyService->paginate($user, min(max($request->integer('per_page', 25), 1), 100), $state ?: null);
 
         return response()->json([
-            'data' => ApiKeyResource::collection($keys->items())->resolve($request),
+            'data' => ApiKeyResource::collection($lengthAwarePaginator->items())->resolve($request),
             'meta' => [
-                'current_page' => $keys->currentPage(),
-                'last_page' => $keys->lastPage(),
-                'per_page' => $keys->perPage(),
-                'total' => $keys->total(),
+                'current_page' => $lengthAwarePaginator->currentPage(),
+                'last_page' => $lengthAwarePaginator->lastPage(),
+                'per_page' => $lengthAwarePaginator->perPage(),
+                'total' => $lengthAwarePaginator->total(),
             ],
         ]);
     }
 
-    public function store(StoreApiKeyRequest $request): JsonResponse
+    public function store(StoreApiKeyRequest $storeApiKeyRequest): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
-        $validated = $request->validated();
-        $newToken = $this->apiKeyService->create($user, $validated['name'], $validated['abilities']);
+        $user = $storeApiKeyRequest->user();
+        $validated = $storeApiKeyRequest->validated();
+        $newAccessToken = $this->apiKeyService->create($user, $validated['name'], $validated['abilities']);
 
         return response()->json([
             'data' => [
-                'token' => $newToken->plainTextToken,
-                'key' => (new ApiKeyResource($newToken->accessToken))->resolve($request),
+                'token' => $newAccessToken->plainTextToken,
+                'key' => (new ApiKeyResource($newAccessToken->accessToken))->resolve($storeApiKeyRequest),
             ],
         ], 201);
     }
@@ -61,11 +61,11 @@ class ApiKeyController extends Controller
 
     public function destroy(Request $request, int $apiKey): JsonResponse
     {
-        $token = $this->tokenForRequest($request, $apiKey);
-        $this->apiKeyService->revoke($token);
+        $personalAccessToken = $this->tokenForRequest($request, $apiKey);
+        $this->apiKeyService->revoke($personalAccessToken);
 
         return response()->json([
-            'data' => new ApiKeyResource($token->fresh()),
+            'data' => new ApiKeyResource($personalAccessToken->fresh()),
         ]);
     }
 

--- a/app/Http/Controllers/Api/ApiKeyController.php
+++ b/app/Http/Controllers/Api/ApiKeyController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreApiKeyRequest;
+use App\Http\Resources\ApiKeyResource;
+use App\Models\PersonalAccessToken;
+use App\Models\User;
+use App\Services\ApiKeyService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ApiKeyController extends Controller
+{
+    public function __construct(private readonly ApiKeyService $apiKeyService) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $state = $request->string('state')->toString();
+        abort_unless(in_array($state, ['', 'active', 'revoked'], true), 422);
+
+        $keys = $this->apiKeyService->paginate($user, min(max($request->integer('per_page', 25), 1), 100), $state ?: null);
+
+        return response()->json([
+            'data' => ApiKeyResource::collection($keys->items())->resolve($request),
+            'meta' => [
+                'current_page' => $keys->currentPage(),
+                'last_page' => $keys->lastPage(),
+                'per_page' => $keys->perPage(),
+                'total' => $keys->total(),
+            ],
+        ]);
+    }
+
+    public function store(StoreApiKeyRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validated();
+        $newToken = $this->apiKeyService->create($user, $validated['name'], $validated['abilities']);
+
+        return response()->json([
+            'data' => [
+                'token' => $newToken->plainTextToken,
+                'key' => (new ApiKeyResource($newToken->accessToken))->resolve($request),
+            ],
+        ], 201);
+    }
+
+    public function show(Request $request, int $apiKey): JsonResponse
+    {
+        return response()->json([
+            'data' => new ApiKeyResource($this->tokenForRequest($request, $apiKey)),
+        ]);
+    }
+
+    public function destroy(Request $request, int $apiKey): JsonResponse
+    {
+        $token = $this->tokenForRequest($request, $apiKey);
+        $this->apiKeyService->revoke($token);
+
+        return response()->json([
+            'data' => new ApiKeyResource($token->fresh()),
+        ]);
+    }
+
+    private function tokenForRequest(Request $request, int $tokenId): PersonalAccessToken
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $token = $this->apiKeyService->findForUser($user, $tokenId);
+
+        abort_unless($token instanceof PersonalAccessToken, 404);
+
+        return $token;
+    }
+}

--- a/app/Http/Controllers/Api/BearerServerHealthReportController.php
+++ b/app/Http/Controllers/Api/BearerServerHealthReportController.php
@@ -13,15 +13,15 @@ use Illuminate\Http\JsonResponse;
 class BearerServerHealthReportController extends Controller
 {
     public function __invoke(
-        ServerHealthReportRequest $request,
+        ServerHealthReportRequest $serverHealthReportRequest,
         Monitoring $monitoring,
         ServerHealthReportController $serverHealthReportController
     ): JsonResponse {
         /** @var User $user */
-        $user = $request->user();
+        $user = $serverHealthReportRequest->user();
 
         abort_unless($monitoring->isServerHealth() && $monitoring->isManageableBy($user), 404);
 
-        return $serverHealthReportController->store($request, $monitoring);
+        return $serverHealthReportController->store($serverHealthReportRequest, $monitoring);
     }
 }

--- a/app/Http/Controllers/Api/BearerServerHealthReportController.php
+++ b/app/Http/Controllers/Api/BearerServerHealthReportController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ServerHealthReportRequest;
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+
+class BearerServerHealthReportController extends Controller
+{
+    public function __invoke(
+        ServerHealthReportRequest $request,
+        Monitoring $monitoring,
+        ServerHealthReportController $serverHealthReportController
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+
+        abort_unless($monitoring->isServerHealth() && $monitoring->isManageableBy($user), 404);
+
+        return $serverHealthReportController->store($request, $monitoring);
+    }
+}

--- a/app/Http/Controllers/Api/External/ApiKeyController.php
+++ b/app/Http/Controllers/Api/External/ApiKeyController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * External v1 adapter for the user-owned API key contract.
+ */
+class ApiKeyController extends \App\Http\Controllers\Api\ApiKeyController {}

--- a/app/Http/Controllers/Api/External/BearerServerHealthReportController.php
+++ b/app/Http/Controllers/Api/External/BearerServerHealthReportController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * External v1 adapter for telemetry-only Server Health reports.
+ */
+class BearerServerHealthReportController extends \App\Http\Controllers\Api\BearerServerHealthReportController {}

--- a/app/Http/Controllers/Api/ServerHealthReportController.php
+++ b/app/Http/Controllers/Api/ServerHealthReportController.php
@@ -59,6 +59,12 @@ class ServerHealthReportController extends Controller
             ->where('server_health_token', $token)
             ->firstOrFail();
 
+        return $this->store($serverHealthReportRequest, $monitoring);
+    }
+
+    public function store(ServerHealthReportRequest $serverHealthReportRequest, Monitoring $monitoring): JsonResponse
+    {
+
         $validated = $serverHealthReportRequest->validated();
 
         $metrics = $this->extractMetrics($validated);

--- a/app/Http/Controllers/ProfileApiKeyController.php
+++ b/app/Http/Controllers/ProfileApiKeyController.php
@@ -15,21 +15,21 @@ class ProfileApiKeyController extends Controller
 {
     public function __construct(private readonly ApiKeyService $apiKeyService) {}
 
-    public function store(StoreApiKeyRequest $request): RedirectResponse
+    public function store(StoreApiKeyRequest $storeApiKeyRequest): RedirectResponse
     {
         /** @var User $user */
-        $user = $request->user();
-        $validated = $request->validated();
-        $newToken = $this->apiKeyService->create($user, $validated['name'], $validated['abilities']);
+        $user = $storeApiKeyRequest->user();
+        $validated = $storeApiKeyRequest->validated();
+        $newAccessToken = $this->apiKeyService->create($user, $validated['name'], $validated['abilities']);
 
         activity('user')
             ->performedOn($user)
             ->event('api_key_created')
-            ->withProperties(['action' => 'api_key_created', 'key_id' => $newToken->accessToken->getKey()])
+            ->withProperties(['action' => 'api_key_created', 'key_id' => $newAccessToken->accessToken->getKey()])
             ->log('user_api_key_created');
 
         return to_route('profile.edit', ['#api-keys'])
-            ->with('api_key_plaintext', $newToken->plainTextToken)
+            ->with('api_key_plaintext', $newAccessToken->plainTextToken)
             ->with('success', __('api.configuration.messages.created'));
     }
 

--- a/app/Http/Controllers/ProfileApiKeyController.php
+++ b/app/Http/Controllers/ProfileApiKeyController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Api\StoreApiKeyRequest;
+use App\Models\PersonalAccessToken;
+use App\Models\User;
+use App\Services\ApiKeyService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ProfileApiKeyController extends Controller
+{
+    public function __construct(private readonly ApiKeyService $apiKeyService) {}
+
+    public function store(StoreApiKeyRequest $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validated();
+        $newToken = $this->apiKeyService->create($user, $validated['name'], $validated['abilities']);
+
+        activity('user')
+            ->performedOn($user)
+            ->event('api_key_created')
+            ->withProperties(['action' => 'api_key_created', 'key_id' => $newToken->accessToken->getKey()])
+            ->log('user_api_key_created');
+
+        return to_route('profile.edit', ['#api-keys'])
+            ->with('api_key_plaintext', $newToken->plainTextToken)
+            ->with('success', __('api.configuration.messages.created'));
+    }
+
+    public function destroy(Request $request, int $apiKey): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $token = $this->apiKeyService->findForUser($user, $apiKey);
+        abort_unless($token instanceof PersonalAccessToken, 404);
+
+        $revoked = $this->apiKeyService->revoke($token);
+
+        if ($revoked) {
+            activity('user')
+                ->performedOn($user)
+                ->event('api_key_revoked')
+                ->withProperties(['action' => 'api_key_revoked', 'key_id' => $token->getKey()])
+                ->log('user_api_key_revoked');
+        }
+
+        return to_route('profile.edit', ['#api-keys'])
+            ->with('success', __('api.configuration.messages.revoked'));
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\DeleteUserRequest;
 use App\Http\Requests\ProfileRequest;
 use App\Jobs\DeleteUser;
 use App\Models\User;
+use App\Services\ApiKeyService;
 use App\Services\Notifications\NotificationChannelTestService;
 use App\Services\UserDeletionPreparationService;
 use Illuminate\Http\RedirectResponse;
@@ -33,7 +34,7 @@ class ProfileController extends Controller
      * @param  Request  $request  The HTTP request instance.
      * @return View The view for editing the user's profile.
      */
-    public function edit(Request $request): View
+    public function edit(Request $request, ApiKeyService $apiKeyService): View
     {
         $user = $request->user();
         $modalForm = $request->input('modal');
@@ -62,7 +63,7 @@ class ProfileController extends Controller
 
         return view('profile.edit', [
             'user' => $user,
-            'token' => $user?->currentAccessToken(),
+            'apiKeys' => $user instanceof User ? $apiKeyService->paginate($user, 100, null) : null,
             'showNotificationChannelsHint' => $showNotificationChannelsHint,
             'modalForm' => $modalForm,
         ]);
@@ -137,50 +138,6 @@ class ProfileController extends Controller
         $deleteUserRequest->session()->regenerateToken();
 
         return Redirect::to('/');
-    }
-
-    /**
-     * Generate a new API token.
-     *
-     * @param  Request  $request  The HTTP request instance.
-     * @return RedirectResponse A redirect response after generating the token.
-     */
-    public function apiGenerateToken(Request $request): RedirectResponse
-    {
-        $user = $request->user();
-
-        $user->tokens()->delete();
-
-        $user->createToken('api-access');
-
-        activity('user')
-            ->performedOn($user)
-            ->event('api_token_generated')
-            ->withProperties(['action' => 'api_token_generated'])
-            ->log('user_api_token_generated');
-
-        return to_route('profile.edit', ['#api-token']);
-    }
-
-    /**
-     * Revoke the API token.
-     *
-     * @param  Request  $request  The HTTP request instance.
-     * @return RedirectResponse A redirect response after revoking the token.
-     */
-    public function apiRevokeToken(Request $request): RedirectResponse
-    {
-        $user = $request->user();
-
-        $user->tokens()->delete();
-
-        activity('user')
-            ->performedOn($user)
-            ->event('api_token_revoked')
-            ->withProperties(['action' => 'api_token_revoked'])
-            ->log('user_api_token_revoked');
-
-        return back()->with('success', __('api.configuration.messages.tokens_deleted'));
     }
 
     public function sendNotificationChannelTest(

--- a/app/Http/Middleware/RequireApiKeyAbility.php
+++ b/app/Http/Middleware/RequireApiKeyAbility.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireApiKeyAbility
+{
+    public function handle(Request $request, Closure $next, string $ability): Response
+    {
+        $token = $request->user()?->currentAccessToken();
+
+        abort_unless($token instanceof PersonalAccessToken && $token->can($ability), 403);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RequireApiKeyManagement.php
+++ b/app/Http/Middleware/RequireApiKeyManagement.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireApiKeyManagement
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $request->user()?->currentAccessToken();
+
+        if ($token instanceof PersonalAccessToken && ! $token->can('*')) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RequireApiKeyManagement.php
+++ b/app/Http/Middleware/RequireApiKeyManagement.php
@@ -15,9 +15,7 @@ class RequireApiKeyManagement
     {
         $token = $request->user()?->currentAccessToken();
 
-        if ($token instanceof PersonalAccessToken && ! $token->can('*')) {
-            abort(403);
-        }
+        abort_if($token instanceof PersonalAccessToken && ! $token->can('*'), 403);
 
         return $next($request);
     }

--- a/app/Http/Middleware/RequireExternalApiAbility.php
+++ b/app/Http/Middleware/RequireExternalApiAbility.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Models\PersonalAccessToken;
+use App\Services\ApiKeyService;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,6 +14,17 @@ class RequireExternalApiAbility
 {
     public function handle(Request $request, Closure $next): Response
     {
+        $token = $request->user()?->currentAccessToken();
+
+        if ($token instanceof PersonalAccessToken && ApiKeyService::isManagedKey($token)) {
+            abort_unless(
+                $token->can('analytics:read') && $request->routeIs('v1.*.analytics.*'),
+                403
+            );
+
+            return $next($request);
+        }
+
         if (! config('external_api.enforce_token_abilities')) {
             return $next($request);
         }

--- a/app/Http/Requests/Api/StoreApiKeyRequest.php
+++ b/app/Http/Requests/Api/StoreApiKeyRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use App\Enums\ApiKeyAbility;
+use App\Models\User;
+use App\Services\ApiKeyService;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreApiKeyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() instanceof User;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        /** @var User $user */
+        $user = $this->user();
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                function (string $attribute, mixed $value, Closure $fail) use ($user): void {
+                    $exists = $user->tokens()
+                        ->where(function ($query) use ($value): void {
+                            $query->where('name', ApiKeyService::storedName((string) $value));
+
+                            if ($value === ApiKeyService::LEGACY_TOKEN_NAME) {
+                                $query->orWhere('name', ApiKeyService::LEGACY_TOKEN_NAME);
+                            }
+                        })
+                        ->exists();
+
+                    if ($exists) {
+                        $fail(__('validation.unique', ['attribute' => $attribute]));
+                    }
+                },
+            ],
+            'abilities' => ['required', 'array', 'min:1'],
+            'abilities.*' => ['required', 'string', Rule::in(ApiKeyAbility::values()), 'distinct:strict'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'name' => mb_trim((string) $this->input('name')),
+        ]);
+    }
+}

--- a/app/Http/Resources/ApiKeyResource.php
+++ b/app/Http/Resources/ApiKeyResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\PersonalAccessToken;
+use App\Services\ApiKeyService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin PersonalAccessToken */
+class ApiKeyResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->getKey(),
+            'name' => ApiKeyService::displayName($this->resource),
+            'abilities' => $this->abilities,
+            'token_prefix' => $this->getKey() . '|',
+            'created_at' => $this->created_at?->toIso8601String(),
+            'last_used_at' => $this->last_used_at?->toIso8601String(),
+            'revoked_at' => $this->revoked_at?->toIso8601String(),
+            'revoked' => $this->revoked_at !== null,
+            'legacy' => ! ApiKeyService::isManagedKey($this->resource),
+        ];
+    }
+}

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
 
 class PersonalAccessToken extends SanctumPersonalAccessToken
 {
-    protected $casts = [
-        'abilities' => 'json',
-        'last_used_at' => 'datetime',
-        'expires_at' => 'datetime',
-        'revoked_at' => 'datetime',
-    ];
+    use HasFactory;
 
     public static function findToken($token): ?static
     {
@@ -24,5 +20,15 @@ class PersonalAccessToken extends SanctumPersonalAccessToken
         }
 
         return $accessToken;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'abilities' => 'json',
+            'last_used_at' => 'datetime',
+            'expires_at' => 'datetime',
+            'revoked_at' => 'datetime',
+        ];
     }
 }

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
+
+class PersonalAccessToken extends SanctumPersonalAccessToken
+{
+    protected $casts = [
+        'abilities' => 'json',
+        'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
+        'revoked_at' => 'datetime',
+    ];
+
+    public static function findToken($token): ?static
+    {
+        $accessToken = parent::findToken($token);
+
+        if (! $accessToken instanceof static || $accessToken->revoked_at !== null) {
+            return null;
+        }
+
+        return $accessToken;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,7 +21,6 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
 use Laravel\Sanctum\HasApiTokens;
-use Laravel\Sanctum\PersonalAccessToken;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Spatie\Activitylog\Support\LogOptions;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
 use App\Models\MonitoringResponse;
 use App\Models\NotificationChannelDelivery;
+use App\Models\PersonalAccessToken;
 use App\Models\StatusPage;
 use App\Models\StatusPageComponent;
 use App\Models\TeamMembership;
@@ -44,7 +45,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(Router $router): void
     {
-        Sanctum::usePersonalAccessTokenModel(\App\Models\PersonalAccessToken::class);
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
 
         if (app()->isProduction()) {
             URL::forceScheme('https');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,6 +27,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Sanctum\Sanctum;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -43,6 +44,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(Router $router): void
     {
+        Sanctum::usePersonalAccessTokenModel(\App\Models\PersonalAccessToken::class);
+
         if (app()->isProduction()) {
             URL::forceScheme('https');
         }

--- a/app/Services/ApiKeyService.php
+++ b/app/Services/ApiKeyService.php
@@ -21,16 +21,16 @@ class ApiKeyService
         return self::TOKEN_NAME_PREFIX . $displayName;
     }
 
-    public static function displayName(PersonalAccessToken $token): string
+    public static function displayName(PersonalAccessToken $personalAccessToken): string
     {
-        return Str::startsWith($token->name, self::TOKEN_NAME_PREFIX)
-            ? Str::after($token->name, self::TOKEN_NAME_PREFIX)
-            : $token->name;
+        return Str::startsWith($personalAccessToken->name, self::TOKEN_NAME_PREFIX)
+            ? Str::after($personalAccessToken->name, self::TOKEN_NAME_PREFIX)
+            : $personalAccessToken->name;
     }
 
-    public static function isManagedKey(PersonalAccessToken $token): bool
+    public static function isManagedKey(PersonalAccessToken $personalAccessToken): bool
     {
-        return Str::startsWith($token->name, self::TOKEN_NAME_PREFIX);
+        return Str::startsWith($personalAccessToken->name, self::TOKEN_NAME_PREFIX);
     }
 
     /**
@@ -49,8 +49,7 @@ class ApiKeyService
                     ->orWhere('name', self::LEGACY_TOKEN_NAME);
             })
             ->when($state === 'active', fn ($query) => $query->whereNull('revoked_at'))
-            ->when($state === 'revoked', fn ($query) => $query->whereNotNull('revoked_at'))
-            ->orderByDesc('created_at')
+            ->when($state === 'revoked', fn ($query) => $query->whereNotNull('revoked_at'))->latest()
             ->paginate($perPage);
     }
 
@@ -67,13 +66,13 @@ class ApiKeyService
         return $token instanceof PersonalAccessToken ? $token : null;
     }
 
-    public function revoke(PersonalAccessToken $token): bool
+    public function revoke(PersonalAccessToken $personalAccessToken): bool
     {
-        if ($token->revoked_at !== null) {
+        if ($personalAccessToken->revoked_at !== null) {
             return false;
         }
 
-        $token->forceFill(['revoked_at' => now()])->save();
+        $personalAccessToken->forceFill(['revoked_at' => now()])->save();
 
         return true;
     }

--- a/app/Services/ApiKeyService.php
+++ b/app/Services/ApiKeyService.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\PersonalAccessToken;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\NewAccessToken;
+
+class ApiKeyService
+{
+    public const TOKEN_NAME_PREFIX = 'webguard-api-key:';
+
+    public const LEGACY_TOKEN_NAME = 'api-access';
+
+    public static function storedName(string $displayName): string
+    {
+        return self::TOKEN_NAME_PREFIX . $displayName;
+    }
+
+    public static function displayName(PersonalAccessToken $token): string
+    {
+        return Str::startsWith($token->name, self::TOKEN_NAME_PREFIX)
+            ? Str::after($token->name, self::TOKEN_NAME_PREFIX)
+            : $token->name;
+    }
+
+    public static function isManagedKey(PersonalAccessToken $token): bool
+    {
+        return Str::startsWith($token->name, self::TOKEN_NAME_PREFIX);
+    }
+
+    /**
+     * @param  array<int, string>  $abilities
+     */
+    public function create(User $user, string $displayName, array $abilities): NewAccessToken
+    {
+        return $user->createToken(self::storedName($displayName), $abilities);
+    }
+
+    public function paginate(User $user, int $perPage, ?string $state): LengthAwarePaginator
+    {
+        return $user->tokens()
+            ->where(function ($query): void {
+                $query->where('name', 'like', self::TOKEN_NAME_PREFIX . '%')
+                    ->orWhere('name', self::LEGACY_TOKEN_NAME);
+            })
+            ->when($state === 'active', fn ($query) => $query->whereNull('revoked_at'))
+            ->when($state === 'revoked', fn ($query) => $query->whereNotNull('revoked_at'))
+            ->orderByDesc('created_at')
+            ->paginate($perPage);
+    }
+
+    public function findForUser(User $user, int $tokenId): ?PersonalAccessToken
+    {
+        $token = $user->tokens()
+            ->whereKey($tokenId)
+            ->where(function ($query): void {
+                $query->where('name', 'like', self::TOKEN_NAME_PREFIX . '%')
+                    ->orWhere('name', self::LEGACY_TOKEN_NAME);
+            })
+            ->first();
+
+        return $token instanceof PersonalAccessToken ? $token : null;
+    }
+
+    public function revoke(PersonalAccessToken $token): bool
+    {
+        if ($token->revoked_at !== null) {
+            return false;
+        }
+
+        $token->forceFill(['revoked_at' => now()])->save();
+
+        return true;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Http\Middleware\AuthenticateInstance;
 use App\Http\Middleware\CheckUserRole;
 use App\Http\Middleware\PreventCrawling;
+use App\Http\Middleware\RequireApiKeyAbility;
+use App\Http\Middleware\RequireApiKeyManagement;
 use App\Http\Middleware\SetLocaleMiddleware;
 use App\Http\Middleware\SetPublicCacheHeaders;
 use Illuminate\Foundation\Application;
@@ -30,6 +32,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'role' => CheckUserRole::class,
             'auth.instance' => AuthenticateInstance::class,
             'public.cache' => SetPublicCacheHeaders::class,
+            'api-key.ability' => RequireApiKeyAbility::class,
+            'api-key.manage' => RequireApiKeyManagement::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/migrations/2026_08_08_100000_add_revoked_at_to_personal_access_tokens_table.php
+++ b/database/migrations/2026_08_08_100000_add_revoked_at_to_personal_access_tokens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table): void {
+            $table->timestamp('revoked_at')->nullable()->after('last_used_at')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table): void {
+            $table->dropIndex(['revoked_at']);
+            $table->dropColumn('revoked_at');
+        });
+    }
+};

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -53,6 +53,42 @@ headers. Mobile app tokens retain their existing separate behavior.
   and mutating methods require `external:write`; existing wildcard tokens
   continue to work.
 
+## Named scoped API keys
+
+Authenticated browser sessions can create, list, inspect, and revoke keys at
+`/api/v1/api-keys`. The endpoints use the same authenticated session and CSRF
+protection as the profile screen; newly created scoped bearer keys cannot manage
+keys themselves. This prevents a telemetry or analytics integration from
+creating another key or escalating its permissions.
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/api/v1/api-keys?state=active|revoked&per_page=25` | Paginated non-secret key metadata. |
+| `POST` | `/api/v1/api-keys` | Creates a named key; returns its plaintext value exactly once. |
+| `GET` | `/api/v1/api-keys/{id}` | Returns metadata for one key owned by the authenticated user. |
+| `DELETE` | `/api/v1/api-keys/{id}` | Immediately and idempotently revokes one owned key. |
+
+Creation requires a non-empty, unique-per-user `name` and a non-empty
+`abilities` array. The only new key abilities are:
+
+- `server-health:write`: may only send telemetry to the bearer Server Health
+  endpoint for a monitoring the key owner may manage;
+- `analytics:read`: may only read the documented monitoring reporting routes
+  below; it cannot list or mutate monitorings, teams, devices, or API keys.
+
+Metadata includes the key ID, display name, abilities, non-secret Sanctum
+prefix, creation time, last-use time, and revocation state. It never includes a
+plaintext token, token hash, or authorization header. Deleted key records are
+retained as revoked metadata for auditability and cannot authenticate again.
+
+The analytics routes are `GET /api/v1/monitorings/{monitoring}` and its
+`status`, `uptime-downtime`, `uptime-downtime-summary`, `response-times`,
+`checks`, `incidents`, `heatmap`, `ssl`, and `uptime-calendar` subresources.
+All retain their existing ownership checks and response contracts.
+
+Existing pre-scoped external tokens remain compatible. They are not converted
+to new keys automatically; rotate them from the profile when practical.
+
 Scribe generates the OpenAPI and reference documentation from route metadata,
 request rules, controller annotations, and this configuration. Do not edit the
 generated artifacts manually.

--- a/docs/integrations/server-agent-api.md
+++ b/docs/integrations/server-agent-api.md
@@ -23,10 +23,28 @@ trusted local development environment, must not log the URL/token, and must set
 The endpoint has no inbound connection to the customer server and exposes no
 remote-command mechanism.
 
+During the migration window, an agent may instead use a telemetry-only named
+API key created in Profile → API Configuration:
+
+```text
+POST /api/v1/server-health/monitorings/{monitoring-id}
+Authorization: Bearer {telemetry-only-key}
+```
+
+The key needs the `server-health:write` ability, and its owner must be allowed
+to manage the referenced Server Health monitoring. It cannot submit another
+user's monitoring, read reports, access browser routes, or call scanner-instance
+routes. `401` means the bearer token is absent, invalid, or revoked; `403`
+means it lacks the telemetry ability; `404` means the monitoring is not a
+manageable Server Health monitoring. Never log the bearer token.
+
 The report URL is displayed only in the authenticated monitoring detail view.
 An owner can rotate it there; rotation invalidates the previous token
 immediately. The agent should treat a `404` response as a configuration error
 and require the new URL instead of retrying.
+
+The private report URL remains supported throughout this migration. Rotating or
+revoking a named API key does not change that private URL.
 
 ## Version 1 report
 

--- a/resources/lang/de/api.php
+++ b/resources/lang/de/api.php
@@ -7,21 +7,33 @@ return [
     'text' => 'Verwalten Sie Ihre API-Schlüssel und Zugriffstoken für sichere API-Interaktionen.',
     'configuration' => [
         'heading' => 'API-Konfiguration',
-        'description' => 'Verwalten Sie Ihre API-Einstellungen und Konfigurationen in diesem Bereich.',
+        'description' => 'Erstellen Sie getrennte Schlüssel mit minimalen Berechtigungen für jede Integration. Ein Schlüssel wird nur einmal angezeigt; danach bleiben nur sichere Metadaten sichtbar.',
         'fields' => [
             'token' => 'Ihr API-Token',
+            'name' => 'Schlüsselname',
+            'abilities' => 'Berechtigungen',
+            'last_used_at' => 'Zuletzt verwendet',
+            'status' => 'Status',
         ],
         'actions' => [
-            'generate_token' => 'Token generieren',
+            'create_key' => 'API-Schlüssel erstellen',
             'copy' => 'Kopieren',
-            'revoke_token' => 'Token widerrufen',
+            'revoke_key' => 'Schlüssel widerrufen',
         ],
         'messages' => [
             'copied' => 'API-Schlüssel in die Zwischenablage kopiert!',
-            'confirm_revoke_token' => 'Möchten Sie Ihren API-Token wirklich widerrufen? Bestehende Integrationen mit diesem Token funktionieren danach nicht mehr.',
-            'tokens_deleted' => 'Token erfolgreich gelöscht.',
+            'confirm_revoke_key' => 'Möchten Sie diesen API-Schlüssel wirklich widerrufen? Integrationen, die ihn verwenden, funktionieren danach sofort nicht mehr.',
+            'created' => 'API-Schlüssel erstellt. Kopieren Sie ihn jetzt: Er wird nicht erneut angezeigt.',
+            'revoked' => 'API-Schlüssel widerrufen.',
             'api_key_confidential_warning' => 'Halten Sie Ihren API-Schlüssel vertraulich. Wenn Sie glauben, dass Ihr Schlüssel kompromittiert wurde, können Sie einen neuen generieren.',
         ],
+        'abilities' => [
+            'server_health_write' => 'Server Health schreiben — nur Telemetrie senden',
+            'analytics_read' => 'Analytics lesen — nur unterstützte Reporting-Endpunkte verwenden',
+        ],
+        'active' => 'Aktiv',
+        'revoked' => 'Widerrufen',
+        'never_used' => 'Nie',
     ],
     'logs' => [
         'title' => 'API-Protokolle',

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -7,21 +7,33 @@ return [
     'text' => 'Manage your API keys and access tokens for secure API interactions.',
     'configuration' => [
         'heading' => 'API Configuration',
-        'description' => 'Manage your API settings and configurations from this section.',
+        'description' => 'Create separate least-privilege keys for each integration. A key is shown once, then only its non-sensitive metadata remains available.',
         'fields' => [
             'token' => 'Your API token',
+            'name' => 'Key name',
+            'abilities' => 'Permissions',
+            'last_used_at' => 'Last used',
+            'status' => 'Status',
         ],
         'actions' => [
-            'generate_token' => 'Generate token',
+            'create_key' => 'Create API key',
             'copy' => 'Copy',
-            'revoke_token' => 'Revoke token',
+            'revoke_key' => 'Revoke key',
         ],
         'messages' => [
             'copied' => 'API Key copied to clipboard!',
-            'confirm_revoke_token' => 'Are you sure you want to revoke your API token? Existing integrations that use this token will stop working.',
-            'tokens_deleted' => 'Tokens deleted successfully.',
+            'confirm_revoke_key' => 'Are you sure you want to revoke this API key? Integrations that use it will stop working immediately.',
+            'created' => 'API key created. Copy it now: it will not be shown again.',
+            'revoked' => 'API key revoked.',
             'api_key_confidential_warning' => 'Keep your API key confidential. If you believe your key has been compromised, you can generate a new one.',
         ],
+        'abilities' => [
+            'server_health_write' => 'Server Health write — submit telemetry only',
+            'analytics_read' => 'Analytics read — access supported reporting endpoints only',
+        ],
+        'active' => 'Active',
+        'revoked' => 'Revoked',
+        'never_used' => 'Never',
     ],
     'logs' => [
         'title' => 'API Logs',

--- a/resources/views/profile/partials/api-configuration.blade.php
+++ b/resources/views/profile/partials/api-configuration.blade.php
@@ -2,26 +2,69 @@
         {{ __('api.configuration.heading') }}
     </x-heading>
 
-    <x-paragraph>
-        {{ __('api.configuration.description') }}
-    </x-paragraph>
+    <x-paragraph>{{ __('api.configuration.description') }}</x-paragraph>
 
-    <div class="flex flex-wrap items-center gap-3">
-        <form method="POST" action="{{ route('profile.api-generate-token') }}">
-            @csrf
-            <x-primary-button>{{ __('api.configuration.actions.generate_token') }}</x-primary-button>
-        </form>
+    @if (session('api_key_plaintext'))
+        <x-api-token-display :token="session('api_key_plaintext')" />
+    @endif
 
-        <form method="POST" action="{{ route('profile.api-revoke-token') }}"
-            data-confirm-message="{{ __('api.configuration.messages.confirm_revoke_token') }}">
-            @csrf
-            @method('DELETE')
-            <x-danger-button :icon-only="true" title="{{ __('api.configuration.actions.revoke_token') }}"
-                aria-label="{{ __('api.configuration.actions.revoke_token') }}">
-                <x-icon name="x" class="h-4 w-4" />
-            </x-danger-button>
-        </form>
-    </div>
-    @if (Auth::user()->tokens->isNotEmpty())
-        <x-api-token-display :token="Auth::user()->tokens->last()->token" />
+    <form id="api-keys" method="POST" action="{{ route('profile.api-keys.store') }}" class="mt-5 space-y-4">
+        @csrf
+        <div>
+            <x-input-label for="api-key-name" :value="__('api.configuration.fields.name')" />
+            <x-text-input id="api-key-name" name="name" class="mt-1 block w-full" :value="old('name')" required maxlength="100" />
+            <x-input-error class="mt-2" :messages="$errors->get('name')" />
+        </div>
+
+        <fieldset>
+            <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('api.configuration.fields.abilities') }}</legend>
+            <div class="mt-2 space-y-2">
+                @foreach (\App\Enums\ApiKeyAbility::cases() as $ability)
+                    <label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                        <input type="checkbox" name="abilities[]" value="{{ $ability->value }}" @checked(in_array($ability->value, old('abilities', []), true))>
+                        <span>{{ __('api.configuration.abilities.' . str_replace([':', '-'], ['_', '_'], $ability->value)) }}</span>
+                    </label>
+                @endforeach
+            </div>
+            <x-input-error class="mt-2" :messages="$errors->get('abilities')" />
+        </fieldset>
+
+        <x-primary-button>{{ __('api.configuration.actions.create_key') }}</x-primary-button>
+    </form>
+
+    @if ($apiKeys?->isNotEmpty())
+        <div class="mt-6 overflow-x-auto">
+            <table class="min-w-full text-left text-sm">
+                <thead class="border-b border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                    <tr>
+                        <th class="px-3 py-2">{{ __('api.configuration.fields.name') }}</th>
+                        <th class="px-3 py-2">{{ __('api.configuration.fields.abilities') }}</th>
+                        <th class="px-3 py-2">{{ __('api.configuration.fields.last_used_at') }}</th>
+                        <th class="px-3 py-2">{{ __('api.configuration.fields.status') }}</th>
+                        <th class="px-3 py-2"><span class="sr-only">{{ __('api.configuration.actions.revoke_key') }}</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($apiKeys as $apiKey)
+                        <tr class="border-b border-gray-100 dark:border-gray-700/70">
+                            <td class="px-3 py-3 font-medium text-gray-900 dark:text-gray-100">{{ \App\Services\ApiKeyService::displayName($apiKey) }}</td>
+                            <td class="px-3 py-3 text-gray-600 dark:text-gray-300">{{ implode(', ', $apiKey->abilities ?? []) }}</td>
+                            <td class="px-3 py-3 text-gray-600 dark:text-gray-300">{{ $apiKey->last_used_at?->toIso8601String() ?? __('api.configuration.never_used') }}</td>
+                            <td class="px-3 py-3 text-gray-600 dark:text-gray-300">{{ $apiKey->revoked_at ? __('api.configuration.revoked') : __('api.configuration.active') }}</td>
+                            <td class="px-3 py-3 text-right">
+                                @if (! $apiKey->revoked_at)
+                                    <form method="POST" action="{{ route('profile.api-keys.destroy', $apiKey) }}" data-confirm-message="{{ __('api.configuration.messages.confirm_revoke_key') }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <x-danger-button :icon-only="true" title="{{ __('api.configuration.actions.revoke_key') }}" aria-label="{{ __('api.configuration.actions.revoke_key') }}">
+                                            <x-icon name="x" class="h-4 w-4" />
+                                        </x-danger-button>
+                                    </form>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
     @endif

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\External\ApiKeyController;
+use App\Http\Controllers\Api\External\BearerServerHealthReportController;
 use App\Http\Controllers\Api\Mobile\MobileAuthController;
 use App\Http\Controllers\Api\ServerHealthReportController;
 use App\Http\Controllers\ApiController;
@@ -20,6 +22,17 @@ Route::get('/public/status-pages/{statusPage}/uptime-calendar', PublicStatusPage
 Route::post('/v1/server-health/{token}', ServerHealthReportController::class)
     ->middleware('throttle:60,1')
     ->name('v1.server-health.store');
+
+Route::post('/v1/server-health/monitorings/{monitoring}', BearerServerHealthReportController::class)
+    ->middleware(['auth:sanctum', 'api-key.ability:server-health:write', 'throttle:60,1'])
+    ->name('v1.server-health.bearer.store');
+
+Route::group(['prefix' => 'v1/api-keys', 'as' => 'v1.api-keys.', 'middleware' => ['auth:sanctum', 'api-key.manage']], function (): void {
+    Route::get('/', [ApiKeyController::class, 'index'])->name('index');
+    Route::post('/', [ApiKeyController::class, 'store'])->name('store');
+    Route::get('/{apiKey}', [ApiKeyController::class, 'show'])->whereNumber('apiKey')->name('show');
+    Route::delete('/{apiKey}', [ApiKeyController::class, 'destroy'])->whereNumber('apiKey')->name('destroy');
+});
 
 Route::post('/mobile/login', [MobileAuthController::class, 'login'])
     ->middleware('throttle:5,1')

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -24,17 +24,17 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
     Route::post('/{monitoring}/team-ownership', [MonitoringManagementController::class, 'moveToTeam']);
     Route::delete('/{monitoring}/team-ownership', [MonitoringManagementController::class, 'moveToPrivate']);
 
-    Route::get('/{monitoring}', [MonitoringDataController::class, 'all']);
+    Route::get('/{monitoring}', [MonitoringDataController::class, 'all'])->name('analytics.all');
 
-    Route::get('/{monitoring}/status', [MonitoringDataController::class, 'status']);
-    Route::get('/{monitoring}/uptime-downtime', [MonitoringDataController::class, 'uptimeDowntime']);
-    Route::get('/{monitoring}/uptime-downtime-summary', [MonitoringDataController::class, 'uptimeDowntimeSummary']);
-    Route::get('/{monitoring}/response-times', [MonitoringDataController::class, 'responseTimes']);
-    Route::get('/{monitoring}/checks', [MonitoringDataController::class, 'checks']);
-    Route::get('/{monitoring}/incidents', [MonitoringDataController::class, 'incidents']);
-    Route::get('/{monitoring}/heatmap', [MonitoringDataController::class, 'uptimeHeatmap']);
-    Route::get('/{monitoring}/ssl', [MonitoringDataController::class, 'sslStatus']);
-    Route::get('/{monitoring}/uptime-calendar', [MonitoringDataController::class, 'uptimeCalendar']);
+    Route::get('/{monitoring}/status', [MonitoringDataController::class, 'status'])->name('analytics.status');
+    Route::get('/{monitoring}/uptime-downtime', [MonitoringDataController::class, 'uptimeDowntime'])->name('analytics.uptime-downtime');
+    Route::get('/{monitoring}/uptime-downtime-summary', [MonitoringDataController::class, 'uptimeDowntimeSummary'])->name('analytics.uptime-downtime-summary');
+    Route::get('/{monitoring}/response-times', [MonitoringDataController::class, 'responseTimes'])->name('analytics.response-times');
+    Route::get('/{monitoring}/checks', [MonitoringDataController::class, 'checks'])->name('analytics.checks');
+    Route::get('/{monitoring}/incidents', [MonitoringDataController::class, 'incidents'])->name('analytics.incidents');
+    Route::get('/{monitoring}/heatmap', [MonitoringDataController::class, 'uptimeHeatmap'])->name('analytics.heatmap');
+    Route::get('/{monitoring}/ssl', [MonitoringDataController::class, 'sslStatus'])->name('analytics.ssl');
+    Route::get('/{monitoring}/uptime-calendar', [MonitoringDataController::class, 'uptimeCalendar'])->name('analytics.uptime-calendar');
 });
 
 Route::get('/mobile/overview', MobileOverviewController::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\MonitoringGroupController;
 use App\Http\Controllers\MonitoringNotificationPreferenceController;
 use App\Http\Controllers\MonitoringOwnershipController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\ProfileApiKeyController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\PublicLabelController;
 use App\Http\Controllers\PublicStatusPageController;
@@ -126,8 +127,10 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::get('/dashboard', DashboardController::class)->name('dashboard');
 
     Route::group(['prefix' => 'profile', 'as' => 'profile.', 'middleware' => 'role:member,admin'], function (): void {
-        Route::post('/api-generate-token', [ProfileController::class, 'apiGenerateToken'])->name('api-generate-token');
-        Route::delete('/api-revoke-token', [ProfileController::class, 'apiRevokeToken'])->name('api-revoke-token');
+        Route::post('/api-keys', [ProfileApiKeyController::class, 'store'])->name('api-keys.store');
+        Route::delete('/api-keys/{apiKey}', [ProfileApiKeyController::class, 'destroy'])
+            ->whereNumber('apiKey')
+            ->name('api-keys.destroy');
         Route::post('/notification-channels/{channel}/test', [ProfileController::class, 'sendNotificationChannelTest'])
             ->name('notification-channels.test');
     });

--- a/tests/Feature/Api/ApiKeyApiTest.php
+++ b/tests/Feature/Api/ApiKeyApiTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\ApiKeyAbility;
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\PersonalAccessToken;
+use App\Models\User;
+use App\Services\ApiKeyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiKeyApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Package::factory()->create();
+    }
+
+    public function test_authenticated_user_can_create_and_list_a_named_scoped_key_without_exposing_its_secret(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->postJson(route('v1.api-keys.store'), [
+            'name' => 'Server agent',
+            'abilities' => [ApiKeyAbility::SERVER_HEALTH_WRITE->value],
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.key.name', 'Server agent')
+            ->assertJsonPath('data.key.abilities.0', ApiKeyAbility::SERVER_HEALTH_WRITE->value)
+            ->assertJsonPath('data.key.revoked', false);
+
+        $plainTextToken = (string) $response->json('data.token');
+        $token = PersonalAccessToken::query()->sole();
+
+        $this->assertStringContainsString('|', $plainTextToken);
+        $this->assertNotSame($plainTextToken, $token->token);
+        $this->assertSame(ApiKeyService::storedName('Server agent'), $token->name);
+
+        $this->actingAs($user)->getJson(route('v1.api-keys.index'))
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $token->id)
+            ->assertJsonPath('data.0.name', 'Server agent')
+            ->assertJsonPath('data.0.token_prefix', $token->id . '|')
+            ->assertJsonMissing(['token' => $plainTextToken])
+            ->assertJsonMissing(['token' => $token->token]);
+    }
+
+    public function test_key_names_are_unique_per_user_and_require_allowed_abilities(): void
+    {
+        $user = User::factory()->create();
+        $user->createToken(ApiKeyService::storedName('Analytics'), [ApiKeyAbility::ANALYTICS_READ->value]);
+
+        $this->actingAs($user)->postJson(route('v1.api-keys.store'), [
+            'name' => 'Analytics',
+            'abilities' => [],
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['name', 'abilities']);
+
+        $this->actingAs($user)->postJson(route('v1.api-keys.store'), [
+            'name' => 'Other key',
+            'abilities' => ['external:write'],
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['abilities.0']);
+    }
+
+    public function test_profile_surface_flashes_the_plaintext_key_once_after_creation(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('profile.api-keys.store'), [
+            'name' => 'Profile key',
+            'abilities' => [ApiKeyAbility::ANALYTICS_READ->value],
+        ]);
+
+        $response->assertRedirect(route('profile.edit', ['#api-keys']))
+            ->assertSessionHas('api_key_plaintext', fn (string $token): bool => str_contains($token, '|'));
+
+        $this->actingAs($user)->get(route('profile.edit'))
+            ->assertOk()
+            ->assertSee('Profile key')
+            ->assertSee('Analytics read');
+    }
+
+    public function test_key_metadata_is_scoped_to_its_owner_and_revocation_is_idempotent(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $token = $owner->createToken(ApiKeyService::storedName('Analytics'), [ApiKeyAbility::ANALYTICS_READ->value])->accessToken;
+
+        $this->actingAs($otherUser)->getJson(route('v1.api-keys.show', $token))
+            ->assertNotFound();
+
+        $this->actingAs($owner)->deleteJson(route('v1.api-keys.destroy', $token))
+            ->assertOk()
+            ->assertJsonPath('data.revoked', true);
+
+        $this->actingAs($owner)->deleteJson(route('v1.api-keys.destroy', $token))
+            ->assertOk()
+            ->assertJsonPath('data.revoked', true);
+
+        $this->assertNotNull($token->fresh()?->revoked_at);
+    }
+
+    public function test_analytics_key_can_only_read_analytics_routes_and_tracks_its_last_use(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $plainTextToken = $user->createToken(
+            ApiKeyService::storedName('Analytics'),
+            [ApiKeyAbility::ANALYTICS_READ->value]
+        )->plainTextToken;
+
+        $this->withToken($plainTextToken)
+            ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+            ->assertOk();
+
+        $this->withToken($plainTextToken)
+            ->deleteJson('/api/v1/monitorings/' . $monitoring->id)
+            ->assertForbidden();
+
+        $token = PersonalAccessToken::query()->where('name', ApiKeyService::storedName('Analytics'))->sole();
+        $this->assertNotNull($token->last_used_at);
+    }
+
+    public function test_server_health_key_can_submit_only_its_owners_server_health_monitoring(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($owner)->create([
+            'type' => MonitoringType::SERVER_HEALTH,
+        ]);
+        $otherMonitoring = Monitoring::factory()->for($otherUser)->create([
+            'type' => MonitoringType::SERVER_HEALTH,
+        ]);
+        $plainTextToken = $owner->createToken(
+            ApiKeyService::storedName('Server agent'),
+            [ApiKeyAbility::SERVER_HEALTH_WRITE->value]
+        )->plainTextToken;
+
+        $this->withToken($plainTextToken)
+            ->postJson(route('v1.server-health.bearer.store', $monitoring), ['cpu_usage_percent' => 42.5])
+            ->assertOk();
+
+        $this->withToken($plainTextToken)
+            ->postJson(route('v1.server-health.bearer.store', $otherMonitoring), ['cpu_usage_percent' => 42.5])
+            ->assertNotFound();
+
+        $this->withToken($plainTextToken)
+            ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+            ->assertForbidden();
+    }
+
+    public function test_revoked_key_can_no_longer_authenticate_but_existing_legacy_token_stays_compatible(): void
+    {
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $newToken = $user->createToken(
+            ApiKeyService::storedName('Analytics'),
+            [ApiKeyAbility::ANALYTICS_READ->value]
+        );
+        $legacyToken = $user->createToken(ApiKeyService::LEGACY_TOKEN_NAME)->plainTextToken;
+
+        resolve(ApiKeyService::class)->revoke($newToken->accessToken);
+
+        $this->withToken($newToken->plainTextToken)
+            ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+            ->assertUnauthorized();
+
+        $this->withToken($legacyToken)
+            ->getJson('/api/v1/monitorings/' . $monitoring->id . '/status')
+            ->assertOk();
+    }
+}

--- a/tests/Feature/Api/ApiKeyApiTest.php
+++ b/tests/Feature/Api/ApiKeyApiTest.php
@@ -29,30 +29,30 @@ class ApiKeyApiTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->postJson(route('v1.api-keys.store'), [
+        $testResponse = $this->actingAs($user)->postJson(route('v1.api-keys.store'), [
             'name' => 'Server agent',
             'abilities' => [ApiKeyAbility::SERVER_HEALTH_WRITE->value],
         ]);
 
-        $response->assertCreated()
+        $testResponse->assertCreated()
             ->assertJsonPath('data.key.name', 'Server agent')
             ->assertJsonPath('data.key.abilities.0', ApiKeyAbility::SERVER_HEALTH_WRITE->value)
             ->assertJsonPath('data.key.revoked', false);
 
-        $plainTextToken = (string) $response->json('data.token');
-        $token = PersonalAccessToken::query()->sole();
+        $plainTextToken = (string) $testResponse->json('data.token');
+        $personalAccessToken = PersonalAccessToken::query()->sole();
 
         $this->assertStringContainsString('|', $plainTextToken);
-        $this->assertNotSame($plainTextToken, $token->token);
-        $this->assertSame(ApiKeyService::storedName('Server agent'), $token->name);
+        $this->assertNotSame($plainTextToken, $personalAccessToken->token);
+        $this->assertSame(ApiKeyService::storedName('Server agent'), $personalAccessToken->name);
 
         $this->actingAs($user)->getJson(route('v1.api-keys.index'))
             ->assertOk()
-            ->assertJsonPath('data.0.id', $token->id)
+            ->assertJsonPath('data.0.id', $personalAccessToken->id)
             ->assertJsonPath('data.0.name', 'Server agent')
-            ->assertJsonPath('data.0.token_prefix', $token->id . '|')
+            ->assertJsonPath('data.0.token_prefix', $personalAccessToken->id . '|')
             ->assertJsonMissing(['token' => $plainTextToken])
-            ->assertJsonMissing(['token' => $token->token]);
+            ->assertJsonMissing(['token' => $personalAccessToken->token]);
     }
 
     public function test_key_names_are_unique_per_user_and_require_allowed_abilities(): void
@@ -79,12 +79,12 @@ class ApiKeyApiTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->post(route('profile.api-keys.store'), [
+        $testResponse = $this->actingAs($user)->post(route('profile.api-keys.store'), [
             'name' => 'Profile key',
             'abilities' => [ApiKeyAbility::ANALYTICS_READ->value],
         ]);
 
-        $response->assertRedirect(route('profile.edit', ['#api-keys']))
+        $testResponse->assertRedirect(route('profile.edit', ['#api-keys']))
             ->assertSessionHas('api_key_plaintext', fn (string $token): bool => str_contains($token, '|'));
 
         $this->actingAs($user)->get(route('profile.edit'))
@@ -130,8 +130,8 @@ class ApiKeyApiTest extends TestCase
             ->deleteJson('/api/v1/monitorings/' . $monitoring->id)
             ->assertForbidden();
 
-        $token = PersonalAccessToken::query()->where('name', ApiKeyService::storedName('Analytics'))->sole();
-        $this->assertNotNull($token->last_used_at);
+        $personalAccessToken = PersonalAccessToken::query()->where('name', ApiKeyService::storedName('Analytics'))->sole();
+        $this->assertNotNull($personalAccessToken->last_used_at);
     }
 
     public function test_server_health_key_can_submit_only_its_owners_server_health_monitoring(): void

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\ApiKeyAbility;
 use App\Enums\MonitoringLifecycleStatus;
 use App\Enums\MonitoringType;
 use App\Models\Monitoring;
@@ -259,15 +260,18 @@ class AuditLogTest extends TestCase
         ]);
         Activity::query()->delete();
 
-        $testResponse = $this->actingAs($user)->post(route('profile.api-generate-token'));
-        $testResponse->assertRedirect(route('profile.edit', ['#api-token']));
+        $testResponse = $this->actingAs($user)->post(route('profile.api-keys.store'), [
+            'name' => 'Audit key',
+            'abilities' => [ApiKeyAbility::ANALYTICS_READ->value],
+        ]);
+        $testResponse->assertRedirect(route('profile.edit', ['#api-keys']));
 
         $resetResponse = $this->actingAs($user)->delete(route('monitorings.destroyResults', $monitoring));
         $resetResponse->assertRedirect(route('monitorings.show', $monitoring));
 
         $this->assertDatabaseHas('activity_log', [
             'log_name' => 'user',
-            'event' => 'api_token_generated',
+            'event' => 'api_key_created',
             'subject_type' => User::class,
             'subject_id' => $user->id,
             'causer_type' => User::class,

--- a/tests/Feature/ProfileNotificationSettingsTest.php
+++ b/tests/Feature/ProfileNotificationSettingsTest.php
@@ -116,7 +116,8 @@ class ProfileNotificationSettingsTest extends TestCase
         $testResponse->assertSeeText(__('profile.notification_settings.unread_reminder.heading'));
         $testResponse->assertDontSeeText(__('profile.notification_settings.expiry_warning_days.heading'));
         $testResponse->assertSeeText(__('profile.notification_settings.hint_banner'));
-        $testResponse->assertSeeHtml('data-confirm-message="' . __('api.configuration.messages.confirm_revoke_token') . '"');
+        $testResponse->assertSeeHtml('id="api-keys"')
+            ->assertSeeHtml('name="abilities[]"');
 
         $secondResponse = $this->actingAs($user->fresh())->get(route('profile.edit'));
         $secondResponse->assertOk();


### PR DESCRIPTION
## What changed

- Added named, user-owned API keys with one-time plaintext delivery, metadata-only listing, filtering, and idempotent revocation.
- Added telemetry-only Server Health bearer ingestion and analytics-read route isolation.
- Retained existing `api-access` token compatibility while preventing new scoped keys from managing keys or crossing route boundaries.
- Documented key rotation, retention, and the Server Health migration path.

## Why

Customers need separate least-privilege credentials for telemetry and analytics integrations without exposing token material after creation.

## Testing

- `composer test` in the Docker PHP environment
- `php ./vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- Focused API-key, API-boundary, documentation, profile, audit-log, and Server Health tests

## Risks and follow-up

- Revoked token records are retained for metadata/auditability and require the included migration before deployment.
- The separate `webguard-server-agent` follow-up can now consume the documented bearer endpoint.

Closes #661