### PR TITLE
fix(monitoring): restore type selection in modal

### DIFF
--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -80,7 +80,7 @@
             }
         }
     }
-}" x-init="$watch('type', value => {
+}" x-on:change="if ($event.target.name === 'type') type = $event.target.value" x-init="$watch('type', value => {
     if ((value === '{{ MonitoringType::HTTP->value }}' || value === '{{ MonitoringType::KEYWORD->value }}') && (!target || !target.startsWith('http'))) {
         target = 'https://';
     } else if (value === '{{ MonitoringType::PING->value }}' || value === '{{ MonitoringType::HEARTBEAT->value }}' || value === '{{ MonitoringType::SERVER_HEALTH->value }}' || value === '{{ MonitoringType::DOMAIN_EXPIRATION->value }}' || value === '{{ MonitoringType::DNS_RECORD->value }}') {
@@ -99,7 +99,8 @@
                     <x-text-input id="type" class="cursor-not-allowed" name="type" :value="__('monitoring.types.' . $monitoring->type->value)" readonly />
                     <input type="hidden" name="type" :value="type">
                 @else
-                    <x-select-input id="type" class="mt-1 block w-full" name="type" x-model="type" required autofocus>
+                    <x-select-input id="type" class="mt-1 block w-full" name="type" required
+                        :autofocus="! ($modal ?? false)">
                         <option value="" disabled hidden>{{ __('monitoring.form.select_type') }}</option>
                         @foreach ($types as $enumType)
                             <option value="{{ $enumType->value }}" @selected(old('type') === $enumType->value)>

--- a/tests/Browser/FormModalInteractionTest.php
+++ b/tests/Browser/FormModalInteractionTest.php
@@ -51,6 +51,7 @@ it('keeps the user monitoring modal usable on desktop and mobile', function (): 
         $submit = $modal . ' form button[type="submit"]';
         $nameField = $modal . ' [x-ref="content"] form input[name="name"]';
         $targetField = $modal . ' [x-ref="content"] form input[name="target"]';
+        $typeField = $modal . ' [x-ref="content"] form select[name="type"]';
 
         $webpage->assertCount($trigger, 1)
             ->click($trigger);
@@ -79,27 +80,17 @@ function () {
 }
 JS, true);
 
-        $webpage->assertScript(<<<'JS'
+        $webpage->select($typeField, 'port')
+            ->assertScript(<<<'JS'
 function () {
     const form = document.querySelector('[data-form-modal="monitoring-form-modal"] [x-ref="content"] form');
     const type = form?.querySelector('select[name="type"]');
 
-    if (! type) {
-        return false;
-    }
+    const port = form?.querySelector('input[name="port"]');
 
-    type.value = 'server_health';
-    type.dispatchEvent(new Event('input', { bubbles: true }));
-    type.dispatchEvent(new Event('change', { bubbles: true }));
-
-    const serverHealthFields = form.querySelector('[x-show="type === \'server_health\'"]');
-    const target = form.querySelector('input[name="target"]')?.closest('div[x-show]');
-
-    return type.value === 'server_health'
-        && serverHealthFields instanceof HTMLElement
-        && getComputedStyle(serverHealthFields).display !== 'none'
-        && target instanceof HTMLElement
-        && getComputedStyle(target).display === 'none';
+    return type?.value === 'port'
+        && port instanceof HTMLInputElement
+        && getComputedStyle(port).display !== 'none';
 }
 JS, true);
 

--- a/tests/Feature/FormModalCrudFlowTest.php
+++ b/tests/Feature/FormModalCrudFlowTest.php
@@ -30,7 +30,12 @@ class FormModalCrudFlowTest extends TestCase
         $this->actingAs($user)->get(route('monitorings.create', ['modal' => 1]))
             ->assertOk()
             ->assertSeeHtml('name="modal_form"')
-            ->assertSeeHtml('action="' . route('monitorings.store') . '"');
+            ->assertSeeHtml('action="' . route('monitorings.store') . '"')
+            ->assertSeeHtml('x-on:change="if ($event.target.name === \'type\') type = $event.target.value"')
+            ->assertDontSeeHtml('autofocus');
+        $this->actingAs($user)->get(route('monitorings.create'))
+            ->assertOk()
+            ->assertSeeHtml('autofocus');
         $this->actingAs($user)->get(route('monitorings.edit', [$monitoring, 'modal' => 1]))
             ->assertOk()
             ->assertSeeHtml('name="modal_form"')


### PR DESCRIPTION
## What changed

- Handle monitoring type changes at the form root so the native select reliably updates the reactive type state.
- Remove competing autofocus from the modal while retaining autofocus on the standalone create page.
- Exercise the native Port selection path in the modal browser test.

## Why

The monitoring create modal could leave the type-specific fields unchanged after selecting another monitoring type. It also emitted a competing autofocus warning when opening.

## Testing

- `php ./vendor/bin/pest tests/Feature/FormModalCrudFlowTest.php`
- `php ./vendor/bin/pint --test resources/views/monitorings/_form.blade.php tests/Browser/FormModalInteractionTest.php tests/Feature/FormModalCrudFlowTest.php`
- `php -l tests/Browser/FormModalInteractionTest.php`

The browser test was updated but could not be run locally because the Docker browser runtime lacks the required Playwright system libraries.

Closes #680
Closes #681