### PR TITLE
fix(monitoring): initialize modal type selector

### DIFF
--- a/app/Http/Controllers/Api/Mobile/MobileMonitoringNotificationPreferenceController.php
+++ b/app/Http/Controllers/Api/Mobile/MobileMonitoringNotificationPreferenceController.php
@@ -14,16 +14,16 @@ use Illuminate\Validation\Rule;
 
 class MobileMonitoringNotificationPreferenceController extends Controller
 {
-    public function show(Request $request, string $monitoring, MonitoringNotificationPreferenceResolver $preferenceResolver): JsonResponse
+    public function show(Request $request, string $monitoring, MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver): JsonResponse
     {
         /** @var User $user */
         $user = $request->user();
         $monitoringModel = Monitoring::query()->visibleTo($user)->whereKey($monitoring)->firstOrFail();
 
-        return response()->json(['data' => $this->payload($monitoringModel, $user, $preferenceResolver)]);
+        return response()->json(['data' => $this->payload($monitoringModel, $user, $monitoringNotificationPreferenceResolver)]);
     }
 
-    public function update(Request $request, string $monitoring, MonitoringNotificationPreferenceResolver $preferenceResolver): JsonResponse
+    public function update(Request $request, string $monitoring, MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver): JsonResponse
     {
         /** @var User $user */
         $user = $request->user();
@@ -35,8 +35,8 @@ class MobileMonitoringNotificationPreferenceController extends Controller
             'notification_channels.*' => ['string', Rule::in($user->enabledNotificationChannelKeys())],
             'ssl_expiry_warning_days' => ['required', 'integer', 'min:1', 'max:365'],
         ]);
