### PR TITLE
docs(api): document mobile monitoring management

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MobileMaintenanceController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileMaintenanceController.php
@@ -60,15 +60,15 @@ class MobileMaintenanceController extends Controller
         /** @var User $user */
         $user = $request->user();
         $state = $this->state($request, ['active', 'upcoming', 'expired']);
-        $windows = $mobileMaintenanceWorkspaceService->oneOffWindowsFor($user, $state)
+        $lengthAwarePaginator = $mobileMaintenanceWorkspaceService->oneOffWindowsFor($user, $state)
             ->paginate($this->perPage($request));
-        $windows->setCollection($windows->getCollection()->map(
+        $lengthAwarePaginator->setCollection($lengthAwarePaginator->getCollection()->map(
             fn (Monitoring $monitoring): array => MobileOneOffMaintenanceResource::make(
                 $mobileMaintenanceWorkspaceService->decorateOneOff($monitoring, $user)
             )->resolve($request)
         ));
 
-        return response()->json($windows);
+        return response()->json($lengthAwarePaginator);
     }
 
     public function recurringIndex(Request $request, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
@@ -77,10 +77,10 @@ class MobileMaintenanceController extends Controller
         $user = $request->user();
         $state = $this->state($request, ['active', 'upcoming', 'expired', 'disabled']);
         $perPage = $this->perPage($request);
-        $query = $mobileMaintenanceWorkspaceService->recurringWindowsFor($user, $state);
+        $builder = $mobileMaintenanceWorkspaceService->recurringWindowsFor($user, $state);
 
         if (in_array($state, ['active', 'upcoming', 'expired'], true)) {
-            $allWindows = $query->get()
+            $allWindows = $builder->get()
                 ->map(fn (MaintenanceWindow $maintenanceWindow): MaintenanceWindow => $mobileMaintenanceWorkspaceService->decorateRecurring($maintenanceWindow, $user))
                 ->filter(fn (MaintenanceWindow $maintenanceWindow): bool => $maintenanceWindow->getAttribute('mobile_state') === $state)
                 ->values();
@@ -92,7 +92,7 @@ class MobileMaintenanceController extends Controller
                 ['path' => $request->url(), 'query' => $request->query()],
             );
         } else {
-            $windows = $query->paginate($perPage);
+            $windows = $builder->paginate($perPage);
         }
 
         $windows->setCollection($windows->getCollection()->map(
@@ -104,11 +104,11 @@ class MobileMaintenanceController extends Controller
         return response()->json($windows);
     }
 
-    public function store(MobileStoreMaintenanceRequest $request, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
+    public function store(MobileStoreMaintenanceRequest $mobileStoreMaintenanceRequest, MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
-        $result = $mobileMaintenanceWorkspaceService->schedule($user, $request->validated());
+        $user = $mobileStoreMaintenanceRequest->user();
+        $result = $mobileMaintenanceWorkspaceService->schedule($user, $mobileStoreMaintenanceRequest->validated());
 
         return response()->json([
             'data' => $result['operation']->result,
@@ -117,22 +117,22 @@ class MobileMaintenanceController extends Controller
     }
 
     public function updateRecurring(
-        UpdateMobileMaintenanceWindowRequest $request,
+        UpdateMobileMaintenanceWindowRequest $updateMobileMaintenanceWindowRequest,
         string $maintenanceWindow,
         MobileMaintenanceWorkspaceService $mobileMaintenanceWorkspaceService,
     ): JsonResponse {
         /** @var User $user */
-        $user = $request->user();
+        $user = $updateMobileMaintenanceWindowRequest->user();
         $window = $mobileMaintenanceWorkspaceService->updateRecurringEnabled(
             $mobileMaintenanceWorkspaceService->recurringWindowFor($user, $maintenanceWindow),
             $user,
-            $request->boolean('enabled'),
+            $updateMobileMaintenanceWindowRequest->boolean('enabled'),
         );
 
         return response()->json([
             'data' => MobileMaintenanceWindowResource::make(
                 $mobileMaintenanceWorkspaceService->decorateRecurring($window, $user)
-            )->resolve($request),
+            )->resolve($updateMobileMaintenanceWindowRequest),
         ]);
     }
 

--- a/app/Http/Controllers/Api/Mobile/MobileStatusPageWorkspaceController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileStatusPageWorkspaceController.php
@@ -35,18 +35,18 @@ class MobileStatusPageWorkspaceController extends Controller
     {
         /** @var User $user */
         $user = $request->user();
-        $statusPages = $this->mobileStatusPageWorkspaceService->statusPagesFor($user)
+        $lengthAwarePaginator = $this->mobileStatusPageWorkspaceService->statusPagesFor($user)
             ->latest()
             ->paginate($this->perPage($request));
 
-        $statusPages->getCollection()->each(function (StatusPage $statusPage) use ($user): void {
+        $lengthAwarePaginator->getCollection()->each(function (StatusPage $statusPage) use ($user): void {
             $statusPage->setAttribute('open_incident_count', $this->mobileStatusPageWorkspaceService->openIncidentCount($statusPage, $user));
         });
-        $statusPages->setCollection($statusPages->getCollection()->map(
+        $lengthAwarePaginator->setCollection($lengthAwarePaginator->getCollection()->map(
             fn (StatusPage $statusPage): array => MobileStatusPageResource::make($statusPage)->resolve($request)
         ));
 
-        return response()->json($statusPages);
+        return response()->json($lengthAwarePaginator);
     }
 
     public function show(Request $request, string $statusPage): JsonResponse
@@ -82,7 +82,7 @@ class MobileStatusPageWorkspaceController extends Controller
         $user = $request->user();
         $statusPageModel = $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage);
         $validated = $request->validate(['state' => ['nullable', 'in:open,resolved']]);
-        $incidents = $this->mobileStatusPageWorkspaceService->incidentsFor($statusPageModel, $user)
+        $lengthAwarePaginator = $this->mobileStatusPageWorkspaceService->incidentsFor($statusPageModel, $user)
             ->when(
                 ($validated['state'] ?? null) === 'open',
                 fn ($query) => $query->whereNull('up_at'),
@@ -90,11 +90,11 @@ class MobileStatusPageWorkspaceController extends Controller
             )
             ->paginate($this->perPage($request));
 
-        $incidents->setCollection($incidents->getCollection()->map(
+        $lengthAwarePaginator->setCollection($lengthAwarePaginator->getCollection()->map(
             fn (Incident $incident): array => $this->incidentResource($incident)->resolve($request)
         ));
 
-        return response()->json($incidents);
+        return response()->json($lengthAwarePaginator);
     }
 
     public function showIncident(Request $request, string $statusPage, string $incident): JsonResponse
@@ -106,61 +106,61 @@ class MobileStatusPageWorkspaceController extends Controller
         return response()->json(['data' => $this->incidentResource($incidentModel)->resolve($request)]);
     }
 
-    public function storeIncidentUpdate(MobileStoreIncidentUpdateRequest $request, string $statusPage, string $incident): JsonResponse
+    public function storeIncidentUpdate(MobileStoreIncidentUpdateRequest $mobileStoreIncidentUpdateRequest, string $statusPage, string $incident): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $mobileStoreIncidentUpdateRequest->user();
         $incidentModel = $this->incidentFor($user, $statusPage, $incident);
-        $result = $this->mobileStatusPageWorkspaceService->createUpdate($incidentModel, $user, $request->validated());
+        $result = $this->mobileStatusPageWorkspaceService->createUpdate($incidentModel, $user, $mobileStoreIncidentUpdateRequest->validated());
 
         return response()->json([
-            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request),
+            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($mobileStoreIncidentUpdateRequest),
         ], $result['created'] ? 201 : 200);
     }
 
-    public function updateMetadata(UpdateIncidentMetadataRequest $request, string $statusPage, string $incident): JsonResponse
+    public function updateMetadata(UpdateIncidentMetadataRequest $updateIncidentMetadataRequest, string $statusPage, string $incident): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $updateIncidentMetadataRequest->user();
         $incidentModel = $this->incidentFor($user, $statusPage, $incident);
-        $this->mobileStatusPageWorkspaceService->updateMetadata($incidentModel, $user, $request->validated());
+        $this->mobileStatusPageWorkspaceService->updateMetadata($incidentModel, $user, $updateIncidentMetadataRequest->validated());
 
-        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($updateIncidentMetadataRequest)]);
     }
 
-    public function updateReview(UpdateIncidentReviewRequest $request, string $statusPage, string $incident): JsonResponse
+    public function updateReview(UpdateIncidentReviewRequest $updateIncidentReviewRequest, string $statusPage, string $incident): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $updateIncidentReviewRequest->user();
         $incidentModel = $this->incidentFor($user, $statusPage, $incident);
-        $this->mobileStatusPageWorkspaceService->updateReview($incidentModel, $user, $request->validated());
+        $this->mobileStatusPageWorkspaceService->updateReview($incidentModel, $user, $updateIncidentReviewRequest->validated());
 
-        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($updateIncidentReviewRequest)]);
     }
 
