### PR TITLE
feat(api): add mobile maintenance operations

### DIFF
--- a/app/Http/Controllers/Api/External/MobileMaintenanceController.php
+++ b/app/Http/Controllers/Api/External/MobileMaintenanceController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/**
+ * Compatibility adapter for the externally supported v1 mobile maintenance contract.
+ *
+ * @group Mobile maintenance
+ *
+ * List and manage authorized one-off and recurring maintenance windows from native clients.
+ */
+class MobileMaintenanceController extends \App\Http\Controllers\Api\Mobile\MobileMaintenanceController {}

--- a/app/Http/Controllers/Api/Mobile/MobileMaintenanceController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileMaintenanceController.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Mobile\MobileStoreMaintenanceRequest;
+use App\Http\Requests\Api\Mobile\UpdateMobileMaintenanceWindowRequest;
+use App\Http\Resources\External\MobileMaintenanceWindowResource;
+use App\Http\Resources\External\MobileOneOffMaintenanceResource;
+use App\Models\MaintenanceWindow;
+use App\Models\Monitoring;
+use App\Models\User;
+use App\Services\MobileMaintenanceWorkspaceService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class MobileMaintenanceController extends Controller
+{
+    public function capabilities(Request $request, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $monitorings = Monitoring::query()
+            ->manageableBy($user)
+            ->orderBy('name')
+            ->orderBy('id')
+            ->get(['id', 'name', 'team_id']);
+
+        return response()->json([
+            'data' => [
+                'can_schedule' => ! $user->isDemo() && $monitorings->isNotEmpty(),
+                'manageable_monitoring_ids' => $monitorings->pluck('id')->values()->all(),
+                'manageable_monitorings' => $monitorings->map(fn (Monitoring $monitoring): array => [
+                    'id' => $monitoring->id,
+                    'name' => $monitoring->name,
+                    'ownership' => $monitoring->team_id === null ? 'private' : 'team_admin',
+                ])->values()->all(),
+                'monitoring_groups' => $user->monitoringGroups()
+                    ->withCount('monitorings')
+                    ->orderBy('name')
+                    ->get(['id', 'name'])
+                    ->map(fn ($group): array => [
+                        'id' => $group->id,
+                        'name' => $group->name,
+                        'monitorings_count' => (int) $group->monitorings_count,
+                    ])->values()->all(),
+                'idempotency' => [
+                    'create_header' => 'Idempotency-Key',
+                    'required_for_create' => true,
+                ],
+            ],
+        ]);
+    }
+
+    public function oneOffIndex(Request $request, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $state = $this->state($request, ['active', 'upcoming', 'expired']);
+        $windows = $mobileMaintenanceWorkspaceService->oneOffWindowsFor($user, $state)
+            ->paginate($this->perPage($request));
+        $windows->setCollection($windows->getCollection()->map(
+            fn (Monitoring $monitoring): array => MobileOneOffMaintenanceResource::make(
+                $mobileMaintenanceWorkspaceService->decorateOneOff($monitoring, $user)
+            )->resolve($request)
+        ));
+
+        return response()->json($windows);
+    }
+
+    public function recurringIndex(Request $request, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $state = $this->state($request, ['active', 'upcoming', 'expired', 'disabled']);
+        $perPage = $this->perPage($request);
+        $query = $mobileMaintenanceWorkspaceService->recurringWindowsFor($user, $state);
+
+        if (in_array($state, ['active', 'upcoming', 'expired'], true)) {
+            $allWindows = $query->get()
+                ->map(fn (MaintenanceWindow $maintenanceWindow): MaintenanceWindow => $mobileMaintenanceWorkspaceService->decorateRecurring($maintenanceWindow, $user))
+                ->filter(fn (MaintenanceWindow $maintenanceWindow): bool => $maintenanceWindow->getAttribute('mobile_state') === $state)
+                ->values();
+            $windows = new LengthAwarePaginator(
+                $allWindows->forPage($request->integer('page', 1), $perPage)->values(),
+                $allWindows->count(),
+                $perPage,
+                $request->integer('page', 1),
+                ['path' => $request->url(), 'query' => $request->query()],
+            );
+        } else {
+            $windows = $query->paginate($perPage);
+        }
+
+        $windows->setCollection($windows->getCollection()->map(
+            fn (MaintenanceWindow $maintenanceWindow): array => MobileMaintenanceWindowResource::make(
+                $mobileMaintenanceWorkspaceService->decorateRecurring($maintenanceWindow, $user)
+            )->resolve($request)
+        ));
+
+        return response()->json($windows);
+    }
+
+    public function store(MobileStoreMaintenanceRequest $request, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $result = $mobileMaintenanceWorkspaceService->schedule($user, $request->validated());
+
+        return response()->json([
+            'data' => $result['operation']->result,
+            'idempotent' => ! $result['created'],
+        ], $result['created'] ? 201 : 200);
+    }
+
+    public function updateRecurring(
+        UpdateMobileMaintenanceWindowRequest $request,
+        string $maintenanceWindow,
+        MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService,
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $request->user();
+        $window = $mobileMaintenanceWorkspaceService->updateRecurringEnabled(
+            $mobileMaintenanceWorkspaceService->recurringWindowFor($user, $maintenanceWindow),
+            $user,
+            $request->boolean('enabled'),
+        );
+
+        return response()->json([
+            'data' => MobileMaintenanceWindowResource::make(
+                $mobileMaintenanceWorkspaceService->decorateRecurring($window, $user)
+            )->resolve($request),
+        ]);
+    }
+
+    public function cancelOneOff(Request $request, string $monitoring, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $mobileMaintenanceWorkspaceService->cancelOneOff(
+            Monitoring::query()->visibleTo($user)->whereKey($monitoring)->firstOrFail(),
+            $user,
+        );
+
+        return response()->json(status: 204);
+    }
+
+    private function state(Request $request, array $allowed): ?string
+    {
+        $state = $request->string('state')->toString();
+        abort_unless($state === '' || in_array($state, $allowed, true), 422);
+
+        return $state === '' ? null : $state;
+    }
+
+    private function perPage(Request $request): int
+    {
+        return min(max((int) $request->integer('per_page', 25), 1), 100);
+    }
+}

