### PR TITLE
feat(api): add mobile monitoring group management

### DIFF
--- a/app/Http/Controllers/Api/External/MobileMonitoringGroupController.php
+++ b/app/Http/Controllers/Api/External/MobileMonitoringGroupController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 mobile monitoring-group contract.
+ *
+ * @group Mobile monitoring groups
+ *
+ * Manage private monitoring groups and their safe assignment metadata for native clients.
+ */
+class MobileMonitoringGroupController extends \App\Http\Controllers\Api\Mobile\MobileMonitoringGroupController {}

--- a/app/Http/Controllers/Api/Mobile/MobileMonitoringGroupController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileMonitoringGroupController.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Mobile\MobileMonitoringGroupRequest;
+use App\Http\Resources\External\MobileMonitoringAssignmentResource;
+use App\Http\Resources\External\MobileMonitoringGroupResource;
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\User;
+use App\Services\Monitorings\MonitoringGroupAssignmentService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+
+class MobileMonitoringGroupController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $monitoringGroups = $this->ownedGroups($user)
+            ->orderBy('name')
+            ->orderBy('id')
+            ->paginate($this->perPage($request));
+
+        $monitoringGroups->setCollection($monitoringGroups->getCollection()->map(
+            fn (MonitoringGroup $monitoringGroup): array => MobileMonitoringGroupResource::make($monitoringGroup)->resolve($request)
+        ));
+
+        return response()->json($monitoringGroups);
+    }
+
+    public function show(Request $request, string $monitoringGroup): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $group = $this->ownedGroup($user, $monitoringGroup)->load([
+            'monitorings' => fn ($query) => $query->privateOwnedBy($user)->orderBy('name')->orderBy('id'),
+        ])->loadCount([
+            'monitorings as assignable_monitoring_count' => fn ($query) => $query->privateOwnedBy($user),
+        ]);
+
+        return response()->json([
+            'data' => MobileMonitoringGroupResource::make($group)->resolve($request),
+        ]);
+    }
+
+    public function assignmentOptions(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $monitorings = Monitoring::query()
+            ->privateOwnedBy($user)
+            ->orderBy('name')
+            ->orderBy('id')
+            ->paginate($this->perPage($request));
+
+        $monitorings->setCollection($monitorings->getCollection()->map(
+            fn (Monitoring $monitoring): array => MobileMonitoringAssignmentResource::make($monitoring)->resolve($request)
+        ));
+
+        return response()->json($monitorings);
+    }
+
+    public function store(
+        MobileMonitoringGroupRequest $mobileMonitoringGroupRequest,
+        MonitoringGroupAssignmentService $monitoringGroupAssignmentService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $mobileMonitoringGroupRequest->user();
+        abort_if($user->isDemo(), 403);
+
+        $validated = $mobileMonitoringGroupRequest->validated();
+        $monitoringIds = $validated['monitoring_ids'] ?? [];
+        unset($validated['monitoring_ids']);
+
+        $monitoringGroup = DB::transaction(function () use ($user, $validated, $monitoringIds, $monitoringGroupAssignmentService): MonitoringGroup {
+            $monitoringGroup = $user->monitoringGroups()->create($validated);
+            $monitoringGroupAssignmentService->syncAssignableMonitorings($monitoringGroup, $user, $monitoringIds);
+
+            return $monitoringGroup;
+        });
+
+        return response()->json([
+            'data' => MobileMonitoringGroupResource::make($this->groupForResponse($user, $monitoringGroup))->resolve($mobileMonitoringGroupRequest),
+        ], 201);
+    }
+
+    public function update(
+        MobileMonitoringGroupRequest $mobileMonitoringGroupRequest,
+        string $monitoringGroup,
+        MonitoringGroupAssignmentService $monitoringGroupAssignmentService
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $mobileMonitoringGroupRequest->user();
+        abort_if($user->isDemo(), 403);
+
+        $group = $this->ownedGroup($user, $monitoringGroup);
+        $validated = $mobileMonitoringGroupRequest->validated();
+        $hasMonitoringIds = array_key_exists('monitoring_ids', $validated);
+        $monitoringIds = $validated['monitoring_ids'] ?? [];
+        $attributes = Arr::except($validated, ['monitoring_ids']);
+
+        DB::transaction(function () use ($group, $attributes, $hasMonitoringIds, $monitoringIds, $user, $monitoringGroupAssignmentService): void {
+            if ($attributes !== []) {
+                $group->update($attributes);
+            }
+
+            if ($hasMonitoringIds) {
+                $monitoringGroupAssignmentService->syncAssignableMonitorings($group, $user, $monitoringIds);
+            }
+        });
+
+        return response()->json([
+            'data' => MobileMonitoringGroupResource::make($this->groupForResponse($user, $group))->resolve($mobileMonitoringGroupRequest),
+        ]);
+    }
+
+    public function destroy(Request $request, string $monitoringGroup): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+
+        $this->ownedGroup($user, $monitoringGroup)->delete();
+
+        return response()->json(status: 204);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Builder<MonitoringGroup>
+     */
+    private function ownedGroups(User $user): \Illuminate\Database\Eloquent\Builder
+    {
+        return $user->monitoringGroups()->getQuery()->withCount([
+            'monitorings as assignable_monitoring_count' => fn ($query) => $query->privateOwnedBy($user),
+        ]);
+    }
+
+    private function ownedGroup(User $user, string $monitoringGroup): MonitoringGroup
+    {
+        return $this->ownedGroups($user)->whereKey($monitoringGroup)->firstOrFail();
+    }
+
+    private function groupForResponse(User $user, MonitoringGroup $monitoringGroup): MonitoringGroup
+    {
+        return $this->ownedGroups($user)
+            ->with(['monitorings' => fn ($query) => $query->privateOwnedBy($user)->orderBy('name')->orderBy('id')])
+            ->whereKey($monitoringGroup->id)
+            ->firstOrFail();
+    }
+
+    private function perPage(Request $request): int
+    {
+        return min(max((int) $request->integer('per_page', 25), 1), 100);
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/MobileMonitoringGroupController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileMonitoringGroupController.php
@@ -12,6 +12,7 @@ use App\Models\Monitoring;
 use App\Models\MonitoringGroup;
 use App\Models\User;
 use App\Services\Monitorings\MonitoringGroupAssignmentService;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -24,16 +25,16 @@ class MobileMonitoringGroupController extends Controller
         /** @var User $user */
         $user = $request->user();
 
-        $monitoringGroups = $this->ownedGroups($user)
+        $lengthAwarePaginator = $this->ownedGroups($user)
             ->orderBy('name')
             ->orderBy('id')
             ->paginate($this->perPage($request));
 
-        $monitoringGroups->setCollection($monitoringGroups->getCollection()->map(
+        $lengthAwarePaginator->setCollection($lengthAwarePaginator->getCollection()->map(
             fn (MonitoringGroup $monitoringGroup): array => MobileMonitoringGroupResource::make($monitoringGroup)->resolve($request)
         ));
 
-        return response()->json($monitoringGroups);
+        return response()->json($lengthAwarePaginator);
     }
 
     public function show(Request $request, string $monitoringGroup): JsonResponse
@@ -136,9 +137,9 @@ class MobileMonitoringGroupController extends Controller
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Builder<MonitoringGroup>
+     * @return Builder<MonitoringGroup>
      */
-    private function ownedGroups(User $user): \Illuminate\Database\Eloquent\Builder
+    private function ownedGroups(User $user): Builder
     {
         return $user->monitoringGroups()->getQuery()->withCount([
             'monitorings as assignable_monitoring_count' => fn ($query) => $query->privateOwnedBy($user),

--- a/app/Http/Controllers/Api/MonitoringManagementController.php
+++ b/app/Http/Controllers/Api/MonitoringManagementController.php
@@ -10,11 +10,14 @@ use App\Http\Resources\External\MonitoringResource;
 use App\Models\Monitoring;
 use App\Models\Team;
 use App\Models\User;
+use App\Services\Monitorings\MonitoringGroupAssignmentService;
 use App\Services\Monitorings\MonitoringOwnershipService;
 use App\Support\MonitoringPayload;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 
 /**
  * @group Monitoring Management
@@ -30,6 +33,10 @@ class MonitoringManagementController extends Controller
 
         $monitorings = Monitoring::query()
             ->visibleTo($user)
+            ->with([
+                'groups' => fn ($query) => $query->where('user_id', $user->id)->select(['id', 'name', 'description']),
+                'team.memberships' => fn ($query) => $query->where('user_id', $user->id),
+            ])
             ->orderBy('name')
             ->orderBy('id')
             ->paginate(min(max((int) $request->integer('per_page', 25), 1), 100));
@@ -41,8 +48,10 @@ class MonitoringManagementController extends Controller
         return response()->json($monitorings);
     }
 
-    public function store(MonitoringRequest $monitoringRequest): JsonResponse
-    {
+    public function store(
+        MonitoringRequest $monitoringRequest,
+        MonitoringGroupAssignmentService $monitoringGroupAssignmentService
+    ): JsonResponse {
         /** @var User $user */
         $user = $monitoringRequest->user();
         abort_if($user->isDemo(), 403);
@@ -54,41 +63,74 @@ class MonitoringManagementController extends Controller
 
         $validated = $monitoringRequest->validated();
         $teamId = $validated['team_id'] ?? null;
+        $groupIds = $validated['group_ids'] ?? [];
         unset($validated['group_ids'], $validated['team_id']);
+
+        if ($teamId !== null && $groupIds !== []) {
+            throw ValidationException::withMessages([
+                'group_ids' => [__('monitoring_group.validation.monitoring_not_manageable')],
+            ]);
+        }
 
         $payload = MonitoringPayload::prepareStore($validated);
 
-        if ($teamId) {
-            $payload['user_id'] = null;
-            $payload['team_id'] = $teamId;
-            $payload['created_by_user_id'] = $user->id;
+        $monitoring = DB::transaction(function () use ($teamId, $payload, $user, $groupIds, $monitoringGroupAssignmentService): Monitoring {
+            if ($teamId) {
+                $payload['user_id'] = null;
+                $payload['team_id'] = $teamId;
+                $payload['created_by_user_id'] = $user->id;
 
-            $monitoring = Monitoring::query()->create($payload);
-        } else {
+                return Monitoring::query()->create($payload);
+            }
+
             $monitoring = $user->monitorings()->create($payload);
-        }
+            $monitoringGroupAssignmentService->syncGroupsForPrivateMonitoring($monitoring, $user, $groupIds);
 
-        return response()->json(['data' => MonitoringResource::make($monitoring)->resolve($monitoringRequest)], 201);
+            return $monitoring;
+        });
+
+        return response()->json(['data' => MonitoringResource::make($monitoring->load([
+            'groups' => fn ($query) => $query->where('user_id', $user->id)->select(['id', 'name', 'description']),
+        ]))->resolve($monitoringRequest)], 201);
     }
 
-    public function update(MonitoringRequest $monitoringRequest, Monitoring $monitoring): JsonResponse
-    {
+    public function update(
+        MonitoringRequest $monitoringRequest,
+        Monitoring $monitoring,
+        MonitoringGroupAssignmentService $monitoringGroupAssignmentService
+    ): JsonResponse {
         /** @var User $user */
         $user = $monitoringRequest->user();
         abort_if($user->isDemo(), 403);
         abort_unless($monitoring->isManageableBy($user), 403);
 
         $validated = $monitoringRequest->validated();
+        $hasGroupIds = array_key_exists('group_ids', $validated);
+        $groupIds = $validated['group_ids'] ?? [];
         unset($validated['group_ids'], $validated['team_id']);
+
+        if ($hasGroupIds && ! $monitoring->isPrivateOwned()) {
+            throw ValidationException::withMessages([
+                'group_ids' => [__('monitoring_group.validation.monitoring_not_manageable')],
+            ]);
+        }
 
         $payload = MonitoringPayload::prepareUpdate($validated, $monitoring);
         if (! isset($payload['public_label_enabled']) || ! $payload['public_label_enabled']) {
             $payload['public_label_enabled'] = false;
         }
 
-        $monitoring->update($payload);
+        DB::transaction(function () use ($monitoring, $payload, $hasGroupIds, $groupIds, $user, $monitoringGroupAssignmentService): void {
+            $monitoring->update($payload);
 
-        return response()->json(['data' => MonitoringResource::make($monitoring->refresh())->resolve($monitoringRequest)]);
+            if ($hasGroupIds) {
+                $monitoringGroupAssignmentService->syncGroupsForPrivateMonitoring($monitoring, $user, $groupIds);
+            }
+        });
+
+        return response()->json(['data' => MonitoringResource::make($monitoring->refresh()->load([
+            'groups' => fn ($query) => $query->where('user_id', $user->id)->select(['id', 'name', 'description']),
+        ]))->resolve($monitoringRequest)]);
     }
 
     public function destroy(Request $request, Monitoring $monitoring): JsonResponse
@@ -128,7 +170,9 @@ class MonitoringManagementController extends Controller
         $team = Team::query()->findOrFail($validated['team_id']);
 
         return response()->json([
-            'data' => MonitoringResource::make($monitoringOwnershipService->moveToTeam($monitoring, $team, $user))->resolve($request),
+            'data' => MonitoringResource::make($monitoringOwnershipService->moveToTeam($monitoring, $team, $user)->load([
+                'groups' => fn ($query) => $query->where('user_id', $user->id)->select(['id', 'name', 'description']),
+            ]))->resolve($request),
         ]);
     }
 
@@ -142,7 +186,9 @@ class MonitoringManagementController extends Controller
         abort_if($user->isDemo(), 403);
 
         return response()->json([
-            'data' => MonitoringResource::make($monitoringOwnershipService->moveToPrivate($monitoring, $user))->resolve($request),
+            'data' => MonitoringResource::make($monitoringOwnershipService->moveToPrivate($monitoring, $user)->load([
+                'groups' => fn ($query) => $query->where('user_id', $user->id)->select(['id', 'name', 'description']),
+            ]))->resolve($request),
         ]);
     }
 }

--- a/app/Http/Requests/Api/Mobile/MobileMonitoringGroupRequest.php
+++ b/app/Http/Requests/Api/Mobile/MobileMonitoringGroupRequest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MobileMonitoringGroupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        /** @var MonitoringGroup|string|null $monitoringGroup */
+        $monitoringGroup = $this->route('monitoringGroup');
+        $monitoringGroupId = $monitoringGroup instanceof MonitoringGroup
+            ? $monitoringGroup->id
+            : $monitoringGroup;
+
+        return [
+            'name' => [
+                $this->isMethod('post') ? 'required' : 'sometimes',
+                'string',
+                'max:100',
+                Rule::unique('monitoring_groups', 'name')
+                    ->where('user_id', $this->user()?->id)
+                    ->ignore($monitoringGroupId),
+            ],
+            'description' => ['sometimes', 'nullable', 'string'],
+            'monitoring_ids' => ['sometimes', 'array', 'max:100'],
+            'monitoring_ids.*' => [
+                'string',
+                'distinct',
+                function (string $attribute, mixed $value, Closure $fail): void {
+                    $user = $this->user();
+
+                    if ($user === null || ! Monitoring::query()->privateOwnedBy($user)->whereKey((string) $value)->exists()) {
+                        $fail(__('monitoring_group.validation.monitoring_not_manageable'));
+                    }
+                },
+            ],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $prepared = [];
+
+        if ($this->has('name')) {
+            $prepared['name'] = mb_trim((string) $this->input('name'));
+        }
+
+        if ($this->has('description')) {
+            $description = mb_trim((string) $this->input('description'));
+            $prepared['description'] = $description !== '' ? $description : null;
+        }
+
+        if ($this->has('monitoring_ids')) {
+            $monitoringIds = $this->input('monitoring_ids', []);
+            if (! is_array($monitoringIds)) {
+                $monitoringIds = [$monitoringIds];
+            }
+
+            $prepared['monitoring_ids'] = array_values(array_filter(
+                array_map(static fn (mixed $monitoringId): string => (string) $monitoringId, $monitoringIds),
+                static fn (string $monitoringId): bool => $monitoringId !== ''
+            ));
+        }
+
+        $this->merge($prepared);
+    }
+}

--- a/app/Http/Requests/MonitoringRequest.php
+++ b/app/Http/Requests/MonitoringRequest.php
@@ -311,6 +311,7 @@ class MonitoringRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        $hasGroupIds = $this->has('group_ids');
         $type = mb_strtolower((string) $this->input('type'));
         $httpHeaders = $this->normalizeHttpHeaders();
         $dnsRecordType = DnsRecordExpectation::normalizeRecordType($this->input('dns_record_type'));
@@ -328,13 +329,16 @@ class MonitoringRequest extends FormRequest
             'notification_on_failure' => $this->boolean('notification_on_failure'),
             'notification_channels' => $this->normalizeNotificationChannels(),
             'team_id' => $this->normalizeTeamId(),
-            'group_ids' => $this->normalizeGroupIds(),
             'failure_confirmation_threshold' => $this->input('failure_confirmation_threshold', 2),
             'response_time_threshold_ms' => $this->normalizeNullableInteger('response_time_threshold_ms'),
             'response_time_confirmation_threshold' => $this->normalizeNullableInteger('response_time_confirmation_threshold'),
             'ssl_expiry_warning_days' => $this->input('ssl_expiry_warning_days', 7),
             'heartbeat_grace_minutes' => $this->input('heartbeat_grace_minutes', 5),
         ];