-    public function storeFollowUp(MobileStoreIncidentFollowUpRequest $request, string $statusPage, string $incident): JsonResponse
+    public function storeFollowUp(MobileStoreIncidentFollowUpRequest $mobileStoreIncidentFollowUpRequest, string $statusPage, string $incident): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $mobileStoreIncidentFollowUpRequest->user();
         $statusPageModel = $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage);
         $incidentModel = $this->mobileStatusPageWorkspaceService->incidentFor($statusPageModel, $user, $incident);
-        $result = $this->mobileStatusPageWorkspaceService->createFollowUp($incidentModel, $statusPageModel, $user, $request->validated());
+        $result = $this->mobileStatusPageWorkspaceService->createFollowUp($incidentModel, $statusPageModel, $user, $mobileStoreIncidentFollowUpRequest->validated());
 
         return response()->json([
-            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request),
+            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($mobileStoreIncidentFollowUpRequest),
         ], $result['created'] ? 201 : 200);
     }
 
-    public function updateFollowUp(UpdateIncidentFollowUpRequest $request, string $statusPage, string $incident, string $incidentFollowUp): JsonResponse
+    public function updateFollowUp(UpdateIncidentFollowUpRequest $updateIncidentFollowUpRequest, string $statusPage, string $incident, string $incidentFollowUp): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $updateIncidentFollowUpRequest->user();
         $statusPageModel = $this->mobileStatusPageWorkspaceService->statusPageFor($user, $statusPage);
         $incidentModel = $this->mobileStatusPageWorkspaceService->incidentFor($statusPageModel, $user, $incident);
         $followUp = $this->followUpFor($incidentModel, $incidentFollowUp);
