### PR TITLE
fix(monitoring): toggle check configuration by type

### DIFF
--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -18,6 +18,15 @@
     $heartbeatTypeValue = MonitoringType::HEARTBEAT->value;
     $serverHealthTypeValue = MonitoringType::SERVER_HEALTH->value;
     $selectedType = old('type', $monitoring->type->value ?? ($types[0]->value ?? ''));
+    $checkConfigurationTypeValues = [
+        MonitoringType::HTTP->value,
+        MonitoringType::KEYWORD->value,
+        MonitoringType::PORT->value,
+        MonitoringType::HEARTBEAT->value,
+        MonitoringType::SERVER_HEALTH->value,
+        MonitoringType::DNS_RECORD->value,
+    ];
+    $showCheckConfiguration = in_array($selectedType, $checkConfigurationTypeValues, true);
     $targetPlaceholders = [
         MonitoringType::HTTP->value => __('monitoring.form.placeholders.http_target'),
         MonitoringType::PING->value => __('monitoring.form.placeholders.ping_target'),
@@ -215,10 +224,16 @@
             </div>
         </details>
 
-        <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-            <div>
+        <details data-monitoring-check-configuration data-monitoring-type-fields="{{ implode(' ', $checkConfigurationTypeValues) }}" {{ $showCheckConfiguration ? '' : 'hidden' }} class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 [&::-webkit-details-marker]:hidden">
                 <x-heading type="h2">{{ __('monitoring.form.sections.check') }}</x-heading>
-            </div>
+                <svg class="size-5 shrink-0 text-gray-500 transition-transform group-open:rotate-180 dark:text-gray-400"
+                    viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                </svg>
+            </summary>
+
+            <div class="space-y-4 pt-4">
 
     <div data-monitoring-type-fields="{{ MonitoringType::PORT->value }}" class="mt-4">
             <x-input-label for="port" :value="__('monitoring.form.port')" />
@@ -417,7 +432,8 @@
 
     </details>
 
-        </section>
+            </div>
+        </details>
 
         <details class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
             <summary class="group flex cursor-pointer list-none items-center justify-between gap-4 [&::-webkit-details-marker]:hidden">

--- a/tests/Browser/MonitoringTypeFieldVisibilityTest.php
+++ b/tests/Browser/MonitoringTypeFieldVisibilityTest.php
@@ -36,42 +36,61 @@ it('shows only the monitoring type-specific fields on initial form load', functi
         'type' => MonitoringType::DNS_RECORD,
         'preferred_location' => $instanceCode,
     ]);
+    $pingMonitoring = Monitoring::factory()->for($user)->create([
+        'type' => MonitoringType::PING,
+        'preferred_location' => $instanceCode,
+    ]);
 
     $webpage = visit('/login')
         ->type('email', $user->email)
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]');
 
