### PR TITLE
test(theme): cover bootstrap layouts

### DIFF
--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -35,6 +35,7 @@ class ErrorPagesTest extends TestCase
         $testResponse->assertSeeText(__('errors.status.404.title'));
         $testResponse->assertSeeText(__('errors.eyebrow'));
         $testResponse->assertSee(__('app.logo_alt'));
+        $testResponse->assertSeeHtml('<meta name="color-scheme" content="light dark">');
     }
 
     public function test_error_page_uses_the_active_application_locale(): void

--- a/tests/Feature/ThemePreferenceTest.php
+++ b/tests/Feature/ThemePreferenceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Models\Package;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -28,5 +30,15 @@ class ThemePreferenceTest extends TestCase
         $testResponse->assertSeeHtml("html.classList.toggle('dark', isDark);");
         $testResponse->assertSeeHtml('html.dark {');
         $testResponse->assertSeeHtml('background-color: #020617;');
+    }
+
+    public function test_authenticated_layout_includes_theme_bootstrap_before_assets_load(): void
+    {
+        $user = User::factory()->for(Package::factory())->create();
+
+        $testResponse = $this->actingAs($user)->get(route('dashboard'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('<meta name="color-scheme" content="light dark">');
     }
 }


### PR DESCRIPTION
## Summary

Adds focused feature coverage for the theme bootstrap across the authenticated and error layouts.

Closes #678

## Coverage

Initial scoped coverage:
- `View/Components/GuestLayout`: 100%
- `View/Components/AppLayout`: 0%
- The development PHP container could not run coverage because it omits Xdebug; the project-defined Docker CI target was used for the report.

Identified gaps:
- The authenticated layout did not assert the early color-scheme bootstrap.
- The error layout did not assert the early color-scheme bootstrap.

Final scoped coverage:
- `View/Components/GuestLayout`: 100%
- `View/Components/AppLayout`: 100%
- The error-page render path asserts the shared bootstrap meta tag.

## Validation

- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec php ./vendor/bin/pest tests/Feature/ThemePreferenceTest.php tests/Feature/ErrorPagesTest.php`
- Project Docker CI target with `XDEBUG_MODE=coverage`: `./vendor/bin/pest tests/Feature/ThemePreferenceTest.php tests/Feature/ErrorPagesTest.php --coverage --min=0`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml exec php ./vendor/bin/pint tests/Feature/ThemePreferenceTest.php tests/Feature/ErrorPagesTest.php`