### PR TITLE
fix(monitoring): hide type-specific form fields initially

### DIFF
--- a/resources/views/monitorings/_form.blade.php
+++ b/resources/views/monitorings/_form.blade.php
@@ -26,6 +26,10 @@
         MonitoringType::SERVER_HEALTH->value,
         MonitoringType::DNS_RECORD->value,
     ];
+    $httpConfigurationTypeValues = [
+        MonitoringType::HTTP->value,
+        MonitoringType::KEYWORD->value,
+    ];
     $showCheckConfiguration = in_array($selectedType, $checkConfigurationTypeValues, true);
     $targetPlaceholders = [
         MonitoringType::HTTP->value => __('monitoring.form.placeholders.http_target'),
@@ -187,12 +191,14 @@
                     </div>
                     <div
                         data-monitoring-type-fields="{{ $heartbeatTypeValue }}"
+                        {{ $selectedType !== $heartbeatTypeValue ? 'hidden' : '' }}
                         class="mt-2 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-600 dark:border-gray-600 dark:text-gray-300"
                     >
                         {{ __('monitoring.form.heartbeat_target_generated') }}
                     </div>
                     <div
                         data-monitoring-type-fields="{{ $serverHealthTypeValue }}"
+                        {{ $selectedType !== $serverHealthTypeValue ? 'hidden' : '' }}
                         class="mt-2 rounded-md border border-dashed border-gray-300 p-4 text-sm text-gray-600 dark:border-gray-600 dark:text-gray-300"
                     >
                         {{ __('monitoring.form.server_health_target_generated') }}
@@ -298,13 +304,21 @@
             </summary>
 
             <div class="space-y-4 pt-4">
-                <div data-monitoring-type-fields="{{ MonitoringType::PORT->value }}" class="mt-4">
+                <div
+                    data-monitoring-type-fields="{{ MonitoringType::PORT->value }}"
+                    {{ $selectedType !== MonitoringType::PORT->value ? 'hidden' : '' }}
+                    class="mt-4"
+                >
                     <x-input-label for="port" :value="__('monitoring.form.port')" />
                     <x-text-input id="port" type="number" name="port" :value="old('port', $monitoring->port ?? '')" />
                     <x-input-error :messages="$errors->get('port')" />
                 </div>
 
-                <div data-monitoring-type-fields="{{ MonitoringType::KEYWORD->value }}" class="mt-4">
+                <div
+                    data-monitoring-type-fields="{{ MonitoringType::KEYWORD->value }}"
+                    {{ $selectedType !== MonitoringType::KEYWORD->value ? 'hidden' : '' }}
+                    class="mt-4"
+                >
                     <x-input-label for="keyword" :value="__('monitoring.form.keyword')" />
                     <x-text-input
                         id="keyword"
@@ -317,6 +331,7 @@
 
                 <div
                     data-monitoring-type-fields="{{ MonitoringType::HEARTBEAT->value }}"
+                    {{ $selectedType !== MonitoringType::HEARTBEAT->value ? 'hidden' : '' }}
                     class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2"
                 >
                     <div>
@@ -517,6 +532,7 @@
 
                 <div
                     data-monitoring-type-fields="{{ MonitoringType::HTTP->value }} {{ MonitoringType::KEYWORD->value }}"
+                    {{ ! in_array($selectedType, $httpConfigurationTypeValues, true) ? 'hidden' : '' }}
                     class="mt-4"
                 >
                     <x-input-label for="timeout" :value="__('monitoring.form.timeout')" />
@@ -539,6 +555,7 @@
 
                 <div
                     data-monitoring-type-fields="{{ MonitoringType::HTTP->value }} {{ MonitoringType::KEYWORD->value }}"
+                    {{ ! in_array($selectedType, $httpConfigurationTypeValues, true) ? 'hidden' : '' }}
                     class="mt-4 grid gap-4 sm:grid-cols-2"
                 >
                     <div>
@@ -583,6 +600,7 @@
 
                 <div
                     data-monitoring-type-fields="{{ MonitoringType::HTTP->value }} {{ MonitoringType::KEYWORD->value }}"
+                    {{ ! in_array($selectedType, $httpConfigurationTypeValues, true) ? 'hidden' : '' }}
                     class="mt-4"
                 >
                     <x-input-label for="http_method" :value="__('monitoring.form.http_method')" />
@@ -601,6 +619,7 @@
 
                 <div
                     data-monitoring-type-fields="{{ MonitoringType::HTTP->value }} {{ MonitoringType::KEYWORD->value }}"
+                    {{ ! in_array($selectedType, $httpConfigurationTypeValues, true) ? 'hidden' : '' }}
                     class="mt-4"
                 >
                     <x-input-label for="expected_http_statuses" :value="__('monitoring.form.expected_http_statuses')" />
@@ -619,6 +638,7 @@
 
                 <details
                     data-monitoring-type-fields="{{ MonitoringType::HTTP->value }} {{ MonitoringType::KEYWORD->value }}"
+                    {{ ! in_array($selectedType, $httpConfigurationTypeValues, true) ? 'hidden' : '' }}
                     class="mt-4 rounded-md border border-gray-200 p-4 dark:border-gray-700"
                 >
                     <summary class="group [&::-webkit-details-marker]:hidden flex cursor-pointer list-none items-center justify-between gap-4 font-semibold text-gray-800 dark:text-gray-100">

--- a/tests/Browser/MonitoringTypeFieldVisibilityTest.php
+++ b/tests/Browser/MonitoringTypeFieldVisibilityTest.php
@@ -32,6 +32,10 @@ it('shows only the monitoring type-specific fields on initial form load', functi
         'type' => MonitoringType::SERVER_HEALTH,
         'preferred_location' => $instanceCode,
     ]);
