### PR TITLE
feat(api): add mobile status page incident workspace

### DIFF
--- a/app/Http/Controllers/Api/External/MobileStatusPageWorkspaceController.php
+++ b/app/Http/Controllers/Api/External/MobileStatusPageWorkspaceController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 mobile status-page workspace.
+ *
+ * @group Mobile status-page workspace
+ *
+ * Manage private status-page publication and authorized incident communication from native clients.
+ */
+class MobileStatusPageWorkspaceController extends \App\Http\Controllers\Api\Mobile\MobileStatusPageWorkspaceController {}

--- a/app/Http/Controllers/Api/Mobile/MobileStatusPageWorkspaceController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileStatusPageWorkspaceController.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Mobile\MobileStoreIncidentFollowUpRequest;
+use App\Http\Requests\Api\Mobile\MobileStoreIncidentTimelineEventRequest;
+use App\Http\Requests\Api\Mobile\MobileStoreIncidentUpdateRequest;
+use App\Http\Requests\StatusPages\UpdateIncidentFollowUpRequest;
+use App\Http\Requests\StatusPages\UpdateIncidentMetadataRequest;
+use App\Http\Requests\StatusPages\UpdateIncidentReviewRequest;
+use App\Http\Requests\StatusPages\UpdateIncidentTimelineEventRequest;
+use App\Http\Resources\External\MobileIncidentWorkspaceResource;
+use App\Http\Resources\External\MobileStatusPageResource;
+use App\Models\Incident;
+use App\Models\IncidentFollowUp;
+use App\Models\IncidentTimelineEvent;
+use App\Models\StatusPage;
+use App\Models\User;
+use App\Services\IncidentTimelineService;
+use App\Services\MobileStatusPageWorkspaceService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MobileStatusPageWorkspaceController extends Controller
+{
+    public function __construct(
+        private readonly IncidentTimelineService $incidentTimelineService,
+        private readonly MobileStatusPageWorkspaceService $mobileStatusPageWorkspaceService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $statusPages = $this->mobileStatusPageWorkspaceService->statusPagesFor($user)
+            ->latest()
+            ->paginate($this->perPage($request));
+
+        $statusPages->getCollection()->each(function (StatusPage $statusPage) use ($user): void {
+            $statusPage->setAttribute('open_incident_count', $this->mobileStatusPageWorkspaceService->openIncidentCount($statusPage, $user));
+        });
+        $statusPages->setCollection($statusPages->getCollection()->map(
+            fn (StatusPage $statusPage): array => MobileStatusPageResource::make($statusPage)->resolve($request)
+        ));
+
+        return response()->json($statusPages);
+    }
+
+    public function show(Request $request, string $statusPage): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $statusPageModel = $this->workspaceStatusPage($user, $statusPage);
+
+        return response()->json([
+            'data' => MobileStatusPageResource::make($statusPageModel)->resolve($request),
+        ]);
+    }
+
+    public function updatePublication(Request $request, string $statusPage): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validate(['is_public' => ['required', 'boolean']]);
+        $statusPageModel = $this->mobileStatusPageWorkspaceService->updatePublication(
+            $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage),
+            $user,
+            (bool) $validated['is_public'],
+        );
+
+        return response()->json([
+            'data' => MobileStatusPageResource::make($this->workspaceStatusPage($user, $statusPageModel->id))->resolve($request),
+        ]);
+    }
+
+    public function incidents(Request $request, string $statusPage): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $statusPageModel = $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage);
+        $validated = $request->validate(['state' => ['nullable', 'in:open,resolved']]);
+        $incidents = $this->mobileStatusPageWorkspaceService->incidentsFor($statusPageModel, $user)
+            ->when(
+                ($validated['state'] ?? null) === 'open',
+                fn ($query) => $query->whereNull('up_at'),
+                fn ($query) => ($validated['state'] ?? null) === 'resolved' ? $query->whereNotNull('up_at') : $query,
+            )
+            ->paginate($this->perPage($request));
+
+        $incidents->setCollection($incidents->getCollection()->map(
+            fn (Incident $incident): array => $this->incidentResource($incident)->resolve($request)
+        ));
+
+        return response()->json($incidents);
+    }
+
+    public function showIncident(Request $request, string $statusPage, string $incident): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+
+        return response()->json(['data' => $this->incidentResource($incidentModel)->resolve($request)]);
+    }
+
+    public function storeIncidentUpdate(MobileStoreIncidentUpdateRequest $request, string $statusPage, string $incident): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $result = $this->mobileStatusPageWorkspaceService->createUpdate($incidentModel, $user, $request->validated());
+
+        return response()->json([
+            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request),
+        ], $result['created'] ? 201 : 200);
+    }
+
+    public function updateMetadata(UpdateIncidentMetadataRequest $request, string $statusPage, string $incident): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $this->mobileStatusPageWorkspaceService->updateMetadata($incidentModel, $user, $request->validated());
+
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+    }
+
+    public function updateReview(UpdateIncidentReviewRequest $request, string $statusPage, string $incident): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $this->mobileStatusPageWorkspaceService->updateReview($incidentModel, $user, $request->validated());
+
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+    }
+
+    public function storeFollowUp(MobileStoreIncidentFollowUpRequest $request, string $statusPage, string $incident): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $statusPageModel = $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage);
+        $incidentModel = $this->mobileStatusPageWorkspaceService->incidentFor($statusPageModel, $user, $incident);
+        $result = $this->mobileStatusPageWorkspaceService->createFollowUp($incidentModel, $statusPageModel, $user, $request->validated());
+
+        return response()->json([
+            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request),
+        ], $result['created'] ? 201 : 200);
+    }
+
+    public function updateFollowUp(UpdateIncidentFollowUpRequest $request, string $statusPage, string $incident, string $incidentFollowUp): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $statusPageModel = $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage);
+        $incidentModel = $this->mobileStatusPageWorkspaceService->incidentFor($statusPageModel, $user, $incident);
+        $followUp = $this->followUpFor($incidentModel, $incidentFollowUp);
+        $this->mobileStatusPageWorkspaceService->updateFollowUp($followUp, $statusPageModel, $user, $request->validated());
+
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+    }
+
+    public function destroyFollowUp(Request $request, string $statusPage, string $incident, string $incidentFollowUp): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $this->mobileStatusPageWorkspaceService->deleteFollowUp($this->followUpFor($incidentModel, $incidentFollowUp), $user);
+
+        return response()->json(status: 204);
+    }
+
+    public function storeTimelineEvent(MobileStoreIncidentTimelineEventRequest $request, string $statusPage, string $incident): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $result = $this->mobileStatusPageWorkspaceService->createTimelineEvent($incidentModel, $user, $request->validated());
+
+        return response()->json([
+            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request),
+        ], $result['created'] ? 201 : 200);
+    }
+
+    public function updateTimelineEvent(UpdateIncidentTimelineEventRequest $request, string $statusPage, string $incident, string $incidentTimelineEvent): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $timelineEvent = $this->timelineEventFor($incidentModel, $incidentTimelineEvent);
+        $this->mobileStatusPageWorkspaceService->updateTimelineEvent($timelineEvent, $user, $request->validated());
+
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+    }
+
+    public function destroyTimelineEvent(Request $request, string $statusPage, string $incident, string $incidentTimelineEvent): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $incidentModel = $this->incidentFor($user, $statusPage, $incident);
+        $this->mobileStatusPageWorkspaceService->deleteTimelineEvent($this->timelineEventFor($incidentModel, $incidentTimelineEvent), $user);
+
+        return response()->json(status: 204);
+    }
+
+    private function workspaceStatusPage(User $user, string $statusPage): StatusPage
+    {
+        $statusPageModel = $this->mobileStatusPageWorkspaceService->loadWorkspace(
+            $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage),
+            $user,
+        );
+        $statusPageModel->setAttribute('open_incident_count', $this->mobileStatusPageWorkspaceService->openIncidentCount($statusPageModel, $user));
+
+        return $statusPageModel;
+    }
+
+    private function incidentFor(User $user, string $statusPage, string $incident): Incident
+    {
+        return $this->mobileStatusPageWorkspaceService->incidentFor(
+            $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage),
+            $user,
+            $incident,
+        );
+    }
+
+    private function followUpFor(Incident $incident, string $incidentFollowUp): IncidentFollowUp
+    {
+        return $incident->followUps()->whereKey($incidentFollowUp)->firstOrFail();
+    }
+
+    private function timelineEventFor(Incident $incident, string $incidentTimelineEvent): IncidentTimelineEvent
+    {
+        return $incident->timelineEvents()->whereKey($incidentTimelineEvent)->firstOrFail();
+    }
+
+    private function incidentResource(Incident $incident): MobileIncidentWorkspaceResource
+    {
+        return new MobileIncidentWorkspaceResource($incident, $this->incidentTimelineService);
+    }
+
+    private function perPage(Request $request): int
+    {
+        return min(max((int) $request->integer('per_page', 25), 1), 100);
+    }
+}