+
+        if ($hasGroupIds) {
+            $prepared['group_ids'] = $this->normalizeGroupIds();
+        }
 
         if ($type === MonitoringType::SERVER_HEALTH->value) {
             $prepared['server_health_cpu_threshold_percent'] = $this->input('server_health_cpu_threshold_percent', 90);

--- a/app/Http/Resources/External/MobileMonitoringAssignmentResource.php
+++ b/app/Http/Resources/External/MobileMonitoringAssignmentResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\External;
+
+use App\Models\Monitoring;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Monitoring
+ */
+final class MobileMonitoringAssignmentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Monitoring $monitoring */
+        $monitoring = $this->resource;
+
+        return [
+            'id' => $monitoring->id,
+            'name' => $monitoring->name,
+            'target' => $monitoring->target,
+            'type' => $monitoring->type?->value,
+            'status' => $monitoring->status?->value,
+            'ownership' => [
+                'type' => 'private',
+                'user_id' => $monitoring->user_id,
+                'team_id' => null,
+                'can_manage' => true,
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/External/MobileMonitoringGroupResource.php
+++ b/app/Http/Resources/External/MobileMonitoringGroupResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\External;
+
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin MonitoringGroup
+ */
+final class MobileMonitoringGroupResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var MonitoringGroup $monitoringGroup */
+        $monitoringGroup = $this->resource;
+
+        return [
+            'id' => $monitoringGroup->id,
+            'name' => $monitoringGroup->name,
+            'description' => $monitoringGroup->description,
+            'ownership' => [
+                'type' => 'private',
+                'user_id' => $monitoringGroup->user_id,
+                'team_id' => null,
+                'can_manage' => true,
+            ],
+            'assignable_monitoring_count' => (int) ($monitoringGroup->assignable_monitoring_count ?? 0),
+            'assignments' => $monitoringGroup->relationLoaded('monitorings')
+                ? $monitoringGroup->monitorings
+                    ->map(fn (Monitoring $monitoring): array => MobileMonitoringAssignmentResource::make($monitoring)->resolve($request))
+                    ->values()
+                    ->all()
+                : [],
+            'created_at' => $monitoringGroup->created_at?->toIso8601String(),
+            'updated_at' => $monitoringGroup->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/External/MonitoringResource.php
+++ b/app/Http/Resources/External/MonitoringResource.php
@@ -4,4 +4,60 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\External;
 
-final class MonitoringResource extends CompatibilityResource {}
+use App\Enums\TeamRole;
+use App\Models\Monitoring;
+use App\Models\TeamMembership;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+final class MonitoringResource extends CompatibilityResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Monitoring $monitoring */
+        $monitoring = $this->resource;
+        /** @var User|null $user */
+        $user = $request->user();
+        $payload = parent::toArray($request);
+
+        $payload['ownership'] = [
+            'type' => $monitoring->isTeamOwned() ? 'team' : 'private',
+            'user_id' => $monitoring->user_id,
+            'team_id' => $monitoring->team_id,
+            'can_manage' => $this->canManage($monitoring, $user),
+        ];
+        $payload['group_assignments'] = $monitoring->relationLoaded('groups')
+            ? $monitoring->groups
+                ->map(fn ($monitoringGroup): array => [
+                    'id' => $monitoringGroup->id,
+                    'name' => $monitoringGroup->name,
+                    'description' => $monitoringGroup->description,
+                ])
+                ->values()
+                ->all()
+            : [];
+
+        return $payload;
+    }
+
+    private function canManage(Monitoring $monitoring, ?User $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        if ($monitoring->isPrivateOwned()) {
+            return $monitoring->user_id === $user->id;
+        }
+
+        if ($monitoring->team?->relationLoaded('memberships')) {
+            return $monitoring->team->memberships
+                ->contains(fn (TeamMembership $membership): bool => $membership->user_id === $user->id && $membership->role === TeamRole::ADMIN);
+        }
+
+        return $monitoring->isManageableBy($user);
+    }
+}

--- a/app/Http/Resources/External/MonitoringResource.php
+++ b/app/Http/Resources/External/MonitoringResource.php
@@ -55,7 +55,7 @@ final class MonitoringResource extends CompatibilityResource
 
         if ($monitoring->team?->relationLoaded('memberships')) {
             return $monitoring->team->memberships
-                ->contains(fn (TeamMembership $membership): bool => $membership->user_id === $user->id && $membership->role === TeamRole::ADMIN);
+                ->contains(fn (TeamMembership $teamMembership): bool => $teamMembership->user_id === $user->id && $teamMembership->role === TeamRole::ADMIN);
         }
 
         return $monitoring->isManageableBy($user);

--- a/app/Services/Monitorings/MonitoringGroupAssignmentService.php
+++ b/app/Services/Monitorings/MonitoringGroupAssignmentService.php
@@ -11,6 +11,23 @@ use App\Models\User;
 class MonitoringGroupAssignmentService
 {
     /**
+     * @param  list<string>  $monitoringGroupIds
+     */
+    public function syncGroupsForPrivateMonitoring(
+        Monitoring $monitoring,
+        User $user,
+        array $monitoringGroupIds
+    ): void {
+        abort_unless($monitoring->isPrivateOwned() && $monitoring->user_id === $user->id, 403);
+
+        $ownedGroupIds = $user->monitoringGroups()
+            ->whereKey($monitoringGroupIds)
+            ->pluck('monitoring_groups.id');
+
+        $monitoring->groups()->sync($ownedGroupIds->all());
+    }
+
+    /**
      * @param  list<string>  $monitoringIds
      */
     public function syncAssignableMonitorings(

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -89,6 +89,36 @@ All retain their existing ownership checks and response contracts.
 Existing pre-scoped external tokens remain compatible. They are not converted
 to new keys automatically; rotate them from the profile when practical.
 
+## Mobile monitoring groups and ownership
+
+Native clients manage personal monitoring groups through `/api/v1/mobile/monitoring-groups`.
+The list and assignment-options endpoints use the standard Laravel paginator
+(`per_page` 1 through 100, default 25) and order by name and ID. Group payloads
+contain private ownership metadata, the number of safely assignable monitorings,
+and, for a detail or write response, the assigned private monitoring summaries.
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/mobile/monitoring-groups` | Paginated groups owned and manageable by the current user. |
+| `GET` | `/mobile/monitoring-groups/{id}` | One group and its safely visible private assignments. |
+| `GET` | `/mobile/monitoring-groups/assignment-options` | Paginated private monitorings available for assignment. |
+| `POST` | `/mobile/monitoring-groups` | Creates a personal group and optional assignments. |
+| `PATCH` | `/mobile/monitoring-groups/{id}` | Renames a group and/or replaces its supplied assignments. |
+| `DELETE` | `/mobile/monitoring-groups/{id}` | Deletes the group; monitorings remain and their pivot assignments are removed. |
+
+Groups are always personal. Only monitorings privately owned by the current user
+can be assigned; team-owned and foreign monitorings are rejected with `422` and
+field-keyed Laravel validation errors. A monitoring moved to team ownership is
+detached from all personal groups. Monitoring management responses now add
+`ownership` and `group_assignments` fields so mobile clients can render the
+result of create, update, and ownership changes without browser-form data.
+
+`POST` does not accept an idempotency key and should not be blindly retried after
+an unknown outcome. `PATCH` replaces assignments only when `monitoring_ids` is
+provided; omitting it leaves existing assignments unchanged. `DELETE` returns
+`404` for an unknown or inaccessible group, so clients should re-list groups
+after an unknown deletion outcome.
+
 Scribe generates the OpenAPI and reference documentation from route metadata,
 request rules, controller annotations, and this configuration. Do not edit the
 generated artifacts manually.

--- a/docs/architecture/api-boundaries.md
+++ b/docs/architecture/api-boundaries.md
@@ -24,6 +24,7 @@ The route family, authentication boundary, and owner are as follows.
 | Consumer | Route family | Authentication | Compatibility policy |
 | --- | --- | --- | --- |
 | External integrations | `/api/v1/*` | Sanctum personal-access token | Stable public contract; changes are additive or use a new major version. |
+| Native mobile clients | `/api/v1/mobile/*` | Sanctum mobile-app token | Stable client contract; browser form payloads are never part of this boundary. |
 | Management UI | `/api/v1/internal/ui/*` | Authenticated, verified browser session; CSRF protection for unsafe requests | Private application contract; evolve with the Core UI behind reversible rollout switches. |
 | Scanner instances | `/api/v1/internal/instances/*` | `X-INSTANCE-CODE` and `X-API-KEY` through `auth.instance` | Separate compatibility contract shared with `webguard-instance`. |
 | Public read endpoints | `/api/public/*` and explicit public routes | No account authentication; strict allowlisted payloads | Never expose private monitoring, team, token, or notification data. |

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
 use App\Http\Controllers\Api\External\MonitoringDataController;
@@ -39,6 +40,15 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
 Route::get('/mobile/overview', MobileOverviewController::class)
     ->name('mobile.overview');
+
+Route::group(['prefix' => 'mobile/monitoring-groups', 'as' => 'mobile.monitoring-groups.'], function (): void {
+    Route::get('/', [MobileMonitoringGroupController::class, 'index'])->name('index');
+    Route::get('/assignment-options', [MobileMonitoringGroupController::class, 'assignmentOptions'])->name('assignment-options');
+    Route::post('/', [MobileMonitoringGroupController::class, 'store'])->name('store');
+    Route::get('/{monitoringGroup}', [MobileMonitoringGroupController::class, 'show'])->name('show');
+    Route::patch('/{monitoringGroup}', [MobileMonitoringGroupController::class, 'update'])->name('update');
+    Route::delete('/{monitoringGroup}', [MobileMonitoringGroupController::class, 'destroy'])->name('destroy');
+});
 
 Route::apiResource('mobile-push-devices', MobilePushDeviceController::class)
     ->only(['index', 'store', 'update', 'destroy']);

--- a/tests/Feature/Api/MobileMonitoringGroupApiTest.php
+++ b/tests/Feature/Api/MobileMonitoringGroupApiTest.php
@@ -30,13 +30,13 @@ class MobileMonitoringGroupApiTest extends TestCase
         $foreignGroup = MonitoringGroup::factory()->for(User::factory()->create())->create(['name' => 'Hidden group']);
         Sanctum::actingAs($user);
 
-        $createResponse = $this->postJson('/api/v1/mobile/monitoring-groups', [
+        $testResponse = $this->postJson('/api/v1/mobile/monitoring-groups', [
             'name' => 'Production',
             'description' => 'Critical services',
             'monitoring_ids' => [$firstMonitoring->id],
         ]);
 
-        $createResponse
+        $testResponse
             ->assertCreated()
             ->assertJsonPath('data.name', 'Production')
             ->assertJsonPath('data.ownership.type', 'private')
@@ -132,17 +132,17 @@ class MobileMonitoringGroupApiTest extends TestCase
         $secondGroup = MonitoringGroup::factory()->for($user)->create(['name' => 'Billing']);
         Sanctum::actingAs($user);
 
-        $createResponse = $this->postJson('/api/v1/monitorings', $this->monitoringPayload($serverInstance, [
+        $testResponse = $this->postJson('/api/v1/monitorings', $this->monitoringPayload($serverInstance, [
             'group_ids' => [$firstGroup->id],
         ]));
 
-        $createResponse
+        $testResponse
             ->assertCreated()
             ->assertJsonPath('data.ownership.type', 'private')
             ->assertJsonPath('data.ownership.can_manage', true)
             ->assertJsonPath('data.group_assignments.0.id', $firstGroup->id);
 
-        $monitoringId = $createResponse->json('data.id');
+        $monitoringId = $testResponse->json('data.id');
 
         $this->patchJson('/api/v1/monitorings/' . $monitoringId, $this->monitoringPayload($serverInstance, [
             'group_ids' => [$secondGroup->id],

--- a/tests/Feature/Api/MobileMonitoringGroupApiTest.php
+++ b/tests/Feature/Api/MobileMonitoringGroupApiTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringLifecycleStatus;
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\Team;
+use App\Models\TeamMembership;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MobileMonitoringGroupApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_list_create_update_and_delete_own_mobile_monitoring_groups(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $firstMonitoring = Monitoring::factory()->for($user)->create(['name' => 'API']);
+        $secondMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Website']);
+        $foreignGroup = MonitoringGroup::factory()->for(User::factory()->create())->create(['name' => 'Hidden group']);
+        Sanctum::actingAs($user);
+
+        $createResponse = $this->postJson('/api/v1/mobile/monitoring-groups', [
+            'name' => 'Production',
+            'description' => 'Critical services',
+            'monitoring_ids' => [$firstMonitoring->id],
+        ]);
+
+        $createResponse
+            ->assertCreated()
+            ->assertJsonPath('data.name', 'Production')
+            ->assertJsonPath('data.ownership.type', 'private')
+            ->assertJsonPath('data.ownership.can_manage', true)
+            ->assertJsonPath('data.assignable_monitoring_count', 1)
+            ->assertJsonPath('data.assignments.0.id', $firstMonitoring->id);
+
+        $monitoringGroup = MonitoringGroup::query()->where('name', 'Production')->firstOrFail();
+
+        $this->getJson('/api/v1/mobile/monitoring-groups?per_page=1')
+            ->assertOk()
+            ->assertJsonPath('per_page', 1)
+            ->assertJsonPath('data.0.id', $monitoringGroup->id)
+            ->assertJsonMissing(['name' => $foreignGroup->name]);
+
+        $this->getJson('/api/v1/mobile/monitoring-groups/' . $monitoringGroup->id)
+            ->assertOk()
+            ->assertJsonPath('data.assignments.0.target', $firstMonitoring->target);
+
+        $this->patchJson('/api/v1/mobile/monitoring-groups/' . $monitoringGroup->id, [
+            'name' => 'Production services',
+            'monitoring_ids' => [$secondMonitoring->id],
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Production services')
+            ->assertJsonPath('data.assignments.0.id', $secondMonitoring->id);
+
+        $this->assertDatabaseMissing('monitoring_group_monitoring', [
+            'monitoring_group_id' => $monitoringGroup->id,
+            'monitoring_id' => $firstMonitoring->id,
+        ]);
+        $this->assertDatabaseHas('monitoring_group_monitoring', [
+            'monitoring_group_id' => $monitoringGroup->id,
+            'monitoring_id' => $secondMonitoring->id,
+        ]);
+
+        $this->deleteJson('/api/v1/mobile/monitoring-groups/' . $monitoringGroup->id)
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('monitoring_groups', ['id' => $monitoringGroup->id]);
+        $this->assertDatabaseHas('monitorings', ['id' => $secondMonitoring->id]);
+    }
+
+    public function test_mobile_group_assignment_options_and_mutations_exclude_team_and_foreign_monitorings(): void
+    {
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $privateMonitoring = Monitoring::factory()->for($user)->create(['name' => 'Private API']);
+        $foreignMonitoring = Monitoring::factory()->create(['name' => 'Foreign API']);
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        TeamMembership::factory()->for($team)->for($user)->admin()->create();
+        $teamMonitoring = Monitoring::factory()->for($team)->create([
+            'user_id' => null,
+            'name' => 'Team API',
+        ]);
+        $monitoringGroup = MonitoringGroup::factory()->for($user)->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/mobile/monitoring-groups/assignment-options')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $privateMonitoring->id)
+            ->assertJsonMissing(['id' => $foreignMonitoring->id])
+            ->assertJsonMissing(['id' => $teamMonitoring->id]);
+
+        $this->patchJson('/api/v1/mobile/monitoring-groups/' . $monitoringGroup->id, [
+            'monitoring_ids' => [$foreignMonitoring->id, $teamMonitoring->id],
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['monitoring_ids.0', 'monitoring_ids.1']);
+
+        $this->getJson('/api/v1/mobile/monitoring-groups/' . $monitoringGroup->id)
+            ->assertOk()
+            ->assertJsonPath('data.assignable_monitoring_count', 0);
+
+        $otherUser = User::factory()->create();
+        Sanctum::actingAs($otherUser);
+
+        $this->getJson('/api/v1/mobile/monitoring-groups/' . $monitoringGroup->id)
+            ->assertNotFound();
+    }
+
+    public function test_monitoring_management_contract_includes_group_assignments_and_ownership_metadata(): void
+    {
+        $package = Package::factory()->create(['monitoring_limit' => 5]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $serverInstance = ServerInstance::query()->create([
+            'code' => 'mobile-group-api',
+            'ip_address' => '192.0.2.71',
+            'api_key_hash' => 'test-token-1234567890',
+            'is_active' => true,
+        ]);
+        $firstGroup = MonitoringGroup::factory()->for($user)->create(['name' => 'Production']);
+        $secondGroup = MonitoringGroup::factory()->for($user)->create(['name' => 'Billing']);
+        Sanctum::actingAs($user);
+
+        $createResponse = $this->postJson('/api/v1/monitorings', $this->monitoringPayload($serverInstance, [
+            'group_ids' => [$firstGroup->id],
+        ]));
+
+        $createResponse
+            ->assertCreated()
+            ->assertJsonPath('data.ownership.type', 'private')
+            ->assertJsonPath('data.ownership.can_manage', true)
+            ->assertJsonPath('data.group_assignments.0.id', $firstGroup->id);
+
+        $monitoringId = $createResponse->json('data.id');
+
+        $this->patchJson('/api/v1/monitorings/' . $monitoringId, $this->monitoringPayload($serverInstance, [
+            'group_ids' => [$secondGroup->id],
+        ]))
+            ->assertOk()
+            ->assertJsonPath('data.group_assignments.0.id', $secondGroup->id);
+
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        TeamMembership::factory()->for($team)->for($user)->admin()->create();
+
+        $this->postJson('/api/v1/monitorings/' . $monitoringId . '/team-ownership', ['team_id' => $team->id])
+            ->assertOk()
+            ->assertJsonPath('data.ownership.type', 'team')
+            ->assertJsonPath('data.ownership.team_id', $team->id)
+            ->assertJsonPath('data.group_assignments', []);
+
+        $this->patchJson('/api/v1/monitorings/' . $monitoringId, $this->monitoringPayload($serverInstance, [
+            'group_ids' => [$firstGroup->id],
+        ]))
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('group_ids');
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function monitoringPayload(ServerInstance $serverInstance, array $overrides = []): array
+    {
+        return array_replace([
+            'name' => 'Mobile API Check',
+            'type' => MonitoringType::HTTP->value,
+            'target' => 'https://mobile.example.test',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'timeout' => 5,
+            'http_method' => 'get',
+            'expected_http_statuses' => '200-299',
+            'preferred_locations' => [$serverInstance->code],
+            'notification_on_failure' => true,
+            'failure_confirmation_threshold' => 1,
+            'ssl_expiry_warning_days' => 7,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## What changed

- adds versioned mobile monitoring-group endpoints with pagination, ownership metadata, and safe private-monitoring assignment options
- lets native clients create, rename, update assignments for, and delete personal monitoring groups
- adds additive ownership and group-assignment metadata to monitoring management and ownership responses
- documents the mobile v1 contract, retries, validation behavior, and API boundary

## Why

Native operator clients need a stable group and ownership workspace without depending on browser form payloads. The contract preserves existing private-versus-team ownership boundaries.

## Testing

- `composer test` in the Docker PHP container
- `php ./vendor/bin/phpstan analyse --no-progress --memory-limit=1G` in the Docker PHP container
- `php ./vendor/bin/pint --test` in the Docker PHP container
- focused mobile monitoring-group, monitoring-management, and route-boundary API tests

Closes #657