### PR TITLE
fix(monitoring): render server health initializer

### DIFF
--- a/resources/views/monitorings/show.blade.php
+++ b/resources/views/monitorings/show.blade.php
@@ -129,9 +129,7 @@
     loadHeatmap();
     loadUptime();
     loadPerformanceChart(responseTimeRange);
-    @if ($monitoring->type === MonitoringType::SERVER_HEALTH)
-    loadServerHealthTelemetry(serverHealthTelemetryRange);
-    @endif
+    {{ $monitoring->type === MonitoringType::SERVER_HEALTH ? 'loadServerHealthTelemetry(serverHealthTelemetryRange);' : '' }}
     loadIncidents(incidentsRange);
     loadChecks();
     initializeDeferredLoads();" x-data="monitoringDetail('{{ $monitoring->id }}', {

--- a/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
+++ b/tests/Feature/MonitoringDetailRecentChecksSectionTest.php
@@ -100,5 +100,7 @@ class MonitoringDetailRecentChecksSectionTest extends TestCase
         $testResponse->assertSeeHtml('data-server-health-telemetry');
         $testResponse->assertSeeHtml('id="server-health-telemetry-range"');
         $testResponse->assertSeeHtml('id="server-health-telemetry-chart"');
+        $testResponse->assertSeeHtml('loadServerHealthTelemetry(serverHealthTelemetryRange)');
+        $testResponse->assertDontSeeHtml('@if ($monitoring->type === MonitoringType::SERVER_HEALTH)');
     }
 }


### PR DESCRIPTION
## What changed
- Render the server-health telemetry initializer through Blade interpolation.
- Add regression coverage that rejects unrendered Blade directives in the Alpine expression.

## Why
Blade directives inside the component attribute reached the browser literally, causing Alpine to reject the x-init expression.

## Validation
- docker compose run --rm --no-deps --entrypoint php php ./vendor/bin/pest tests/Feature/MonitoringDetailRecentChecksSectionTest.php
- docker compose run --rm --no-deps --entrypoint bun node run build

Closes #686