--- a/app/Http/Requests/Api/Mobile/Concerns/RequiresMobileIdempotencyKey.php
+++ b/app/Http/Requests/Api/Mobile/Concerns/RequiresMobileIdempotencyKey.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile\Concerns;
+
+trait RequiresMobileIdempotencyKey
+{
+    protected function prepareMobileIdempotencyKey(): void
+    {
+        $this->merge([
+            'idempotency_key' => mb_trim((string) $this->header('Idempotency-Key')),
+        ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function mobileIdempotencyKeyRules(): array
+    {
+        return ['required', 'string', 'max:100'];
+    }
+}

--- a/app/Http/Requests/Api/Mobile/MobileStoreIncidentFollowUpRequest.php
+++ b/app/Http/Requests/Api/Mobile/MobileStoreIncidentFollowUpRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use App\Http\Requests\Api\Mobile\Concerns\RequiresMobileIdempotencyKey;
+use App\Http\Requests\StatusPages\StoreIncidentFollowUpRequest;
+
+class MobileStoreIncidentFollowUpRequest extends StoreIncidentFollowUpRequest
+{
+    use RequiresMobileIdempotencyKey;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            ...parent::rules(),
+            'idempotency_key' => $this->mobileIdempotencyKeyRules(),
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        parent::prepareForValidation();
+        $this->prepareMobileIdempotencyKey();
+    }
+}

--- a/app/Http/Requests/Api/Mobile/MobileStoreIncidentTimelineEventRequest.php
+++ b/app/Http/Requests/Api/Mobile/MobileStoreIncidentTimelineEventRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use App\Http\Requests\Api\Mobile\Concerns\RequiresMobileIdempotencyKey;
+use App\Http\Requests\StatusPages\StoreIncidentTimelineEventRequest;
+
+class MobileStoreIncidentTimelineEventRequest extends StoreIncidentTimelineEventRequest
+{
+    use RequiresMobileIdempotencyKey;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            ...parent::rules(),
+            'idempotency_key' => $this->mobileIdempotencyKeyRules(),
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        parent::prepareForValidation();
+        $this->prepareMobileIdempotencyKey();
+    }
+}

--- a/app/Http/Requests/Api/Mobile/MobileStoreIncidentUpdateRequest.php
+++ b/app/Http/Requests/Api/Mobile/MobileStoreIncidentUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use App\Http\Requests\Api\Mobile\Concerns\RequiresMobileIdempotencyKey;
+use App\Http\Requests\StatusPages\StoreIncidentUpdateRequest;
+
+class MobileStoreIncidentUpdateRequest extends StoreIncidentUpdateRequest
+{
+    use RequiresMobileIdempotencyKey;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            ...parent::rules(),
+            'idempotency_key' => $this->mobileIdempotencyKeyRules(),
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        parent::prepareForValidation();
+        $this->prepareMobileIdempotencyKey();
+    }
+}

