### PR TITLE
fix(theme): prevent dark-mode navigation flash

### DIFF
--- a/resources/js/components/ThemeSwitcher.ts
+++ b/resources/js/components/ThemeSwitcher.ts
@@ -23,7 +23,7 @@ function initializeTheme(): void {
     applyTheme(sessionTheme);
 }
 
-document.addEventListener('DOMContentLoaded', initializeTheme);
+initializeTheme();
 
 window.setTheme = function(theme: string): void {
     // When theme is changed by user, it's saved to the database and applied on next request

--- a/resources/views/components/theme-bootstrap.blade.php
+++ b/resources/views/components/theme-bootstrap.blade.php
@@ -1,0 +1,22 @@
+<meta name="color-scheme" content="light dark">
+<script>
+    (() => {
+        const html = document.documentElement;
+        const theme = html.dataset.theme || 'system';
+        const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+        html.classList.toggle('dark', isDark);
+        html.style.colorScheme = isDark ? 'dark' : 'light';
+    })();
+</script>
+<style>
+    html {
+        background-color: #f8fafc;
+        color-scheme: light;
+    }
+
+    html.dark {
+        background-color: #020617;
+        color-scheme: dark;
+    }
+</style>

--- a/resources/views/errors/layout.blade.php
+++ b/resources/views/errors/layout.blade.php
@@ -20,6 +20,7 @@
     <link rel="icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
     <link rel="apple-touch-icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
 
+    <x-theme-bootstrap />
     @vite(['resources/css/app.css', 'resources/js/app.ts'])
 </head>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,7 @@
     <link rel="icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
     <link rel="apple-touch-icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
 
+    <x-theme-bootstrap />
     @vite(['resources/css/app.css', 'resources/js/app.ts'])
     <script>
         window.App = {

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -25,6 +25,7 @@
     <link rel="icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
     <link rel="apple-touch-icon" href="{{ Vite::asset('resources/images/Logo-WebGuard.png') }}" type="image/png">
 
+    <x-theme-bootstrap />
     @vite(['resources/css/app.css', 'resources/js/app.ts'])
 </head>
 

--- a/tests/Feature/ThemePreferenceTest.php
+++ b/tests/Feature/ThemePreferenceTest.php
@@ -18,4 +18,15 @@ class ThemePreferenceTest extends TestCase
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('data-theme="system"');
     }
+
+    public function test_theme_bootstrap_applies_system_dark_mode_before_assets_load(): void
+    {
+        $testResponse = $this->get(route('login'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('<meta name="color-scheme" content="light dark">');
+        $testResponse->assertSeeHtml("html.classList.toggle('dark', isDark);");
+        $testResponse->assertSeeHtml('html.dark {');
+        $testResponse->assertSeeHtml('background-color: #020617;');
+    }
 }


### PR DESCRIPTION
## What changed

- Adds a critical theme bootstrap before Vite assets load.
- Applies the bootstrap to authenticated, guest, and error layouts.
- Initializes the theme switcher immediately and adds regression coverage.

## Why

Navigating in dark mode could briefly render a white page because the system theme was applied only after `DOMContentLoaded` and the initial document canvas had no dark background.

## Testing

- Docker Pest: `tests/Feature/ThemePreferenceTest.php` (2 tests, 7 assertions; local `.env` warning only)
- Docker Pint: `tests/Feature/ThemePreferenceTest.php`
- Docker `bun run build`

## Risks and follow-up

No API, schema, or authentication behavior changes. Visual browser QA could not access the local Docker route from the in-app browser.

Closes #674.