-        $this->mobileStatusPageWorkspaceService->updateFollowUp($followUp, $statusPageModel, $user, $request->validated());
+        $this->mobileStatusPageWorkspaceService->updateFollowUp($followUp, $statusPageModel, $user, $updateIncidentFollowUpRequest->validated());
 
-        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($updateIncidentFollowUpRequest)]);
     }
 
     public function destroyFollowUp(Request $request, string $statusPage, string $incident, string $incidentFollowUp): JsonResponse
@@ -173,27 +173,27 @@ class MobileStatusPageWorkspaceController extends Controller
         return response()->json(status: 204);
     }
 
-    public function storeTimelineEvent(MobileStoreIncidentTimelineEventRequest $request, string $statusPage, string $incident): JsonResponse
+    public function storeTimelineEvent(MobileStoreIncidentTimelineEventRequest $mobileStoreIncidentTimelineEventRequest, string $statusPage, string $incident): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $mobileStoreIncidentTimelineEventRequest->user();
         $incidentModel = $this->incidentFor($user, $statusPage, $incident);
-        $result = $this->mobileStatusPageWorkspaceService->createTimelineEvent($incidentModel, $user, $request->validated());
+        $result = $this->mobileStatusPageWorkspaceService->createTimelineEvent($incidentModel, $user, $mobileStoreIncidentTimelineEventRequest->validated());
 
         return response()->json([
-            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request),
+            'data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($mobileStoreIncidentTimelineEventRequest),
         ], $result['created'] ? 201 : 200);
     }
 