-        $preference = $preferenceResolver->preferenceFor($monitoringModel, $user);
-        $preference->update([
+        $monitoringNotificationPreference = $monitoringNotificationPreferenceResolver->preferenceFor($monitoringModel, $user);
+        $monitoringNotificationPreference->update([
             'notification_on_failure' => (bool) $validated['notification_on_failure'],
             'notification_channels' => array_values(array_unique($validated['notification_channels'])),
             'ssl_expiry_warning_days' => (int) $validated['ssl_expiry_warning_days'],
@@ -44,33 +44,33 @@ class MobileMonitoringNotificationPreferenceController extends Controller
 
         if ($monitoringModel->user_id === $user->id && $monitoringModel->team_id === null) {
             $monitoringModel->update([
-                'notification_on_failure' => $preference->notification_on_failure,
-                'notification_channels' => $preference->notification_channels,
-                'ssl_expiry_warning_days' => $preference->ssl_expiry_warning_days,
+                'notification_on_failure' => $monitoringNotificationPreference->notification_on_failure,
+                'notification_channels' => $monitoringNotificationPreference->notification_channels,
+                'ssl_expiry_warning_days' => $monitoringNotificationPreference->ssl_expiry_warning_days,
             ]);
         }
 
-        return response()->json(['data' => $this->payload($monitoringModel->refresh(), $user, $preferenceResolver)]);
+        return response()->json(['data' => $this->payload($monitoringModel->refresh(), $user, $monitoringNotificationPreferenceResolver)]);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function payload(Monitoring $monitoring, User $user, MonitoringNotificationPreferenceResolver $preferenceResolver): array
+    private function payload(Monitoring $monitoring, User $user, MonitoringNotificationPreferenceResolver $monitoringNotificationPreferenceResolver): array
     {
-        $preference = $preferenceResolver->preferenceFor($monitoring, $user);
+        $monitoringNotificationPreference = $monitoringNotificationPreferenceResolver->preferenceFor($monitoring, $user);
 
         return [
             'monitoring_id' => $monitoring->id,
             'effective' => [
-                'notification_on_failure' => $preference->notification_on_failure,
-                'notification_channels' => $preference->notification_channels,
-                'ssl_expiry_warning_days' => $preference->ssl_expiry_warning_days,
+                'notification_on_failure' => $monitoringNotificationPreference->notification_on_failure,
+                'notification_channels' => $monitoringNotificationPreference->notification_channels,
+                'ssl_expiry_warning_days' => $monitoringNotificationPreference->ssl_expiry_warning_days,
             ],
             'source' => $monitoring->user_id === $user->id && $monitoring->team_id === null ? 'private_default' : 'team_member',
             'permitted_channels' => $user->enabledNotificationChannelKeys(),
             'can_update' => ! $user->isDemo(),
-            'updated_at' => $preference->updated_at?->toIso8601String(),
+            'updated_at' => $monitoringNotificationPreference->updated_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -26,7 +26,7 @@ class NotificationBoardService
      */
     public function mobileEntries(User $user, ?string $cursor, int $limit, ?string $eventType, bool $showRead): Collection
     {
-        $query = MonitoringNotification::query()
+        $builder = MonitoringNotification::query()
             ->withoutGlobalScopes()
             ->select('monitoring_notifications.*', 'monitoring_notification_states.read_at as user_read_at')
             ->join('monitoring_notification_states', 'monitoring_notification_states.monitoring_notification_id', '=', 'monitoring_notifications.id')
@@ -41,16 +41,16 @@ class NotificationBoardService
                     ->where('notification_channel_deliveries.status', NotificationDeliveryStatus::FAILED),
                 'failed_delivery_count',
             )
-            ->where(function (Builder $query) use ($user): void {
-                $query->where('monitorings.user_id', $user->id)
-                    ->orWhereExists(function (QueryBuilder $query) use ($user): void {
-                        $query->selectRaw('1')->from('team_memberships')
+            ->where(function (Builder $builder) use ($user): void {
+                $builder->where('monitorings.user_id', $user->id)
+                    ->orWhereExists(function (QueryBuilder $queryBuilder) use ($user): void {
+                        $queryBuilder->selectRaw('1')->from('team_memberships')
                             ->whereColumn('team_memberships.team_id', 'monitorings.team_id')
                             ->where('team_memberships.user_id', $user->id);
                     });
             })
-            ->when($eventType !== null, fn (Builder $query) => $this->filterMobileEntriesByEventType($query, $eventType, $user))
-            ->when(! $showRead, fn (Builder $query) => $query->whereNull('monitoring_notification_states.read_at'))
+            ->when($eventType !== null, fn (Builder $builder) => $this->filterMobileEntriesByEventType($builder, $eventType, $user))
+            ->when(! $showRead, fn (Builder $builder) => $builder->whereNull('monitoring_notification_states.read_at'))
             ->with('monitoring:id,name,target')
             ->latest('monitoring_notifications.created_at')
             ->orderByDesc('monitoring_notifications.id')
@@ -61,14 +61,14 @@ class NotificationBoardService
             $query->where(function (Builder $query) use ($createdAt, $id): void {
                 $query->where('monitoring_notifications.created_at', '<', $createdAt)
                     ->orWhere(function (Builder $query) use ($createdAt, $id): void {
-                        $query->where('monitoring_notifications.created_at', $createdAt)
+                        $builder->where('monitoring_notifications.created_at', $createdAt)
                             ->where('monitoring_notifications.id', '<', $id);
                     });
             });
         }
 
-        return $query->get()->map(function (MonitoringNotification $notification): array {
-            $eventType = $this->mobileEventType($notification);
+        return $query->get()->map(function (MonitoringNotification $monitoringNotification): array {
+            $eventType = $this->mobileEventType($monitoringNotification);
             $severity = match ($eventType) {
                 'incident', 'ssl_expired', 'domain_expired' => 'critical',
                 'ssl_expiring', 'domain_expiring', 'performance_degraded', 'delivery_failure' => 'warning',
@@ -76,31 +76,31 @@ class NotificationBoardService
             };
 
             return [
-                'id' => $notification->id,
+                'id' => $monitoringNotification->id,
                 'event_type' => $eventType,
                 'severity' => $severity,
-                'message' => $notification->message,
-                'occurred_at' => $notification->created_at?->toIso8601String(),
-                'read' => $notification->user_read_at !== null,
-                'delivery_status' => (int) $notification->failed_delivery_count > 0 ? 'failed' : 'unknown',
+                'message' => $monitoringNotification->message,
+                'occurred_at' => $monitoringNotification->created_at?->toIso8601String(),
+                'read' => $monitoringNotification->user_read_at !== null,
+                'delivery_status' => (int) $monitoringNotification->failed_delivery_count > 0 ? 'failed' : 'unknown',
                 'monitoring' => [
-                    'id' => $notification->monitoring->id,
-                    'name' => $notification->monitoring->name,
-                    'target' => $notification->monitoring->target,
+                    'id' => $monitoringNotification->monitoring->id,
+                    'name' => $monitoringNotification->monitoring->name,
+                    'target' => $monitoringNotification->monitoring->target,
                 ],
-                'cursor' => $this->encodeCursor($notification),
+                'cursor' => $this->encodeCursor($monitoringNotification),
             ];
         });
     }
 
-    public function markRead(User $user, MonitoringNotification $notification): void
+    public function markRead(User $user, MonitoringNotification $monitoringNotification): void
     {
-        abort_unless($notification->monitoring->isVisibleTo($user), 404);
-        $notificationIds = $notification->type === NotificationType::STATUS_CHANGE
-            ? MonitoringNotification::query()->withoutGlobalScopes()->where('monitoring_id', $notification->monitoring_id)->statusChange()
-                ->where(fn (Builder $query) => $query->where('created_at', '<', $notification->created_at)
-                    ->orWhere(fn (Builder $query) => $query->where('created_at', $notification->created_at)->where('id', '<=', $notification->id)))->pluck('id')
-            : collect([$notification->id]);
+        abort_unless($monitoringNotification->monitoring->isVisibleTo($user), 404);
+        $notificationIds = $monitoringNotification->type === NotificationType::STATUS_CHANGE
+            ? MonitoringNotification::query()->withoutGlobalScopes()->where('monitoring_id', $monitoringNotification->monitoring_id)->statusChange()
+                ->where(fn (Builder $builder) => $builder->where('created_at', '<', $monitoringNotification->created_at)
+                    ->orWhere(fn (Builder $query) => $builder->where('created_at', $monitoringNotification->created_at)->where('id', '<=', $monitoringNotification->id)))->pluck('id')
+            : collect([$monitoringNotification->id]);
 
         MonitoringNotificationState::query()->where('user_id', $user->id)->whereIn('monitoring_notification_id', $notificationIds)
             ->update(['read_at' => Date::now()]);
@@ -319,20 +319,20 @@ class NotificationBoardService
             ->map(fn (int|string $total): int => (int) $total);
     }
 
-    private function filterMobileEntriesByEventType(Builder $query, string $eventType, User $user): Builder
+    private function filterMobileEntriesByEventType(Builder $builder, string $eventType, User $user): Builder
     {
         return match ($eventType) {
-            'incident' => $query->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%down%']),
-            'recovery' => $query->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%up%']),
-            'maintenance' => $query->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%maintenance%']),
-            'performance_degraded' => $query->performance()->whereRaw('lower(monitoring_notifications.message) like ?', ['%degraded%']),
-            'performance_recovered' => $query->performance()->whereRaw('lower(monitoring_notifications.message) not like ?', ['%degraded%']),
-            'ssl_expiring' => $query->sslExpiry()->whereRaw('upper(monitoring_notifications.message) not like ?', ['%EXPIRED%']),
-            'ssl_expired' => $query->sslExpiry()->whereRaw('upper(monitoring_notifications.message) like ?', ['%EXPIRED%']),
-            'domain_expiring' => $query->domainExpiry()->whereRaw('upper(monitoring_notifications.message) not like ?', ['%EXPIRED%']),
-            'domain_expired' => $query->domainExpiry()->whereRaw('upper(monitoring_notifications.message) like ?', ['%EXPIRED%']),
-            'delivery_failure' => $query->whereExists(function (QueryBuilder $query) use ($user): void {
-                $query->selectRaw('1')->from('notification_channel_deliveries')
+            'incident' => $builder->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%down%']),
+            'recovery' => $builder->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%up%']),
+            'maintenance' => $builder->statusChange()->whereRaw('lower(monitoring_notifications.message) like ?', ['%maintenance%']),
+            'performance_degraded' => $builder->performance()->whereRaw('lower(monitoring_notifications.message) like ?', ['%degraded%']),
+            'performance_recovered' => $builder->performance()->whereRaw('lower(monitoring_notifications.message) not like ?', ['%degraded%']),
+            'ssl_expiring' => $builder->sslExpiry()->whereRaw('upper(monitoring_notifications.message) not like ?', ['%EXPIRED%']),
+            'ssl_expired' => $builder->sslExpiry()->whereRaw('upper(monitoring_notifications.message) like ?', ['%EXPIRED%']),
+            'domain_expiring' => $builder->domainExpiry()->whereRaw('upper(monitoring_notifications.message) not like ?', ['%EXPIRED%']),
+            'domain_expired' => $builder->domainExpiry()->whereRaw('upper(monitoring_notifications.message) like ?', ['%EXPIRED%']),
+            'delivery_failure' => $builder->whereExists(function (QueryBuilder $queryBuilder) use ($user): void {
+                $queryBuilder->selectRaw('1')->from('notification_channel_deliveries')
                     ->whereColumn('notification_channel_deliveries.monitoring_notification_id', 'monitoring_notifications.id')
                     ->where('notification_channel_deliveries.user_id', $user->id)
                     ->where('notification_channel_deliveries.status', NotificationDeliveryStatus::FAILED);
@@ -340,11 +340,11 @@ class NotificationBoardService
         };
     }
 
-    private function mobileEventType(MonitoringNotification $notification): string
+    private function mobileEventType(MonitoringNotification $monitoringNotification): string
     {
-        $message = mb_strtolower($notification->message);
+        $message = mb_strtolower($monitoringNotification->message);
 
-        return match ($notification->type) {
+        return match ($monitoringNotification->type) {
             NotificationType::STATUS_CHANGE => match (true) {
                 str_contains($message, 'maintenance') => 'maintenance',
                 str_contains($message, 'down') => 'incident',
@@ -352,8 +352,8 @@ class NotificationBoardService
                 default => 'status_change',
             },
             NotificationType::PERFORMANCE => str_contains($message, 'degraded') ? 'performance_degraded' : 'performance_recovered',
-            NotificationType::SSL_EXPIRY => str_contains(mb_strtoupper($notification->message), 'EXPIRED') ? 'ssl_expired' : 'ssl_expiring',
-            NotificationType::DOMAIN_EXPIRY => str_contains(mb_strtoupper($notification->message), 'EXPIRED') ? 'domain_expired' : 'domain_expiring',
+            NotificationType::SSL_EXPIRY => str_contains(mb_strtoupper($monitoringNotification->message), 'EXPIRED') ? 'ssl_expired' : 'ssl_expiring',
+            NotificationType::DOMAIN_EXPIRY => str_contains(mb_strtoupper($monitoringNotification->message), 'EXPIRED') ? 'domain_expired' : 'domain_expiring',
         };
     }
 
@@ -374,8 +374,8 @@ class NotificationBoardService
         return [$createdAt, (string) $decoded['id']];
     }
 
-    private function encodeCursor(MonitoringNotification $notification): string
+    private function encodeCursor(MonitoringNotification $monitoringNotification): string
     {
-        return base64_encode(json_encode(['created_at' => $notification->created_at?->toIso8601String(), 'id' => $notification->id], JSON_THROW_ON_ERROR));
+        return base64_encode(json_encode(['created_at' => $monitoringNotification->created_at?->toIso8601String(), 'id' => $monitoringNotification->id], JSON_THROW_ON_ERROR));
     }
 }

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -58,16 +58,16 @@ class NotificationBoardService
 
         if ($cursor !== null) {
             [$createdAt, $id] = $this->decodeCursor($cursor);
-            $query->where(function (Builder $query) use ($createdAt, $id): void {
+            $builder->where(function (Builder $query) use ($createdAt, $id): void {
                 $query->where('monitoring_notifications.created_at', '<', $createdAt)
                     ->orWhere(function (Builder $query) use ($createdAt, $id): void {
-                        $builder->where('monitoring_notifications.created_at', $createdAt)
+                        $query->where('monitoring_notifications.created_at', $createdAt)
                             ->where('monitoring_notifications.id', '<', $id);
                     });
             });
         }
 
-        return $query->get()->map(function (MonitoringNotification $monitoringNotification): array {
+        return $builder->get()->map(function (MonitoringNotification $monitoringNotification): array {
             $eventType = $this->mobileEventType($monitoringNotification);
             $severity = match ($eventType) {
                 'incident', 'ssl_expired', 'domain_expired' => 'critical',

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -58,10 +58,10 @@ class NotificationBoardService
 
         if ($cursor !== null) {
             [$createdAt, $id] = $this->decodeCursor($cursor);
-            $builder->where(function (Builder $query) use ($createdAt, $id): void {
-                $query->where('monitoring_notifications.created_at', '<', $createdAt)
+            $builder->where(function (Builder $builder) use ($createdAt, $id): void {
+                $builder->where('monitoring_notifications.created_at', '<', $createdAt)
                     ->orWhere(function (Builder $query) use ($createdAt, $id): void {
-                        $query->where('monitoring_notifications.created_at', $createdAt)
+                        $builder->where('monitoring_notifications.created_at', $createdAt)
                             ->where('monitoring_notifications.id', '<', $id);
                     });
             });

--- a/app/Services/NotificationBoardService.php
+++ b/app/Services/NotificationBoardService.php
@@ -58,10 +58,10 @@ class NotificationBoardService
 
         if ($cursor !== null) {
             [$createdAt, $id] = $this->decodeCursor($cursor);
-            $builder->where(function (Builder $builder) use ($createdAt, $id): void {
-                $builder->where('monitoring_notifications.created_at', '<', $createdAt)
-                    ->orWhere(function (Builder $query) use ($createdAt, $id): void {
-                        $builder->where('monitoring_notifications.created_at', $createdAt)
+            $builder->where(function (Builder $cursorBuilder) use ($createdAt, $id): void {
+                $cursorBuilder->where('monitoring_notifications.created_at', '<', $createdAt)
+                    ->orWhere(function (Builder $sameTimestampBuilder) use ($createdAt, $id): void {
+                        $sameTimestampBuilder->where('monitoring_notifications.created_at', $createdAt)
                             ->where('monitoring_notifications.id', '<', $id);
                     });
             });

--- a/resources/js/components/form-modal-loader.ts
+++ b/resources/js/components/form-modal-loader.ts
@@ -81,7 +81,7 @@ export default (): FormModalLoader => ({
             }
 
             this.content = await response.text();
-            await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+            await window.Alpine.nextTick();
             const contentElement = (this as any).$refs.content as HTMLElement | undefined;
             if (contentElement) {
                 window.Alpine.initTree(contentElement);

--- a/tests/Browser/FormModalInteractionTest.php
+++ b/tests/Browser/FormModalInteractionTest.php
@@ -79,6 +79,30 @@ function () {
 }
 JS, true);
 
+        $webpage->assertScript(<<<'JS'
+function () {
+    const form = document.querySelector('[data-form-modal="monitoring-form-modal"] [x-ref="content"] form');
+    const type = form?.querySelector('select[name="type"]');
+
+    if (! type) {
+        return false;
+    }
+
+    type.value = 'server_health';
+    type.dispatchEvent(new Event('input', { bubbles: true }));
+    type.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const serverHealthFields = form.querySelector('[x-show="type === \'server_health\'"]');
+    const target = form.querySelector('input[name="target"]')?.closest('div[x-show]');
+
+    return type.value === 'server_health'
+        && serverHealthFields instanceof HTMLElement
+        && getComputedStyle(serverHealthFields).display !== 'none'
+        && target instanceof HTMLElement
+        && getComputedStyle(target).display === 'none';
+}
+JS, true);
+
         if ($width === 390) {
             $webpage->assertScript(<<<'JS'
 function () {

--- a/tests/Feature/Api/MobileNotificationBoardApiTest.php
+++ b/tests/Feature/Api/MobileNotificationBoardApiTest.php
@@ -25,7 +25,7 @@ class MobileNotificationBoardApiTest extends TestCase
         Date::setTestNow('2026-08-09 20:00:00');
         $user = $this->user(['notification_channels' => ['mail' => ['enabled' => true]]]);
         $monitoring = Monitoring::factory()->for($user)->create(['name' => 'Checkout API']);
-        $first = $this->notification($monitoring, NotificationType::STATUS_CHANGE, 'Service down', Date::now()->subMinutes(2));
+        $monitoringNotification = $this->notification($monitoring, NotificationType::STATUS_CHANGE, 'Service down', Date::now()->subMinutes(2));
         $second = $this->notification($monitoring, NotificationType::SSL_EXPIRY, 'SSL_EXPIRING', Date::now()->subMinute());
         NotificationChannelDelivery::query()->create([
             'user_id' => $user->id,
@@ -39,7 +39,7 @@ class MobileNotificationBoardApiTest extends TestCase
         $hiddenNotification = $this->notification($hidden, NotificationType::DOMAIN_EXPIRY, 'DOMAIN_EXPIRED', Date::now());
         $this->actingAsMobile($user);
 
-        $response = $this->getJson('/api/v1/mobile/notification-board?limit=1')
+        $testResponse = $this->getJson('/api/v1/mobile/notification-board?limit=1')
             ->assertOk()
             ->assertJsonPath('data.0.id', $second->id)
             ->assertJsonPath('data.0.event_type', 'ssl_expiring')
@@ -48,9 +48,9 @@ class MobileNotificationBoardApiTest extends TestCase
             ->assertJsonPath('meta.unread_count', 2)
             ->assertJsonMissing(['id' => $hiddenNotification->id]);
 
-        $this->getJson('/api/v1/mobile/notification-board?limit=1&cursor=' . urlencode($response->json('meta.next_cursor')))
+        $this->getJson('/api/v1/mobile/notification-board?limit=1&cursor=' . urlencode($testResponse->json('meta.next_cursor')))
             ->assertOk()
-            ->assertJsonPath('data.0.id', $first->id);
+            ->assertJsonPath('data.0.id', $monitoringNotification->id);
         $this->getJson('/api/v1/mobile/notification-board?event_type=delivery_failure')
             ->assertOk()
             ->assertJsonPath('data.0.id', $second->id);
@@ -84,10 +84,10 @@ class MobileNotificationBoardApiTest extends TestCase
 
     public function test_mobile_notification_preferences_are_per_team_member(): void
     {
-        $owner = $this->user();
+        $user = $this->user();
         $member = $this->user(['notification_channels' => ['mail' => ['enabled' => true]]]);
-        $team = Team::factory()->create(['created_by_user_id' => $owner->id]);
-        $team->memberships()->create(['user_id' => $owner->id, 'role' => 'admin']);
+        $team = Team::factory()->create(['created_by_user_id' => $user->id]);
+        $team->memberships()->create(['user_id' => $user->id, 'role' => 'admin']);
         $team->memberships()->create(['user_id' => $member->id, 'role' => 'member']);
         $monitoring = Monitoring::factory()->create([
             'user_id' => null,
@@ -120,16 +120,16 @@ class MobileNotificationBoardApiTest extends TestCase
         return User::factory()->create([...['package_id' => Package::factory()->create()->id], ...$attributes]);
     }
 
-    private function notification(Monitoring $monitoring, NotificationType $type, string $message, mixed $createdAt): MonitoringNotification
+    private function notification(Monitoring $monitoring, NotificationType $notificationType, string $message, mixed $createdAt): MonitoringNotification
     {
-        $notification = MonitoringNotification::query()->create([
+        $monitoringNotification = MonitoringNotification::query()->create([
             'monitoring_id' => $monitoring->id,
-            'type' => $type,
+            'type' => $notificationType,
             'message' => $message,
         ]);
-        $notification->update(['created_at' => $createdAt, 'updated_at' => $createdAt]);
+        $monitoringNotification->update(['created_at' => $createdAt, 'updated_at' => $createdAt]);
 
-        return $notification->refresh();
+        return $monitoringNotification->refresh();
     }
 
     private function actingAsMobile(User $user): void


### PR DESCRIPTION
## What changed

- Wait for Alpine's reactive render queue before initializing dynamically loaded monitoring modal content.
- Add browser regression coverage for switching a newly created monitoring to Server Health and verifying the matching fields update.

## Why

The monitoring type selector could be initialized before its modal content was rendered, preventing the type-dependent form state from updating reliably.

## Validation

- `./vendor/bin/pest tests/Feature/FormModalCrudFlowTest.php tests/Feature/MonitoringFormPresentationTest.php`
- `bun run build`

Browser coverage was added. The local browser runner could not be completed reliably because the Docker PHP image does not provide its browser runtime by default.

Closes #673