### PR TITLE
feat(api): add mobile monitoring detail contract

### DIFF
--- a/app/Http/Controllers/Api/External/MobileMonitoringDetailController.php
+++ b/app/Http/Controllers/Api/External/MobileMonitoringDetailController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Mobile\MobileMonitoringDetailRequest;
+use App\Models\User;
+use App\Queries\MonitoringDetailQuery;
+use App\Services\MobileMonitoringDetailPayloadService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @group Mobile monitoring detail
+ *
+ * Read the bounded, server-derived diagnostic detail for one visible monitoring.
+ */
+final class MobileMonitoringDetailController extends Controller
+{
+    public function __invoke(
+        MobileMonitoringDetailRequest $mobileMonitoringDetailRequest,
+        string $monitoring,
+        MonitoringDetailQuery $monitoringDetailQuery,
+        MobileMonitoringDetailPayloadService $mobileMonitoringDetailPayloadService,
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $mobileMonitoringDetailRequest->user();
+
+        return response()->json($mobileMonitoringDetailPayloadService->for(
+            $monitoringDetailQuery->findVisible($user, $monitoring),
+            $user,
+            $mobileMonitoringDetailRequest->days(),
+            $mobileMonitoringDetailRequest->incidentLimit(),
+            $mobileMonitoringDetailRequest->incidentOffset(),
+        ));
+    }
+}

--- a/app/Http/Requests/Api/Mobile/MobileMonitoringDetailRequest.php
+++ b/app/Http/Requests/Api/Mobile/MobileMonitoringDetailRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class MobileMonitoringDetailRequest extends FormRequest
+{
+    /**
+     * @return array<string, list<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'days' => ['nullable', 'integer', 'min:1', 'max:90'],
+            'incident_limit' => ['nullable', 'integer', 'min:1', 'max:50'],
+            'incident_offset' => ['nullable', 'integer', 'min:0', 'max:10000'],
+        ];
+    }
+
+    public function days(): int
+    {
+        return (int) ($this->validated('days') ?? 30);
+    }
+
+    public function incidentLimit(): int
+    {
+        return (int) ($this->validated('incident_limit') ?? 20);
+    }
+
+    public function incidentOffset(): int
+    {
+        return (int) ($this->validated('incident_offset') ?? 0);
+    }
+}

--- a/app/Queries/MonitoringIncidentQuery.php
+++ b/app/Queries/MonitoringIncidentQuery.php
@@ -22,4 +22,19 @@ final class MonitoringIncidentQuery
             ->latest('down_at')
             ->get();
     }
+
+    /**
+     * @return Collection<int, Incident>
+     */
+    public function page(Monitoring $monitoring, Carbon $startDate, Carbon $endDate, int $limit, int $offset): Collection
+    {
+        return $monitoring->incidents()
+            ->whereBetween('down_at', [$startDate->startOfDay(), $endDate->endOfDay()])
+            ->select(['id', 'down_at', 'up_at'])
+            ->latest('down_at')
+            ->latest('id')
+            ->offset($offset)
+            ->limit($limit + 1)
+            ->get();
+    }
 }