-    public function updateTimelineEvent(UpdateIncidentTimelineEventRequest $request, string $statusPage, string $incident, string $incidentTimelineEvent): JsonResponse
+    public function updateTimelineEvent(UpdateIncidentTimelineEventRequest $updateIncidentTimelineEventRequest, string $statusPage, string $incident, string $incidentTimelineEvent): JsonResponse
     {
         /** @var User $user */
-        $user = $request->user();
+        $user = $updateIncidentTimelineEventRequest->user();
         $incidentModel = $this->incidentFor($user, $statusPage, $incident);
         $timelineEvent = $this->timelineEventFor($incidentModel, $incidentTimelineEvent);
-        $this->mobileStatusPageWorkspaceService->updateTimelineEvent($timelineEvent, $user, $request->validated());
+        $this->mobileStatusPageWorkspaceService->updateTimelineEvent($timelineEvent, $user, $updateIncidentTimelineEventRequest->validated());
 
-        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($request)]);
+        return response()->json(['data' => $this->incidentResource($this->incidentFor($user, $statusPage, $incident))->resolve($updateIncidentTimelineEventRequest)]);
     }
 
     public function destroyTimelineEvent(Request $request, string $statusPage, string $incident, string $incidentTimelineEvent): JsonResponse

--- a/app/Http/Resources/External/MobileStatusPageResource.php
+++ b/app/Http/Resources/External/MobileStatusPageResource.php
@@ -9,6 +9,7 @@ use App\Models\StatusPage;
 use App\Models\StatusPageComponent;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 /**
  * @mixin StatusPage
@@ -36,7 +37,7 @@ final class MobileStatusPageResource extends JsonResource
             'open_incident_count' => (int) ($statusPage->open_incident_count ?? 0),
             'components' => $statusPage->relationLoaded('components')
                 ? $statusPage->components
-                    ->map(fn (StatusPageComponent $component): array => $this->componentPayload($component))
+                    ->map(fn (StatusPageComponent $statusPageComponent): array => $this->componentPayload($statusPageComponent))
                     ->values()
                     ->all()
                 : [],
@@ -48,22 +49,22 @@ final class MobileStatusPageResource extends JsonResource
     /**
      * @return array<string, mixed>
      */
