### PR TITLE
fix(monitoring): initialize type-specific form fields

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -38,8 +38,6 @@ Alpine.data('incidentAnalyticsLoader', incidentAnalyticsLoader);
 window.Alpine = Alpine;
 window.Chart = Chart;
 
-initializeMonitoringTypeFields();
-
 registerConfirmableForms({
     title: document.documentElement.dataset.confirmTitle ?? 'Confirm action',
     confirm: document.documentElement.dataset.confirmConfirm ?? 'Confirm',
@@ -47,3 +45,5 @@ registerConfirmableForms({
 });
 
 Alpine.start();
+
+initializeMonitoringTypeFields();

--- a/resources/js/components/monitoring-type-fields.ts
+++ b/resources/js/components/monitoring-type-fields.ts
@@ -16,12 +16,12 @@ const setDisabled = (container: HTMLElement, disabled: boolean): void => {
 };
 
 const updateForm = (form: HTMLElement): void => {
-    const typeControl = form.querySelector<HTMLSelectElement>(typeControlSelector);
-    if (!typeControl) {
+    const type = form.querySelector<HTMLSelectElement>(typeControlSelector)?.value
+        ?? form.dataset.monitoringCurrentType;
+
+    if (!type) {
         return;
     }
-
-    const type = typeControl.value;
 
     form.querySelectorAll<HTMLElement>(typeFieldsSelector).forEach((container) => {
         const visible = typesFor(container).includes(type);

--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -77,6 +77,7 @@
     publicLabelEnabled: @js(old('public_label_enabled', $monitoring->public_label_enabled ?? false)),
     notificationOnFailure: @js(old('notification_on_failure', $monitoring->notification_on_failure ?? true))
 }" data-monitoring-type-form
+    data-monitoring-current-type="{{ $selectedType }}"
     @if (isset($monitoring)) data-monitoring-existing @endif
     data-monitoring-target-generated-types="{{ $heartbeatTypeValue }} {{ $serverHealthTypeValue }}"
     data-monitoring-url-types="{{ MonitoringType::HTTP->value }} {{ MonitoringType::KEYWORD->value }}"
@@ -249,7 +250,7 @@
             </p>
     </div>
 
-    <div data-monitoring-type-fields="{{ MonitoringType::SERVER_HEALTH->value }}" class="mt-4 space-y-4">
+    <div data-monitoring-type-fields="{{ MonitoringType::SERVER_HEALTH->value }}" {{ $selectedType !== MonitoringType::SERVER_HEALTH->value ? 'hidden' : '' }} class="mt-4 space-y-4">
             <div class="rounded-md border border-gray-200 p-4 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300">
                 <p>{{ __('monitoring.form.server_health_help') }}</p>
                 <a href="{{ route('scribe') }}" target="_blank" rel="noopener"
@@ -308,7 +309,7 @@
             </div>
     </div>
 
-    <div data-monitoring-type-fields="{{ MonitoringType::DNS_RECORD->value }}" class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+    <div data-monitoring-type-fields="{{ MonitoringType::DNS_RECORD->value }}" {{ $selectedType !== MonitoringType::DNS_RECORD->value ? 'hidden' : '' }} class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
             <div>
                 <x-input-label for="dns_record_type" :value="__('monitoring.form.dns_record_type')" />
                 <x-select-input id="dns_record_type" class="mt-1 block w-full" name="dns_record_type">

--- a/tests/Browser/MonitoringTypeFieldVisibilityTest.php
+++ b/tests/Browser/MonitoringTypeFieldVisibilityTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+it('shows only the monitoring type-specific fields on initial form load', function (): void {
+    if (! file_exists(public_path('build/manifest.json'))) {
+        $this->markTestSkipped('Browser test requires built Vite assets in public/build.');
+    }
+
+    $this->withVite();
+
+    $package = Package::factory()->create(['monitoring_limit' => 10]);
+    $user = User::factory()->create([
+        'package_id' => $package->id,
+        'password' => Hash::make('password'),
+    ]);
+    $instanceCode = 'browser-' . Str::lower(Str::random(8));
+    ServerInstance::query()->create([
+        'code' => $instanceCode,
+        'api_key_hash' => 'browser-type-fields-instance-key',
+        'is_active' => true,
+    ]);
+    $serverHealthMonitoring = Monitoring::factory()->for($user)->create([
+        'type' => MonitoringType::SERVER_HEALTH,
+        'preferred_location' => $instanceCode,
+    ]);
+    $dnsMonitoring = Monitoring::factory()->for($user)->create([
+        'type' => MonitoringType::DNS_RECORD,
+        'preferred_location' => $instanceCode,
+    ]);
+
+    $webpage = visit('/login')
+        ->type('email', $user->email)
+        ->type('password', 'password')
+        ->press('form[action$="/login"] button[type="submit"]');
+
+    $assertFields = static function (bool $serverHealthVisible, bool $dnsVisible): string {
+        $serverHealthHidden = $serverHealthVisible ? 'false' : 'true';
+        $dnsHidden = $dnsVisible ? 'false' : 'true';
+
+        return <<<JS
+function () {
+    const form = document.querySelector('[data-monitoring-type-form]');
+    const serverHealthFields = form?.querySelector('[data-monitoring-type-fields="server_health"]');
+    const dnsFields = form?.querySelector('[data-monitoring-type-fields="dns_record"]');
+
+    return serverHealthFields instanceof HTMLElement
+        && dnsFields instanceof HTMLElement
+        && serverHealthFields.hidden === {$serverHealthHidden}
+        && dnsFields.hidden === {$dnsHidden};
+}
+JS;
+    };
+
+    $webpage->navigate('/monitorings/create')
+        ->waitForText(__('monitoring.form.sections.basic'))
+        ->assertScript($assertFields(false, false), true)
+        ->select('select[name="type"]', MonitoringType::SERVER_HEALTH->value)
+        ->assertScript($assertFields(true, false), true)
+        ->select('select[name="type"]', MonitoringType::DNS_RECORD->value)
+        ->assertScript($assertFields(false, true), true)
+        ->navigate('/monitorings/' . $serverHealthMonitoring->getRouteKey() . '/edit')
+        ->waitForText(__('monitoring.edit.title', ['monitoring' => $serverHealthMonitoring->name]))
+        ->assertScript($assertFields(true, false), true)
+        ->navigate('/monitorings/' . $dnsMonitoring->getRouteKey() . '/edit')
+        ->waitForText(__('monitoring.edit.title', ['monitoring' => $dnsMonitoring->name]))
+        ->assertScript($assertFields(false, true), true)
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/MonitoringTypeFieldVisibilityTest.php
+++ b/tests/Feature/MonitoringTypeFieldVisibilityTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\MonitoringType;
+use App\Models\Monitoring;
+use App\Models\Package;
+use App\Models\ServerInstance;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MonitoringTypeFieldVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_form_hides_server_health_and_dns_fields_until_their_type_is_selected(): void
+    {
+        $user = $this->createUserWithServerInstance();
+
+        $testResponse = $this->actingAs($user)->get(route('monitorings.create'));
+
+        $testResponse->assertOk();
+        $testResponse->assertSeeHtml('data-monitoring-current-type="http"');
+        $testResponse->assertSeeHtml('data-monitoring-type-fields="server_health" hidden');
+        $testResponse->assertSeeHtml('data-monitoring-type-fields="dns_record" hidden');
+    }
+
+    public function test_edit_form_uses_the_monitoring_type_to_set_initial_field_visibility(): void
+    {
+        $user = $this->createUserWithServerInstance();
+        $serverHealthMonitoring = Monitoring::factory()->for($user)->create([
+            'type' => MonitoringType::SERVER_HEALTH,
+        ]);
+        $dnsMonitoring = Monitoring::factory()->for($user)->create([
+            'type' => MonitoringType::DNS_RECORD,
+        ]);
+
+        $this->actingAs($user)->get(route('monitorings.edit', $serverHealthMonitoring))
+            ->assertOk()
+            ->assertSeeHtml('data-monitoring-current-type="server_health"')
+            ->assertSeeHtml('data-monitoring-type-fields="dns_record" hidden')
+            ->assertDontSeeHtml('data-monitoring-type-fields="server_health" hidden');
+
+        $this->actingAs($user)->get(route('monitorings.edit', $dnsMonitoring))
+            ->assertOk()
+            ->assertSeeHtml('data-monitoring-current-type="dns_record"')
+            ->assertSeeHtml('data-monitoring-type-fields="server_health" hidden')
+            ->assertDontSeeHtml('data-monitoring-type-fields="dns_record" hidden');
+    }
+
+    private function createUserWithServerInstance(): User
+    {
+        ServerInstance::query()->firstOrCreate(
+            ['code' => 'de-1'],
+            ['api_key_hash' => 'test-token-1234567890', 'is_active' => true]
+        );
+
+        return User::factory()->create([
+            'package_id' => Package::factory()->create()->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## What changed
- Hide server-health threshold fields unless the server health type is active.
- Hide DNS record fields unless the DNS record type is active.
- Initialize type-dependent form state after Alpine starts and support immutable types on edit forms.
- Add feature and browser regression coverage.

## Why
The form initializer required an editable type select, so edit forms left all conditional inputs visible. Initial rendering could also occur before Alpine completed setup.

## Validation
- docker compose run --rm --no-deps --entrypoint php php ./vendor/bin/pint --test resources/views/monitorings/_form.blade.php resources/js/app.ts resources/js/components/monitoring-type-fields.ts tests/Feature/MonitoringTypeFieldVisibilityTest.php tests/Browser/MonitoringTypeFieldVisibilityTest.php
- docker compose run --rm --no-deps --entrypoint php php ./vendor/bin/pest tests/Feature/MonitoringTypeFieldVisibilityTest.php
- docker compose run --rm --no-deps --entrypoint bun node run build
- Browser test added but local execution is blocked because Playwright is unavailable in the Docker test environment.

Closes #688