-    $assertFields = static function (bool $serverHealthVisible, bool $dnsVisible): string {
+    $assertFields = static function (bool $serverHealthVisible, bool $dnsVisible, bool $checkConfigurationVisible): string {
         $serverHealthHidden = $serverHealthVisible ? 'false' : 'true';
         $dnsHidden = $dnsVisible ? 'false' : 'true';
+        $checkConfigurationHidden = $checkConfigurationVisible ? 'false' : 'true';
 
         return <<<JS
 function () {
     const form = document.querySelector('[data-monitoring-type-form]');
     const serverHealthFields = form?.querySelector('[data-monitoring-type-fields="server_health"]');
     const dnsFields = form?.querySelector('[data-monitoring-type-fields="dns_record"]');
+    const checkConfiguration = form?.querySelector('[data-monitoring-check-configuration]');
 
     return serverHealthFields instanceof HTMLElement
         && dnsFields instanceof HTMLElement
+        && checkConfiguration instanceof HTMLDetailsElement
         && serverHealthFields.hidden === {$serverHealthHidden}
-        && dnsFields.hidden === {$dnsHidden};
+        && dnsFields.hidden === {$dnsHidden}
+        && checkConfiguration.hidden === {$checkConfigurationHidden};
 }
 JS;
     };
 
     $webpage->navigate('/monitorings/create')
         ->waitForText(__('monitoring.form.sections.basic'))
-        ->assertScript($assertFields(false, false), true)
+        ->assertScript($assertFields(false, false, true), true)
         ->select('select[name="type"]', MonitoringType::SERVER_HEALTH->value)
-        ->assertScript($assertFields(true, false), true)
+        ->assertScript($assertFields(true, false, true), true)
+        ->click('[data-monitoring-check-configuration] > summary')
+        ->assertScript(<<<'JS'
+function () {
+    return document.querySelector('[data-monitoring-check-configuration]')?.open === true;
+}
+JS, true)
         ->select('select[name="type"]', MonitoringType::DNS_RECORD->value)
-        ->assertScript($assertFields(false, true), true)
+        ->assertScript($assertFields(false, true, true), true)
+        ->select('select[name="type"]', MonitoringType::PING->value)
+        ->assertScript($assertFields(false, false, false), true)
         ->navigate('/monitorings/' . $serverHealthMonitoring->getRouteKey() . '/edit')
         ->waitForText(__('monitoring.edit.title', ['monitoring' => $serverHealthMonitoring->name]))
-        ->assertScript($assertFields(true, false), true)
+        ->assertScript($assertFields(true, false, true), true)
         ->navigate('/monitorings/' . $dnsMonitoring->getRouteKey() . '/edit')
         ->waitForText(__('monitoring.edit.title', ['monitoring' => $dnsMonitoring->name]))
-        ->assertScript($assertFields(false, true), true)
+        ->assertScript($assertFields(false, true, true), true)
+        ->navigate('/monitorings/' . $pingMonitoring->getRouteKey() . '/edit')
+        ->waitForText(__('monitoring.edit.title', ['monitoring' => $pingMonitoring->name]))
+        ->assertScript($assertFields(false, false, false), true)
         ->assertNoJavaScriptErrors();
 });

--- a/tests/Feature/MonitoringTypeFieldVisibilityTest.php
+++ b/tests/Feature/MonitoringTypeFieldVisibilityTest.php
@@ -51,6 +51,24 @@ class MonitoringTypeFieldVisibilityTest extends TestCase
             ->assertDontSeeHtml('data-monitoring-type-fields="dns_record" hidden');
     }
 
+    public function test_check_configuration_is_hidden_when_the_monitoring_type_has_no_configuration_fields(): void
+    {
+        $user = $this->createUserWithServerInstance();
+        $pingMonitoring = Monitoring::factory()->for($user)->create([
+            'type' => MonitoringType::PING,
+        ]);
+
+        $this->actingAs($user)->get(route('monitorings.create'))
+            ->assertOk()
+            ->assertSeeHtml('data-monitoring-check-configuration')
+            ->assertSeeHtml('data-monitoring-type-fields="http keyword port heartbeat server_health dns_record"')
+            ->assertDontSeeHtml('data-monitoring-check-configuration data-monitoring-type-fields="http keyword port heartbeat server_health dns_record" hidden');
+
+        $this->actingAs($user)->get(route('monitorings.edit', $pingMonitoring))
+            ->assertOk()
+            ->assertSeeHtml('data-monitoring-check-configuration data-monitoring-type-fields="http keyword port heartbeat server_health dns_record" hidden');
+    }
+
     private function createUserWithServerInstance(): User
     {
         ServerInstance::query()->firstOrCreate(


### PR DESCRIPTION
## What changed
- Convert check configuration into a collapsible form section.
- Show it only for monitoring types with applicable check-specific fields.
- Hide it for types such as ping and domain expiration.
- Extend feature and browser regression coverage.

## Why
The check configuration was always rendered although several monitoring types have no configuration items to display.

## Validation
- docker compose run --rm --no-deps --entrypoint php php ./vendor/bin/pint resources/views/monitorings/_form.blade.php tests/Feature/MonitoringTypeFieldVisibilityTest.php tests/Browser/MonitoringTypeFieldVisibilityTest.php
- docker compose run --rm --no-deps --entrypoint php php ./vendor/bin/pest tests/Feature/MonitoringTypeFieldVisibilityTest.php
- docker compose run --rm --no-deps --entrypoint bun node run build
- Browser test added but local execution is blocked because Playwright is unavailable in the Docker test environment.

Closes #690