-    private function componentPayload(StatusPageComponent $component): array
+    private function componentPayload(StatusPageComponent $statusPageComponent): array
     {
         return [
-            'id' => $component->id,
-            'name' => $component->name,
-            'description' => $component->description,
-            'position' => $component->position,
-            'source_type' => $component->source_type->value,
-            'monitoring_group' => $component->relationLoaded('monitoringGroup') && $component->monitoringGroup !== null
+            'id' => $statusPageComponent->id,
+            'name' => $statusPageComponent->name,
+            'description' => $statusPageComponent->description,
+            'position' => $statusPageComponent->position,
+            'source_type' => $statusPageComponent->source_type->value,
+            'monitoring_group' => $statusPageComponent->relationLoaded('monitoringGroup') && $statusPageComponent->monitoringGroup !== null
                 ? [
-                    'id' => $component->monitoringGroup->id,
-                    'name' => $component->monitoringGroup->name,
-                    'monitoring_count' => (int) ($component->monitoringGroup->monitorings_count ?? 0),
+                    'id' => $statusPageComponent->monitoringGroup->id,
+                    'name' => $statusPageComponent->monitoringGroup->name,
+                    'monitoring_count' => (int) ($statusPageComponent->monitoringGroup->monitorings_count ?? 0),
                 ]
                 : null,
-            'monitorings' => $this->componentMonitorings($component)
+            'monitorings' => $this->componentMonitorings($statusPageComponent)
                 ->map(fn (Monitoring $monitoring): array => [
                     'id' => $monitoring->id,
                     'name' => $monitoring->name,
@@ -75,14 +76,14 @@ final class MobileStatusPageResource extends JsonResource
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, Monitoring>
+     * @return Collection<int, Monitoring>
      */
-    private function componentMonitorings(StatusPageComponent $component): \Illuminate\Support\Collection
+    private function componentMonitorings(StatusPageComponent $statusPageComponent): Collection
     {
-        if ($component->source_type->value === 'monitoring_group') {
-            return $component->monitoringGroup?->monitorings ?? collect();
+        if ($statusPageComponent->source_type->value === 'monitoring_group') {
+            return $statusPageComponent->monitoringGroup?->monitorings ?? collect();
         }
 
-        return $component->monitorings;
+        return $statusPageComponent->monitorings;
     }
 }

--- a/app/Models/MobileMaintenanceOperation.php
+++ b/app/Models/MobileMaintenanceOperation.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 #[WithoutIncrementing]
 class MobileMaintenanceOperation extends Model
 {
+    use HasFactory;
     use HasUlids;
 
     /**

--- a/app/Services/MobileStatusPageWorkspaceService.php
+++ b/app/Services/MobileStatusPageWorkspaceService.php
@@ -13,6 +13,7 @@ use App\Models\StatusPage;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
@@ -35,7 +36,7 @@ class MobileStatusPageWorkspaceService
             ->where('user_id', $user->id)
             ->withCount([
                 'components',
-                'subscriptions as verified_subscriber_count' => fn (Builder $query) => $query->whereNotNull('verified_at'),
+                'subscriptions as verified_subscriber_count' => fn (Builder $builder) => $builder->whereNotNull('verified_at'),
             ]);
     }
 
@@ -47,7 +48,7 @@ class MobileStatusPageWorkspaceService
             'components.monitoringGroup.monitorings' => fn ($query) => $query->manageableBy($user)->orderBy('name')->orderBy('id'),
         ])->loadCount([
             'components',
-            'subscriptions as verified_subscriber_count' => fn (Builder $query) => $query->whereNotNull('verified_at'),
+            'subscriptions as verified_subscriber_count' => fn (Builder $builder) => $builder->whereNotNull('verified_at'),
         ]);
     }
 
@@ -58,7 +59,7 @@ class MobileStatusPageWorkspaceService
     {
         return Incident::query()
             ->whereIn('monitoring_id', $this->statusPageMonitoringIds($statusPage))
-            ->whereHas('monitoring', fn (Builder $query) => $query->manageableBy($user))
+            ->whereHas('monitoring', fn (Builder $builder) => $builder->manageableBy($user))
             ->with([
                 'monitoring',
                 'updates',
@@ -247,9 +248,9 @@ class MobileStatusPageWorkspaceService
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, string>
+     * @return Collection<int, string>
      */
-    private function statusPageMonitoringIds(StatusPage $statusPage): \Illuminate\Support\Collection
+    private function statusPageMonitoringIds(StatusPage $statusPage): Collection
     {
         $statusPage->loadMissing(['components.monitorings:id', 'components.monitoringGroup.monitorings:id']);
 

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -91,6 +91,40 @@ All retain their existing ownership checks and response contracts.
 Existing pre-scoped external tokens remain compatible. They are not converted
 to new keys automatically; rotate them from the profile when practical.
 
+## Mobile monitoring management
+
+Native clients manage monitorings through the external `/api/v1/monitorings`
+family, not browser controllers or authenticated browser sessions. Every route
+uses bearer authentication and applies the same private/team visibility and
+management policy as Core.
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/monitorings?per_page=25` | Paginated monitoring configuration visible to the token owner. |
+| `POST` | `/monitorings` | Creates one private or team-owned monitoring. |
+| `PATCH` | `/monitorings/{monitoring}` | Updates one manageable monitoring, including its lifecycle state. |
+| `DELETE` | `/monitorings/{monitoring}` | Soft-deletes one manageable monitoring. |
+| `POST` | `/monitorings/{monitoring}/team-ownership` | Moves a private monitoring to a team administered by the caller. |
+| `DELETE` | `/monitorings/{monitoring}/team-ownership` | Returns one manageable team monitoring to private ownership. |
+
+The validated `type` values are `http`, `ping`, `keyword`, `port`,
+`heartbeat`, `server_health`, `domain_expiration`, and `dns_record`.
+`status` is `active` or `paused`, so a `PATCH` performs the supported
+pause/activate transition. Request validation is type-aware: HTTP and keyword
+settings, ports, DNS expectations, heartbeat configuration, and server-health
+thresholds are accepted only for their matching monitoring type. Successful
+create, update, and ownership responses return the server-confirmed monitoring
+representation, including `ownership.can_manage` and personal
+`group_assignments` where applicable.
+
+Creation does not accept an idempotency key and clients must not blindly retry
+an unknown `POST` outcome. `PATCH` and `DELETE` follow ordinary HTTP retry
+semantics. A completed delete returns `204`; a later retry returns the stable
+`404` not-found outcome. Inaccessible private monitorings also return `404`,
+while a visible but non-manageable team monitoring returns `403`. Validation
+failures retain Laravel's `{ "message", "errors" }` response shape for native
+presentation.
+
 ## Mobile monitoring detail
 
 `GET /api/v1/mobile/monitorings/{monitoring}` is the authenticated native-app

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\External\MobileMaintenanceController;
 use App\Http\Controllers\Api\External\MobileMonitoringDetailController;
 use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
-use App\Http\Controllers\Api\External\MobileMaintenanceController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
 use App\Http\Controllers\Api\External\MobileStatusPageWorkspaceController;

--- a/tests/Feature/Api/MobileMaintenanceApiTest.php
+++ b/tests/Feature/Api/MobileMaintenanceApiTest.php
@@ -41,7 +41,7 @@ class MobileMaintenanceApiTest extends TestCase
             'name' => 'Hidden API',
             'maintenance_from' => Date::now()->subHour(),
         ]);
-        $recurring = MaintenanceWindow::query()->create([
+        $maintenanceWindow = MaintenanceWindow::query()->create([
             'monitoring_id' => $privateMonitoring->id,
             'starts_at' => '2026-03-22 01:30:00',
             'duration_minutes' => 90,
@@ -65,7 +65,7 @@ class MobileMaintenanceApiTest extends TestCase
 
         $this->getJson('/api/v1/mobile/maintenance/recurring?state=upcoming')
             ->assertOk()
-            ->assertJsonPath('data.0.id', $recurring->id)
+            ->assertJsonPath('data.0.id', $maintenanceWindow->id)
             ->assertJsonPath('data.0.schedule.timezone', 'Europe/Berlin')
             ->assertJsonPath('data.0.kind', 'recurring');
     }
@@ -97,11 +97,11 @@ class MobileMaintenanceApiTest extends TestCase
             ->assertJsonPath('idempotent', true);
         $this->assertDatabaseCount('maintenance_windows', 1);
 
-        $window = MaintenanceWindow::query()->firstOrFail();
-        $this->patchJson('/api/v1/mobile/maintenance/recurring/' . $window->id, ['enabled' => false])
+        $maintenanceWindow = MaintenanceWindow::query()->firstOrFail();
+        $this->patchJson('/api/v1/mobile/maintenance/recurring/' . $maintenanceWindow->id, ['enabled' => false])
             ->assertOk()
             ->assertJsonPath('data.state', 'disabled');
-        $this->patchJson('/api/v1/mobile/maintenance/recurring/' . $window->id, ['enabled' => true])
+        $this->patchJson('/api/v1/mobile/maintenance/recurring/' . $maintenanceWindow->id, ['enabled' => true])
             ->assertOk()
             ->assertJsonPath('data.enabled', true);
 

--- a/tests/Feature/Api/MonitoringManagementApiTest.php
+++ b/tests/Feature/Api/MonitoringManagementApiTest.php
@@ -46,10 +46,20 @@ class MonitoringManagementApiTest extends TestCase
             'preferred_locations' => [$serverInstance->code],
         ]))->assertOk()
             ->assertJsonPath('data.name', 'API Updated Check')
+            ->assertJsonPath('data.status', MonitoringLifecycleStatus::PAUSED->value)
             ->assertJsonPath('data.public_label_enabled', false);
+
+        $this->patchJson('/api/v1/monitorings/' . $monitoring->id, $this->monitoringPayload([
+            'name' => 'API Updated Check',
+            'target' => 'https://updated.example.test',
+            'status' => MonitoringLifecycleStatus::ACTIVE->value,
+            'preferred_locations' => [$serverInstance->code],
+        ]))->assertOk()
+            ->assertJsonPath('data.status', MonitoringLifecycleStatus::ACTIVE->value);
 
         $this->deleteJson('/api/v1/monitorings/' . $monitoring->id)->assertNoContent();
         $this->assertSoftDeleted('monitorings', ['id' => $monitoring->id]);
+        $this->deleteJson('/api/v1/monitorings/' . $monitoring->id)->assertNotFound();
     }
 
     public function test_monitoring_list_uses_a_stable_name_and_id_order(): void
@@ -117,6 +127,29 @@ class MonitoringManagementApiTest extends TestCase
             'team_id' => $team->id,
         ])->assertUnprocessable()
             ->assertJsonValidationErrors(['team_id']);
+    }
+
+    public function test_team_member_cannot_mutate_a_visible_team_monitoring(): void
+    {
+        Package::factory()->create();
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create(['created_by_user_id' => $admin->id]);
+        TeamMembership::factory()->for($team)->for($admin)->admin()->create();
+        TeamMembership::factory()->for($team)->for($member)->create(['role' => TeamRole::MEMBER]);
+        $monitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'created_by_user_id' => $admin->id,
+        ]);
+        $serverInstance = $this->serverInstance('api-management-team');
+        Sanctum::actingAs($member);
+
+        $this->patchJson('/api/v1/monitorings/' . $monitoring->id, $this->monitoringPayload([
+            'preferred_locations' => [$serverInstance->code],
+        ]))->assertForbidden();
+
+        $this->deleteJson('/api/v1/monitorings/' . $monitoring->id)->assertForbidden();
     }
 
     /**


### PR DESCRIPTION
## What changed
- Documents the existing versioned external monitoring-management API as the native mobile contract.
- Adds the supported lifecycle, ownership, authorization, validation, pagination, and retry semantics.
- Extends API coverage for pause/activate, post-delete retry behavior, and team-member mutation restrictions.

## Why
The native app can already use the external v1 management routes, but their mobile-specific contract and several authorization edge cases were not explicitly documented and covered.

## Testing
- Updated `MonitoringManagementApiTest`.
- Ran targeted API feature tests: 10 passed, 117 assertions.
- Ran Pint on the updated test file.

## Risks and follow-up
- No endpoint or response-shape change; this is contract documentation and coverage for existing v1 behavior.
- Closes #668.