--- a/app/Http/Resources/External/MobileIncidentWorkspaceResource.php
+++ b/app/Http/Resources/External/MobileIncidentWorkspaceResource.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\External;
+
+use App\Models\Incident;
+use App\Models\IncidentFollowUp;
+use App\Models\IncidentTimelineEvent;
+use App\Models\IncidentUpdate;
+use App\Services\IncidentTimelineService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Incident
+ */
+final class MobileIncidentWorkspaceResource extends JsonResource
+{
+    public function __construct(Incident $resource, private readonly IncidentTimelineService $incidentTimelineService)
+    {
+        parent::__construct($resource);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Incident $incident */
+        $incident = $this->resource;
+
+        return [
+            'id' => $incident->id,
+            'monitoring' => [
+                'id' => $incident->monitoring->id,
+                'name' => $incident->monitoring->name,
+                'target' => $incident->monitoring->target,
+            ],
+            'lifecycle' => [
+                'state' => $incident->up_at === null ? 'open' : 'resolved',
+                'opened_at' => $incident->down_at?->toIso8601String(),
+                'resolved_at' => $incident->up_at?->toIso8601String(),
+            ],
+            'metadata' => [
+                'incident_type' => $incident->incident_type?->value,
+                'severity' => $incident->severity?->value,
+                'affected_service' => $incident->affected_service,
+                'customer_impact' => $incident->customer_impact?->value,
+                'contributing_category' => $incident->contributing_category?->value,
+                'problem_description' => $incident->problem_description,
+                'resolution_description' => $incident->resolution_description,
+            ],
+            'readiness' => [
+                'can_publish_update' => true,
+                'requires_public_update' => $incident->up_at === null && $incident->updates->isEmpty(),
+                'update_count' => $incident->updates->count(),
+            ],
+            'updates' => $incident->updates
+                ->map(fn (IncidentUpdate $incidentUpdate): array => [
+                    'id' => $incidentUpdate->id,
+                    'status' => $incidentUpdate->status->value,
+                    'message' => $incidentUpdate->message,
+                    'published_at' => $incidentUpdate->created_at?->toIso8601String(),
+                ])
+                ->values()
+                ->all(),
+            'follow_ups' => $incident->followUps
+                ->map(fn (IncidentFollowUp $incidentFollowUp): array => [
+                    'id' => $incidentFollowUp->id,
+                    'title' => $incidentFollowUp->title,
+                    'description' => $incidentFollowUp->description,
+                    'status' => $incidentFollowUp->status->value,
+                    'assigned_user' => $incidentFollowUp->assignedUser === null ? null : [
+                        'id' => $incidentFollowUp->assignedUser->id,
+                        'name' => $incidentFollowUp->assignedUser->name,
+                    ],
+                    'due_at' => $incidentFollowUp->due_at?->toDateString(),
+                    'completed_at' => $incidentFollowUp->completed_at?->toIso8601String(),
+                    'external_url' => $incidentFollowUp->external_url,
+                    'updated_at' => $incidentFollowUp->updated_at?->toIso8601String(),
+                ])
+                ->values()
+                ->all(),
+            'timeline' => $this->incidentTimelineService->events($incident)
+                ->map(fn (array $event): array => [
+                    'id' => $event['id'],
+                    'title' => $event['title'],
+                    'description' => $event['description'],
+                    'occurred_at' => $event['occurred_at']->toIso8601String(),
+                    'source_type' => $event['source_type'],
+                    'can_edit' => $event['source_type'] === 'custom',
+                ])
+                ->values()
+                ->all(),
+            'custom_timeline_events' => $incident->timelineEvents
+                ->map(fn (IncidentTimelineEvent $incidentTimelineEvent): array => [
+                    'id' => $incidentTimelineEvent->id,
+                    'title' => $incidentTimelineEvent->title,
+                    'description' => $incidentTimelineEvent->description,
+                    'occurred_at' => $incidentTimelineEvent->occurred_at->toIso8601String(),
+                    'updated_at' => $incidentTimelineEvent->updated_at?->toIso8601String(),
+                ])
+                ->values()
+                ->all(),
+            'updated_at' => $incident->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/External/MobileStatusPageResource.php
+++ b/app/Http/Resources/External/MobileStatusPageResource.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\External;
+
+use App\Models\Monitoring;
+use App\Models\StatusPage;
+use App\Models\StatusPageComponent;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin StatusPage
+ */
+final class MobileStatusPageResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var StatusPage $statusPage */
+        $statusPage = $this->resource;
+
+        return [
+            'id' => $statusPage->id,
+            'name' => $statusPage->name,
+            'description' => $statusPage->description,
+            'publication' => [
+                'is_public' => $statusPage->is_public,
+                'can_change' => true,
+            ],
+            'component_count' => (int) ($statusPage->components_count ?? 0),
+            'verified_subscriber_count' => (int) ($statusPage->verified_subscriber_count ?? 0),
+            'open_incident_count' => (int) ($statusPage->open_incident_count ?? 0),
+            'components' => $statusPage->relationLoaded('components')
+                ? $statusPage->components
+                    ->map(fn (StatusPageComponent $component): array => $this->componentPayload($component))
+                    ->values()
+                    ->all()
+                : [],
+            'created_at' => $statusPage->created_at?->toIso8601String(),
+            'updated_at' => $statusPage->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function componentPayload(StatusPageComponent $component): array
+    {
+        return [
+            'id' => $component->id,
+            'name' => $component->name,
+            'description' => $component->description,
+            'position' => $component->position,
+            'source_type' => $component->source_type->value,
+            'monitoring_group' => $component->relationLoaded('monitoringGroup') && $component->monitoringGroup !== null
+                ? [
+                    'id' => $component->monitoringGroup->id,
+                    'name' => $component->monitoringGroup->name,
+                    'monitoring_count' => (int) ($component->monitoringGroup->monitorings_count ?? 0),
+                ]
+                : null,
+            'monitorings' => $this->componentMonitorings($component)
+                ->map(fn (Monitoring $monitoring): array => [
+                    'id' => $monitoring->id,
+                    'name' => $monitoring->name,
+                    'target' => $monitoring->target,
+                ])
+                ->values()
+                ->all(),
+        ];
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, Monitoring>
+     */
+    private function componentMonitorings(StatusPageComponent $component): \Illuminate\Support\Collection
+    {
+        if ($component->source_type->value === 'monitoring_group') {
+            return $component->monitoringGroup?->monitorings ?? collect();
+        }
+
+        return $component->monitorings;
+    }
+}

--- a/app/Models/IncidentFollowUp.php
+++ b/app/Models/IncidentFollowUp.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
     'due_at',
     'completed_at',
     'external_url',
+    'mobile_idempotency_key',
 ])]
 #[WithoutIncrementing]
 class IncidentFollowUp extends Model

--- a/app/Models/IncidentTimelineEvent.php
+++ b/app/Models/IncidentTimelineEvent.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
     'description',
     'occurred_at',
     'source_type',
+    'mobile_idempotency_key',
 ])]
 #[WithoutIncrementing]
 class IncidentTimelineEvent extends Model

