### PR TITLE
feat(api): add mobile notification board

### DIFF
--- a/app/Http/Controllers/Api/External/MobileMonitoringNotificationPreferenceController.php
+++ b/app/Http/Controllers/Api/External/MobileMonitoringNotificationPreferenceController.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/** @group Mobile monitoring notification preferences */
+class MobileMonitoringNotificationPreferenceController extends \App\Http\Controllers\Api\Mobile\MobileMonitoringNotificationPreferenceController {}

--- a/app/Http/Controllers/Api/External/MobileNotificationBoardController.php
+++ b/app/Http/Controllers/Api/External/MobileNotificationBoardController.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\External;
+
+/** @group Mobile notification board */
+class MobileNotificationBoardController extends \App\Http\Controllers\Api\Mobile\MobileNotificationBoardController {}

--- a/app/Http/Controllers/Api/Mobile/MobileMonitoringNotificationPreferenceController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileMonitoringNotificationPreferenceController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Monitoring;
+use App\Models\User;
+use App\Services\Notifications\MonitoringNotificationPreferenceResolver;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class MobileMonitoringNotificationPreferenceController extends Controller
+{
+    public function show(Request $request, string $monitoring, MonitoringNotificationPreferenceResolver $preferenceResolver): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $monitoringModel = Monitoring::query()->visibleTo($user)->whereKey($monitoring)->firstOrFail();
+
+        return response()->json(['data' => $this->payload($monitoringModel, $user, $preferenceResolver)]);
+    }
+
+    public function update(Request $request, string $monitoring, MonitoringNotificationPreferenceResolver $preferenceResolver): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_if($user->isDemo(), 403);
+        $monitoringModel = Monitoring::query()->visibleTo($user)->whereKey($monitoring)->firstOrFail();
+        $validated = $request->validate([
+            'notification_on_failure' => ['required', 'boolean'],
+            'notification_channels' => ['required', 'array'],
+            'notification_channels.*' => ['string', Rule::in($user->enabledNotificationChannelKeys())],
+            'ssl_expiry_warning_days' => ['required', 'integer', 'min:1', 'max:365'],
+        ]);
+        $preference = $preferenceResolver->preferenceFor($monitoringModel, $user);
+        $preference->update([
+            'notification_on_failure' => (bool) $validated['notification_on_failure'],
+            'notification_channels' => array_values(array_unique($validated['notification_channels'])),
+            'ssl_expiry_warning_days' => (int) $validated['ssl_expiry_warning_days'],
+        ]);
+
+        if ($monitoringModel->user_id === $user->id && $monitoringModel->team_id === null) {
+            $monitoringModel->update([
+                'notification_on_failure' => $preference->notification_on_failure,
+                'notification_channels' => $preference->notification_channels,
+                'ssl_expiry_warning_days' => $preference->ssl_expiry_warning_days,
+            ]);
+        }
+
+        return response()->json(['data' => $this->payload($monitoringModel->refresh(), $user, $preferenceResolver)]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(Monitoring $monitoring, User $user, MonitoringNotificationPreferenceResolver $preferenceResolver): array
+    {
+        $preference = $preferenceResolver->preferenceFor($monitoring, $user);
+
+        return [
+            'monitoring_id' => $monitoring->id,
+            'effective' => [
+                'notification_on_failure' => $preference->notification_on_failure,
+                'notification_channels' => $preference->notification_channels,
+                'ssl_expiry_warning_days' => $preference->ssl_expiry_warning_days,
+            ],
+            'source' => $monitoring->user_id === $user->id && $monitoring->team_id === null ? 'private_default' : 'team_member',
+            'permitted_channels' => $user->enabledNotificationChannelKeys(),
+            'can_update' => ! $user->isDemo(),
+            'updated_at' => $preference->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/MobileNotificationBoardController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileNotificationBoardController.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\MonitoringNotification;
+use App\Models\User;
+use App\Services\NotificationBoardService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class MobileNotificationBoardController extends Controller
+{
+    public function index(Request $request, NotificationBoardService $notificationBoardService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $validated = $request->validate([
+            'cursor' => ['nullable', 'string'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'event_type' => ['nullable', Rule::in([
+                'incident', 'recovery', 'maintenance', 'performance_degraded', 'performance_recovered',
+                'ssl_expiring', 'ssl_expired', 'domain_expiring', 'domain_expired', 'delivery_failure',
+            ])],
+            'show_read' => ['nullable', 'boolean'],
+        ]);
+        $entries = $notificationBoardService->mobileEntries(
+            $user,
+            $validated['cursor'] ?? null,
+            (int) ($validated['limit'] ?? 25),
+            $validated['event_type'] ?? null,
+            (bool) ($validated['show_read'] ?? false),
+        );
+        $limit = (int) ($validated['limit'] ?? 25);
+        $hasMore = $entries->count() > $limit;
+        $entries = $entries->take($limit)->values();
+
+        return response()->json([
+            'data' => $entries,
+            'meta' => [
+                'next_cursor' => $hasMore ? $entries->last()['cursor'] : null,
+                'has_more' => $hasMore,
+                'unread_count' => $notificationBoardService->getUnreadNotificationCount(),
+            ],
+        ]);
+    }
+
+    public function markRead(Request $request, string $notification, NotificationBoardService $notificationBoardService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $notificationBoardService->markRead(
+            $user,
+            MonitoringNotification::query()->withoutGlobalScopes()->with('monitoring')->findOrFail($notification),
+        );
+
+        return response()->json(['data' => ['id' => $notification, 'read' => true]]);
+    }
+
+    public function markAllRead(Request $request, NotificationBoardService $notificationBoardService): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $notificationBoardService->markAllRead($user);
+
+        return response()->json(['data' => ['read' => true], 'meta' => ['unread_count' => 0]]);
+    }
+}

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -4,16 +4,113 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Enums\NotificationDeliveryStatus;
 use App\Enums\NotificationType;
 use App\Models\Monitoring;
 use App\Models\MonitoringNotification;
+use App\Models\MonitoringNotificationState;
 use App\Models\MonitoringResponse;
+use App\Models\NotificationChannelDelivery;
+use App\Models\User;
 use App\Support\MonitoringStatusMeta;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Throwable;
 
 class NotificationBoardService
 {
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function mobileEntries(User $user, ?string $cursor, int $limit, ?string $eventType, bool $showRead): Collection
+    {
+        $query = MonitoringNotification::query()
+            ->withoutGlobalScopes()
+            ->select('monitoring_notifications.*', 'monitoring_notification_states.read_at as user_read_at')
+            ->join('monitoring_notification_states', 'monitoring_notification_states.monitoring_notification_id', '=', 'monitoring_notifications.id')
+            ->join('monitorings', 'monitoring_notifications.monitoring_id', '=', 'monitorings.id')
+            ->where('monitoring_notification_states.user_id', $user->id)
+            ->whereNull('monitorings.deleted_at')
+            ->selectSub(
+                NotificationChannelDelivery::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('notification_channel_deliveries.monitoring_notification_id', 'monitoring_notifications.id')
+                    ->where('notification_channel_deliveries.user_id', $user->id)
+                    ->where('notification_channel_deliveries.status', NotificationDeliveryStatus::FAILED),
+                'failed_delivery_count',
+            )
+            ->where(function (Builder $query) use ($user): void {
+                $query->where('monitorings.user_id', $user->id)
+                    ->orWhereExists(function (QueryBuilder $query) use ($user): void {
+                        $query->selectRaw('1')->from('team_memberships')
+                            ->whereColumn('team_memberships.team_id', 'monitorings.team_id')
+                            ->where('team_memberships.user_id', $user->id);
+                    });
+            })
+            ->when($eventType !== null, fn (Builder $query) => $this->filterMobileEntriesByEventType($query, $eventType, $user))
+            ->when(! $showRead, fn (Builder $query) => $query->whereNull('monitoring_notification_states.read_at'))
+            ->with('monitoring:id,name,target')
+            ->latest('monitoring_notifications.created_at')
+            ->orderByDesc('monitoring_notifications.id')
+            ->limit($limit + 1);
+
+        if ($cursor !== null) {
+            [$createdAt, $id] = $this->decodeCursor($cursor);
+            $query->where(function (Builder $query) use ($createdAt, $id): void {
+                $query->where('monitoring_notifications.created_at', '<', $createdAt)
+                    ->orWhere(function (Builder $query) use ($createdAt, $id): void {
+                        $query->where('monitoring_notifications.created_at', $createdAt)
+                            ->where('monitoring_notifications.id', '<', $id);
+                    });
+            });
+        }
+
+        return $query->get()->map(function (MonitoringNotification $notification): array {
+            $eventType = $this->mobileEventType($notification);
+            $severity = match ($eventType) {
+                'incident', 'ssl_expired', 'domain_expired' => 'critical',
+                'ssl_expiring', 'domain_expiring', 'performance_degraded', 'delivery_failure' => 'warning',
+                default => 'info',
+            };
+
+            return [
+                'id' => $notification->id,
+                'event_type' => $eventType,
+                'severity' => $severity,
+                'message' => $notification->message,
+                'occurred_at' => $notification->created_at?->toIso8601String(),
+                'read' => $notification->user_read_at !== null,
+                'delivery_status' => (int) $notification->failed_delivery_count > 0 ? 'failed' : 'unknown',
+                'monitoring' => [
+                    'id' => $notification->monitoring->id,
+                    'name' => $notification->monitoring->name,
+                    'target' => $notification->monitoring->target,
+                ],
+                'cursor' => $this->encodeCursor($notification),
+            ];
+        });
+    }
+
+    public function markRead(User $user, MonitoringNotification $notification): void
+    {
+        abort_unless($notification->monitoring->isVisibleTo($user), 404);
+        $notificationIds = $notification->type === NotificationType::STATUS_CHANGE
+            ? MonitoringNotification::query()->withoutGlobalScopes()->where('monitoring_id', $notification->monitoring_id)->statusChange()
+                ->where(fn (Builder $query) => $query->where('created_at', '<', $notification->created_at)
+                    ->orWhere(fn (Builder $query) => $query->where('created_at', $notification->created_at)->where('id', '<=', $notification->id)))->pluck('id')
+            : collect([$notification->id]);
+
+        MonitoringNotificationState::query()->where('user_id', $user->id)->whereIn('monitoring_notification_id', $notificationIds)
+            ->update(['read_at' => Date::now()]);
+    }
+
+    public function markAllRead(User $user): void
+    {
+        MonitoringNotificationState::query()->where('user_id', $user->id)->whereNull('read_at')->update(['read_at' => Date::now()]);
+    }
+
     /**
      * @return Collection<int, array{
      *     notification_id: string,
@@ -220,5 +317,65 @@ class NotificationBoardService
             ->groupBy('monitoring_notification_states.user_id')
             ->pluck('total', 'user_id')
             ->map(fn (int|string $total): int => (int) $total);
+    }
+
+    private function filterMobileEntriesByEventType(Builder $query, string $eventType, User $user): Builder
+    {
+        return match ($eventType) {
+            'incident' => $query->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%down%']),
+            'recovery' => $query->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%up%']),
+            'maintenance' => $query->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%maintenance%']),
+            'performance_degraded' => $query->performance()->whereRaw('lower(monitoring_notifications.message) like ?', ['%degraded%']),
+            'performance_recovered' => $query->performance()->whereRaw('lower(monitoring_notifications.message) not like ?', ['%degraded%']),
+            'ssl_expiring' => $query->sslExpiry()->whereRaw('upper(monitoring_notifications.message) not like ?', ['%EXPIRED%']),
+            'ssl_expired' => $query->sslExpiry()->whereRaw('upper(monitoring_notifications.message) like ?', ['%EXPIRED%']),
+            'domain_expiring' => $query->domainExpiry()->whereRaw('upper(monitoring_notifications.message) not like ?', ['%EXPIRED%']),
+            'domain_expired' => $query->domainExpiry()->whereRaw('upper(monitoring_notifications.message) like ?', ['%EXPIRED%']),
+            'delivery_failure' => $query->whereExists(function (QueryBuilder $query) use ($user): void {
+                $query->selectRaw('1')->from('notification_channel_deliveries')
+                    ->whereColumn('notification_channel_deliveries.monitoring_notification_id', 'monitoring_notifications.id')
+                    ->where('notification_channel_deliveries.user_id', $user->id)
+                    ->where('notification_channel_deliveries.status', NotificationDeliveryStatus::FAILED);
+            }),
+        };
+    }
+
+    private function mobileEventType(MonitoringNotification $notification): string
+    {
+        $message = mb_strtolower($notification->message);
+
+        return match ($notification->type) {
+            NotificationType::STATUS_CHANGE => match (true) {
+                str_contains($message, 'maintenance') => 'maintenance',
+                str_contains($message, 'down') => 'incident',
+                str_contains($message, 'up') => 'recovery',
+                default => 'status_change',
+            },
+            NotificationType::PERFORMANCE => str_contains($message, 'degraded') ? 'performance_degraded' : 'performance_recovered',
+            NotificationType::SSL_EXPIRY => str_contains(mb_strtoupper($notification->message), 'EXPIRED') ? 'ssl_expired' : 'ssl_expiring',
+            NotificationType::DOMAIN_EXPIRY => str_contains(mb_strtoupper($notification->message), 'EXPIRED') ? 'domain_expired' : 'domain_expiring',
+        };
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function decodeCursor(string $cursor): array
+    {
+        $decoded = json_decode((string) base64_decode($cursor, true), true);
+        abort_unless(is_array($decoded) && isset($decoded['created_at'], $decoded['id']), 422);
+
+        try {
+            $createdAt = Date::parse((string) $decoded['created_at'])->toDateTimeString();
+        } catch (Throwable) {
+            abort(422);
+        }
+
+        return [$createdAt, (string) $decoded['id']];
+    }
+
+    private function encodeCursor(MonitoringNotification $notification): string
+    {
+        return base64_encode(json_encode(['created_at' => $notification->created_at?->toIso8601String(), 'id' => $notification->id], JSON_THROW_ON_ERROR));
     }
 }

--- a/docs/api/external-v1.md
+++ b/docs/api/external-v1.md
@@ -183,6 +183,34 @@ values and authorization headers are never recorded. Public status-page
 endpoints and browser management routes keep their existing contracts and do
 not expose this private workspace payload.
 
+## Mobile notification board and preferences
+
+Native clients use `/api/v1/mobile/notification-board` for a token-scoped
+notification history. Entries include a monitoring summary, event type,
+severity, occurrence time, and the authenticated user's read state. The
+default response excludes read entries; `show_read=true` includes them.
+Results are ordered newest first and use an opaque `next_cursor`, so clients
+must pass the cursor unchanged to fetch the next page.
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/mobile/notification-board?cursor=&limit=&event_type=&show_read=` | Cursor-paginated private notification history and unread count. |
+| `PATCH` | `/mobile/notification-board/{notification}/read` | Marks one visible notification read; repeated calls remain successful. |
+| `PATCH` | `/mobile/notification-board/read-all` | Marks the token owner's notifications read; repeated calls remain successful. |
+| `GET` | `/mobile/monitorings/{monitoring}/notification-preferences` | Effective notification settings, source, permitted channels, and mutation capability. |
+| `PATCH` | `/mobile/monitorings/{monitoring}/notification-preferences` | Updates the authenticated user's monitoring preferences. |
+
+The board emits machine-readable incident, recovery, maintenance, performance,
+and SSL/domain expiry events. The `delivery_failure` filter and
+`delivery_status` report a failed channel delivery without changing the
+underlying notification event.
+Notification state is stored per recipient, so a read
+operation never changes another user's history. Preference updates apply to
+the caller's recipient record; private-monitoring updates also synchronize the
+legacy monitoring defaults for compatibility. Missing or invisible resources
+return `404`; malformed cursors and invalid fields use Laravel's normal `422`
+validation response.
+
 ## Mobile maintenance operations
 
 Native clients use the dedicated \`/api/v1/mobile/maintenance\` family rather

--- a/routes/api/external.php
+++ b/routes/api/external.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\External\MobileMaintenanceController;
 use App\Http\Controllers\Api\External\MobileMonitoringDetailController;
 use App\Http\Controllers\Api\External\MobileMonitoringGroupController;
-use App\Http\Controllers\Api\External\MobileMaintenanceController;
+use App\Http\Controllers\Api\External\MobileMonitoringNotificationPreferenceController;
+use App\Http\Controllers\Api\External\MobileNotificationBoardController;
 use App\Http\Controllers\Api\External\MobileOverviewController;
 use App\Http\Controllers\Api\External\MobilePushDeviceController;
 use App\Http\Controllers\Api\External\MobileStatusPageWorkspaceController;
@@ -45,6 +47,17 @@ Route::get('/mobile/overview', MobileOverviewController::class)
     ->name('mobile.overview');
 Route::get('/mobile/monitorings/{monitoring}', MobileMonitoringDetailController::class)
     ->name('mobile.monitorings.show');
+Route::get('/mobile/monitorings/{monitoring}/notification-preferences', [MobileMonitoringNotificationPreferenceController::class, 'show'])
+    ->name('mobile.monitorings.notification-preferences.show');
+Route::patch('/mobile/monitorings/{monitoring}/notification-preferences', [MobileMonitoringNotificationPreferenceController::class, 'update'])
+    ->name('mobile.monitorings.notification-preferences.update');
+
+Route::get('/mobile/notification-board', [MobileNotificationBoardController::class, 'index'])
+    ->name('mobile.notification-board.index');
+Route::patch('/mobile/notification-board/{notification}/read', [MobileNotificationBoardController::class, 'markRead'])
+    ->name('mobile.notification-board.read');
+Route::patch('/mobile/notification-board/read-all', [MobileNotificationBoardController::class, 'markAllRead'])
+    ->name('mobile.notification-board.read-all');
 
 Route::group(['prefix' => 'mobile/maintenance', 'as' => 'mobile.maintenance.'], function (): void {
     Route::get('/capabilities', [MobileMaintenanceController::class, 'capabilities'])->name('capabilities');

--- a/tests/Feature/Api/MobileNotificationBoardApiTest.php
+++ b/tests/Feature/Api/MobileNotificationBoardApiTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Enums\NotificationDeliveryStatus;
+use App\Enums\NotificationType;
+use App\Models\Monitoring;
+use App\Models\MonitoringNotification;
+use App\Models\NotificationChannelDelivery;
+use App\Models\Package;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class MobileNotificationBoardApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mobile_notification_board_is_cursor_paginated_scoped_and_read_safe(): void
+    {
+        Date::setTestNow('2026-08-09 20:00:00');
+        $user = $this->user(['notification_channels' => ['mail' => ['enabled' => true]]]);
+        $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
+        $first = $this->notification($monitoring, NotificationType::STATUS_CHANGE, 'Service down', Date::now()->subMinutes(2));
+        $second = $this->notification($monitoring, NotificationType::SSL_EXPIRY, 'SSL_EXPIRING', Date::now()->subMinute());
+        NotificationChannelDelivery::query()->create([
+            'user_id' => $user->id,
+            'monitoring_notification_id' => $second->id,
+            'channel' => 'slack',
+            'event_type' => 'ssl_expiring',
+            'status' => NotificationDeliveryStatus::FAILED,
+            'error_message' => 'Webhook failed.',
+        ]);
+        $hidden = Monitoring::factory()->for($this->user())->create();
+        $hiddenNotification = $this->notification($hidden, NotificationType::DOMAIN_EXPIRY, 'DOMAIN_EXPIRED', Date::now());
+        $this->actingAsMobile($user);
+
+        $response = $this->getJson('/api/v1/mobile/notification-board?limit=1')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $second->id)
+            ->assertJsonPath('data.0.event_type', 'ssl_expiring')
+            ->assertJsonPath('data.0.severity', 'warning')
+            ->assertJsonPath('data.0.delivery_status', 'failed')
+            ->assertJsonPath('meta.unread_count', 2)
+            ->assertJsonMissing(['id' => $hiddenNotification->id]);
+
+        $this->getJson('/api/v1/mobile/notification-board?limit=1&cursor=' . urlencode($response->json('meta.next_cursor')))
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $first->id);
+        $this->getJson('/api/v1/mobile/notification-board?event_type=delivery_failure')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $second->id);
+        $this->patchJson('/api/v1/mobile/notification-board/' . $second->id . '/read')
+            ->assertOk()
+            ->assertJsonPath('data.read', true);
+        $this->patchJson('/api/v1/mobile/notification-board/' . $second->id . '/read')->assertOk();
+        $this->patchJson('/api/v1/mobile/notification-board/read-all')
+            ->assertOk()
+            ->assertJsonPath('meta.unread_count', 0);
+    }
+
+    public function test_mobile_notification_preferences_follow_private_defaults(): void
+    {
+        $user = $this->user(['notification_channels' => ['mail' => ['enabled' => true], 'slack' => ['enabled' => true]]]);
+        $monitoring = Monitoring::factory()->for($user)->create();
+        $this->actingAsMobile($user);
+
+        $this->getJson('/api/v1/mobile/monitorings/' . $monitoring->id . '/notification-preferences')
+            ->assertOk()
+            ->assertJsonPath('data.source', 'private_default')
+            ->assertJsonPath('data.can_update', true);
+        $this->patchJson('/api/v1/mobile/monitorings/' . $monitoring->id . '/notification-preferences', [
+            'notification_on_failure' => false,
+            'notification_channels' => ['slack'],
+            'ssl_expiry_warning_days' => 14,
+        ])->assertOk()
+            ->assertJsonPath('data.effective.notification_channels.0', 'slack');
+        $this->assertDatabaseHas('monitorings', ['id' => $monitoring->id, 'notification_on_failure' => false, 'ssl_expiry_warning_days' => 14]);
+    }
+
+    public function test_mobile_notification_preferences_are_per_team_member(): void
+    {
+        $owner = $this->user();
+        $member = $this->user(['notification_channels' => ['mail' => ['enabled' => true]]]);
+        $team = Team::factory()->create(['created_by_user_id' => $owner->id]);
+        $team->memberships()->create(['user_id' => $owner->id, 'role' => 'admin']);
+        $team->memberships()->create(['user_id' => $member->id, 'role' => 'member']);
+        $monitoring = Monitoring::factory()->create([
+            'user_id' => null,
+            'team_id' => $team->id,
+            'notification_on_failure' => true,
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 30,
+        ]);
+        $this->actingAsMobile($member);
+
+        $this->patchJson('/api/v1/mobile/monitorings/' . $monitoring->id . '/notification-preferences', [
+            'notification_on_failure' => false,
+            'notification_channels' => ['mail'],
+            'ssl_expiry_warning_days' => 7,
+        ])->assertOk()
+            ->assertJsonPath('data.source', 'team_member');
+
+        $this->assertDatabaseHas('monitoring_notification_preferences', [
+            'monitoring_id' => $monitoring->id,
+            'user_id' => $member->id,
+            'notification_on_failure' => false,
+            'ssl_expiry_warning_days' => 7,
+        ]);
+        $this->assertTrue($monitoring->refresh()->notification_on_failure);
+        $this->assertSame(30, $monitoring->ssl_expiry_warning_days);
+    }
+
+    private function user(array $attributes = []): User
+    {
+        return User::factory()->create([...['package_id' => Package::factory()->create()->id], ...$attributes]);
+    }
+
+    private function notification(Monitoring $monitoring, NotificationType $type, string $message, mixed $createdAt): MonitoringNotification
+    {
+        $notification = MonitoringNotification::query()->create([
+            'monitoring_id' => $monitoring->id,
+            'type' => $type,
+            'message' => $message,
+        ]);
+        $notification->update(['created_at' => $createdAt, 'updated_at' => $createdAt]);
+
+        return $notification->refresh();
+    }
+
+    private function actingAsMobile(User $user): void
+    {
+        $this->withToken($user->createToken('ios-app: Test Device')->plainTextToken);
+    }
+}


### PR DESCRIPTION
## What changed
- Added Sanctum-authenticated mobile notification-board endpoints with cursor pagination, per-user read state, unread counts, event/severity metadata, and delivery-failure status.
- Added idempotent single-entry and bulk read operations.
- Added mobile per-monitoring notification preference read/update endpoints using the existing resolver.
- Documented the mobile contract and added API coverage for pagination, visibility, state transitions, delivery failures, and private/team preference precedence.

## Why
Native clients need a server-synchronized notification history and preferences contract that remains distinct from browser response shapes.

## Testing
- `composer test` (Docker)
- `composer analyse` (Docker)
- Focused mobile notification-board, notification-status, preference, and external-route contract tests (Docker)

## Risks and follow-up
The mobile routes are additive and preserve browser notification and push-delivery behavior. Notification retention follows the existing notification and recipient-state retention/deletion lifecycle.

Closes #654