--- a/app/Services/MobileMonitoringDetailPayloadService.php
+++ b/app/Services/MobileMonitoringDetailPayloadService.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Monitoring;
+use App\Models\User;
+use App\Support\MonitoringDateRange;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Date;
+
+final class MobileMonitoringDetailPayloadService
+{
+    public function __construct(
+        private readonly MonitoringAvailabilityService $monitoringAvailabilityService,
+        private readonly MonitoringResponseTimeService $monitoringResponseTimeService,
+        private readonly MonitoringIncidentService $monitoringIncidentService,
+        private readonly MonitoringHeatmapService $monitoringHeatmapService,
+        private readonly MonitoringUptimeCalendarService $monitoringUptimeCalendarService,
+        private readonly MonitoringDashboardPayloadService $monitoringDashboardPayloadService,
+        private readonly MonitoringStatusPayloadService $monitoringStatusPayloadService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function for(Monitoring $monitoring, User $user, int $days, int $incidentLimit, int $incidentOffset): array
+    {
+        $generatedAt = Date::now();
+        $dateRange = MonitoringDateRange::pastDays($days);
+        $currentCheck = $this->monitoringStatusPayloadService->getPayload($monitoring, false)->toArray();
+        $availability = $this->monitoringAvailabilityService->getUptimeDowntime(
+            $monitoring,
+            $dateRange->startDate,
+            $dateRange->endDate,
+            $dateRange->shouldUseUptimeAggregates($monitoring),
+            $dateRange->shouldIncludeIntradayRawData(),
+        )->toArray();
+        $responseTimes = $this->monitoringResponseTimeService->getResponseTimes(
+            $monitoring,
+            $dateRange->startDate,
+            $dateRange->endDate,
+            $dateRange->shouldUseResponseTimeAggregates(),
+        )->toArray();
+        $incidents = $this->monitoringIncidentService->getIncidentPage(
+            $monitoring,
+            $dateRange->startDate,
+            $dateRange->endDate,
+            $incidentLimit,
+            $incidentOffset,
+        );
+        $heatmap = $this->monitoringHeatmapService
+            ->getHeatmap($monitoring, $generatedAt->copy()->subHours(23), $generatedAt)
+            ->map(static fn (array $point): array => [
+                'date' => $point['date']->toIso8601String(),
+                'uptime' => $point['uptime'],
+                'downtime' => $point['downtime'],
+                'unknown' => $point['unknown'],
+            ])
+            ->values()
+            ->all();
+        $calendar = $this->monitoringUptimeCalendarService
+            ->getGroupedByDateAndMonth($monitoring, $dateRange->startDate, $dateRange->endDate)
+            ->toArray();
+        $ssl = $this->monitoringDashboardPayloadService->getSslPayload($monitoring)->toArray();
+        $domain = $this->domainPayload($monitoring);
+
+        return [
+            'data' => [
+                'summary' => $this->summaryPayload($monitoring, $user),
+                'current_check' => $currentCheck,
+                'availability' => $availability,
+                'response_times' => $responseTimes,
+                'incidents' => $incidents['data'],
+                'heatmap' => $heatmap,
+                'maintenance' => [
+                    'active' => $monitoring->isUnderMaintenance(),
+                    'starts_at' => $monitoring->maintenance_from?->toIso8601String(),
+                    'ends_at' => $monitoring->maintenance_until?->toIso8601String(),
+                    'has_recurring_window' => $monitoring->has_enabled_maintenance_windows,
+                ],
+                'ssl' => $ssl,
+                'domain' => $domain,
+                'uptime_calendar' => $calendar,
+                'capabilities' => [
+                    'can_manage' => $monitoring->isManageableBy($user),
+                ],
+            ],
+            'meta' => [
+                'generated_at' => $generatedAt->toIso8601String(),
+                'range' => [
+                    'days' => $days,
+                    'from' => $dateRange->startDate->toIso8601String(),
+                    'to' => $dateRange->endDate->toIso8601String(),
+                ],
+                'incidents' => [
+                    'limit' => $incidentLimit,
+                    'offset' => $incidentOffset,
+                    'has_more' => $incidents['has_more'],
+                    'next_offset' => $incidents['next_offset'],
+                ],
+                'sections' => [
+                    'summary' => $this->sectionMeta('current', $generatedAt),
+                    'current_check' => $this->sectionMeta($this->currentCheckState($currentCheck, $generatedAt), $generatedAt),
+                    'availability' => $this->sectionMeta($availability['has_data'] ? 'current' : 'empty', $generatedAt),
+                    'response_times' => $this->sectionMeta($responseTimes['data']->isEmpty() ? 'empty' : 'current', $generatedAt),
+                    'incidents' => $this->sectionMeta($incidents['data'] === [] ? 'empty' : 'current', $generatedAt),
+                    'heatmap' => $this->sectionMeta($availability['has_data'] ? 'current' : 'empty', $generatedAt),
+                    'maintenance' => $this->sectionMeta('current', $generatedAt),
+                    'ssl' => $this->sectionMeta($monitoring->sslResult === null ? 'unavailable' : 'current', $generatedAt),
+                    'domain' => $this->sectionMeta($domain === null ? 'unavailable' : 'current', $generatedAt),
+                    'uptime_calendar' => $this->sectionMeta($this->calendarHasData($calendar) ? 'current' : 'empty', $generatedAt),
+                    'capabilities' => $this->sectionMeta('current', $generatedAt),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function summaryPayload(Monitoring $monitoring, User $user): array
+    {
+        return [
+            'id' => $monitoring->getKey(),
+            'name' => $monitoring->name,
+            'target' => $monitoring->target,
+            'type' => $monitoring->type->value,
+            'lifecycle_status' => $monitoring->status->value,
+            'ownership' => [
+                'type' => $monitoring->isTeamOwned() ? 'team' : 'private',
+                'can_manage' => $monitoring->isManageableBy($user),
+            ],
+            'performance' => $monitoring->performanceState ? [
+                'status' => $monitoring->performanceState->status?->value,
+                'consecutive_breaches' => $monitoring->performanceState->consecutive_breaches,
+                'degraded_at' => $monitoring->performanceState->degraded_at?->toIso8601String(),
+            ] : null,
+            'open_incident' => $monitoring->latestIncident?->up_at === null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function domainPayload(Monitoring $monitoring): ?array
+    {
+        if ($monitoring->domainResult === null) {
+            return null;
+        }
+
+        return [
+            'valid' => $monitoring->domainResult->is_valid,
+            'expires_at' => $monitoring->domainResult->expires_at?->toIso8601String(),
+            'registrar' => $monitoring->domainResult->registrar,
+            'checked_at' => $monitoring->domainResult->checked_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $currentCheck
+     */
+    private function currentCheckState(array $currentCheck, Carbon $generatedAt): string
+    {
+        $checkedAt = $currentCheck['checked_at'] ?? null;
+
+        if (! is_string($checkedAt)) {
+            return 'empty';
+        }
+
+        $interval = max((int) ($currentCheck['interval'] ?? 0), 60);
+
+        return Date::parse($checkedAt)->lt($generatedAt->copy()->subSeconds($interval * 2))
+            ? 'stale'
+            : 'current';
+    }
+
+    /**
+     * @return array{state: string, generated_at: string}
+     */
+    private function sectionMeta(string $state, Carbon $generatedAt): array
+    {
+        return [
+            'state' => $state,
+            'generated_at' => $generatedAt->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<string, array{days: list<array{date: string, uptime_percentage: float|null}>, monthly_average_uptime: float|null}>  $calendar
+     */
+    private function calendarHasData(array $calendar): bool
+    {
+        foreach ($calendar as $month) {
+            foreach ($month['days'] as $day) {
+                if ($day['uptime_percentage'] !== null) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Services/MobileMonitoringDetailPayloadService.php
+++ b/app/Services/MobileMonitoringDetailPayloadService.php
@@ -28,25 +28,25 @@ final class MobileMonitoringDetailPayloadService
     public function for(Monitoring $monitoring, User $user, int $days, int $incidentLimit, int $incidentOffset): array
     {
         $generatedAt = Date::now();
-        $dateRange = MonitoringDateRange::pastDays($days);
+        $monitoringDateRange = MonitoringDateRange::pastDays($days);
         $currentCheck = $this->monitoringStatusPayloadService->getPayload($monitoring, false)->toArray();
         $availability = $this->monitoringAvailabilityService->getUptimeDowntime(
             $monitoring,
-            $dateRange->startDate,
-            $dateRange->endDate,
-            $dateRange->shouldUseUptimeAggregates($monitoring),
-            $dateRange->shouldIncludeIntradayRawData(),
+            $monitoringDateRange->startDate,
+            $monitoringDateRange->endDate,
+            $monitoringDateRange->shouldUseUptimeAggregates($monitoring),
+            $monitoringDateRange->shouldIncludeIntradayRawData(),
         )->toArray();
         $responseTimes = $this->monitoringResponseTimeService->getResponseTimes(
             $monitoring,
-            $dateRange->startDate,
-            $dateRange->endDate,
-            $dateRange->shouldUseResponseTimeAggregates(),
+            $monitoringDateRange->startDate,
+            $monitoringDateRange->endDate,
+            $monitoringDateRange->shouldUseResponseTimeAggregates(),
         )->toArray();
         $incidents = $this->monitoringIncidentService->getIncidentPage(
             $monitoring,
-            $dateRange->startDate,
-            $dateRange->endDate,
+            $monitoringDateRange->startDate,
+            $monitoringDateRange->endDate,
             $incidentLimit,
             $incidentOffset,
         );
@@ -61,7 +61,7 @@ final class MobileMonitoringDetailPayloadService
             ->values()
             ->all();
         $calendar = $this->monitoringUptimeCalendarService
-            ->getGroupedByDateAndMonth($monitoring, $dateRange->startDate, $dateRange->endDate)
+            ->getGroupedByDateAndMonth($monitoring, $monitoringDateRange->startDate, $monitoringDateRange->endDate)
             ->toArray();
         $ssl = $this->monitoringDashboardPayloadService->getSslPayload($monitoring)->toArray();
         $domain = $this->domainPayload($monitoring);
@@ -91,8 +91,8 @@ final class MobileMonitoringDetailPayloadService
                 'generated_at' => $generatedAt->toIso8601String(),
                 'range' => [
                     'days' => $days,
-                    'from' => $dateRange->startDate->toIso8601String(),
-                    'to' => $dateRange->endDate->toIso8601String(),
+                    'from' => $monitoringDateRange->startDate->toIso8601String(),
+                    'to' => $monitoringDateRange->endDate->toIso8601String(),
                 ],
                 'incidents' => [
                     'limit' => $incidentLimit,

--- a/app/Services/MonitoringIncidentService.php
+++ b/app/Services/MonitoringIncidentService.php
@@ -32,4 +32,42 @@ class MonitoringIncidentService
                 );
             });
     }
+
+    /**
+     * @return array{data: list<array{down_at: string, up_at: string|null}>, has_more: bool, next_offset: int|null}
+     */
+    public function getIncidentPage(
+        Monitoring $monitoring,
+        Carbon $startDate,
+        Carbon $endDate,
+        int $limit,
+        int $offset,
+    ): array {
+        $incidents = $this->monitoringIncidentQuery->page($monitoring, $startDate, $endDate, $limit, $offset);
+        $hasMore = $incidents->count() > $limit;
+
+        return [
+            'data' => $incidents
+                ->take($limit)
+                ->map(fn ($incident): array => $this->incidentPayload($incident))
+                ->values()
+                ->all(),
+            'has_more' => $hasMore,
+            'next_offset' => $hasMore ? $offset + $limit : null,
+        ];
+    }
+
+    /**
+     * @return array{down_at: string, up_at: string|null}
+     */
+    private function incidentPayload(object $incident): array
+    {
+        $downAt = Date::parse($incident->down_at);
+        $upAt = $incident->up_at ? Date::parse($incident->up_at) : null;
+
+        return [
+            'down_at' => $downAt->toIso8601String(),
+            'up_at' => $upAt?->toIso8601String(),
+        ];
+    }
 }

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -89,6 +89,31 @@ All retain their existing ownership checks and response contracts.
 Existing pre-scoped external tokens remain compatible. They are not converted
 to new keys automatically; rotate them from the profile when practical.
 
+## Mobile monitoring detail
+
+`GET /api/v1/mobile/monitorings/{monitoring}` is the authenticated native-app
+detail contract. It is separate from browser UI and scanner-instance routes and
+only resolves monitorings visible to the current token owner. Unauthenticated
+requests return `401`; a missing or inaccessible monitoring returns `404`.
+
+The response is an envelope with `data` and `meta`. `data` contains the
+monitoring summary, current check state, availability and response-time series,
+recent incidents, heatmap, maintenance context, SSL and domain results, uptime
+calendar, and capability flags. The server derives all monitoring semantics;
+clients must not infer uptime, maintenance, or certificate status from raw
+checks.
+
+`days` is optional, defaults to `30`, and is bounded from `1` through `90`.
+Incident history uses deterministic `down_at`/`id` descending order and supports
+`incident_limit` (default `20`, maximum `50`) plus `incident_offset`. Its
+metadata provides `has_more` and `next_offset` for retry-safe pagination.
+Invalid query values retain Laravel's stable `422` validation envelope.
+
+`meta.sections` has a `state` and `generated_at` entry for every section. The
+state is `current`, `stale`, `empty`, or `unavailable`, allowing a native client
+to render partial detail safely without treating an unavailable SSL or domain
+result as a failed monitoring check.
+
 ## Mobile monitoring groups and ownership
 
 Native clients manage personal monitoring groups through `/api/v1/mobile/monitoring-groups`.

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\External\MobileMonitoringDetailController;
 use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
-use App\Http\Controllers\Api\External\MobileMonitoringDetailController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
 use App\Http\Controllers\Api\External\MonitoringDataController;
 use App\Http\Controllers\Api\External\MonitoringManagementController;

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
+use App\Http\Controllers\Api\External\MobileMonitoringDetailController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
 use App\Http\Controllers\Api\External\MonitoringDataController;
 use App\Http\Controllers\Api\External\MonitoringManagementController;
@@ -40,6 +41,8 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
 Route::get('/mobile/overview', MobileOverviewController::class)
     ->name('mobile.overview');
+Route::get('/mobile/monitorings/{monitoring}', MobileMonitoringDetailController::class)
+    ->name('mobile.monitorings.show');
 
 Route::group(['prefix' => 'mobile/monitoring-groups', 'as' => 'mobile.monitoring-groups.'], function (): void {
     Route::get('/', [MobileMonitoringGroupController::class, 'index'])->name('index');

--- a/tests/Feature/Api/MobileMonitoringDetailApiTest.php
+++ b/tests/Feature/Api/MobileMonitoringDetailApiTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MonitoringStatus;
+use App\Models\Incident;
+use App\Models\Monitoring;
+use App\Models\MonitoringDomainResult;
+use App\Models\MonitoringResponse;
+use App\Models\Package;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MobileMonitoringDetailApiTest extends TestCase
+{
+    public function test_authenticated_user_can_read_a_bounded_mobile_monitoring_detail_payload(): void
+    {
+        Date::setTestNow('2026-08-09 12:00:00');
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Primary API']);
+        MonitoringResponse::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'status' => MonitoringStatus::UP,
+            'http_status_code' => 200,
+            'response_time' => 120,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+        Incident::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'down_at' => now()->subHours(2),
+            'up_at' => now()->subHour(),
+        ]);
+        MonitoringDomainResult::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'is_valid' => true,
+            'expires_at' => now()->addYear(),
+            'registrar' => 'Example Registrar',
+            'checked_at' => now()->subMinute(),
+        ]);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id)
+            ->assertOk()
+            ->assertJsonPath('data.summary.id', $monitoring->id)
+            ->assertJsonPath('data.summary.name', 'Primary API')
+            ->assertJsonPath('data.current_check.status', MonitoringStatus::UP->value)
+            ->assertJsonPath('data.incidents.0.down_at', now()->subHours(2)->toIso8601String())
+            ->assertJsonPath('data.domain.registrar', 'Example Registrar')
+            ->assertJsonPath('meta.incidents.limit', 20)
+            ->assertJsonPath('meta.sections.current_check.state', 'current')
+            ->assertJsonPath('meta.sections.availability.state', 'empty')
+            ->assertJsonPath('meta.sections.ssl.state', 'unavailable')
+            ->assertJsonPath('meta.sections.domain.state', 'current');
+    }
+
+    public function test_mobile_monitoring_detail_paginates_incidents_deterministically(): void
+    {
+        Date::setTestNow('2026-08-09 12:00:00');
+        Package::factory()->create();
+        $user = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($user)->create();
+        Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHours(3)]);
+        $second = Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHours(2)]);
+        Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHour()]);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id . '?incident_limit=1&incident_offset=1')
+            ->assertOk()
+            ->assertJsonPath('data.incidents.0.down_at', $second->down_at->toIso8601String())
+            ->assertJsonPath('meta.incidents.offset', 1)
+            ->assertJsonPath('meta.incidents.has_more', true)
+            ->assertJsonPath('meta.incidents.next_offset', 2);
+    }
+
+    public function test_mobile_monitoring_detail_hides_foreign_monitorings_and_rejects_invalid_ranges(): void
+    {
+        Package::factory()->create();
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $monitoring = Monitoring::factory()->for($owner)->create();
+
+        $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id)->assertUnauthorized();
+
+        Sanctum::actingAs($otherUser);
+
+        $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id)->assertNotFound();
+
+        Sanctum::actingAs($owner);
+        $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id . '?days=0')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['days']);
+    }
+}