--- a/app/Http/Requests/Api/Mobile/MobileStoreMaintenanceRequest.php
+++ b/app/Http/Requests/Api/Mobile/MobileStoreMaintenanceRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use App\Http\Requests\Api\Mobile\Concerns\RequiresMobileIdempotencyKey;
+use App\Http\Requests\MaintenanceRequest;
+
+class MobileStoreMaintenanceRequest extends MaintenanceRequest
+{
+    use RequiresMobileIdempotencyKey;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            ...parent::rules(),
+            'idempotency_key' => $this->mobileIdempotencyKeyRules(),
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        parent::prepareForValidation();
+        $this->prepareMobileIdempotencyKey();
+    }
+}

--- a/app/Http/Requests/Api/Mobile/UpdateMobileMaintenanceWindowRequest.php
+++ b/app/Http/Requests/Api/Mobile/UpdateMobileMaintenanceWindowRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Mobile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateMobileMaintenanceWindowRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null && ! $this->user()->isDemo();
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'enabled' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Resources/External/MobileMaintenanceWindowResource.php
+++ b/app/Http/Resources/External/MobileMaintenanceWindowResource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\External;
+
+use App\Models\MaintenanceWindow;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin MaintenanceWindow
+ */
+final class MobileMaintenanceWindowResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var MaintenanceWindow $maintenanceWindow */
+        $maintenanceWindow = $this->resource;
+
+        return [
+            'id' => $maintenanceWindow->id,
+            'kind' => 'recurring',
+            'state' => (string) $maintenanceWindow->getAttribute('mobile_state'),
+            'enabled' => $maintenanceWindow->enabled,
+            'target' => [
+                'type' => $maintenanceWindow->monitoring_id === null ? 'monitoring_group' : 'monitoring',
+                'id' => $maintenanceWindow->monitoring_id ?? $maintenanceWindow->monitoring_group_id,
+                'name' => $maintenanceWindow->monitoring?->name ?? $maintenanceWindow->monitoringGroup?->name,
+                'manageable_monitoring_ids' => $maintenanceWindow->getAttribute('manageable_monitoring_ids'),
+            ],
+            'schedule' => [
+                'starts_at' => $maintenanceWindow->starts_at->toIso8601String(),
+                'ends_at' => $maintenanceWindow->getAttribute('mobile_ends_at'),
+                'timezone' => $maintenanceWindow->timezone,
+                'recurrence' => $maintenanceWindow->recurrence->value,
+                'duration_minutes' => $maintenanceWindow->duration_minutes,
+                'repeat_until' => $maintenanceWindow->repeat_until?->toIso8601String(),
+                'next_occurrence' => $maintenanceWindow->getAttribute('mobile_next_occurrence'),
+            ],
+            'can_manage' => (bool) $maintenanceWindow->getAttribute('mobile_can_manage'),
+            'updated_at' => $maintenanceWindow->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/External/MobileOneOffMaintenanceResource.php
+++ b/app/Http/Resources/External/MobileOneOffMaintenanceResource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\External;
+
+use App\Models\Monitoring;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Monitoring
+ */
+final class MobileOneOffMaintenanceResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Monitoring $monitoring */
+        $monitoring = $this->resource;
+
+        return [
+            'id' => $monitoring->id,
+            'kind' => 'one_off',
+            'state' => (string) $monitoring->getAttribute('mobile_maintenance_state'),
+            'enabled' => true,
+            'target' => [
+                'type' => 'monitoring',
+                'id' => $monitoring->id,
+                'name' => $monitoring->name,
+                'manageable_monitoring_ids' => $monitoring->getAttribute('mobile_can_manage') ? [(string) $monitoring->id] : [],
+            ],
+            'schedule' => [
+                'starts_at' => $monitoring->maintenance_from?->toIso8601String(),
+                'ends_at' => $monitoring->maintenance_until?->toIso8601String(),
+                'timezone' => 'UTC',
+                'recurrence' => null,
+                'duration_minutes' => null,
+                'repeat_until' => null,
+                'next_occurrence' => null,
+            ],
+            'can_manage' => (bool) $monitoring->getAttribute('mobile_can_manage'),
+            'updated_at' => $monitoring->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/MobileMaintenanceOperation.php
+++ b/app/Models/MobileMaintenanceOperation.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'user_id',
+    'idempotency_key',
+    'fingerprint',
+    'operation',
+    'maintenance_window_id',
+    'result',
+])]
+#[WithoutIncrementing]
+class MobileMaintenanceOperation extends Model
+{
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<MaintenanceWindow, $this>
+     */
+    public function maintenanceWindow(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceWindow::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function casts(): array
+    {
+        return [
+            'result' => 'array',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Services/MaintenanceWindowService.php
+++ b/app/Services/MaintenanceWindowService.php
@@ -35,6 +35,18 @@ final class MaintenanceWindowService
     }
 
     /**
+     * @return array{starts_at: CarbonInterface, ends_at: CarbonInterface, active: bool, recurring: bool}|null
+     */
+    public function occurrence(MaintenanceWindow $maintenanceWindow, ?CarbonInterface $at = null): ?array
+    {
+        if (! $maintenanceWindow->enabled) {
+            return null;
+        }
+
+        return $this->resolveOccurrence($maintenanceWindow, $at ?? Date::now());
+    }
+
+    /**
      * @return Collection<int, MaintenanceWindow>
      */
     private function recurringWindows(Monitoring $monitoring): Collection

--- a/app/Services/MobileMaintenanceWorkspaceService.php
+++ b/app/Services/MobileMaintenanceWorkspaceService.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\MaintenanceWindow;
+use App\Models\MobileMaintenanceOperation;
+use App\Models\Monitoring;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+final class MobileMaintenanceWorkspaceService
+{
+    public function __construct(private readonly MaintenanceWindowService $maintenanceWindowService) {}
+
+    /**
+     * @return Builder<Monitoring>
+     */
+    public function oneOffWindowsFor(User $user, ?string $state): Builder
+    {
+        $query = Monitoring::query()
+            ->visibleTo($user)
+            ->whereNotNull('maintenance_from')
+            ->select(['id', 'name', 'target', 'user_id', 'team_id', 'maintenance_from', 'maintenance_until', 'updated_at']);
+
+        $now = Date::now();
+        match ($state) {
+            'active' => $query->where('maintenance_from', '<=', $now)
+                ->where(fn (Builder $builder) => $builder->whereNull('maintenance_until')->orWhere('maintenance_until', '>=', $now)),
+            'upcoming' => $query->where('maintenance_from', '>', $now),
+            'expired' => $query->whereNotNull('maintenance_until')->where('maintenance_until', '<', $now),
+            default => null,
+        };
+
+        return $query->orderBy('maintenance_from')->orderBy('id');
+    }
+
+    /**
+     * @return Builder<MaintenanceWindow>
+     */
+    public function recurringWindowsFor(User $user, ?string $state): Builder
+    {
+        $query = MaintenanceWindow::query()
+            ->visibleTo($user)
+            ->with([
+                'monitoring:id,name',
+                'monitoringGroup:id,name',
+                'monitoringGroup.monitorings:id',
+            ])
+            ->latest('starts_at');
+
+        if ($state === 'disabled') {
+            $query->where('enabled', false);
+        } elseif ($state !== null) {
+            $query->where('enabled', true);
+        }
+
+        return $query;
+    }
+
+    public function decorateOneOff(Monitoring $monitoring, User $user): Monitoring
+    {
+        $now = Date::now();
+        $monitoring->setAttribute('mobile_maintenance_state', match (true) {
+            $monitoring->maintenance_from?->gt($now) === true => 'upcoming',
+            $monitoring->maintenance_until !== null && $monitoring->maintenance_until->lt($now) => 'expired',
+            default => 'active',
+        });
+        $monitoring->setAttribute('mobile_can_manage', $monitoring->isManageableBy($user));
+
+        return $monitoring;
+    }
+
+    public function decorateRecurring(MaintenanceWindow $maintenanceWindow, User $user): MaintenanceWindow
+    {
+        $occurrence = $this->maintenanceWindowService->occurrence($maintenanceWindow);
+        $manageableMonitoringIds = $maintenanceWindow->monitoring_id !== null
+            ? ($maintenanceWindow->monitoring?->isManageableBy($user) ? [$maintenanceWindow->monitoring_id] : [])
+            : $maintenanceWindow->monitoringGroup?->monitorings
+                ->filter(fn (Monitoring $monitoring): bool => $monitoring->isManageableBy($user))
+                ->pluck('id')
+                ->values()
+                ->all() ?? [];
+
+        $maintenanceWindow->setAttribute('mobile_state', match (true) {
+            ! $maintenanceWindow->enabled => 'disabled',
+            $occurrence === null => 'expired',
+            $occurrence['active'] => 'active',
+            default => 'upcoming',
+        });
+        $maintenanceWindow->setAttribute('mobile_can_manage', $maintenanceWindow->isManageableBy($user));
+        $maintenanceWindow->setAttribute('manageable_monitoring_ids', $manageableMonitoringIds);
+        $maintenanceWindow->setAttribute('mobile_ends_at', $occurrence === null ? null : $occurrence['ends_at']->toIso8601String());
+        $maintenanceWindow->setAttribute('mobile_next_occurrence', $occurrence === null ? null : [
+            'starts_at' => $occurrence['starts_at']->toIso8601String(),
+            'ends_at' => $occurrence['ends_at']->toIso8601String(),
+            'active' => $occurrence['active'],
+        ]);
+
+        return $maintenanceWindow;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{operation: MobileMaintenanceOperation, created: bool}
+     */
+    public function schedule(User $user, array $attributes): array
+    {
+        $idempotencyKey = (string) Arr::pull($attributes, 'idempotency_key');
+        $fingerprint = hash('sha256', json_encode(Arr::sortRecursive($attributes), JSON_THROW_ON_ERROR));
+
+        return DB::transaction(function () use ($user, $attributes, $idempotencyKey, $fingerprint): array {
+            $operation = MobileMaintenanceOperation::query()
+                ->where('user_id', $user->id)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+
+            if ($operation instanceof MobileMaintenanceOperation) {
+                if (! hash_equals($operation->fingerprint, $fingerprint)) {
+                    throw ValidationException::withMessages([
+                        'idempotency_key' => ['This idempotency key was already used for a different maintenance operation.'],
+                    ]);
+                }
+
+                return ['operation' => $operation, 'created' => false];
+            }
+
+            if ($attributes['mode'] === 'recurring') {
+                $timezone = (string) $attributes['recurring_timezone'];
+                $maintenanceWindow = MaintenanceWindow::query()->create([
+                    ...$this->target($user, $attributes),
+                    'starts_at' => Date::parse((string) $attributes['recurring_starts_at'], $timezone)->setTimezone('UTC'),
+                    'duration_minutes' => (int) $attributes['recurring_duration_minutes'],
+                    'recurrence' => $attributes['recurrence'],
+                    'repeat_until' => isset($attributes['recurring_repeat_until'])
+                        ? Date::parse((string) $attributes['recurring_repeat_until'], $timezone)->endOfDay()->setTimezone('UTC')
+                        : null,
+                    'timezone' => $timezone,
+                    'enabled' => true,
+                ]);
+                $result = ['kind' => 'recurring', 'maintenance_window_id' => $maintenanceWindow->id];
+            } else {
+                $updatedCount = $this->targetMonitorings($user, $attributes)->update([
+                    'maintenance_from' => Date::parse((string) $attributes['maintenance_from']),
+                    'maintenance_until' => isset($attributes['maintenance_until'])
+                        ? Date::parse((string) $attributes['maintenance_until'])
+                        : null,
+                ]);
+                $maintenanceWindow = null;
+                $result = ['kind' => 'one_off', 'updated_count' => $updatedCount];
+            }
+
+            $operation = MobileMaintenanceOperation::query()->create([
+                'user_id' => $user->id,
+                'idempotency_key' => $idempotencyKey,
+                'fingerprint' => $fingerprint,
+                'operation' => 'schedule',
+                'maintenance_window_id' => $maintenanceWindow?->id,
+                'result' => $result,
+            ]);
+
+            return ['operation' => $operation, 'created' => true];
+        });
+    }
+
+    public function recurringWindowFor(User $user, string $maintenanceWindow): MaintenanceWindow
+    {
+        return MaintenanceWindow::query()
+            ->visibleTo($user)
+            ->whereKey($maintenanceWindow)
+            ->firstOrFail();
+    }
+
+    public function updateRecurringEnabled(MaintenanceWindow $maintenanceWindow, User $user, bool $enabled): MaintenanceWindow
+    {
+        abort_unless($maintenanceWindow->isManageableBy($user), 404);
+        $maintenanceWindow->update(['enabled' => $enabled]);
+
+        return $maintenanceWindow->refresh()->load([
+            'monitoring:id,name',
+            'monitoringGroup:id,name',
+            'monitoringGroup.monitorings:id',
+        ]);
+    }
+
+    public function cancelOneOff(Monitoring $monitoring, User $user): void
+    {
+        abort_unless($monitoring->isManageableBy($user), 404);
+        $monitoring->update(['maintenance_from' => null, 'maintenance_until' => null]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{monitoring_id?: string, monitoring_group_id?: string}
+     */
+    private function target(User $user, array $attributes): array
+    {
+        if ($attributes['scope'] === 'group') {
+            return ['monitoring_group_id' => (string) $attributes['monitoring_group_id']];
+        }
+
+        $this->monitoringForManagement($user, (string) $attributes['monitoring_id']);
+
+        return ['monitoring_id' => (string) $attributes['monitoring_id']];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return Builder<Monitoring>
+     */
+    private function targetMonitorings(User $user, array $attributes): Builder
+    {
+        $query = Monitoring::query()->manageableBy($user);
+
+        if ($attributes['scope'] === 'group') {
+            return $query->whereHas('groups', fn (Builder $builder): Builder => $builder->whereKey((string) $attributes['monitoring_group_id']));
+        }
+
+        return $query->whereKey((string) $attributes['monitoring_id']);
+    }
+
+    private function monitoringForManagement(User $user, string $monitoring): Monitoring
+    {
+        return Monitoring::query()->manageableBy($user)->whereKey($monitoring)->firstOrFail();
+    }
+}

--- a/database/migrations/2026_08_09_220000_create_mobile_maintenance_operations_table.php
+++ b/database/migrations/2026_08_09_220000_create_mobile_maintenance_operations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mobile_maintenance_operations', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->string('idempotency_key', 100);
+            $table->char('fingerprint', 64);
+            $table->string('operation', 32);
+            $table->foreignUlid('maintenance_window_id')->nullable()->constrained()->nullOnDelete();
+            $table->json('result');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'idempotency_key'], 'mobile_maintenance_operations_user_key_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mobile_maintenance_operations');
+    }
+};

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -42,8 +42,10 @@ headers. Mobile app tokens retain their existing separate behavior.
   support; request tokens and authorization headers are never logged.
 - `GET`, `HEAD`, `PUT`, `PATCH`, and `DELETE` follow their HTTP idempotency
   semantics. `POST /mobile-push-devices` is idempotent for a provider/token
-  pair. Other creation endpoints do not currently accept `Idempotency-Key`, so
-  clients must avoid blind retries after an unknown write outcome.
+  pair. Mobile status-page communications and mobile maintenance scheduling
+  define their required `Idempotency-Key` behavior below. Other creation
+  endpoints do not currently accept `Idempotency-Key`, so clients must avoid
+  blind retries after an unknown write outcome.
 - API changes are additive within v1. A deprecated v1 endpoint will announce a
   successor through `Deprecation`, `Sunset`, and `Link` headers before removal;
   a response-shape change requires v2.
@@ -155,6 +157,38 @@ are recorded in the activity log with the authenticated user as causer; token
 values and authorization headers are never recorded. Public status-page
 endpoints and browser management routes keep their existing contracts and do
 not expose this private workspace payload.
+
+## Mobile maintenance operations
+
+Native clients use the dedicated \`/api/v1/mobile/maintenance\` family rather
+than browser maintenance routes. It returns only windows visible to the token
+owner; an item separately reports \`can_manage\`. Private monitorings are
+manageable by their owner, while team-owned monitorings require the existing
+team-administrator role. A team member can therefore see a window without
+being able to change or cancel it.
+
+| Method | Path | Result |
+| --- | --- | --- |
+| \`GET\` | \`/mobile/maintenance/capabilities\` | Manageable monitoring IDs, ownership metadata, personal monitoring groups, and retry capability. |
+| \`GET\` | \`/mobile/maintenance/one-off?state=active|upcoming|expired\` | Paginated visible one-off windows. |
+| \`GET\` | \`/mobile/maintenance/recurring?state=active|upcoming|expired|disabled\` | Paginated visible recurring windows, including enabled state and next occurrence. |
+| \`POST\` | \`/mobile/maintenance\` | Schedules one-off or recurring maintenance with the existing \`mode\` and \`scope\` request fields. |
+| \`PATCH\` | \`/mobile/maintenance/recurring/{maintenanceWindow}\` | Enables or disables an authorized recurring window. |
+| \`DELETE\` | \`/mobile/maintenance/one-off/{monitoring}\` | Cancels one authorized one-off maintenance window. |
+
+All timestamps are ISO-8601 with offsets. Recurring payloads include their
+IANA timezone, duration, repeat-until boundary, and server-calculated next
+occurrence so the client does not recalculate recurrence or DST rules.
+\`state\` is one of \`active\`, \`upcoming\`, \`expired\`, or \`disabled\`; recurring
+windows report \`disabled\` only when they have been switched off.
+
+\`POST\` requires an \`Idempotency-Key\` header (one to 100 characters). A retry
+with the same key and payload returns the original operation result with \`200\`
+and \`idempotent: true\`; the initial operation returns \`201\`. Reusing a key for
+a different payload yields a field-keyed \`422\` validation error. \`PATCH\` and
+\`DELETE\` retain normal HTTP idempotency semantics. Existing Laravel validation
+errors remain \`{ "message", "errors" }\`, while missing, invisible, or
+unmanageable mutation targets return \`404\`.
 
 Scribe generates the OpenAPI and reference documentation from route metadata,
 request rules, controller annotations, and this configuration. Do not edit the

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
+use App\Http\Controllers\Api\External\MobileMaintenanceController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
 use App\Http\Controllers\Api\External\MobileStatusPageWorkspaceController;
@@ -41,6 +42,15 @@ Route::group(['prefix' => 'monitorings', 'as' => 'monitorings.'], function (): v
 
 Route::get('/mobile/overview', MobileOverviewController::class)
     ->name('mobile.overview');
+
+Route::group(['prefix' => 'mobile/maintenance', 'as' => 'mobile.maintenance.'], function (): void {
+    Route::get('/capabilities', [MobileMaintenanceController::class, 'capabilities'])->name('capabilities');
+    Route::get('/one-off', [MobileMaintenanceController::class, 'oneOffIndex'])->name('one-off.index');
+    Route::get('/recurring', [MobileMaintenanceController::class, 'recurringIndex'])->name('recurring.index');
+    Route::post('/', [MobileMaintenanceController::class, 'store'])->name('store');
+    Route::patch('/recurring/{maintenanceWindow}', [MobileMaintenanceController::class, 'updateRecurring'])->name('recurring.update');
+    Route::delete('/one-off/{monitoring}', [MobileMaintenanceController::class, 'cancelOneOff'])->name('one-off.destroy');
+});
 
 Route::group(['prefix' => 'mobile/monitoring-groups', 'as' => 'mobile.monitoring-groups.'], function (): void {
     Route::get('/', [MobileMonitoringGroupController::class, 'index'])->name('index');

--- a/tests/Feature/Api/MobileMaintenanceApiTest.php
+++ b/tests/Feature/Api/MobileMaintenanceApiTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\MaintenanceWindowRecurrence;
+use App\Enums\TeamRole;
+use App\Models\MaintenanceWindow;
+use App\Models\Monitoring;
+use App\Models\MonitoringGroup;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class MobileMaintenanceApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mobile_workspace_scopes_visible_windows_and_management_capabilities(): void
+    {
+        Date::setTestNow('2026-03-29 12:00:00 UTC');
+        $user = $this->user();
+        $privateMonitoring = Monitoring::factory()->for($user)->create([
+            'name' => 'Private API',
+            'maintenance_from' => Date::now()->subHour(),
+            'maintenance_until' => Date::now()->addHour(),
+        ]);
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::MEMBER]);
+        $teamMonitoring = Monitoring::factory()->for($team)->create([
+            'user_id' => null,
+            'name' => 'Team API',
+            'maintenance_from' => Date::now()->addHour(),
+            'maintenance_until' => Date::now()->addHours(2),
+        ]);
+        $otherMonitoring = Monitoring::factory()->for($this->user())->create([
+            'name' => 'Hidden API',
+            'maintenance_from' => Date::now()->subHour(),
+        ]);
+        $recurring = MaintenanceWindow::query()->create([
+            'monitoring_id' => $privateMonitoring->id,
+            'starts_at' => '2026-03-22 01:30:00',
+            'duration_minutes' => 90,
+            'recurrence' => MaintenanceWindowRecurrence::WEEKLY,
+            'timezone' => 'Europe/Berlin',
+            'enabled' => true,
+        ]);
+        $this->actingAsMobile($user);
+
+        $this->getJson('/api/v1/mobile/maintenance/capabilities')
+            ->assertOk()
+            ->assertJsonPath('data.can_schedule', true)
+            ->assertJsonPath('data.manageable_monitoring_ids.0', $privateMonitoring->id)
+            ->assertJsonMissing(['id' => $teamMonitoring->id]);
+
+        $this->getJson('/api/v1/mobile/maintenance/one-off')
+            ->assertOk()
+            ->assertJsonFragment(['id' => $privateMonitoring->id, 'state' => 'active', 'can_manage' => true])
+            ->assertJsonFragment(['id' => $teamMonitoring->id, 'state' => 'upcoming', 'can_manage' => false])
+            ->assertJsonMissing(['id' => $otherMonitoring->id]);
+
+        $this->getJson('/api/v1/mobile/maintenance/recurring?state=upcoming')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $recurring->id)
+            ->assertJsonPath('data.0.schedule.timezone', 'Europe/Berlin')
+            ->assertJsonPath('data.0.kind', 'recurring');
+    }
+
+    public function test_mobile_user_can_idempotently_schedule_and_toggle_recurring_maintenance(): void
+    {
+        $user = $this->user();
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+        $this->actingAsMobile($user);
+
+        $payload = [
+            'mode' => 'recurring',
+            'scope' => 'monitoring',
+            'monitoring_id' => $monitoring->id,
+            'recurring_starts_at' => '2026-10-25T02:30:00',
+            'recurring_duration_minutes' => 90,
+            'recurrence' => MaintenanceWindowRecurrence::WEEKLY->value,
+            'recurring_timezone' => 'Europe/Berlin',
+        ];
+
+        $this->withHeaders(['Idempotency-Key' => 'recurring-maintenance-001'])
+            ->postJson('/api/v1/mobile/maintenance', $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.kind', 'recurring')
+            ->assertJsonPath('idempotent', false);
+        $this->withHeaders(['Idempotency-Key' => 'recurring-maintenance-001'])
+            ->postJson('/api/v1/mobile/maintenance', $payload)
+            ->assertOk()
+            ->assertJsonPath('idempotent', true);
+        $this->assertDatabaseCount('maintenance_windows', 1);
+
+        $window = MaintenanceWindow::query()->firstOrFail();
+        $this->patchJson('/api/v1/mobile/maintenance/recurring/' . $window->id, ['enabled' => false])
+            ->assertOk()
+            ->assertJsonPath('data.state', 'disabled');
+        $this->patchJson('/api/v1/mobile/maintenance/recurring/' . $window->id, ['enabled' => true])
+            ->assertOk()
+            ->assertJsonPath('data.enabled', true);
+
+        $this->postJson('/api/v1/mobile/maintenance', [
+            'scope' => 'monitoring',
+            'monitoring_id' => $monitoring->id,
+            'maintenance_from' => '2026-10-26T10:00:00+01:00',
+            'maintenance_until' => '2026-10-26T11:00:00+01:00',
+        ])->assertUnprocessable()->assertJsonValidationErrors('idempotency_key');
+    }
+
+    public function test_mobile_user_can_schedule_group_one_off_maintenance_and_cannot_mutate_team_member_windows(): void
+    {
+        $user = $this->user();
+        $group = MonitoringGroup::factory()->for($user)->create();
+        $firstMonitoring = Monitoring::factory()->for($user)->create();
+        $secondMonitoring = Monitoring::factory()->for($user)->create();
+        $group->monitorings()->attach([$firstMonitoring->id, $secondMonitoring->id]);
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::MEMBER]);
+        $teamMonitoring = Monitoring::factory()->for($team)->create(['user_id' => null]);
+        $this->actingAsMobile($user);
+
+        $payload = [
+            'scope' => 'group',
+            'monitoring_group_id' => $group->id,
+            'maintenance_from' => '2026-08-10T10:00:00Z',
+            'maintenance_until' => '2026-08-10T11:00:00Z',
+        ];
+        $this->withHeaders(['Idempotency-Key' => 'group-maintenance-001'])
+            ->postJson('/api/v1/mobile/maintenance', $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.updated_count', 2);
+        $this->withHeaders(['Idempotency-Key' => 'group-maintenance-001'])
+            ->postJson('/api/v1/mobile/maintenance', $payload)
+            ->assertOk()
+            ->assertJsonPath('idempotent', true);
+        $this->assertDatabaseHas('monitorings', ['id' => $firstMonitoring->id, 'maintenance_until' => '2026-08-10 11:00:00']);
+        $this->deleteJson('/api/v1/mobile/maintenance/one-off/' . $teamMonitoring->id)->assertNotFound();
+
+        $this->deleteJson('/api/v1/mobile/maintenance/one-off/' . $firstMonitoring->id)->assertNoContent();
+        $this->assertDatabaseHas('monitorings', ['id' => $firstMonitoring->id, 'maintenance_from' => null, 'maintenance_until' => null]);
+    }
+
+    private function user(): User
+    {
+        return User::factory()->create(['package_id' => Package::factory()->create(['monitoring_limit' => 20])->id]);
+    }
+
+    private function actingAsMobile(User $user): void
+    {
+        $this->withToken($user->createToken('ios-app: Test Device')->plainTextToken);
+    }
+}


### PR DESCRIPTION
## Summary

- add the authenticated v1 mobile maintenance workspace for capabilities, one-off windows, and recurring windows
- expose server-calculated state, next recurrence, timezone, ownership, and manageable monitoring metadata
- add safe recurring enable/disable and one-off cancellation operations
- persist idempotency records for mobile scheduling retries and document the contract

## Why

Native clients need maintenance operations without depending on browser controllers or recalculating recurrence and DST behavior.

## Testing

- `composer test`
- `composer analyse`
- `php ./vendor/bin/pint --dirty`
- added `MobileMaintenanceApiTest` for token scoping, team permissions, recurrence/DST payloads, idempotent retries, group updates, and cancellation

## Risks and follow-up

The endpoints are additive within external API v1. Existing browser maintenance flows and existing API clients retain their current routes and response contracts.

Closes #655