--- a/app/Models/IncidentUpdate.php
+++ b/app/Models/IncidentUpdate.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
     'incident_id',
     'status',
     'message',
+    'mobile_idempotency_key',
 ])]
 #[WithoutIncrementing]
 class IncidentUpdate extends Model

--- a/app/Services/MobileStatusPageWorkspaceService.php
+++ b/app/Services/MobileStatusPageWorkspaceService.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\IncidentFollowUpStatus;
+use App\Models\Incident;
+use App\Models\IncidentFollowUp;
+use App\Models\IncidentTimelineEvent;
+use App\Models\IncidentUpdate;
+use App\Models\StatusPage;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+class MobileStatusPageWorkspaceService
+{
+    public function statusPageFor(User $user, string $statusPageId): StatusPage
+    {
+        return StatusPage::query()
+            ->where('user_id', $user->id)
+            ->whereKey($statusPageId)
+            ->firstOrFail();
+    }
+
+    /**
+     * @return Builder<StatusPage>
+     */
+    public function statusPagesFor(User $user): Builder
+    {
+        return StatusPage::query()
+            ->where('user_id', $user->id)
+            ->withCount([
+                'components',
+                'subscriptions as verified_subscriber_count' => fn (Builder $query) => $query->whereNotNull('verified_at'),
+            ]);
+    }
+
+    public function loadWorkspace(StatusPage $statusPage, User $user): StatusPage
+    {
+        return $statusPage->load([
+            'components.monitoringGroup' => fn ($query) => $query->withCount('monitorings'),
+            'components.monitorings' => fn ($query) => $query->manageableBy($user)->orderBy('name')->orderBy('id'),
+            'components.monitoringGroup.monitorings' => fn ($query) => $query->manageableBy($user)->orderBy('name')->orderBy('id'),
+        ])->loadCount([
+            'components',
+            'subscriptions as verified_subscriber_count' => fn (Builder $query) => $query->whereNotNull('verified_at'),
+        ]);
+    }
+
+    /**
+     * @return Builder<Incident>
+     */
+    public function incidentsFor(StatusPage $statusPage, User $user): Builder
+    {
+        return Incident::query()
+            ->whereIn('monitoring_id', $this->statusPageMonitoringIds($statusPage))
+            ->whereHas('monitoring', fn (Builder $query) => $query->manageableBy($user))
+            ->with([
+                'monitoring',
+                'updates',
+                'followUps.assignedUser',
+                'timelineEvents',
+            ])
+            ->latest('down_at');
+    }
+
+    public function incidentFor(StatusPage $statusPage, User $user, string $incidentId): Incident
+    {
+        return $this->incidentsFor($statusPage, $user)
+            ->whereKey($incidentId)
+            ->firstOrFail();
+    }
+
+    public function openIncidentCount(StatusPage $statusPage, User $user): int
+    {
+        return $this->incidentsFor($statusPage, $user)
+            ->whereNull('up_at')
+            ->count();
+    }
+
+    public function updatePublication(StatusPage $statusPage, User $user, bool $isPublic): StatusPage
+    {
+        abort_if($user->isDemo(), 403);
+
+        $statusPage->update(['is_public' => $isPublic]);
+        $this->log($user, $statusPage, $isPublic ? 'status_page_published' : 'status_page_unpublished');
+
+        return $statusPage->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{incidentUpdate: IncidentUpdate, created: bool}
+     */
+    public function createUpdate(Incident $incident, User $user, array $attributes): array
+    {
+        $idempotencyKey = (string) Arr::pull($attributes, 'idempotency_key');
+
+        return DB::transaction(function () use ($incident, $user, $attributes, $idempotencyKey): array {
+            $incidentUpdate = $incident->updates()
+                ->where('mobile_idempotency_key', $idempotencyKey)
+                ->first();
+
+            if ($incidentUpdate instanceof IncidentUpdate) {
+                return ['incidentUpdate' => $incidentUpdate, 'created' => false];
+            }
+
+            $incidentUpdate = $incident->updates()->create([
+                ...$attributes,
+                'mobile_idempotency_key' => $idempotencyKey,
+            ]);
+            $this->log($user, $incident, 'incident_update_published', ['incident_update_id' => $incidentUpdate->id]);
+
+            return ['incidentUpdate' => $incidentUpdate, 'created' => true];
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function updateMetadata(Incident $incident, User $user, array $attributes): Incident
+    {
+        abort_if($user->isDemo(), 403);
+        $incident->update($attributes);
+        $this->log($user, $incident, 'incident_metadata_updated');
+
+        return $incident->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function updateReview(Incident $incident, User $user, array $attributes): Incident
+    {
+        abort_if($user->isDemo(), 403);
+        $incident->update($attributes);
+        $this->log($user, $incident, 'incident_review_updated');
+
+        return $incident->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{incidentFollowUp: IncidentFollowUp, created: bool}
+     */
+    public function createFollowUp(Incident $incident, StatusPage $statusPage, User $user, array $attributes): array
+    {
+        abort_if($user->isDemo(), 403);
+        $this->assertAssignedUserIsStatusPageOwner($statusPage, $attributes['assigned_user_id'] ?? null);
+        $idempotencyKey = (string) Arr::pull($attributes, 'idempotency_key');
+
+        return DB::transaction(function () use ($incident, $user, $attributes, $idempotencyKey): array {
+            $incidentFollowUp = $incident->followUps()
+                ->where('mobile_idempotency_key', $idempotencyKey)
+                ->first();
+
+            if ($incidentFollowUp instanceof IncidentFollowUp) {
+                return ['incidentFollowUp' => $incidentFollowUp, 'created' => false];
+            }
+
+            $incidentFollowUp = $incident->followUps()->create([
+                ...$attributes,
+                'status' => IncidentFollowUpStatus::OPEN,
+                'mobile_idempotency_key' => $idempotencyKey,
+            ]);
+            $this->log($user, $incident, 'incident_follow_up_created', ['incident_follow_up_id' => $incidentFollowUp->id]);
+
+            return ['incidentFollowUp' => $incidentFollowUp, 'created' => true];
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function updateFollowUp(IncidentFollowUp $incidentFollowUp, StatusPage $statusPage, User $user, array $attributes): IncidentFollowUp
+    {
+        abort_if($user->isDemo(), 403);
+        $this->assertAssignedUserIsStatusPageOwner($statusPage, $attributes['assigned_user_id'] ?? null);
+        $attributes['completed_at'] = $attributes['status'] === IncidentFollowUpStatus::COMPLETED->value
+            ? ($incidentFollowUp->completed_at ?? Date::now())
+            : null;
+        $incidentFollowUp->update($attributes);
+        $this->log($user, $incidentFollowUp->incident, 'incident_follow_up_updated', ['incident_follow_up_id' => $incidentFollowUp->id]);
+
+        return $incidentFollowUp->refresh();
+    }
+
+    public function deleteFollowUp(IncidentFollowUp $incidentFollowUp, User $user): void
+    {
+        abort_if($user->isDemo(), 403);
+        $incident = $incidentFollowUp->incident;
+        $incidentFollowUp->delete();
+        $this->log($user, $incident, 'incident_follow_up_deleted', ['incident_follow_up_id' => $incidentFollowUp->id]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{incidentTimelineEvent: IncidentTimelineEvent, created: bool}
+     */
+    public function createTimelineEvent(Incident $incident, User $user, array $attributes): array
+    {
+        abort_if($user->isDemo(), 403);
+        $idempotencyKey = (string) Arr::pull($attributes, 'idempotency_key');
+
+        return DB::transaction(function () use ($incident, $user, $attributes, $idempotencyKey): array {
+            $incidentTimelineEvent = $incident->timelineEvents()
+                ->where('mobile_idempotency_key', $idempotencyKey)
+                ->first();
+
+            if ($incidentTimelineEvent instanceof IncidentTimelineEvent) {
+                return ['incidentTimelineEvent' => $incidentTimelineEvent, 'created' => false];
+            }
+
+            $incidentTimelineEvent = $incident->timelineEvents()->create([
+                ...$attributes,
+                'source_type' => 'custom',
+                'mobile_idempotency_key' => $idempotencyKey,
+            ]);
+            $this->log($user, $incident, 'incident_timeline_event_created', ['incident_timeline_event_id' => $incidentTimelineEvent->id]);
+
+            return ['incidentTimelineEvent' => $incidentTimelineEvent, 'created' => true];
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function updateTimelineEvent(IncidentTimelineEvent $incidentTimelineEvent, User $user, array $attributes): IncidentTimelineEvent
+    {
+        abort_if($user->isDemo(), 403);
+        $incidentTimelineEvent->update($attributes);
+        $this->log($user, $incidentTimelineEvent->incident, 'incident_timeline_event_updated', ['incident_timeline_event_id' => $incidentTimelineEvent->id]);
+
+        return $incidentTimelineEvent->refresh();
+    }
+
+    public function deleteTimelineEvent(IncidentTimelineEvent $incidentTimelineEvent, User $user): void
+    {
+        abort_if($user->isDemo(), 403);
+        $incident = $incidentTimelineEvent->incident;
+        $incidentTimelineEvent->delete();
+        $this->log($user, $incident, 'incident_timeline_event_deleted', ['incident_timeline_event_id' => $incidentTimelineEvent->id]);
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, string>
+     */
+    private function statusPageMonitoringIds(StatusPage $statusPage): \Illuminate\Support\Collection
+    {
+        $statusPage->loadMissing(['components.monitorings:id', 'components.monitoringGroup.monitorings:id']);
+
+        return $statusPage->components
+            ->flatMap(fn ($component) => $component->source_type->value === 'monitoring_group'
+                ? $component->monitoringGroup?->monitorings->pluck('id') ?? []
+                : $component->monitorings->pluck('id'))
+            ->unique()
+            ->values();
+    }
+
+    private function assertAssignedUserIsStatusPageOwner(StatusPage $statusPage, ?string $assignedUserId): void
+    {
+        abort_unless($assignedUserId === null || $assignedUserId === $statusPage->user_id, 422);
+    }
+
+    /**
+     * @param  array<string, string>  $properties
+     */
+    private function log(User $user, mixed $subject, string $event, array $properties = []): void
+    {
+        activity('status_page')
+            ->causedBy($user)
+            ->performedOn($subject)
+            ->event($event)
+            ->withProperties(['action' => $event, ...$properties])
+            ->log($event);
+    }
+}

--- a/database/migrations/2026_08_09_210000_add_mobile_idempotency_keys_to_incident_communications.php
+++ b/database/migrations/2026_08_09_210000_add_mobile_idempotency_keys_to_incident_communications.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('incident_updates', function (Blueprint $table): void {
+            $table->string('mobile_idempotency_key', 100)->nullable()->after('message');
+            $table->unique(['incident_id', 'mobile_idempotency_key'], 'incident_updates_mobile_idempotency_unique');
+        });
+
+        Schema::table('incident_follow_ups', function (Blueprint $table): void {
+            $table->string('mobile_idempotency_key', 100)->nullable()->after('external_url');
+            $table->unique(['incident_id', 'mobile_idempotency_key'], 'incident_follow_ups_mobile_idempotency_unique');
+        });
+
+        Schema::table('incident_timeline_events', function (Blueprint $table): void {
+            $table->string('mobile_idempotency_key', 100)->nullable()->after('source_type');
+            $table->unique(['incident_id', 'mobile_idempotency_key'], 'incident_timeline_mobile_idempotency_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('incident_updates', function (Blueprint $table): void {
+            $table->dropUnique('incident_updates_mobile_idempotency_unique');
+            $table->dropColumn('mobile_idempotency_key');
+        });
+
+        Schema::table('incident_follow_ups', function (Blueprint $table): void {
+            $table->dropUnique('incident_follow_ups_mobile_idempotency_unique');
+            $table->dropColumn('mobile_idempotency_key');
+        });
+
+        Schema::table('incident_timeline_events', function (Blueprint $table): void {
+            $table->dropUnique('incident_timeline_mobile_idempotency_unique');
+            $table->dropColumn('mobile_idempotency_key');
+        });
+    }
+};

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -119,6 +119,43 @@ provided; omitting it leaves existing assignments unchanged. `DELETE` returns
 `404` for an unknown or inaccessible group, so clients should re-list groups
 after an unknown deletion outcome.
 
+## Mobile status-page incident workspace
+
+Native clients use `/api/v1/mobile/status-pages` for a private workspace that
+is deliberately separate from public status-page output and browser management
+routes. A status page is visible only to its owner. Incidents are included only
+when their monitoring is manageable by that user; team-owned monitorings
+therefore require the existing team-administrator permission. Inaccessible
+status pages and incidents return `404`, avoiding ownership disclosure.
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/mobile/status-pages` | Paginated private status-page summaries, including publication state, component and verified subscriber counts, and open incident count. |
+| `GET` | `/mobile/status-pages/{statusPage}` | One workspace with safely manageable components and monitoring-group context. |
+| `PATCH` | `/mobile/status-pages/{statusPage}/publication` | Publishes or unpublishes the status page with `is_public`. |
+| `GET` | `/mobile/status-pages/{statusPage}/incidents?state=open|resolved` | Paginated incident workspaces for the status page. |
+| `GET` | `/mobile/status-pages/{statusPage}/incidents/{incident}` | One incident with private metadata, readiness, updates, follow-ups, and timeline. |
+| `POST` | `/mobile/status-pages/{statusPage}/incidents/{incident}/updates` | Creates a public incident update. |
+| `PATCH` | `/mobile/status-pages/{statusPage}/incidents/{incident}/metadata` | Updates incident severity, affected service, and private metadata. |
+| `PATCH` | `/mobile/status-pages/{statusPage}/incidents/{incident}/review` | Updates post-incident review fields. |
+| `POST`, `PATCH`, `DELETE` | `/mobile/status-pages/{statusPage}/incidents/{incident}/follow-ups[/{followUp}]` | Creates, updates, or removes follow-up work. |
+| `POST`, `PATCH`, `DELETE` | `/mobile/status-pages/{statusPage}/incidents/{incident}/timeline[/{timelineEvent}]` | Creates, updates, or removes custom timeline entries. |
+
+`POST` requests for updates, follow-ups, and custom timeline events require an
+`Idempotency-Key` header (one to 100 characters). The key is stored per
+incident and communication type: the first request returns `201`, while a
+retry with the same key returns the original resource with `200` and creates no
+additional update, follow-up, timeline event, or audit record. `PATCH` and
+`DELETE` have normal HTTP idempotency semantics; clients should use the returned
+current resource state or re-read after an unknown outcome rather than infer a
+concurrent write result.
+
+The workspace uses ordinary Laravel field-keyed validation errors. Mutations
+are recorded in the activity log with the authenticated user as causer; token
+values and authorization headers are never recorded. Public status-page
+endpoints and browser management routes keep their existing contracts and do
+not expose this private workspace payload.
+
 Scribe generates the OpenAPI and reference documentation from route metadata,
 request rules, controller annotations, and this configuration. Do not edit the
 generated artifacts manually.

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
+use App\Http\Controllers\Api\External\MobileStatusPageWorkspaceController;
 use App\Http\Controllers\Api\External\MonitoringDataController;
 use App\Http\Controllers\Api\External\MonitoringManagementController;
 use App\Http\Controllers\Api\External\TeamController;
@@ -48,6 +49,23 @@ Route::group(['prefix' => 'mobile/monitoring-groups', 'as' => 'mobile.monitoring
     Route::get('/{monitoringGroup}', [MobileMonitoringGroupController::class, 'show'])->name('show');
     Route::patch('/{monitoringGroup}', [MobileMonitoringGroupController::class, 'update'])->name('update');
     Route::delete('/{monitoringGroup}', [MobileMonitoringGroupController::class, 'destroy'])->name('destroy');
+});
+
+Route::group(['prefix' => 'mobile/status-pages', 'as' => 'mobile.status-pages.'], function (): void {
+    Route::get('/', [MobileStatusPageWorkspaceController::class, 'index'])->name('index');
+    Route::get('/{statusPage}', [MobileStatusPageWorkspaceController::class, 'show'])->name('show');
+    Route::patch('/{statusPage}/publication', [MobileStatusPageWorkspaceController::class, 'updatePublication'])->name('publication.update');
+    Route::get('/{statusPage}/incidents', [MobileStatusPageWorkspaceController::class, 'incidents'])->name('incidents.index');
+    Route::get('/{statusPage}/incidents/{incident}', [MobileStatusPageWorkspaceController::class, 'showIncident'])->name('incidents.show');
+    Route::post('/{statusPage}/incidents/{incident}/updates', [MobileStatusPageWorkspaceController::class, 'storeIncidentUpdate'])->name('incidents.updates.store');
+    Route::patch('/{statusPage}/incidents/{incident}/metadata', [MobileStatusPageWorkspaceController::class, 'updateMetadata'])->name('incidents.metadata.update');
+    Route::patch('/{statusPage}/incidents/{incident}/review', [MobileStatusPageWorkspaceController::class, 'updateReview'])->name('incidents.review.update');
+    Route::post('/{statusPage}/incidents/{incident}/follow-ups', [MobileStatusPageWorkspaceController::class, 'storeFollowUp'])->name('incidents.follow-ups.store');
+    Route::patch('/{statusPage}/incidents/{incident}/follow-ups/{incidentFollowUp}', [MobileStatusPageWorkspaceController::class, 'updateFollowUp'])->name('incidents.follow-ups.update');
+    Route::delete('/{statusPage}/incidents/{incident}/follow-ups/{incidentFollowUp}', [MobileStatusPageWorkspaceController::class, 'destroyFollowUp'])->name('incidents.follow-ups.destroy');
+    Route::post('/{statusPage}/incidents/{incident}/timeline', [MobileStatusPageWorkspaceController::class, 'storeTimelineEvent'])->name('incidents.timeline.store');
+    Route::patch('/{statusPage}/incidents/{incident}/timeline/{incidentTimelineEvent}', [MobileStatusPageWorkspaceController::class, 'updateTimelineEvent'])->name('incidents.timeline.update');
+    Route::delete('/{statusPage}/incidents/{incident}/timeline/{incidentTimelineEvent}', [MobileStatusPageWorkspaceController::class, 'destroyTimelineEvent'])->name('incidents.timeline.destroy');
 });
 
 Route::apiResource('mobile-push-devices', MobilePushDeviceController::class)

--- a/tests/Feature/Api/MobileStatusPageWorkspaceApiTest.php
+++ b/tests/Feature/Api/MobileStatusPageWorkspaceApiTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\IncidentFollowUpStatus;
+use App\Enums\IncidentUpdateStatus;
+use App\Enums\TeamRole;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\StatusPage;
+use App\Models\StatusPageSubscription;
+use App\Models\Team;
+use App\Models\TeamMembership;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MobileStatusPageWorkspaceApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_list_status_pages_and_change_publication_state(): void
+    {
+        ['user' => $user, 'statusPage' => $statusPage] = $this->workspace();
+        $monitoringGroup = MonitoringGroup::factory()->for($user)->create(['name' => 'Customer-facing']);
+        $monitoringGroup->monitorings()->attach($statusPage->components->first()->monitorings->first()->id);
+        $statusPage->components->first()->update(['monitoring_group_id' => $monitoringGroup->id, 'source_type' => 'monitoring_group']);
+        StatusPageSubscription::query()->create([
+            'status_page_id' => $statusPage->id,
+            'email' => 'subscriber@example.test',
+            'unsubscribe_token' => 'subscriber-unsubscribe-token',
+            'verified_at' => Date::now(),
+        ]);
+        $this->actingAsMobile($user);
+
+        $this->getJson('/api/v1/mobile/status-pages')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $statusPage->id)
+            ->assertJsonPath('data.0.publication.is_public', true)
+            ->assertJsonPath('data.0.verified_subscriber_count', 1)
+            ->assertJsonPath('data.0.open_incident_count', 1);
+
+        $this->getJson('/api/v1/mobile/status-pages/' . $statusPage->id)
+            ->assertOk()
+            ->assertJsonPath('data.components.0.monitoring_group.id', $monitoringGroup->id)
+            ->assertJsonPath('data.components.0.monitorings.0.id', $statusPage->components->first()->monitorings->first()->id);
+
+        $this->patchJson('/api/v1/mobile/status-pages/' . $statusPage->id . '/publication', ['is_public' => false])
+            ->assertOk()
+            ->assertJsonPath('data.publication.is_public', false);
+
+        $this->assertDatabaseHas('activity_log', [
+            'event' => 'status_page_unpublished',
+            'causer_id' => $user->id,
+        ]);
+    }
+
+    public function test_owner_can_publish_an_idempotent_incident_update_and_manage_incident_workspace(): void
+    {
+        ['user' => $user, 'statusPage' => $statusPage, 'incident' => $incident] = $this->workspace();
+        $this->actingAsMobile($user);
+        $base = '/api/v1/mobile/status-pages/' . $statusPage->id . '/incidents/' . $incident->id;
+
+        $this->getJson($base)
+            ->assertOk()
+            ->assertJsonPath('data.readiness.requires_public_update', true)
+            ->assertJsonPath('data.lifecycle.state', 'open');
+
+        $this->withHeaders(['Idempotency-Key' => 'incident-update-001'])
+            ->postJson($base . '/updates', [
+                'status' => IncidentUpdateStatus::IDENTIFIED->value,
+                'message' => 'The upstream dependency is being restored.',
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.updates.0.message', 'The upstream dependency is being restored.')
+            ->assertJsonPath('data.readiness.requires_public_update', false);
+
+        $this->withHeaders(['Idempotency-Key' => 'incident-update-001'])
+            ->postJson($base . '/updates', [
+                'status' => IncidentUpdateStatus::IDENTIFIED->value,
+                'message' => 'The upstream dependency is being restored.',
+            ])
+            ->assertOk();
+        $this->assertDatabaseCount('incident_updates', 1);
+
+        $this->patchJson($base . '/metadata', [
+            'severity' => 'high',
+            'affected_service' => 'Checkout API',
+        ])->assertOk()
+            ->assertJsonPath('data.metadata.severity', 'high');
+        $this->patchJson($base . '/review', [
+            'problem_description' => 'An upstream dependency was unavailable.',
+        ])->assertOk()
+            ->assertJsonPath('data.metadata.problem_description', 'An upstream dependency was unavailable.');
+
+        $this->withHeaders(['Idempotency-Key' => 'follow-up-001'])
+            ->postJson($base . '/follow-ups', [
+                'title' => 'Add a provider fallback',
+                'assigned_user_id' => $user->id,
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.follow_ups.0.title', 'Add a provider fallback');
+        $this->withHeaders(['Idempotency-Key' => 'follow-up-001'])
+            ->postJson($base . '/follow-ups', [
+                'title' => 'Add a provider fallback',
+                'assigned_user_id' => $user->id,
+            ])
+            ->assertOk();
+        $this->assertDatabaseCount('incident_follow_ups', 1);
+
+        $followUpId = $this->getJson($base)->json('data.follow_ups.0.id');
+        $this->patchJson($base . '/follow-ups/' . $followUpId, [
+            'title' => 'Add a provider fallback',
+            'status' => IncidentFollowUpStatus::COMPLETED->value,
+        ])->assertOk()
+            ->assertJsonPath('data.follow_ups.0.status', IncidentFollowUpStatus::COMPLETED->value);
+
+        $this->withHeaders(['Idempotency-Key' => 'timeline-001'])
+            ->postJson($base . '/timeline', [
+                'title' => 'Fallback activated',
+                'occurred_at' => Date::now()->subMinutes(5)->toIso8601String(),
+            ])
+            ->assertCreated()
+            ->assertJsonPath('data.timeline.1.title', 'Fallback activated');
+        $this->withHeaders(['Idempotency-Key' => 'timeline-001'])
+            ->postJson($base . '/timeline', [
+                'title' => 'Fallback activated',
+                'occurred_at' => Date::now()->subMinutes(5)->toIso8601String(),
+            ])
+            ->assertOk();
+        $this->assertDatabaseCount('incident_timeline_events', 1);
+
+        $timelineEventId = $this->getJson($base)->json('data.custom_timeline_events.0.id');
+        $this->patchJson($base . '/timeline/' . $timelineEventId, [
+            'title' => 'Fallback active',
+            'occurred_at' => Date::now()->subMinutes(5)->toIso8601String(),
+        ])->assertOk()
+            ->assertJsonPath('data.custom_timeline_events.0.title', 'Fallback active');
+        $this->deleteJson($base . '/timeline/' . $timelineEventId)->assertNoContent();
+        $this->deleteJson($base . '/follow-ups/' . $followUpId)->assertNoContent();
+        $this->assertDatabaseCount('incident_timeline_events', 0);
+        $this->assertDatabaseCount('incident_follow_ups', 0);
+
+        $this->assertDatabaseHas('activity_log', [
+            'event' => 'incident_update_published',
+            'causer_id' => $user->id,
+        ]);
+        $this->get(route('public-status-pages.show', $statusPage))
+            ->assertOk()
+            ->assertSeeText('The upstream dependency is being restored.');
+    }
+
+    public function test_incident_communication_requires_status_page_ownership_and_monitoring_management(): void
+    {
+        ['user' => $user, 'statusPage' => $statusPage, 'incident' => $incident] = $this->workspace();
+        $otherUser = User::factory()->create();
+        $this->actingAsMobile($otherUser);
+
+        $this->getJson('/api/v1/mobile/status-pages/' . $statusPage->id)->assertNotFound();
+
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        TeamMembership::factory()->for($team)->for($user)->create(['role' => TeamRole::MEMBER]);
+        $teamMonitoring = Monitoring::factory()->for($team)->create(['user_id' => null]);
+        $teamStatusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Team Status',
+            'is_public' => true,
+        ]);
+        $teamStatusPage->components()->create(['name' => 'Team API', 'position' => 0])
+            ->monitorings()
+            ->attach($teamMonitoring->id, ['position' => 0]);
+        $teamIncident = Incident::query()->create([
+            'monitoring_id' => $teamMonitoring->id,
+            'down_at' => Date::now()->subMinutes(10),
+        ]);
+        Sanctum::actingAs($user);
+        $this->getJson('/api/v1/mobile/status-pages/' . $teamStatusPage->id)
+            ->assertOk();
+        $this->getJson('/api/v1/mobile/status-pages/' . $teamStatusPage->id . '/incidents')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+        $this->getJson('/api/v1/mobile/status-pages/' . $teamStatusPage->id . '/incidents/' . $teamIncident->id)
+            ->assertNotFound();
+        $this->postJson('/api/v1/mobile/status-pages/' . $statusPage->id . '/incidents/' . $incident->id . '/updates', [
+            'status' => IncidentUpdateStatus::INVESTIGATING->value,
+            'message' => 'Missing idempotency key.',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('idempotency_key');
+    }
+
+    /**
+     * @return array{user: User, statusPage: StatusPage, incident: Incident}
+     */
+    private function workspace(): array
+    {
+        Date::setTestNow('2026-08-09 20:00:00');
+        $package = Package::factory()->create(['monitoring_limit' => 10]);
+        $user = User::factory()->create(['package_id' => $package->id]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+        $statusPage = StatusPage::query()->create([
+            'user_id' => $user->id,
+            'name' => 'Acme Status',
+            'is_public' => true,
+        ]);
+        $statusPage->components()->create(['name' => 'API', 'position' => 0])
+            ->monitorings()
+            ->attach($monitoring->id, ['position' => 0]);
+        $incident = Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => Date::now()->subMinutes(20),
+        ]);
+
+        return compact('user', 'statusPage', 'incident');
+    }
+
+    private function actingAsMobile(User $user): void
+    {
+        $this->withToken($user->createToken('ios-app: Test Device')->plainTextToken);
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated authenticated mobile status-page and incident communication workspace under `/api/v1/mobile/status-pages`
- expose publication state, component/group context, subscriber and incident summaries, plus incident readiness, updates, follow-ups, and timeline data
- add owner and team-management scoping, audit events, and durable per-incident idempotency keys for communication creation
- document the v1 mobile contract, retry behavior, validation, and route boundary

## Why

Native clients need to coordinate status-page publication and incident communications without relying on browser management routes or public status output.

## Testing

- `composer test`
- `composer analyse`
- `php ./vendor/bin/pint --dirty`
- added `MobileStatusPageWorkspaceApiTest` covering authorization, mobile-token requests, idempotent retries, audit logging, and follow-up/timeline actions

## Risks and follow-up

The endpoints are additive within external API v1. Existing browser and public status-page contracts remain unchanged. 

Closes #656