--- a/tests/Feature/Api/MobileMonitoringDetailApiTest.php
+++ b/tests/Feature/Api/MobileMonitoringDetailApiTest.php
@@ -66,13 +66,13 @@ class MobileMonitoringDetailApiTest extends TestCase
         $user = User::factory()->create();
         $monitoring = Monitoring::factory()->for($user)->create();
         Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHours(3)]);
-        $second = Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHours(2)]);
+        $incident = Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHours(2)]);
         Incident::query()->create(['monitoring_id' => $monitoring->id, 'down_at' => now()->subHour()]);
         Sanctum::actingAs($user);
 
         $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id . '?incident_limit=1&incident_offset=1')
             ->assertOk()
-            ->assertJsonPath('data.incidents.0.down_at', $second->down_at->toIso8601String())
+            ->assertJsonPath('data.incidents.0.down_at', $incident->down_at->toIso8601String())
             ->assertJsonPath('meta.incidents.offset', 1)
             ->assertJsonPath('meta.incidents.has_more', true)
             ->assertJsonPath('meta.incidents.next_offset', 2);


### PR DESCRIPTION
## What changed
- Adds an authenticated `GET /api/v1/mobile/monitorings/{monitoring}` contract for native monitoring diagnostics.
- Returns server-derived status, availability, response-time, incident, maintenance, SSL, domain, heatmap, calendar, ownership, and capability data with per-section freshness states.
- Adds deterministic, bounded incident pagination and documents the mobile contract.

## Why
The native app needs one stable external detail payload without consuming browser UI or scanner-instance responses.

## Testing
- Added `MobileMonitoringDetailApiTest` covering authentication, data isolation, validation, partial section states, and incident pagination.
- Ran targeted API feature tests: 12 passed, 112 assertions.
- Ran Pint on all changed PHP files.
- Ran targeted PHPStan successfully. The full PHPStan scan was terminated by the Docker host with exit code 137 before analysis began.

## Risks and follow-up
- The route is additive within v1. Existing browser and scanner-instance endpoints are unchanged.
- Closes #667.