+    $heartbeatMonitoring = Monitoring::factory()->for($user)->create([
+        'type' => MonitoringType::HEARTBEAT,
+        'preferred_location' => $instanceCode,
+    ]);
     $dnsMonitoring = Monitoring::factory()->for($user)->create([
         'type' => MonitoringType::DNS_RECORD,
         'preferred_location' => $instanceCode,
@@ -46,7 +50,8 @@ it('shows only the monitoring type-specific fields on initial form load', functi
         ->type('password', 'password')
         ->press('form[action$="/login"] button[type="submit"]');
 
-    $assertFields = static function (bool $serverHealthVisible, bool $dnsVisible, bool $checkConfigurationVisible): string {
+    $assertFields = static function (bool $heartbeatVisible, bool $serverHealthVisible, bool $dnsVisible, bool $checkConfigurationVisible): string {
+        $heartbeatHidden = $heartbeatVisible ? 'false' : 'true';
         $serverHealthHidden = $serverHealthVisible ? 'false' : 'true';
         $dnsHidden = $dnsVisible ? 'false' : 'true';
         $checkConfigurationHidden = $checkConfigurationVisible ? 'false' : 'true';
@@ -54,13 +59,20 @@ it('shows only the monitoring type-specific fields on initial form load', functi
         return <<<JS
 function () {
     const form = document.querySelector('[data-monitoring-type-form]');
-    const serverHealthFields = form?.querySelector('[data-monitoring-type-fields="server_health"]');
+    const heartbeatFields = form?.querySelector('[data-monitoring-type-fields="heartbeat"]:not(.border-dashed)');
+    const heartbeatNotice = form?.querySelector('[data-monitoring-type-fields="heartbeat"].border-dashed');
+    const serverHealthNotice = form?.querySelector('[data-monitoring-type-fields="server_health"].border-dashed');
+    const serverHealthFields = form?.querySelector('[data-monitoring-type-fields="server_health"]:not(.border-dashed)');
     const dnsFields = form?.querySelector('[data-monitoring-type-fields="dns_record"]');
     const checkConfiguration = form?.querySelector('[data-monitoring-check-configuration]');
 
-    return serverHealthFields instanceof HTMLElement
+    return heartbeatFields instanceof HTMLElement
+        && serverHealthFields instanceof HTMLElement
         && dnsFields instanceof HTMLElement
         && checkConfiguration instanceof HTMLDetailsElement
+        && heartbeatFields.hidden === {$heartbeatHidden}
+        && (heartbeatNotice === null || heartbeatNotice.hidden === {$heartbeatHidden})
+        && (serverHealthNotice === null || serverHealthNotice.hidden === {$serverHealthHidden})
         && serverHealthFields.hidden === {$serverHealthHidden}
         && dnsFields.hidden === {$dnsHidden}
         && checkConfiguration.hidden === {$checkConfigurationHidden};
@@ -70,9 +82,11 @@ JS;
 
     $webpage->navigate('/monitorings/create')
         ->waitForText(__('monitoring.form.sections.basic'))
-        ->assertScript($assertFields(false, false, true), true)
+        ->assertScript($assertFields(false, false, false, true), true)
+        ->select('select[name="type"]', MonitoringType::HEARTBEAT->value)
+        ->assertScript($assertFields(true, false, false, true), true)
         ->select('select[name="type"]', MonitoringType::SERVER_HEALTH->value)
-        ->assertScript($assertFields(true, false, true), true)
+        ->assertScript($assertFields(false, true, false, true), true)
         ->click('[data-monitoring-check-configuration] > summary')
         ->assertScript(<<<'JS'
 function () {
@@ -80,17 +94,20 @@ function () {
 }
 JS, true)
         ->select('select[name="type"]', MonitoringType::DNS_RECORD->value)
-        ->assertScript($assertFields(false, true, true), true)
+        ->assertScript($assertFields(false, false, true, true), true)
         ->select('select[name="type"]', MonitoringType::PING->value)
-        ->assertScript($assertFields(false, false, false), true)
+        ->assertScript($assertFields(false, false, false, false), true)
+        ->navigate('/monitorings/' . $heartbeatMonitoring->getRouteKey() . '/edit')
+        ->waitForText(__('monitoring.edit.title', ['monitoring' => $heartbeatMonitoring->name]))
+        ->assertScript($assertFields(true, false, false, true), true)
         ->navigate('/monitorings/' . $serverHealthMonitoring->getRouteKey() . '/edit')
         ->waitForText(__('monitoring.edit.title', ['monitoring' => $serverHealthMonitoring->name]))
-        ->assertScript($assertFields(true, false, true), true)
+        ->assertScript($assertFields(false, true, false, true), true)
         ->navigate('/monitorings/' . $dnsMonitoring->getRouteKey() . '/edit')
         ->waitForText(__('monitoring.edit.title', ['monitoring' => $dnsMonitoring->name]))
-        ->assertScript($assertFields(false, true, true), true)
+        ->assertScript($assertFields(false, false, true, true), true)
         ->navigate('/monitorings/' . $pingMonitoring->getRouteKey() . '/edit')
         ->waitForText(__('monitoring.edit.title', ['monitoring' => $pingMonitoring->name]))
-        ->assertScript($assertFields(false, false, false), true)
+        ->assertScript($assertFields(false, false, false, false), true)
         ->assertNoJavaScriptErrors();
 });

--- a/tests/Feature/MonitoringTypeFieldVisibilityTest.php
+++ b/tests/Feature/MonitoringTypeFieldVisibilityTest.php
@@ -16,7 +16,7 @@ class MonitoringTypeFieldVisibilityTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_create_form_hides_server_health_and_dns_fields_until_their_type_is_selected(): void
+    public function test_create_form_hides_type_specific_fields_and_generated_url_notices_until_their_type_is_selected(): void
     {
         $user = $this->createUserWithServerInstance();
 
@@ -24,8 +24,18 @@ class MonitoringTypeFieldVisibilityTest extends TestCase
 
         $testResponse->assertOk();
         $testResponse->assertSeeHtml('data-monitoring-current-type="http"');
+        $this->assertTypeFieldsAreHidden($testResponse->getContent(), 'port');
+        $this->assertTypeFieldsAreHidden($testResponse->getContent(), 'keyword');
+        $this->assertTypeFieldsAreHidden($testResponse->getContent(), 'heartbeat');
         $this->assertTypeFieldsAreHidden($testResponse->getContent(), 'server_health');
         $this->assertTypeFieldsAreHidden($testResponse->getContent(), 'dns_record');
+        $this->assertTypeFieldsAreVisible($testResponse->getContent(), 'http keyword');
+
+        $modalResponse = $this->actingAs($user)->get(route('monitorings.create', ['modal' => 1]));
+
+        $modalResponse->assertOk();
+        $this->assertTypeFieldsAreHidden($modalResponse->getContent(), 'heartbeat');
+        $this->assertTypeFieldsAreHidden($modalResponse->getContent(), 'server_health');
     }
 
     public function test_edit_form_uses_the_monitoring_type_to_set_initial_field_visibility(): void
@@ -53,6 +63,18 @@ class MonitoringTypeFieldVisibilityTest extends TestCase
             ->assertSeeHtml('data-monitoring-current-type="dns_record"');
         $this->assertTypeFieldsAreHidden($dnsResponse->getContent(), 'server_health');
         $this->assertTypeFieldsAreVisible($dnsResponse->getContent(), 'dns_record');
+
+        $httpMonitoring = Monitoring::factory()->for($user)->create([
+            'type' => MonitoringType::HTTP,
+        ]);
+
+        $httpResponse = $this->actingAs($user)->get(route('monitorings.edit', $httpMonitoring));
+
+        $httpResponse
+            ->assertOk()
+            ->assertSeeHtml('data-monitoring-current-type="http"');
+        $this->assertTypeFieldsAreHidden($httpResponse->getContent(), 'heartbeat');
+        $this->assertTypeFieldsAreHidden($httpResponse->getContent(), 'server_health');
     }
 
     public function test_check_configuration_is_hidden_when_the_monitoring_type_has_no_configuration_fields(): void


### PR DESCRIPTION
## What changed

- Render monitoring-type-specific fields and generated-URL notices hidden unless the initial type applies.
- Cover create-page, create-modal, and edit-form initial visibility, including Heartbeat and Server-Zustand.
- Retain the existing JavaScript type-switching behavior.

## Why

HTTP monitor forms briefly displayed Heartbeat and Server-Zustand configuration before the client-side initializer ran. Rendering the initial state server-side makes the form correct from its first response.

Closes #694

## Testing

- Docker: `./vendor/bin/pest tests/Feature/MonitoringTypeFieldVisibilityTest.php` — passed (27 assertions; local `.env`-absence warnings only).
- Docker: `bun run build` — passed.
- PHP syntax checks for the updated test files — passed.
- Browser test was prepared but could not be completed because Docker Desktop Containerd began returning host I/O errors after the focused checks; the initial attempt was also blocked by the locally missing Playwright browser runtime.

## Risk

The change adds only initial `hidden` attributes to type-bound form sections. Existing client-side switching still owns subsequent type changes.